### PR TITLE
Clarify workflow and manual testing rules

### DIFF
--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -54,6 +54,10 @@ You **MUST** consider the user input before proceeding (if not empty).
      - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
      - Completed items: Lines matching `- [X]` or `- [x]`
      - Incomplete items: Lines matching `- [ ]`
+   - Treat `manual-testing.md` specially:
+     - It MUST exist before implementation begins
+     - Its incompleteness does **not** block `/speckit.implement`
+     - It is completed and signed off later, before opening the PR
    - Create a status table:
 
      ```text
@@ -65,18 +69,24 @@ You **MUST** consider the user input before proceeding (if not empty).
      ```
 
    - Calculate overall status:
-     - **PASS**: All checklists have 0 incomplete items
-     - **FAIL**: One or more checklists have incomplete items
+     - **PASS**: All non-manual checklists have 0 incomplete items, and `manual-testing.md` exists
+     - **FAIL**: One or more non-manual checklists have incomplete items, or `manual-testing.md` is missing
 
-   - **If any checklist is incomplete**:
+   - **If any non-manual checklist is incomplete**:
      - Display the table with incomplete item counts
      - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
      - Wait for user response before continuing
      - If user says "no" or "wait" or "stop", halt execution
      - If user says "yes" or "proceed" or "continue", proceed to step 3
 
-   - **If all checklists are complete**:
-     - Display the table showing all checklists passed
+   - **If `manual-testing.md` is missing**:
+     - **STOP** and ask: "The feature is missing `checklists/manual-testing.md`. Do you want me to create it before implementation continues? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", create the file and then proceed to step 3
+
+   - **If all non-manual checklists are complete and `manual-testing.md` exists**:
+     - Display the table showing checklist status, and note that `manual-testing.md` is expected to remain incomplete until after implementation
      - Automatically proceed to step 3
 
 3. Load and analyze the implementation context:

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -166,6 +166,7 @@ A feature is complete only when all of the following are true:
 - [ ] Tests pass and linting is clean
 - [ ] No TODOs, dead code, `console.log`, or untyped values remain
 - [ ] All spec documents for the feature are current
+- [ ] `specs/NNN-feature-name/checklists/manual-testing.md` exists for the feature
 - [ ] Manual testing checklist completed and signed off
 - [ ] README updated for any user-facing or setup changes
 - [ ] Constitution compliance verified — no rule violated
@@ -176,11 +177,12 @@ A feature is complete only when all of the following are true:
 
 1. All work happens on feature branches. No direct commits to `main`.
 2. All tests must pass and linting must be clean before a PR is merged.
-3. A manual testing checklist must be completed and signed off before submitting a PR.
-4. README must be updated to reflect any user-facing or setup changes before submitting a PR.
-5. A PR must be opened and merged before starting the next feature.
-5. Credentials go in `.env.local` only — never committed. `.env.example` is committed with placeholder values.
-6. README is updated when a completed feature changes the user-facing behavior or setup steps.
+3. Every feature must maintain `specs/NNN-feature-name/checklists/manual-testing.md`.
+4. A manual testing checklist must be completed and signed off before submitting a PR.
+5. README must be updated to reflect any user-facing or setup changes before submitting a PR.
+6. A PR must be opened and merged before starting the next feature.
+7. Credentials go in `.env.local` only — never committed. `.env.example` is committed with placeholder values.
+8. README is updated when a completed feature changes the user-facing behavior or setup steps.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ Command definitions are available in `.claude/commands/`.
 - `/speckit.tasks` — generate task list
 - `/speckit.implement` — execute plan
 
+These command definitions live in `.claude/commands/`.
+
 Before running any `/speckit.*` command, always read `docs/PRODUCT.md`. The spec must be traceable to the acceptance criteria and out-of-scope boundaries defined there.
 Before choosing the next feature to implement, always read `docs/DEVELOPMENT.md` for the current implementation order.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -38,6 +38,8 @@ Review the task list before implementation begins.
 
 > `/speckit.implement` `[P1-F01]`
 
+Each feature must include a manual testing checklist at `specs/NNN-feature-name/checklists/manual-testing.md`. Create it during the feature workflow if it does not already exist, and complete/sign it off before opening the PR.
+
 ### Step 5 — PR
 
 Before opening a PR, verify the Definition of Done (constitution Section XII):
@@ -61,10 +63,10 @@ This is the planned implementation order for Phase 1. It may differ from the fea
 | # | Feature ID | Feature | Status |
 |---|---|---|---|
 | 1 | P1-F01 | Repo Input | ✅ Done |
-| 2 | P1-F02 | Authentication | — |
+| 2 | P1-F02 | Authentication | ✅ Done |
 | 3 | P1-F04 | Data Fetching | — |
-| 4 | P1-F03 | Deployment | — |
-| 5 | P1-F05 | Ecosystem Map | — |
+| 4 | P1-F05 | Ecosystem Map | — |
+| 5 | P1-F03 | Deployment | — |
 | 6 | P1-F06 | Repo Comparison | — |
 | 7 | P1-F07 | Metric Cards | — |
 | 8 | P1-F14 | GitHub OAuth Authentication | — |
@@ -87,5 +89,6 @@ When Phase 1 is complete and deployed, run the same loop for each Phase 2 featur
 
 - `.specify/` is managed by SpecKit. Do not manually edit files inside it outside of the workflows above.
 - Feature specs live in `specs/NNN-feature-name/`.
+- Every feature must have `specs/NNN-feature-name/checklists/manual-testing.md`.
 - Constitution: `.specify/memory/constitution.md`
 - Product definition: `docs/PRODUCT.md`


### PR DESCRIPTION
## Summary
- make the manual testing checklist file an explicit project requirement
- clarify that `docs/DEVELOPMENT.md` defines implementation order while `docs/PRODUCT.md` remains the product definition
- update `/speckit.implement` so `manual-testing.md` must exist before implementation but does not block implementation while still incomplete
- point `CLAUDE.md` at the command definitions and implementation-order guidance

## Notes
- this PR is intentionally separated from the `P1-F04` feature work so process changes can be reviewed independently
