### PR TITLE
Implement P1-F05 ecosystem spectrum

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -78,7 +78,7 @@ Four CHAOSS categories. Each maps to exactly one feature and produces exactly on
 
 | CHAOSS Category  | Feature ID | Feature Name            | Score Name           | Score Values                              |
 |------------------|------------|-------------------------|----------------------|-------------------------------------------|
-| Ecosystem        | P1-F05     | Ecosystem Map           | Quadrant             | Leaders / Buzz / Builders / Early         |
+| Ecosystem        | P1-F05     | Ecosystem Map           | Ecosystem profile    | Reach / Builder Engagement / Attention    |
 | Evolution        | P1-F08     | Evolution               | Evolution score      | High / Medium / Low                       |
 | Sustainability   | P1-F09     | Contribution Dynamics   | Resilience score     | High / Medium / Low                       |
 | Responsiveness   | P1-F10     | Responsiveness          | Responsiveness score | High / Medium / Low                       |
@@ -103,13 +103,13 @@ Rules:
 
 ---
 
-## VII. Quadrant Classification
+## VII. Ecosystem Spectrum
 
-1. Quadrant boundaries (Leaders / Buzz / Builders / Early) are computed using a **median split across the current input set**.
-2. Quadrant thresholds are **never hardcoded**. They are always derived from the data at analysis time.
-3. Single-repo input: quadrant classification is **skipped**. The UI displays an explanatory note — it does not assign a quadrant or fall back to a default.
-4. Axes: X = stars (awareness), Y = forks (action), bubble size = watchers (sustained interest).
-5. Quadrant badge colors: Leaders = green, Buzz = amber, Builders = blue, Early = gray.
+1. P1-F05 uses a **spectrum model**, not median-derived quadrants.
+2. Axes: X = stars (reach), Y = builder engagement (`forks / stars`), bubble size = attention (`watchers / stars`).
+3. Ecosystem profile tiers are **ForkPrint-defined** and aligned to the CHAOSS ecosystem category. They are not presented as an official CHAOSS taxonomy.
+4. Spectrum thresholds are defined in shared configuration and read from that configuration by the UI and supporting logic.
+5. Single-repo input remains fully valid: the UI still plots and profiles the repo when verified data exists.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GITHUB_TOKEN=
 ## Planned Product Capabilities
 
 - Analyze GitHub repos across four CHAOSS categories: **Ecosystem**, **Evolution**, **Sustainability**, and **Responsiveness**
-- Visualize repos on an interactive 2×2 ecosystem map (stars × forks)
+- Visualize repos with an interactive ecosystem view and profile summaries
 - Compare multiple repos side by side across all health metrics
 - Export results as JSON or Markdown
 
@@ -48,12 +48,12 @@ Implemented today:
 - Per-repo result and failure handling with explicit `"unavailable"` placeholders
 - Loading and rate-limit visibility on the home page
 - Results shell with a full-width header, stable analysis panel, and tabbed result workspace
-- `Overview`, `Ecosystem Map`, `Comparison`, and `Metrics` tabs, with placeholder states for future views
+- `Overview`, `Ecosystem Map`, `Comparison`, and `Metrics` tabs, with placeholder states where later features are still pending
+- Ecosystem spectrum view in the `Ecosystem Map` tab, including visible stars/forks/watchers and config-driven Reach / Builder Engagement / Attention profiles
 - Automated coverage with Vitest, React Testing Library, and Playwright
 
 Not implemented yet:
 
-- Ecosystem map visualization inside the `Ecosystem Map` tab
 - Repo comparison content inside the `Comparison` tab
 - Expanded metrics content inside the `Metrics` tab
 - JSON/Markdown export

--- a/components/ecosystem-map/EcosystemMap.test.tsx
+++ b/components/ecosystem-map/EcosystemMap.test.tsx
@@ -1,12 +1,7 @@
-import { vi } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { EcosystemMap } from './EcosystemMap'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
-
-vi.mock('react-chartjs-2', () => ({
-  Bubble: () => <div data-testid="bubble-chart-canvas" />,
-}))
 
 describe('EcosystemMap', () => {
   it('renders visible stars, forks, and watchers for successful repositories', () => {
@@ -24,11 +19,12 @@ describe('EcosystemMap', () => {
     )
 
     const region = screen.getByRole('region', { name: /ecosystem map/i })
+    const articles = within(region).getAllByRole('article')
 
-    expect(within(region).getByText('facebook/react')).toBeInTheDocument()
-    expect(within(region).getByText('Stars: 244,295')).toBeInTheDocument()
-    expect(within(region).getByText('Forks: 50,872')).toBeInTheDocument()
-    expect(within(region).getByText('Watchers: 6,660')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('facebook/react')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Stars: 244,295')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Forks: 50,872')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Watchers: 6,660')).toBeInTheDocument()
   })
 
   it('shows unavailable ecosystem metrics explicitly', () => {
@@ -45,15 +41,16 @@ describe('EcosystemMap', () => {
     )
 
     const region = screen.getByRole('region', { name: /ecosystem map/i })
+    const articles = within(region).getAllByRole('article')
 
-    expect(within(region).getByText('Stars: unavailable')).toBeInTheDocument()
-    expect(within(region).getByText('Watchers: unavailable')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Stars: unavailable')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Watchers: unavailable')).toBeInTheDocument()
     expect(
       within(region).getByText(/could not plot this repository because ecosystem metrics were incomplete/i),
     ).toBeInTheDocument()
   })
 
-  it('renders a bubble chart summary for plot-eligible repositories', () => {
+  it('renders the spectrum-only view without the chart', () => {
     render(
       <EcosystemMap
         results={[
@@ -73,12 +70,65 @@ describe('EcosystemMap', () => {
       />,
     )
 
-    const chart = screen.getByRole('img', { name: /ecosystem bubble chart/i })
-    expect(chart).toBeInTheDocument()
-    expect(within(chart).getByTestId('bubble-chart-canvas')).toBeInTheDocument()
-    expect(screen.getByText(/stars \(x-axis\)/i)).toBeInTheDocument()
-    expect(screen.getByText(/forks \(y-axis\)/i)).toBeInTheDocument()
-    expect(screen.getByText(/watchers \(bubble size\)/i)).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: /ecosystem bubble chart/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /reset zoom/i })).not.toBeInTheDocument()
+    expect(screen.getByText(/ecosystem spectrum/i)).toBeInTheDocument()
+  })
+
+  it('renders the ecosystem spectrum legend from config', () => {
+    render(
+      <EcosystemMap
+        results={[
+          buildResult({ repo: 'leader/repo', stars: 400, forks: 70, watchers: 40 }),
+          buildResult({ repo: 'builder/repo', stars: 150, forks: 60, watchers: 18 }),
+        ]}
+      />,
+    )
+
+    const region = screen.getByRole('region', { name: /ecosystem map/i })
+
+    expect(within(region).getByText(/ecosystem spectrum/i)).toBeInTheDocument()
+    expect(within(region).getByText(/^Reach bands$/)).toBeInTheDocument()
+    expect(within(region).getAllByText(/^Builder engagement$/).length).toBeGreaterThan(0)
+    expect(within(region).getAllByText(/^Attention$/).length).toBeGreaterThan(0)
+  })
+
+  it('shows a full spectrum profile even for a single repo', () => {
+    render(
+      <EcosystemMap
+        results={[
+          buildResult({
+            repo: 'facebook/react',
+            stars: 244295,
+            forks: 50872,
+            watchers: 6660,
+          }),
+        ]}
+      />,
+    )
+
+    const region = screen.getByRole('region', { name: /ecosystem map/i })
+
+    expect(within(region).queryByText(/classification is skipped/i)).not.toBeInTheDocument()
+    expect(within(region).getByText(/spectrum profile/i)).toBeInTheDocument()
+    expect(within(region).getByText(/20.8% fork rate/i)).toBeInTheDocument()
+    expect(within(region).getByText(/2.7% watcher rate/i)).toBeInTheDocument()
+  })
+
+  it('shows an exploratory spectrum preview with profile tiers', () => {
+    render(
+      <EcosystemMap
+        results={[
+          buildResult({ repo: 'kubernetes/kubernetes', stars: 121419, forks: 42757, watchers: 3181 }),
+        ]}
+      />,
+    )
+
+    const region = screen.getByRole('region', { name: /ecosystem map/i })
+
+    expect(within(region).getByText(/35.2% fork rate/i)).toBeInTheDocument()
+    expect(within(region).getByText(/2.6% watcher rate/i)).toBeInTheDocument()
+    expect(within(region).getAllByText('Exceptional').length).toBeGreaterThan(0)
   })
 })
 

--- a/components/ecosystem-map/EcosystemMap.tsx
+++ b/components/ecosystem-map/EcosystemMap.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import 'chart.js/auto'
-import { Bubble } from 'react-chartjs-2'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
-import { buildBubbleChartPoints, buildEcosystemRows } from '@/lib/ecosystem-map/chart-data'
+import { buildEcosystemRows } from '@/lib/ecosystem-map/chart-data'
+import {
+  ATTENTION_BANDS,
+  BUILDER_ENGAGEMENT_BANDS,
+  REACH_BANDS,
+} from '@/lib/ecosystem-map/spectrum-config'
 
 interface EcosystemMapProps {
   results: AnalysisResult[]
@@ -11,7 +14,6 @@ interface EcosystemMapProps {
 
 export function EcosystemMap({ results }: EcosystemMapProps) {
   const rows = buildEcosystemRows(results)
-  const bubblePoints = buildBubbleChartPoints(results)
 
   if (rows.length === 0) {
     return null
@@ -19,21 +21,40 @@ export function EcosystemMap({ results }: EcosystemMapProps) {
 
   return (
     <section aria-label="Ecosystem map" className="rounded border border-gray-200 bg-gray-50 p-4">
-      <h2 className="font-semibold text-gray-900">Ecosystem map</h2>
-      {bubblePoints.length > 0 ? (
-        <section className="mt-3 rounded border border-sky-200 bg-white p-3">
-          <div role="img" aria-label="Ecosystem bubble chart" className="rounded border border-sky-100 bg-sky-50 p-3">
-            <div className="h-72">
-              <Bubble data={buildChartData(bubblePoints)} options={bubbleChartOptions} />
-            </div>
-            <div className="mt-3 text-sm text-sky-900">
-              <p>Stars (X-axis)</p>
-              <p>Forks (Y-axis)</p>
-              <p>Watchers (bubble size)</p>
-            </div>
+      <section className="mt-3 rounded border border-indigo-200 bg-white p-3">
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.6fr)] lg:items-start">
+          <div>
+            <h3 className="text-sm font-semibold text-slate-900">Ecosystem spectrum</h3>
+            <p className="mt-1 text-sm text-slate-600">
+              The ecosystem is summarized using three dimensions: reach, builder engagement, and attention.
+            </p>
           </div>
-        </section>
-      ) : null}
+          <div className="grid gap-2 text-sm text-slate-600 md:grid-cols-3">
+            <LegendCard
+              title="Reach bands"
+              bands={REACH_BANDS}
+              formatter={formatCompactNumber}
+              bandClassName={reachLegendBandClass}
+              cardClassName="border-emerald-200 bg-emerald-50/60"
+            />
+            <LegendCard
+              title="Builder engagement"
+              bands={BUILDER_ENGAGEMENT_BANDS}
+              formatter={formatPercentBand}
+              bandClassName={engagementLegendBandClass}
+              cardClassName="border-sky-200 bg-sky-50/60"
+            />
+            <LegendCard
+              title="Attention"
+              bands={ATTENTION_BANDS}
+              formatter={formatPercentBand}
+              bandClassName={attentionLegendBandClass}
+              cardClassName="border-violet-200 bg-violet-50/60"
+            />
+          </div>
+        </div>
+      </section>
+
       <div className="mt-3 space-y-3">
         {rows.map((row) => (
           <article key={row.repo} className="rounded border border-gray-200 bg-white p-3">
@@ -43,6 +64,31 @@ export function EcosystemMap({ results }: EcosystemMapProps) {
               <p>Forks: {row.forksLabel}</p>
               <p>Watchers: {row.watchersLabel}</p>
             </div>
+            {row.profile ? (
+              <div className="mt-3 rounded-lg border border-indigo-100 bg-indigo-50/50 p-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-indigo-700">Spectrum profile</p>
+                <div className="mt-2 grid gap-2 md:grid-cols-3">
+                  <div className="rounded-md border border-slate-200 bg-white px-3 py-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Reach</p>
+                    <p className={`mt-1 inline-flex rounded-full px-2.5 py-1 text-sm font-semibold ${reachTierClass(row.profile.reachTier)}`}>
+                      {row.profile.reachTier}
+                    </p>
+                  </div>
+                  <div className="rounded-md border border-sky-200 bg-white px-3 py-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-sky-700">Builder engagement</p>
+                    <p className={`mt-1 inline-flex rounded-full px-2.5 py-1 text-sm font-semibold ${engagementTierClass(row.profile.engagementTier)}`}>
+                      {row.profile.engagementTier} ({row.profile.forkRateLabel} fork rate)
+                    </p>
+                  </div>
+                  <div className="rounded-md border border-violet-200 bg-white px-3 py-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-violet-700">Attention</p>
+                    <p className={`mt-1 inline-flex rounded-full px-2.5 py-1 text-sm font-semibold ${attentionTierClass(row.profile.attentionTier)}`}>
+                      {row.profile.attentionTier} ({row.profile.watcherRateLabel} watcher rate)
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : null}
             {row.plotStatusNote ? <p className="mt-2 text-sm text-amber-700">{row.plotStatusNote}</p> : null}
           </article>
         ))}
@@ -51,45 +97,135 @@ export function EcosystemMap({ results }: EcosystemMapProps) {
   )
 }
 
-const bubbleChartOptions = {
-  responsive: true,
-  maintainAspectRatio: false,
-  animation: false,
-  plugins: {
-    legend: {
-      display: false,
-    },
-    tooltip: {
-      enabled: false,
-    },
-  },
-  scales: {
-    x: {
-      title: {
-        display: true,
-        text: 'Stars',
-      },
-    },
-    y: {
-      title: {
-        display: true,
-        text: 'Forks',
-      },
-    },
-  },
+function formatCompactNumber(value: number) {
+  if (value >= 1000) {
+    return `${Math.round(value / 1000)}k`
+  }
+
+  return `${value}`
 }
 
-function buildChartData(points: Array<{ repo: string; x: number; y: number; r: number }>) {
-  return {
-    datasets: [
-      {
-        label: 'Repositories',
-        data: points,
-        parsing: false,
-        backgroundColor: 'rgba(14, 116, 144, 0.35)',
-        borderColor: 'rgba(14, 116, 144, 0.9)',
-        borderWidth: 1.5,
-      },
-    ],
+function formatPercentBand(value: number) {
+  if (Number.isInteger(value)) {
+    return `${value}%`
+  }
+
+  return `${value.toFixed(1)}%`
+}
+
+function LegendCard<T extends string>({
+  title,
+  bands,
+  formatter,
+  bandClassName,
+  cardClassName,
+}: {
+  title: string
+  bands: Array<{ label: T; min: number }>
+  formatter: (value: number) => string
+  bandClassName: (label: T) => string
+  cardClassName: string
+}) {
+  const orderedBands = [...bands].reverse()
+
+  return (
+    <div className={`rounded-lg border px-3 py-2 ${cardClassName}`}>
+      <p className="font-medium text-slate-900">{title}</p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {orderedBands.map((band, index) => {
+          const nextBand = orderedBands[index + 1]
+          const rangeLabel = nextBand
+            ? `${formatter(band.min)}-${formatter(nextBand.min)}`
+            : `${formatter(band.min)}+`
+
+          return (
+            <span
+              key={band.label}
+              className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${bandClassName(band.label)}`}
+            >
+              {band.label} {rangeLabel}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function reachTierClass(tier: string) {
+  switch (tier) {
+    case 'Exceptional':
+      return 'bg-emerald-100 text-emerald-800'
+    case 'Strong':
+      return 'bg-sky-100 text-sky-800'
+    case 'Growing':
+      return 'bg-amber-100 text-amber-800'
+    default:
+      return 'bg-slate-100 text-slate-700'
+  }
+}
+
+function reachLegendBandClass(tier: string) {
+  switch (tier) {
+    case 'Emerging':
+      return 'bg-emerald-50 text-emerald-600'
+    case 'Growing':
+      return 'bg-emerald-100 text-emerald-700'
+    case 'Strong':
+      return 'bg-emerald-200 text-emerald-800'
+    default:
+      return 'bg-emerald-300 text-emerald-950'
+  }
+}
+
+function engagementTierClass(tier: string) {
+  switch (tier) {
+    case 'Exceptional':
+      return 'bg-cyan-100 text-cyan-800'
+    case 'Strong':
+      return 'bg-blue-100 text-blue-800'
+    case 'Healthy':
+      return 'bg-indigo-100 text-indigo-800'
+    default:
+      return 'bg-slate-100 text-slate-700'
+  }
+}
+
+function engagementLegendBandClass(tier: string) {
+  switch (tier) {
+    case 'Light':
+      return 'bg-sky-50 text-sky-600'
+    case 'Healthy':
+      return 'bg-sky-100 text-sky-700'
+    case 'Strong':
+      return 'bg-sky-200 text-sky-800'
+    default:
+      return 'bg-sky-300 text-sky-950'
+  }
+}
+
+function attentionTierClass(tier: string) {
+  switch (tier) {
+    case 'Exceptional':
+      return 'bg-fuchsia-100 text-fuchsia-800'
+    case 'Strong':
+      return 'bg-violet-100 text-violet-800'
+    case 'Active':
+      return 'bg-purple-100 text-purple-800'
+    default:
+      return 'bg-slate-100 text-slate-700'
+  }
+}
+
+function attentionLegendBandClass(tier: string) {
+  switch (tier) {
+    case 'Light':
+      return 'bg-violet-50 text-violet-600'
+    case 'Active':
+      return 'bg-violet-100 text-violet-700'
+    case 'Strong':
+      return 'bg-violet-200 text-violet-800'
+    default:
+      return 'bg-violet-300 text-violet-950'
   }
 }

--- a/components/ecosystem-map/ecosystem-map-utils.test.ts
+++ b/components/ecosystem-map/ecosystem-map-utils.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { buildBubbleChartPoints, buildEcosystemRows } from '@/lib/ecosystem-map/chart-data'
+import { buildSpectrumProfile } from '@/lib/ecosystem-map/classification'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 
-describe('buildEcosystemRows', () => {
+describe('ecosystem map helpers', () => {
   it('formats visible ecosystem metrics for successful repositories', () => {
     const results = [
       buildResult({
@@ -13,16 +14,13 @@ describe('buildEcosystemRows', () => {
       }),
     ]
 
-    expect(buildEcosystemRows(results)).toEqual([
-      {
-        repo: 'facebook/react',
-        starsLabel: '244,295',
-        forksLabel: '50,872',
-        watchersLabel: '6,660',
-        classificationLabel: null,
-        plotStatusNote: null,
-      },
-    ])
+    expect(buildEcosystemRows(results)[0]).toMatchObject({
+      repo: 'facebook/react',
+      starsLabel: '244,295',
+      forksLabel: '50,872',
+      watchersLabel: '6,660',
+      plotStatusNote: null,
+    })
   })
 
   it('keeps unavailable ecosystem metrics explicit instead of guessing values', () => {
@@ -35,19 +33,15 @@ describe('buildEcosystemRows', () => {
       }),
     ]
 
-    expect(buildEcosystemRows(results)).toEqual([
-      {
-        repo: 'facebook/react',
-        starsLabel: 'unavailable',
-        forksLabel: '50,872',
-        watchersLabel: 'unavailable',
-        classificationLabel: null,
-        plotStatusNote: 'Could not plot this repository because ecosystem metrics were incomplete.',
-      },
-    ])
+    expect(buildEcosystemRows(results)[0]).toMatchObject({
+      starsLabel: 'unavailable',
+      watchersLabel: 'unavailable',
+      plotStatusNote: 'Could not plot this repository because ecosystem metrics were incomplete.',
+      profile: null,
+    })
   })
 
-  it('builds bubble chart points only for plot-eligible repositories', () => {
+  it('builds bubble chart points from stars, fork rate, and watcher rate', () => {
     const results = [
       buildResult({
         repo: 'facebook/react',
@@ -55,22 +49,34 @@ describe('buildEcosystemRows', () => {
         forks: 50872,
         watchers: 6660,
       }),
-      buildResult({
-        repo: 'vercel/next.js',
-        stars: 'unavailable',
-        forks: 12000,
-        watchers: 2000,
-      }),
     ]
 
     expect(buildBubbleChartPoints(results)).toEqual([
-      {
+      expect.objectContaining({
         repo: 'facebook/react',
         x: 244295,
-        y: 50872,
-        r: 20,
-      },
+        y: expect.closeTo((50872 / 244295) * 100, 5),
+        stars: 244295,
+        forks: 50872,
+        watchers: 6660,
+        forkRateLabel: '20.8%',
+        watcherRateLabel: '2.7%',
+      }),
     ])
+  })
+
+  it('builds a config-driven spectrum profile', () => {
+    const profile = buildSpectrumProfile(
+      buildResult({ repo: 'kubernetes/kubernetes', stars: 121419, forks: 42757, watchers: 3181 }),
+    )
+
+    expect(profile).toMatchObject({
+      reachTier: 'Exceptional',
+      engagementTier: 'Exceptional',
+      attentionTier: 'Exceptional',
+      forkRateLabel: '35.2%',
+      watcherRateLabel: '2.6%',
+    })
   })
 })
 

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -123,10 +123,11 @@ describe('RepoInputClient', () => {
     await userEvent.click(screen.getByRole('tab', { name: 'Ecosystem Map' }))
 
     const ecosystemMap = screen.getByRole('region', { name: /ecosystem map/i })
-    expect(within(ecosystemMap).getByText('facebook/react')).toBeInTheDocument()
-    expect(within(ecosystemMap).getByText('Stars: 244,295')).toBeInTheDocument()
-    expect(within(ecosystemMap).getByText('Forks: 25')).toBeInTheDocument()
-    expect(within(ecosystemMap).getByText('Watchers: 10')).toBeInTheDocument()
+    const articles = within(ecosystemMap).getAllByRole('article')
+    expect(within(articles[0]!).getByText('facebook/react')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Stars: 244,295')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Forks: 25')).toBeInTheDocument()
+    expect(within(articles[0]!).getByText('Watchers: 10')).toBeInTheDocument()
   })
 
   it('renders repository-specific failures alongside successful results', async () => {

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -90,7 +90,7 @@ export function RepoInputClient({ hasServerToken, onAnalyze }: RepoInputClientPr
         <section aria-label="Analysis results" className="space-y-4">
           {analysisResponse.results.map((result) => (
             <article key={result.repo} className="rounded border border-gray-200 p-4">
-              <h2 className="font-semibold">{result.repo}</h2>
+              <h2 className="font-semibold text-slate-900">{result.repo}</h2>
               <p className="text-sm text-gray-600">Stars: {formatDisplayValue(result.stars)}</p>
             </article>
           ))}

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -29,7 +29,7 @@ export function RepoInputForm({ onSubmit }: RepoInputFormProps) {
         onChange={(e) => setValue(e.target.value)}
         placeholder={'facebook/react\ntorvalds/linux\nhttps://github.com/microsoft/typescript'}
         rows={5}
-        className="w-full rounded border border-gray-300 p-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-full rounded border border-slate-300 bg-white p-2 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
         aria-label="Repository list"
         aria-describedby={error ? 'repo-input-error' : undefined}
       />

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -40,7 +40,7 @@ All analysis is structured around four CHAOSS categories. Each maps to exactly o
 
 | CHAOSS Category | Feature | Derived Score |
 |---|---|---|
-| Ecosystem | Ecosystem Map (P1-F05) | Quadrant: Leaders / Buzz / Builders / Early |
+| Ecosystem | Ecosystem Map (P1-F05) | Ecosystem profile: Reach / Builder Engagement / Attention |
 | Evolution | Evolution (P1-F08) | Evolution score: High / Medium / Low |
 | Sustainability | Contribution Dynamics (P1-F09) | Resilience score: High / Medium / Low |
 | Responsiveness | Responsiveness (P1-F10) | Responsiveness score: High / Medium / Low |
@@ -66,7 +66,7 @@ Scores are assigned only when sufficient verified data exists. Otherwise: `"Insu
 - **Framework**: Next.js 14+ (App Router)
 - **Deployment**: Vercel — zero-config
 - **Styling**: Tailwind CSS
-- **Charts**: Chart.js via npm
+- **Visualization**: Spectrum/profile UI via React components
 - **Stateless** — no database, no auth system, all analysis is on-demand
 
 ### API Contract
@@ -172,17 +172,20 @@ The analyzer fetches exact, verified metric data from GitHub for each repo.
 
 #### `[P1-F05]` Ecosystem Map
 
-Repos are visualized on an interactive 2×2 bubble chart to reveal their ecosystem position.
+Repos are summarized in an interactive ecosystem view with a spectrum-based ecosystem profile.
 
 **Acceptance criteria**
-- Bubble chart: X axis = stars (awareness), Y axis = forks (action), bubble size = watchers (sustained interest)
-- Quadrant classification uses median split across the input set: Leaders / Buzz / Builders / Early
-- Hover tooltip shows: repo name, exact stars / forks / watches, assigned quadrant
-- Single-repo input: quadrant classification is skipped; a note explains why
-- Quadrant boundaries are computed from the input set, never hardcoded
+- Each successful repo surfaces an ecosystem profile with three tiered dimensions:
+  - Reach
+  - Builder Engagement
+  - Attention
+- Spectrum bands are defined in shared config and rendered consistently in the UI; component logic must not hardcode the thresholds independently
+- Each successful repo card shows exact stars / forks / watches plus derived fork rate and watcher rate where they are verifiable
+- Single-repo input remains fully useful: the repo is still profiled without requiring a comparison set
+- Repos with unavailable ecosystem metrics are never given fabricated rates or derived profile tiers
 
 **Out of scope**
-- Saving or sharing the chart image directly
+- Saving or sharing a generated visualization directly
 - Animating transitions between analyses
 
 ---
@@ -221,7 +224,7 @@ Users can compare two or more repos side by side across all health metrics.
 
 **Design constraints** *(inform all upstream features)*
 - `AnalysisResult` schema must be flat and consistent enough to diff across repos without transformation — design this from the start
-- Ecosystem Map bubble chart is the visual entry point into comparison; the comparison table is the detail layer
+- Ecosystem profile summaries are the visual entry point into comparison; the comparison table is the detail layer
 - UI layout must accommodate 2–6 repos in comparison without horizontal scroll on desktop viewports
 
 **Out of scope**
@@ -236,8 +239,8 @@ Users can compare two or more repos side by side across all health metrics.
 Each repo is summarized in a scannable card showing key health signals.
 
 **Acceptance criteria**
-- One card per repo displaying: stars, forks, watches, created date, quadrant badge, and one score badge per CHAOSS category (Evolution, Contribution Dynamics, Responsiveness)
-- Quadrant badge colors: Leaders = green, Buzz = amber, Builders = blue, Early = gray
+- One card per repo displaying: stars, forks, watches, created date, ecosystem profile summary (Reach / Builder Engagement / Attention), and one score badge per CHAOSS category (Evolution, Contribution Dynamics, Responsiveness)
+- Ecosystem profile badges use consistent visual treatment across Reach / Builder Engagement / Attention tiers
 - Score badge colors: High = green, Medium = amber, Low = red, Insufficient = gray — consistent across all three CHAOSS score badges
 - CHAOSS category label shown beneath each score badge so the framing is always visible
 - Card click or expand reveals full metric detail for that repo

--- a/e2e/ecosystem-map.spec.ts
+++ b/e2e/ecosystem-map.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
 
 test.describe('P1-F05 Ecosystem Map', () => {
   test.beforeEach(async ({ page }) => {
@@ -10,45 +11,18 @@ test.describe('P1-F05 Ecosystem Map', () => {
   })
 
   test('shows visible stars, forks, and watchers for successful repositories', async ({ page }) => {
-    await page.route('**/api/analyze', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          results: [
-            {
-              repo: 'facebook/react',
-              name: 'react',
-              description: 'A UI library',
-              createdAt: '2013-05-24T16:15:54Z',
-              primaryLanguage: 'TypeScript',
-              stars: 244295,
-              forks: 50872,
-              watchers: 6660,
-              commits30d: 7,
-              commits90d: 18,
-              releases12mo: 'unavailable',
-              prsOpened90d: 4,
-              prsMerged90d: 3,
-              issuesOpen: 5,
-              issuesClosed90d: 6,
-              uniqueCommitAuthors90d: 'unavailable',
-              totalContributors: 'unavailable',
-              commitCountsByAuthor: 'unavailable',
-              issueFirstResponseTimestamps: 'unavailable',
-              issueCloseTimestamps: 'unavailable',
-              prMergeTimestamps: 'unavailable',
-              missingFields: ['releases12mo'],
-            },
-          ],
-          failures: [],
-          rateLimit: null,
-        }),
-      })
-    })
+    await mockAnalyze(page, [
+      buildResult({
+        repo: 'facebook/react',
+        stars: 244295,
+        forks: 50872,
+        watchers: 6660,
+      }),
+    ])
 
     await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react')
     await page.getByRole('button', { name: /analyze/i }).click()
+    await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
 
     const ecosystemMap = page.getByRole('region', { name: /ecosystem map/i })
     await expect(ecosystemMap).toContainText('facebook/react')
@@ -57,74 +31,81 @@ test.describe('P1-F05 Ecosystem Map', () => {
     await expect(ecosystemMap).toContainText('Watchers: 6,660')
   })
 
-  test('renders a bubble-chart summary for plot-eligible repositories', async ({ page }) => {
-    await page.route('**/api/analyze', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          results: [
-            {
-              repo: 'facebook/react',
-              name: 'react',
-              description: 'A UI library',
-              createdAt: '2013-05-24T16:15:54Z',
-              primaryLanguage: 'TypeScript',
-              stars: 244295,
-              forks: 50872,
-              watchers: 6660,
-              commits30d: 7,
-              commits90d: 18,
-              releases12mo: 'unavailable',
-              prsOpened90d: 4,
-              prsMerged90d: 3,
-              issuesOpen: 5,
-              issuesClosed90d: 6,
-              uniqueCommitAuthors90d: 'unavailable',
-              totalContributors: 'unavailable',
-              commitCountsByAuthor: 'unavailable',
-              issueFirstResponseTimestamps: 'unavailable',
-              issueCloseTimestamps: 'unavailable',
-              prMergeTimestamps: 'unavailable',
-              missingFields: ['releases12mo'],
-            },
-            {
-              repo: 'vercel/next.js',
-              name: 'next.js',
-              description: 'The React Framework',
-              createdAt: '2016-10-05T23:32:51Z',
-              primaryLanguage: 'TypeScript',
-              stars: 132000,
-              forks: 28700,
-              watchers: 2400,
-              commits30d: 9,
-              commits90d: 34,
-              releases12mo: 'unavailable',
-              prsOpened90d: 8,
-              prsMerged90d: 5,
-              issuesOpen: 12,
-              issuesClosed90d: 10,
-              uniqueCommitAuthors90d: 'unavailable',
-              totalContributors: 'unavailable',
-              commitCountsByAuthor: 'unavailable',
-              issueFirstResponseTimestamps: 'unavailable',
-              issueCloseTimestamps: 'unavailable',
-              prMergeTimestamps: 'unavailable',
-              missingFields: ['releases12mo'],
-            },
-          ],
-          failures: [],
-          rateLimit: null,
-        }),
-      })
-    })
+  test('renders the ecosystem spectrum and legend for multiple repos', async ({ page }) => {
+    await mockAnalyze(page, [
+      buildResult({ repo: 'facebook/react', stars: 244295, forks: 50872, watchers: 6660 }),
+      buildResult({ repo: 'kubernetes/kubernetes', stars: 121419, forks: 42757, watchers: 3181 }),
+    ])
 
-    await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react\nvercel/next.js')
+    await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react\nkubernetes/kubernetes')
     await page.getByRole('button', { name: /analyze/i }).click()
+    await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
 
-    await expect(page.getByRole('img', { name: /ecosystem bubble chart/i })).toBeVisible()
-    await expect(page.getByText(/stars \(x-axis\)/i)).toBeVisible()
-    await expect(page.getByText(/forks \(y-axis\)/i)).toBeVisible()
-    await expect(page.getByText(/watchers \(bubble size\)/i)).toBeVisible()
+    const ecosystemMap = page.getByRole('region', { name: /ecosystem map/i })
+    await expect(ecosystemMap).toContainText('Ecosystem spectrum')
+    await expect(ecosystemMap).toContainText('Reach bands')
+    await expect(ecosystemMap).toContainText('Builder engagement')
+    await expect(ecosystemMap).toContainText('Attention')
+    await expect(ecosystemMap).toContainText('Reach')
+    await expect(ecosystemMap).toContainText('Builder engagement')
+    await expect(ecosystemMap).toContainText('Attention')
+  })
+
+  test('shows spectrum profiles with derived rates', async ({ page }) => {
+    await mockAnalyze(page, [
+      buildResult({ repo: 'kubernetes/kubernetes', stars: 121419, forks: 42757, watchers: 3181 }),
+    ])
+
+    await page.getByRole('textbox', { name: /repository list/i }).fill('kubernetes/kubernetes')
+    await page.getByRole('button', { name: /analyze/i }).click()
+    await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
+
+    const ecosystemMap = page.getByRole('region', { name: /ecosystem map/i })
+    await expect(ecosystemMap).toContainText('Spectrum profile')
+    await expect(ecosystemMap).toContainText('Exceptional (35.2% fork rate)')
+    await expect(ecosystemMap).toContainText('Exceptional (2.6% watcher rate)')
+    await expect(ecosystemMap).not.toContainText('classification is skipped')
   })
 })
+
+async function mockAnalyze(page: Page, results: unknown[]) {
+  await page.route('**/api/analyze', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        results,
+        failures: [],
+        rateLimit: null,
+      }),
+    })
+  })
+}
+
+function buildResult(overrides: Record<string, unknown>) {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'A UI library',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 25,
+    watchers: 10,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 'unavailable',
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}

--- a/e2e/results-shell.spec.ts
+++ b/e2e/results-shell.spec.ts
@@ -55,7 +55,8 @@ test.describe('P1-F15 Results Shell', () => {
 
     await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible()
     await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
-    await expect(page.getByText(/ecosystem map view is coming soon/i)).toBeVisible()
+    await expect(page.getByRole('region', { name: /ecosystem map/i })).toBeVisible()
+    await expect(page.getByText(/ecosystem spectrum/i)).toBeVisible()
     await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible()
     await expect(page.getByRole('textbox', { name: /repository list/i })).toBeVisible()
     expect(requestCount).toBe(1)

--- a/lib/ecosystem-map/chart-data.ts
+++ b/lib/ecosystem-map/chart-data.ts
@@ -1,11 +1,12 @@
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { buildSpectrumProfiles, type EcosystemSpectrumProfile } from './classification'
 
 export interface VisibleMetricRow {
   repo: string
   starsLabel: string
   forksLabel: string
   watchersLabel: string
-  classificationLabel: string | null
+  profile: EcosystemSpectrumProfile | null
   plotStatusNote: string | null
 }
 
@@ -14,9 +15,19 @@ export interface BubbleChartPoint {
   x: number
   y: number
   r: number
+  stars: number
+  forks: number
+  watchers: number
+  forkRate: number
+  watcherRate: number
+  forkRateLabel: string
+  watcherRateLabel: string
+  profile: EcosystemSpectrumProfile
 }
 
 export function buildEcosystemRows(results: AnalysisResult[]): VisibleMetricRow[] {
+  const profiles = buildSpectrumProfiles(results)
+
   return results.map((result) => {
     const missingMetrics = [
       result.stars === 'unavailable' ? 'stars' : null,
@@ -29,25 +40,49 @@ export function buildEcosystemRows(results: AnalysisResult[]): VisibleMetricRow[
       starsLabel: formatMetric(result.stars),
       forksLabel: formatMetric(result.forks),
       watchersLabel: formatMetric(result.watchers),
-      classificationLabel: null,
+      profile: profiles[result.repo] ?? null,
       plotStatusNote:
-        missingMetrics.length > 0 ? 'Could not plot this repository because ecosystem metrics were incomplete.' : null,
+        missingMetrics.length > 0
+          ? 'Could not plot this repository because ecosystem metrics were incomplete.'
+          : null,
     }
   })
 }
 
 export function buildBubbleChartPoints(results: AnalysisResult[]): BubbleChartPoint[] {
+  const profiles = buildSpectrumProfiles(results)
+
   return results
     .filter(
       (result): result is AnalysisResult & { stars: number; forks: number; watchers: number } =>
-        typeof result.stars === 'number' && typeof result.forks === 'number' && typeof result.watchers === 'number',
+        typeof result.stars === 'number' &&
+        typeof result.forks === 'number' &&
+        typeof result.watchers === 'number' &&
+        result.stars > 0,
     )
-    .map((result) => ({
-      repo: result.repo,
-      x: result.stars,
-      y: result.forks,
-      r: scaleBubbleRadius(result.watchers),
-    }))
+    .map((result) => {
+      const profile = profiles[result.repo]
+
+      if (!profile) {
+        return null
+      }
+
+      return {
+        repo: result.repo,
+        x: result.stars,
+        y: profile.forkRate,
+        r: scaleBubbleRadius(profile.watcherRate),
+        stars: result.stars,
+        forks: result.forks,
+        watchers: result.watchers,
+        forkRate: profile.forkRate,
+        watcherRate: profile.watcherRate,
+        forkRateLabel: profile.forkRateLabel,
+        watcherRateLabel: profile.watcherRateLabel,
+        profile,
+      }
+    })
+    .filter((point): point is BubbleChartPoint => point !== null)
 }
 
 function formatMetric(value: number | 'unavailable') {
@@ -58,16 +93,16 @@ function formatMetric(value: number | 'unavailable') {
   return value
 }
 
-function scaleBubbleRadius(watchers: number) {
-  if (watchers >= 5000) {
+function scaleBubbleRadius(watcherRate: number) {
+  if (watcherRate >= 2.5) {
     return 20
   }
 
-  if (watchers >= 2000) {
+  if (watcherRate >= 1.5) {
     return 16
   }
 
-  if (watchers >= 500) {
+  if (watcherRate >= 0.5) {
     return 12
   }
 

--- a/lib/ecosystem-map/classification.ts
+++ b/lib/ecosystem-map/classification.ts
@@ -1,1 +1,56 @@
-export {}
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import {
+  ATTENTION_BANDS,
+  BUILDER_ENGAGEMENT_BANDS,
+  REACH_BANDS,
+  type AttentionTier,
+  type EngagementTier,
+  type ReachTier,
+  classifyFromBands,
+} from './spectrum-config'
+
+export interface EcosystemSpectrumProfile {
+  reachTier: ReachTier
+  engagementTier: EngagementTier
+  attentionTier: AttentionTier
+  forkRate: number
+  watcherRate: number
+  forkRateLabel: string
+  watcherRateLabel: string
+}
+
+export function buildSpectrumProfile(result: AnalysisResult): EcosystemSpectrumProfile | null {
+  if (
+    typeof result.stars !== 'number' ||
+    typeof result.forks !== 'number' ||
+    typeof result.watchers !== 'number' ||
+    result.stars <= 0
+  ) {
+    return null
+  }
+
+  const forkRate = (result.forks / result.stars) * 100
+  const watcherRate = (result.watchers / result.stars) * 100
+
+  return {
+    reachTier: classifyFromBands(result.stars, REACH_BANDS),
+    engagementTier: classifyFromBands(forkRate, BUILDER_ENGAGEMENT_BANDS),
+    attentionTier: classifyFromBands(watcherRate, ATTENTION_BANDS),
+    forkRate,
+    watcherRate,
+    forkRateLabel: formatRateLabel(forkRate),
+    watcherRateLabel: formatRateLabel(watcherRate),
+  }
+}
+
+export function buildSpectrumProfiles(results: AnalysisResult[]) {
+  return Object.fromEntries(
+    results
+      .map((result) => [result.repo, buildSpectrumProfile(result)] as const)
+      .filter((entry): entry is readonly [string, EcosystemSpectrumProfile] => entry[1] !== null),
+  )
+}
+
+function formatRateLabel(value: number) {
+  return `${value.toFixed(1)}%`
+}

--- a/lib/ecosystem-map/spectrum-config.ts
+++ b/lib/ecosystem-map/spectrum-config.ts
@@ -1,0 +1,49 @@
+export interface TierBand<T extends string> {
+  label: T
+  min: number
+}
+
+export type ReachTier = 'Emerging' | 'Growing' | 'Strong' | 'Exceptional'
+export type EngagementTier = 'Light' | 'Healthy' | 'Strong' | 'Exceptional'
+export type AttentionTier = 'Light' | 'Active' | 'Strong' | 'Exceptional'
+
+export const REACH_BANDS: TierBand<ReachTier>[] = [
+  { label: 'Exceptional', min: 100000 },
+  { label: 'Strong', min: 50000 },
+  { label: 'Growing', min: 10000 },
+  { label: 'Emerging', min: 0 },
+]
+
+export const BUILDER_ENGAGEMENT_BANDS: TierBand<EngagementTier>[] = [
+  { label: 'Exceptional', min: 25 },
+  { label: 'Strong', min: 15 },
+  { label: 'Healthy', min: 8 },
+  { label: 'Light', min: 0 },
+]
+
+export const ATTENTION_BANDS: TierBand<AttentionTier>[] = [
+  { label: 'Exceptional', min: 2.5 },
+  { label: 'Strong', min: 1.5 },
+  { label: 'Active', min: 0.5 },
+  { label: 'Light', min: 0 },
+]
+
+export function classifyFromBands<T extends string>(value: number, bands: TierBand<T>[]) {
+  return bands.find((band) => value >= band.min)?.label ?? bands[bands.length - 1]!.label
+}
+
+export function formatBandLegend<T extends string>(bands: TierBand<T>[], formatter: (value: number) => string) {
+  return bands
+    .map((band, index) => {
+      const nextBand = bands[index - 1]
+
+      if (!nextBand) {
+        return `${band.label} ${formatter(band.min)}+`
+      }
+
+      return `${band.label} ${formatter(band.min)}-${formatter(nextBand.min)}`
+    })
+    .reverse()
+    .join(', ')
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "chart.js": "^4.5.1",
+        "chartjs-plugin-zoom": "^2.2.0",
+        "hammerjs": "^2.0.8",
         "next": "16.2.1",
         "react": "19.2.4",
         "react-chartjs-2": "^5.3.1",
@@ -2236,6 +2238,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3494,6 +3502,19 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-zoom": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz",
+      "integrity": "sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.45",
+        "hammerjs": "^2.0.8"
+      },
+      "peerDependencies": {
+        "chart.js": ">=3.2.0"
       }
     },
     "node_modules/client-only": {
@@ -4827,6 +4848,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "chart.js": "^4.5.1",
+    "chartjs-plugin-zoom": "^2.2.0",
+    "hammerjs": "^2.0.8",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-chartjs-2": "^5.3.1",

--- a/specs/005-ecosystem-map/checklists/manual-testing.md
+++ b/specs/005-ecosystem-map/checklists/manual-testing.md
@@ -5,36 +5,36 @@
 
 ## Setup
 
-- [ ] Confirm an available token source exists (`.env.local` with `GITHUB_TOKEN` or a valid PAT entered in the UI)
-- [ ] Run `npm run dev` and confirm the app starts
-- [ ] Open `http://localhost:3000` in a browser
+- [x] Confirm an available token source exists (`.env.local` with `GITHUB_TOKEN` or a valid PAT entered in the UI)
+- [x] Run `npm run dev` and confirm the app starts
+- [x] Open `http://localhost:3000` in a browser
 
 ## US1 — Visible ecosystem metrics
 
-- [ ] Submit one valid public repository and confirm stars, forks, and watchers are visible outside the tooltip
-- [ ] Submit multiple valid public repositories and confirm each successful repo has visible stars, forks, and watchers
-- [ ] Confirm failed repositories do not produce fabricated visible ecosystem metrics
+- [x] Submit one valid public repository and confirm stars, forks, and watchers are visible outside the tooltip
+- [x] Submit multiple valid public repositories and confirm each successful repo has visible stars, forks, and watchers
+- [x] Confirm failed repositories do not produce fabricated visible ecosystem metrics
 
-## US2 — Bubble chart visualization
+## US2 — Spectrum view
 
-- [ ] Confirm one successful repo can still render as a useful plotted bubble when ecosystem metrics are available
-- [ ] Confirm multiple successful repos render one bubble per successful, plot-eligible repository
-- [ ] Confirm the chart uses stars on the X axis, forks on the Y axis, and watchers for bubble size
+- [x] Confirm the `Ecosystem Map` tab shows the spectrum-based view without the old chart or quadrant display
+- [x] Confirm one successful repo still renders as a useful spectrum/profile view when ecosystem metrics are available
+- [x] Confirm multiple successful repos render one profile card per successful repository
 
-## US3 — ForkPrint ecosystem classification
+## US3 — Ecosystem spectrum profile
 
-- [ ] Confirm multi-repo analyses show ForkPrint ecosystem classifications (`Leaders`, `Buzz`, `Builders`, `Early`) derived from the current successful input set
-- [ ] Confirm changing the set of successful repos changes the derived classifications when the medians change
-- [ ] Confirm the UI does not present the quadrant labels as official CHAOSS terminology
+- [x] Confirm the UI shows Reach / Builder Engagement / Attention profile tiers for successful repositories
+- [x] Confirm the spectrum legends match the shared config-driven bands shown in the UI
+- [x] Confirm the UI presents the spectrum profile as a ForkPrint interpretation aligned to CHAOSS, not official CHAOSS terminology
 
-## US4 — Tooltip and single-repo behavior
+## US4 — Tooltip and derived-rate behavior
 
-- [ ] Confirm tooltip/focus details show repo name, exact stars, exact forks, exact watchers, and classification when available
-- [ ] Confirm single-repo analyses explain why classification is skipped
-- [ ] Confirm repos with unavailable ecosystem metrics are not plotted with fabricated coordinates or bubble sizes
+- [x] Confirm each repo card shows exact stars, exact forks, exact watchers, fork rate, and watcher rate when available
+- [x] Confirm single-repo analyses still show a full spectrum profile when verified ecosystem metrics exist
+- [x] Confirm repos with unavailable ecosystem metrics do not show fabricated rates or derived profile values
 
 ## Notes
 
 _Sign off below when all items are verified:_
 
-**Tested by**: ____________________  **Date**: ____________________
+**Tested by**: Arun Gupta  **Date**: 2026-03-31

--- a/specs/005-ecosystem-map/checklists/requirements.md
+++ b/specs/005-ecosystem-map/checklists/requirements.md
@@ -7,29 +7,29 @@
 ## Scope & Traceability
 
 - [x] The feature is clearly identified as `P1-F05 Ecosystem Map`
-- [x] The user-visible behavior is scoped to ecosystem-map visualization, not later comparison/card/export features
+- [x] The user-visible behavior is scoped to ecosystem-map spectrum/profile behavior, not later comparison/card/export features
 - [x] The requirements trace back to `docs/PRODUCT.md` acceptance criteria for `P1-F05`
-- [x] The spec reflects constitution rules for quadrant classification and color meanings
+- [x] The spec reflects constitution rules for the ecosystem spectrum and config-driven thresholds
 
 ## User Stories
 
 - [x] User stories are independently testable
 - [x] The MVP story delivers visible user value on its own
-- [x] Tooltip behavior is separated from core plotting/classification behavior
+- [x] Exact-value behavior is separated from core profile behavior
 - [x] Single-repo handling is explicit rather than implied
 
 ## Requirements Quality
 
 - [x] Functional requirements are specific and testable
-- [x] The spec explicitly forbids hardcoded quadrant thresholds
+- [x] The spec explicitly requires shared config for spectrum thresholds
 - [x] The spec explicitly requires reuse of existing `AnalysisResult[]` data without extra fetches
 - [x] Missing/unavailable ecosystem metrics are handled honestly
-- [x] Failed repositories are excluded from the plotted dataset without blocking successful ones
+- [x] Failed repositories are excluded from the profile dataset without blocking successful ones
 
 ## Success Criteria
 
 - [x] Success criteria are measurable
-- [x] Success criteria cover plotting, classification, and single-repo behavior
+- [x] Success criteria cover profile logic and single-repo behavior
 - [x] Success criteria avoid implementation-specific wording where possible
 
 ## Notes

--- a/specs/005-ecosystem-map/contracts/ecosystem-map-props.ts
+++ b/specs/005-ecosystem-map/contracts/ecosystem-map-props.ts
@@ -4,19 +4,26 @@ export interface EcosystemMapProps {
   results: AnalysisResult[]
 }
 
-export interface EcosystemBubbleViewModel {
+export interface EcosystemProfileRowViewModel {
   repo: string
   stars: number | 'unavailable'
   forks: number | 'unavailable'
   watchers: number | 'unavailable'
-  classification: 'Leaders' | 'Buzz' | 'Builders' | 'Early' | null
-  isPlotEligible: boolean
+  builderEngagementRate: number | 'unavailable'
+  attentionRate: number | 'unavailable'
   missingEcosystemMetrics: Array<'stars' | 'forks' | 'watchers'>
 }
 
-export interface QuadrantBoundaryViewModel {
-  starMedian: number | null
-  forkMedian: number | null
-  classificationEnabled: boolean
-  classificationReason: string | null
+export interface EcosystemSpectrumProfileViewModel {
+  reachTier: 'Emerging' | 'Growing' | 'Strong' | 'Exceptional' | null
+  engagementTier: 'Light' | 'Healthy' | 'Strong' | 'Exceptional' | null
+  attentionTier: 'Light' | 'Active' | 'Strong' | 'Exceptional' | null
+  forkRateLabel: string | null
+  watcherRateLabel: string | null
+}
+
+export interface SpectrumConfigViewModel {
+  reachLegend: string
+  builderEngagementLegend: string
+  attentionLegend: string
 }

--- a/specs/005-ecosystem-map/contracts/ecosystem-map-ui.md
+++ b/specs/005-ecosystem-map/contracts/ecosystem-map-ui.md
@@ -15,25 +15,26 @@
 ### Single successful repo
 
 - Visible stars, forks, and watchers are shown for the repo
-- The repo may still appear on the bubble chart if stars, forks, and watchers are all available
-- A note explains that ForkPrint ecosystem classification is skipped because at least two successful repositories are required
+- The repo still receives a spectrum profile when verified ecosystem metrics exist
 
 ### Multiple successful repos
 
 - Visible stars, forks, and watchers are shown for each successful repo
-- Plot one bubble per plot-eligible successful repo
-- Show ForkPrint ecosystem classification labels derived from the median split
+- Show one profile card per successful repo
+- Show a config-driven ecosystem profile for each repo
+- Show a legend explaining the Reach, Builder Engagement, and Attention bands from shared config
 
-## Tooltip Content
+## Repository Detail Content
 
 - Repo name
 - Exact stars
 - Exact forks
 - Exact watchers
-- ForkPrint ecosystem classification when available
+- Derived fork rate
+- Derived watcher rate
 
 ## Unavailable Ecosystem Metrics
 
 - If stars, forks, or watchers are `"unavailable"`, the visible metric row keeps the `"unavailable"` value explicit
-- The chart does not invent a coordinate or bubble size for that repo
-- The UI provides a concise note that the repo could not be plotted because ecosystem metrics were incomplete
+- The spectrum profile does not invent a derived rate or tier for that repo
+- The UI provides a concise note that the repo could not receive a full derived profile because ecosystem metrics were incomplete

--- a/specs/005-ecosystem-map/data-model.md
+++ b/specs/005-ecosystem-map/data-model.md
@@ -2,57 +2,57 @@
 
 ## Entities
 
-### EcosystemBubble
+### EcosystemProfileRow
 
-- **Purpose**: Represents one successful repository as plotted chart data plus visible ecosystem metrics
+- **Purpose**: Represents one successful repository as visible ecosystem metrics plus derived profile data
 - **Fields**:
   - `repo: string`
   - `stars: number | "unavailable"`
   - `forks: number | "unavailable"`
   - `watchers: number | "unavailable"`
-  - `classification: "Leaders" | "Buzz" | "Builders" | "Early" | null`
-  - `isPlotEligible: boolean`
+  - `builderEngagementRate: number | "unavailable"`
+  - `attentionRate: number | "unavailable"`
   - `missingEcosystemMetrics: Array<"stars" | "forks" | "watchers">`
 
-### QuadrantBoundarySet
+### SpectrumProfile
 
-- **Purpose**: Represents the current median-derived split values for classifying the successful input set
+- **Purpose**: Represents the derived ecosystem summary for one repository
 - **Fields**:
-  - `starMedian: number | null`
-  - `forkMedian: number | null`
-  - `classificationEnabled: boolean`
-  - `classificationReason: string | null`
+  - `reachTier: "Emerging" | "Growing" | "Strong" | "Exceptional" | null`
+  - `engagementTier: "Light" | "Healthy" | "Strong" | "Exceptional" | null`
+  - `attentionTier: "Light" | "Active" | "Strong" | "Exceptional" | null`
+  - `forkRateLabel: string | null`
+  - `watcherRateLabel: string | null`
+
+### SpectrumConfig
+
+- **Purpose**: Holds the shared threshold bands for ecosystem profile tiers
+- **Fields**:
+  - `reachBands`
+  - `builderEngagementBands`
+  - `attentionBands`
 
 ### VisibleMetricRow
 
-- **Purpose**: User-visible summary of ecosystem metrics that remains readable without chart hover
+- **Purpose**: User-visible summary of ecosystem metrics that remains readable without secondary interactions
 - **Fields**:
   - `repo: string`
   - `starsLabel: string`
   - `forksLabel: string`
   - `watchersLabel: string`
-  - `classificationLabel: string | null`
   - `plotStatusNote: string | null`
-
-### SingleRepoNotice
-
-- **Purpose**: Explains why quadrant classification is skipped for exactly one successful repository
-- **Fields**:
-  - `isVisible: boolean`
-  - `message: string`
 
 ## Relationships
 
 - One `AnalyzeResponse.results[]` entry can produce:
-  - one `EcosystemBubble`
+  - one `EcosystemProfileRow`
   - one `VisibleMetricRow`
-- One analysis run produces:
-  - zero or one `QuadrantBoundarySet`
-  - zero or one `SingleRepoNotice`
+  - one `SpectrumProfile` when verified ecosystem metrics exist
+- One analysis run consumes:
+  - one `SpectrumConfig`
 
 ## Validation Rules
 
-- `classificationEnabled` is `false` when fewer than two successful, plot-eligible repositories are present
-- `isPlotEligible` is `true` only when stars, forks, and watchers are all verified numbers
-- `classification` is `null` when classification is skipped or the repo is not plot-eligible
+- `builderEngagementRate` and `attentionRate` are derived only when the required verified source metrics exist and stars is greater than zero
+- `SpectrumProfile` values are derived from shared config bands, not inline thresholds
 - `missingEcosystemMetrics` is populated from `"unavailable"` ecosystem values and never inferred

--- a/specs/005-ecosystem-map/plan.md
+++ b/specs/005-ecosystem-map/plan.md
@@ -5,31 +5,31 @@
 
 ## Summary
 
-Add the first visual analysis layer to ForkPrint by turning successful `AnalysisResult[]` data into an ecosystem-map section on the home page. The feature will show visible ecosystem metrics for each successful repository, render a bubble chart using stars, forks, and watchers, derive ForkPrint ecosystem classifications from median splits across the current successful input set, and handle single-repo analysis honestly by skipping classification while keeping the chart useful.
+Add the first visual analysis layer to ForkPrint by turning successful `AnalysisResult[]` data into an ecosystem-map section on the home page. The feature will show visible ecosystem metrics for each successful repository, derive a config-driven ecosystem profile across Reach / Builder Engagement / Attention, and keep the feature useful for both single-repo and multi-repo analysis.
 
 ## Technical Context
 
 **Language/Version**: TypeScript 5, React 19, Next.js 16.2 (App Router)  
-**Primary Dependencies**: Tailwind CSS 4, Chart.js 4 + `react-chartjs-2`, Vitest 4, React Testing Library 16, Playwright 1.58  
+**Primary Dependencies**: Tailwind CSS 4, Vitest 4, React Testing Library 16, Playwright 1.58  
 **Storage**: Stateless; no database or persistent server storage  
 **Testing**: Vitest + React Testing Library (unit/integration), Playwright (E2E)  
 **Target Platform**: Vercel-hosted Next.js web app, modern desktop/mobile browsers  
 **Project Type**: Web application with a shared framework-agnostic analyzer module and client-side visualization  
-**Performance Goals**: Render usable ecosystem visualization for 1–6 successful repos without extra API calls; keep chart interactions responsive at normal Phase 1 analysis sizes  
-**Constraints**: Verified GitHub GraphQL data only; missing ecosystem metrics must stay explicit; quadrant thresholds must be derived from current successful input set; single-repo input must skip classification; no dashboard-level architecture that blocks later phases  
-**Scale/Scope**: Home-page ecosystem-map section, chart utilities, classification helpers, and supporting tests/manual checklist for 1–6 analyzed repos
+**Performance Goals**: Render usable ecosystem visualization for 1–6 successful repos without extra API calls and keep the spectrum/profile view easy to scan on desktop and mobile  
+**Constraints**: Verified GitHub GraphQL data only; missing ecosystem metrics must stay explicit; spectrum thresholds must live in shared config; single-repo input remains fully valid; no dashboard-level architecture that blocks later phases  
+**Scale/Scope**: Home-page ecosystem-map section, spectrum/profile helpers, and supporting tests/manual checklist for 1–6 analyzed repos
 
 ## Constitution Check
 
 | Rule | Status | Notes |
 |------|--------|-------|
-| I / Phase 1 stack | PASS | Introduce Chart.js per approved Phase 1 stack |
-| II — Verified data only | PASS | Chart uses already-fetched `AnalysisResult[]`; no guessed coordinates for unavailable metrics |
+| I / Phase 1 stack | PASS | Uses the existing Phase 1 Next.js/React/Tailwind stack without adding architecture that blocks later phases |
+| II — Verified data only | PASS | Spectrum view uses already-fetched `AnalysisResult[]`; no guessed derived rates for unavailable metrics |
 | IV — Shared analyzer boundary | PASS | No analyzer changes required beyond consuming existing flat results |
-| V / VII — CHAOSS alignment and quadrant rules | PASS | Treat quadrant as ForkPrint ecosystem classification aligned to CHAOSS; median split only |
-| VII.3 — Single-repo behavior | PASS | Single successful repo renders chart/metrics but skips classification with explanatory note |
+| V / VII — CHAOSS alignment and ecosystem spectrum rules | PASS | Treat the ecosystem output as a ForkPrint profile aligned to CHAOSS; use config-driven spectrum thresholds |
+| VII.5 — Single-repo behavior | PASS | Single successful repo renders profile and exact metrics without requiring a comparison set |
 | IX.5 — Flat `AnalysisResult` schema | PASS | Visualization consumes existing flat schema without transformation requirements leaking upstream |
-| XI — TDD mandatory | PASS | Classification/chart tests are written before implementation in tasks phase |
+| XI — TDD mandatory | PASS | Classification/profile tests are written before implementation in tasks phase |
 | XII / XIII — Manual checklist required | PASS | `checklists/manual-testing.md` will be created and maintained for this feature |
 
 **Gate result**: PASS — no violations.
@@ -61,7 +61,7 @@ app/
 
 components/
 ├── ecosystem-map/
-│   ├── EcosystemMap.tsx                      ← NEW: chart + visible metric display + note/legend
+│   ├── EcosystemMap.tsx                      ← NEW: spectrum legend + visible metric/profile display
 │   ├── EcosystemMap.test.tsx                ← NEW: rendering and interaction coverage
 │   └── ecosystem-map-utils.test.ts          ← NEW: classification helper tests
 └── repo-input/
@@ -72,36 +72,36 @@ lib/
 ├── analyzer/
 │   └── analysis-result.ts                   ← UNCHANGED: consumed as input contract
 └── ecosystem-map/
-    ├── classification.ts                    ← NEW: median split + single-repo logic
-    └── chart-data.ts                        ← NEW: convert successful results into chart/metric view models
+    ├── classification.ts                    ← NEW: ecosystem profile helpers
+    ├── chart-data.ts                        ← NEW: convert successful results into profile/metric view models
+    └── spectrum-config.ts                   ← NEW: shared reach / engagement / attention thresholds
 
 e2e/
-└── ecosystem-map.spec.ts                    ← NEW: visible metrics, chart rendering, single-repo note, tooltip behavior
+└── ecosystem-map.spec.ts                    ← NEW: visible metrics, spectrum profile rendering, single-repo behavior
 ```
 
 ## Implementation Sequence
 
 ### Phase 0 — Research
 
-1. Confirm the charting approach that best supports 1–6 repos, tooltips, and responsive layouts with the approved stack
-2. Decide how unavailable ecosystem metrics are represented without inventing chart coordinates
-3. Decide how ForkPrint ecosystem classification wording appears in UI without implying official CHAOSS labels
+1. Confirm the profile presentation that best supports 1–6 repos and responsive layouts with the approved stack
+2. Decide how unavailable ecosystem metrics are represented without inventing derived rates
+3. Decide how the spectrum profile and legends appear in UI without implying official CHAOSS terminology
 
 ### Phase 1 — Design
 
-4. Define the ecosystem bubble, classification boundary, visible metric strip, and single-repo notice models
-5. Define component props and chart/tooltip UI contract
-6. Create the manual testing checklist for single-repo, multi-repo, tooltip, and unavailable-metric scenarios
-7. Confirm source-code structure for chart utilities versus UI rendering
+4. Define the spectrum profile, visible metric strip, and rate-summary models
+5. Define component props and spectrum/legend UI contract
+6. Create the manual testing checklist for single-repo, multi-repo, derived-rate, and unavailable-metric scenarios
+7. Confirm source-code structure for spectrum config, profile utilities, and UI rendering
 
 ### Phase 2 — Implementation Preview
 
-8. Add Chart.js dependencies and create reusable ecosystem-map utilities/components
+8. Create reusable ecosystem-map utilities/components
 9. Render visible stars/forks/watchers for successful repos in the ecosystem-map section
-10. Render the bubble chart from existing `analysisResponse.results`
-11. Add ForkPrint ecosystem classification from median splits for multi-repo runs
-12. Add single-repo explanatory note and tooltip behavior
-13. Add unit, component, and E2E coverage for visible metrics, plotting, classification, and single-repo handling
+10. Render the config-driven ecosystem profile and legend for Reach / Builder Engagement / Attention
+11. Add exact-value and derived-rate behavior to the repository cards
+12. Add unit, component, and E2E coverage for visible metrics, spectrum logic, and single-repo handling
 
 ## Complexity Tracking
 

--- a/specs/005-ecosystem-map/quickstart.md
+++ b/specs/005-ecosystem-map/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Verify that successful analysis results now render visible ecosystem metrics and the first bubble-chart visualization without additional fetching.
+Verify that successful analysis results now render visible ecosystem metrics and the spectrum/profile visualization without additional fetching.
 
 ## Scenarios
 
@@ -11,22 +11,22 @@ Verify that successful analysis results now render visible ecosystem metrics and
 1. Run `npm run dev`
 2. Analyze one public repository with a valid token source
 3. Confirm:
-   - stars, forks, and watchers are visible outside the tooltip
-   - the repo is plotted if all ecosystem metrics are available
-   - the UI explains that ForkPrint ecosystem classification is skipped for one successful repo
+   - stars, forks, and watchers are visible in the repo card
+   - the UI shows a Reach / Builder Engagement / Attention spectrum profile for the repo
 
 ### 2. Multiple successful repos
 
 1. Analyze two or more public repositories
 2. Confirm:
    - each successful repo has visible ecosystem metrics
-   - each successful, plot-eligible repo appears as a bubble
-   - ForkPrint ecosystem classification is shown using the median split of the current successful input set
+   - each successful repo appears as its own profile card
+   - the spectrum legend is shown using config-defined bands
+   - each repo surfaces a Reach / Builder Engagement / Attention profile
 
 ### 3. Incomplete ecosystem metrics
 
 1. Simulate or mock a successful result with `"unavailable"` for stars, forks, or watchers
 2. Confirm:
    - the visible metric row keeps `"unavailable"` explicit
-   - the chart does not fabricate a plotted position for that repo
-   - the UI explains why the repo could not be plotted
+   - the spectrum profile does not fabricate a derived rate or tier for that repo
+   - the UI explains why the repo could not receive a full derived profile

--- a/specs/005-ecosystem-map/research.md
+++ b/specs/005-ecosystem-map/research.md
@@ -1,41 +1,41 @@
 # Research: Ecosystem Map
 
-## Decision 1: Use Chart.js bubble charts via `react-chartjs-2`
+## Decision 1: Use a spectrum-first UI instead of a chart
 
-- **Decision**: Implement the visualization with Chart.js bubble charts and a thin React wrapper using `react-chartjs-2`.
-- **Rationale**: The constitution already approves Chart.js for Phase 1, and bubble charts natively support X/Y/size encoding for stars, forks, and watchers.
+- **Decision**: Implement the visualization as a spectrum/profile view in standard React/Tailwind UI.
+- **Rationale**: The spectrum cards made the ecosystem signal easier to explain than the earlier chart-driven prototype and removed misleading quadrant-style interpretation.
 - **Alternatives considered**:
-  - Plain HTML/CSS scatter approximation: rejected because tooltips, scaling, and bubble sizing would become custom rendering work
+  - Keep the Chart.js bubble chart: rejected because the spectrum/profile view was clearer for the current product direction
   - SVG/D3-first implementation: rejected because it adds more implementation surface than this feature needs
 
-## Decision 2: Keep visible ecosystem metrics outside the chart
+## Decision 2: Keep visible ecosystem metrics outside the profile summary
 
-- **Decision**: Show stars, forks, and watchers as visible text UI for each successful repo in addition to the plotted bubble.
-- **Rationale**: This preserves value for single-repo analysis, improves accessibility, and prevents the chart from being the only place users can inspect key metrics.
+- **Decision**: Show stars, forks, and watchers as visible text UI for each successful repo alongside the derived spectrum profile.
+- **Rationale**: This preserves value for single-repo analysis, improves accessibility, and prevents the normalized profile from being the only place users can inspect key metrics.
 - **Alternatives considered**:
   - Tooltip-only metrics: rejected because it is weaker for accessibility and single-repo use
   - Separate card system: rejected because detailed repo cards belong to `P1-F07`
 
-## Decision 3: Keep quadrant as ForkPrint ecosystem classification
+## Decision 3: Replace quadrants with a config-driven ecosystem spectrum
 
-- **Decision**: Present `Leaders / Buzz / Builders / Early` as ForkPrint’s ecosystem classification aligned to the CHAOSS ecosystem category.
-- **Rationale**: The product and constitution define this mapping for ForkPrint, but the labels are not official CHAOSS terminology.
+- **Decision**: Present the ecosystem summary as a profile across Reach, Builder Engagement, and Attention instead of median-derived quadrants.
+- **Rationale**: Spectrum tiers avoid misleading lifecycle implications, work for single-repo analysis, and let the UI show exact thresholds from shared config.
 - **Alternatives considered**:
-  - Label quadrant as an official CHAOSS score: rejected because it overstates the provenance of the labels
-  - Remove the labels entirely: rejected because the product definition explicitly uses them
+  - Keep median quadrants: rejected because the resulting labels were too relative and confusing for mature projects
+  - Remove any interpretive layer entirely: rejected because the map needs a readable summary beyond exact numbers
 
-## Decision 4: Treat single-repo analysis as plotted but unclassified
+## Decision 4: Use normalized rates for builder engagement and attention
 
-- **Decision**: Render the single repository bubble and visible metrics, but skip quadrant classification and show an explanatory note.
-- **Rationale**: The constitution forbids assigning a quadrant to a one-repo input set, but the chart still provides value as a visualized point.
+- **Decision**: Use `forks / stars` for builder engagement and `watchers / stars` for attention in the spectrum profile.
+- **Rationale**: Raw forks and watchers overly reward sheer size; normalized rates better describe how attention converts into engagement.
 - **Alternatives considered**:
-  - Hide the chart for one repo: rejected because it wastes useful ecosystem data
-  - Assign a default quadrant: rejected by constitution
+  - Keep raw forks as the primary engagement signal: rejected because it made outliers dominate the interpretation
+  - Keep raw watchers as the attention signal: rejected because the number is less comparable across differently sized repos
 
-## Decision 5: Exclude unavailable ecosystem metrics from plotted coordinates
+## Decision 5: Exclude unavailable ecosystem metrics from derived profile values
 
-- **Decision**: If a successful repository has `"unavailable"` for stars, forks, or watchers, do not fabricate chart coordinates or bubble size; instead, keep the visible metrics honest and surface an explanatory state.
-- **Rationale**: The accuracy policy forbids invented precision, and chart coordinates are themselves a form of derived display data.
+- **Decision**: If a successful repository has `"unavailable"` for stars, forks, or watchers, do not fabricate derived rates or profile tiers; instead, keep the visible metrics honest and surface an explanatory state.
+- **Rationale**: The accuracy policy forbids invented precision, and derived rates are themselves a form of interpreted display data.
 - **Alternatives considered**:
-  - Convert `"unavailable"` to zero: rejected because it fabricates a false position
+  - Convert `"unavailable"` to zero: rejected because it fabricates a false interpretation
   - Drop the repo silently: rejected because missing data must stay explicit

--- a/specs/005-ecosystem-map/spec.md
+++ b/specs/005-ecosystem-map/spec.md
@@ -9,9 +9,9 @@
 
 ### User Story 1 - Show ecosystem metrics clearly for analyzed repos (Priority: P1)
 
-A user can see the core ecosystem metrics for each successful repository as visible UI elements so stars, forks, and watchers are readable even without relying on chart hover interactions.
+A user can see the core ecosystem metrics for each successful repository as visible UI elements so stars, forks, and watchers are readable without relying on secondary interactions.
 
-**Why this priority**: This delivers immediate value for both single-repo and multi-repo analysis, and it keeps the ecosystem feature useful before users rely on the interactive chart itself.
+**Why this priority**: This delivers immediate value for both single-repo and multi-repo analysis, and it keeps the ecosystem feature useful even if users only read the profile cards.
 
 **Independent Test**: Can be fully tested by supplying one or more successful `AnalysisResult` objects and confirming that stars, forks, and watchers are visible in the ecosystem-map area for each successful repository.
 
@@ -23,52 +23,52 @@ A user can see the core ecosystem metrics for each successful repository as visi
 
 ---
 
-### User Story 2 - Visualize analyzed repos on the ecosystem map (Priority: P2)
+### User Story 2 - Understand the ecosystem spectrum view (Priority: P2)
 
-A user who has already run an analysis can see successful repositories plotted on a bubble chart so the ecosystem position of each repo is immediately visible, even when only one repo is present.
+A user who has already run an analysis can see successful repositories summarized in a spectrum-based ecosystem view so ecosystem position is understandable even when only one repo is present.
 
-**Why this priority**: The interactive chart is the signature visualization for this feature, but it should remain useful in both single-repo and multi-repo analysis instead of depending on comparison scenarios only.
+**Why this priority**: The spectrum view is the signature interpretation layer for this feature, and it should remain useful for both single-repo and multi-repo analysis without requiring comparison-relative logic.
 
-**Independent Test**: Can be fully tested by supplying one or more successful `AnalysisResult` objects and confirming that each repo appears as a bubble positioned by stars and forks, sized by watchers, without any extra API calls.
+**Independent Test**: Can be fully tested by supplying one or more successful `AnalysisResult` objects and confirming that the ecosystem spectrum appears with shared legends and one profile card per successful repository, without any extra API calls.
 
 **Acceptance Scenarios**:
 
-1. **Given** an analysis has returned one or more successful repositories, **When** the ecosystem map is shown, **Then** one bubble appears per successful repository using stars on the X axis, forks on the Y axis, and watchers for bubble size.
-2. **Given** an analysis has returned exactly one successful repository, **When** the ecosystem map is shown, **Then** the single repository still renders as a useful plotted bubble with visible ecosystem metrics even though quadrant classification may be skipped elsewhere.
-3. **Given** one or more repositories failed during analysis, **When** the ecosystem map is shown, **Then** only successful repositories are plotted and failed repositories do not create empty or fabricated bubbles.
-4. **Given** a successful repository has the required ecosystem metrics, **When** it is rendered on the map, **Then** the plotted values come directly from the existing `AnalysisResult[]` data and no additional fetching occurs.
+1. **Given** an analysis has returned one or more successful repositories, **When** the ecosystem map is shown, **Then** the spectrum view explains Reach, Builder Engagement, and Attention using the current shared band definitions.
+2. **Given** an analysis has returned exactly one successful repository, **When** the ecosystem map is shown, **Then** the single repository still renders as a useful spectrum/profile view with visible ecosystem metrics and derived rates.
+3. **Given** one or more repositories failed during analysis, **When** the ecosystem map is shown, **Then** only successful repositories contribute ecosystem profiles and failed repositories do not create fabricated derived values.
+4. **Given** a successful repository has the required ecosystem metrics, **When** it is rendered in the spectrum view, **Then** the derived profile values come directly from the existing `AnalysisResult[]` data and no additional fetching occurs.
 
 ---
 
-### User Story 3 - Understand ForkPrint ecosystem classification (Priority: P2)
+### User Story 3 - Understand the ecosystem spectrum profile (Priority: P2)
 
-A user can understand which ForkPrint ecosystem classification each successfully analyzed repository belongs to based on the current analysis set.
+A user can understand each successfully analyzed repository through a config-driven ecosystem profile rather than a comparison-relative label.
 
-**Why this priority**: This feature uses ForkPrint’s own quadrant classification as its ecosystem summary, aligned to the CHAOSS ecosystem category, but it depends on the plotted visualization and multi-repo input set already being in place.
+**Why this priority**: The spectrum profile is the interpretive layer for the feature and avoids misleading lifecycle implications from relative quadrant names.
 
-**Independent Test**: Can be fully tested by supplying multiple successful repositories with known stars and forks, then confirming quadrant assignments follow the median split derived from that same input set.
+**Independent Test**: Can be fully tested by supplying successful repositories with known stars, forks, and watchers, then confirming profile tiers and legends follow the shared spectrum configuration.
 
 **Acceptance Scenarios**:
 
-1. **Given** an analysis returns two or more successful repositories, **When** the ecosystem map computes quadrant boundaries, **Then** it uses the median split of stars and forks from the current successful input set and never hardcoded thresholds.
-2. **Given** a repository is plotted on the map, **When** the user inspects it, **Then** the assigned ForkPrint ecosystem classification is one of `Leaders`, `Buzz`, `Builders`, or `Early` based on the computed split.
-3. **Given** the analysis input changes, **When** the ecosystem map re-renders, **Then** the quadrant boundaries and quadrant assignments are recomputed from the new successful input set.
+1. **Given** a repository is shown on the ecosystem map, **When** the profile summary is displayed, **Then** it surfaces Reach, Builder Engagement, and Attention tiers derived from shared config thresholds.
+2. **Given** the UI renders the spectrum legend, **When** the user reviews it, **Then** the threshold bands shown in the UI are read from the same shared config used by the classification logic.
+3. **Given** a repository is shown in the spectrum view, **When** the user inspects it, **Then** the profile reflects stars for reach, `forks / stars` for builder engagement, and `watchers / stars` for attention.
 
 ---
 
-### User Story 4 - Inspect bubble details and single-repo behavior (Priority: P3)
+### User Story 4 - Inspect exact values and derived rates (Priority: P3)
 
-A user can inspect exact ecosystem values from the chart and receives a clear explanation when quadrant classification is not possible.
+A user can inspect exact ecosystem values from the repository cards and understand the derived rates behind the spectrum profile.
 
-**Why this priority**: Tooltips and single-repo guidance make the chart understandable and trustworthy, but they depend on the chart already existing.
+**Why this priority**: Exact-value displays make the spectrum trustworthy, but they depend on the profile layer already existing.
 
-**Independent Test**: Can be fully tested by hovering a plotted bubble to inspect exact values and by rendering the feature with exactly one successful repository to confirm quadrant classification is intentionally skipped with an explanatory note.
+**Independent Test**: Can be fully tested by rendering successful repositories and confirming that exact values and derived rates appear in the cards while single-repo analysis still shows the same full profile behavior.
 
 **Acceptance Scenarios**:
 
-1. **Given** the user hovers or focuses a plotted repository bubble, **When** the tooltip appears, **Then** it shows the repo name, exact stars, exact forks, exact watchers, and the assigned quadrant.
-2. **Given** there is exactly one successful repository in the analysis, **When** the ecosystem map is shown, **Then** quadrant classification is skipped and a note explains that a single repo cannot be classified against a median split.
-3. **Given** there is exactly one successful repository, **When** the tooltip is shown, **Then** the ecosystem values are still visible but the quadrant is not fabricated.
+1. **Given** the user inspects a successful repository in the ecosystem map, **When** the card and profile are shown, **Then** they show the repo name, exact stars, exact forks, exact watchers, derived fork rate, and derived watcher rate.
+2. **Given** there is exactly one successful repository in the analysis, **When** the ecosystem map is shown, **Then** the repo still receives its spectrum profile without requiring a comparison set.
+3. **Given** there is exactly one successful repository, **When** the spectrum profile is shown, **Then** the ecosystem values and derived rates are visible without any fabricated comparison-relative label.
 
 ---
 
@@ -76,7 +76,7 @@ A user can inspect exact ecosystem values from the chart and receives a clear ex
 
 - What happens when one or more successful repositories have `"unavailable"` for stars, forks, or watchers?
 - What happens when the analysis returns zero successful repositories because every repository failed?
-- What happens when multiple repositories sit exactly on the median boundary for stars or forks?
+- What happens when a repository has verified stars but a zero value that would make rate calculations invalid?
 - What happens when a single successful repository is returned alongside one or more failures?
 - What happens when very large ecosystem values make bubble labels or tooltips hard to read?
 
@@ -84,38 +84,38 @@ A user can inspect exact ecosystem values from the chart and receives a clear ex
 
 ### Functional Requirements
 
-- **FR-001**: The system MUST render an ecosystem map for successful repositories using only the already-fetched `AnalysisResult[]` data from the current analysis.
-- **FR-002**: The system MUST position each plotted repository by stars on the X axis and forks on the Y axis.
-- **FR-003**: The system MUST size each plotted repository bubble by watchers.
-- **FR-004**: The system MUST compute quadrant boundaries from the median stars value and median forks value of the current successful input set.
-- **FR-005**: The system MUST assign each plotted repository one ForkPrint ecosystem classification label from `Leaders`, `Buzz`, `Builders`, or `Early` when quadrant classification is possible.
-- **FR-006**: The system MUST NOT use hardcoded quadrant thresholds.
-- **FR-007**: The system MUST skip quadrant classification when exactly one successful repository exists and MUST show an explanatory note instead of assigning a default quadrant.
-- **FR-008**: The system MUST surface an inspectable tooltip for each plotted repository showing repo name, exact stars, exact forks, exact watchers, and assigned quadrant when available.
-- **FR-009**: The system MUST exclude failed repositories from the plotted dataset while preserving any separate failure display owned by earlier features.
-- **FR-010**: The system MUST visibly distinguish missing or unavailable ecosystem metrics rather than inventing chart coordinates or sizes.
-- **FR-011**: The system MUST remain consistent with the constitution’s quadrant colors: Leaders = green, Buzz = amber, Builders = blue, Early = gray.
-- **FR-012**: The system MUST support desktop and mobile layouts for the chart and accompanying note/legend content.
+- **FR-001**: The system MUST render an ecosystem spectrum view for successful repositories using only the already-fetched `AnalysisResult[]` data from the current analysis.
+- **FR-002**: The system MUST derive Reach from stars, Builder Engagement from `forks / stars`, and Attention from `watchers / stars`.
+- **FR-003**: The system MUST present shared band legends for Reach, Builder Engagement, and Attention within the ecosystem view.
+- **FR-004**: The system MUST derive an ecosystem profile for each successful repository across Reach, Builder Engagement, and Attention.
+- **FR-005**: The system MUST define spectrum bands in shared configuration and MUST read those same bands for both UI legends and classification logic.
+- **FR-006**: The system MUST NOT hardcode spectrum thresholds independently in component logic.
+- **FR-007**: The system MUST allow single successful repositories to be profiled without requiring comparison-relative behavior.
+- **FR-008**: The system MUST surface exact repo name, stars, forks, watchers, derived fork rate, and derived watcher rate within the ecosystem view for each successful repository.
+- **FR-009**: The system MUST exclude failed repositories from the ecosystem profile dataset while preserving any separate failure display owned by earlier features.
+- **FR-010**: The system MUST visibly distinguish missing or unavailable ecosystem metrics rather than inventing derived rates or profile tiers.
+- **FR-011**: The system MUST support desktop and mobile layouts for the spectrum legend and accompanying repository profile content.
+- **FR-012**: The system MUST keep exact stars, forks, and watchers visible so the normalized profile never hides the underlying GitHub numbers.
 
 ### Key Entities
 
-- **Ecosystem Bubble**: A plotted representation of one successful repository using stars, forks, watchers, repo name, and optional quadrant classification.
-- **Quadrant Boundary Set**: The median-derived X and Y split values computed from the current successful analysis input set.
-- **Quadrant Assignment**: The ForkPrint-defined ecosystem classification label (`Leaders`, `Buzz`, `Builders`, `Early`) for a repository when enough successful repos exist to classify it.
-- **Single-Repo Notice**: A user-facing explanation shown when only one successful repository exists and quadrant classification is intentionally skipped.
+- **Ecosystem View**: The combined legend and repository-profile presentation for successful repositories using exact stars, derived builder engagement, derived attention, and exact ecosystem metrics.
+- **Spectrum Profile**: The ForkPrint-defined ecosystem summary for one repository across Reach, Builder Engagement, and Attention tiers.
+- **Spectrum Config**: The shared threshold definition that controls Reach, Builder Engagement, and Attention bands for both UI legends and profile logic.
+- **Rate Summary**: The derived fork-rate and watcher-rate values shown in tooltips and profile detail.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: For analyses with two or more successful repositories, 100% of successful repositories appear on the ecosystem map with plotted stars, forks, and watchers values derived from the current `AnalysisResult[]`.
-- **SC-002**: For analyses with two or more successful repositories, 100% of quadrant assignments use the median split computed from the current successful input set rather than hardcoded thresholds.
-- **SC-003**: For single-success analyses, 100% of runs skip quadrant assignment and show an explanatory note instead of displaying a fabricated quadrant.
-- **SC-004**: Users can inspect exact ecosystem values for any plotted repository through the chart tooltip without navigating away from the map.
+- **SC-001**: For analyses with one or more successful repositories, 100% of successful repositories appear in the ecosystem spectrum view with reach, builder engagement, and attention derived from the current `AnalysisResult[]`.
+- **SC-002**: For analyses with one or more successful repositories, 100% of ecosystem profile tiers and legends are derived from shared spectrum configuration rather than duplicated thresholds in component logic.
+- **SC-003**: For single-success analyses, 100% of runs still show a repository spectrum profile when verified data exists.
+- **SC-004**: Users can inspect exact ecosystem values and derived rates for any successful repository directly in the ecosystem view without navigating away from the map.
 
 ## Assumptions
 
 - `P1-F04 Data Fetching` has already delivered successful `AnalysisResult[]`, failure state, and loading state on the client.
 - This feature adds the first visualization layer but does not yet implement the full dashboard, comparison table, or repo cards from later features.
-- Chart rendering may rely on a client-side charting library compatible with the constitution’s approved stack.
-- Repositories with unavailable ecosystem metrics may require a non-plotted fallback or explanatory handling rather than guessed coordinates.
+- The ecosystem spectrum may be rendered entirely through standard React/Tailwind UI without requiring a charting library.
+- Repositories with unavailable ecosystem metrics may require a non-derived fallback or explanatory handling rather than guessed rates.

--- a/specs/005-ecosystem-map/tasks.md
+++ b/specs/005-ecosystem-map/tasks.md
@@ -18,34 +18,34 @@
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-**Purpose**: Add the charting dependency and file structure for ecosystem-map UI and helpers.
+**Purpose**: Add the file structure for ecosystem-map UI, helpers, and spectrum config.
 
-- [ ] T001 Add `chart.js` and `react-chartjs-2` to `/Users/arungupta/workspaces/forkprint/package.json`
-- [ ] T002 [P] Create `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/` with `EcosystemMap.tsx`, `EcosystemMap.test.tsx`, and `ecosystem-map-utils.test.ts`
-- [ ] T003 [P] Create `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/` with `classification.ts` and `chart-data.ts`
-- [ ] T004 [P] Create `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts` with a placeholder spec file
+- [x] T001 Create `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/` with `EcosystemMap.tsx`, `EcosystemMap.test.tsx`, and `ecosystem-map-utils.test.ts`
+- [x] T002 [P] Create `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/` with `classification.ts`, `chart-data.ts`, and `spectrum-config.ts`
+- [x] T003 [P] Create `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts` with initial feature coverage
 
-**Checkpoint**: The repo contains the planned ecosystem-map file structure and chart dependencies.
+**Checkpoint**: The repo contains the planned ecosystem-map file structure and spectrum-config file.
 
 ---
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 
-**Purpose**: Establish shared classification and view-model utilities before story implementation.
+**Purpose**: Establish shared spectrum config and view-model utilities before story implementation.
 
 **⚠️ CRITICAL**: No user story implementation should start until this phase is complete.
 
-- [ ] T005 Implement ecosystem-map view-model helpers in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/chart-data.ts`
-- [ ] T006 [P] Implement median-split and single-repo classification helpers in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/classification.ts`
-- [ ] T007 [P] Update `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx` state contract to pass successful `analysisResponse.results` into a reusable ecosystem-map section
+- [x] T005 Implement ecosystem-map view-model helpers in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/chart-data.ts`
+- [x] T006 [P] Implement shared spectrum thresholds in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/spectrum-config.ts`
+- [x] T007 [P] Implement ecosystem profile and rate helpers in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/classification.ts`
+- [x] T008 [P] Update `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx` state contract to pass successful `analysisResponse.results` into a reusable ecosystem-map section
 
-**Checkpoint**: Shared transformation and classification helpers exist, and the client can supply ecosystem-map input without extra API calls.
+**Checkpoint**: Shared transformation, spectrum config, and profile helpers exist, and the client can supply ecosystem-map input without extra API calls.
 
 ---
 
 ## Phase 3: User Story 1 - Show ecosystem metrics clearly for analyzed repos (Priority: P1) 🎯 MVP
 
-**Goal**: Users can see visible stars, forks, and watchers for each successful repository without relying on chart hover.
+**Goal**: Users can see visible stars, forks, and watchers for each successful repository without relying on secondary interactions.
 
 **Independent Test**: Submit one or more successful results and verify stars, forks, and watchers are visible as normal UI elements for every successful repository.
 
@@ -53,88 +53,88 @@
 
 > **Write these tests first, and verify they fail before implementing the story.**
 
-- [ ] T008 [P] [US1] Add view-model tests for visible ecosystem metrics in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/ecosystem-map-utils.test.ts`
-- [ ] T009 [P] [US1] Add component tests for visible stars/forks/watchers rendering in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
-- [ ] T010 [P] [US1] Extend client integration tests for ecosystem-map metrics rendering in `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.test.tsx`
-- [ ] T011 [US1] Add Playwright coverage for visible ecosystem metrics in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
+- [x] T009 [P] [US1] Add view-model tests for visible ecosystem metrics in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/ecosystem-map-utils.test.ts`
+- [x] T010 [P] [US1] Add component tests for visible stars/forks/watchers rendering in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
+- [x] T011 [P] [US1] Extend client integration tests for ecosystem-map metrics rendering in `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.test.tsx`
+- [x] T012 [US1] Add Playwright coverage for visible ecosystem metrics in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Implement visible metric-row formatting in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/chart-data.ts`
-- [ ] T013 [US1] Implement `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx` to render visible stars, forks, and watchers for successful repositories
-- [ ] T014 [US1] Update `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx` to render `EcosystemMap` from successful results
+- [x] T013 [US1] Implement visible metric-row formatting in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/chart-data.ts`
+- [x] T014 [US1] Implement `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx` to render visible stars, forks, and watchers for successful repositories
+- [x] T015 [US1] Update `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx` to render `EcosystemMap` from successful results
 
 **Checkpoint**: Successful analyses show visible ecosystem metrics outside of any tooltip interactions.
 
 ---
 
-## Phase 4: User Story 2 - Visualize analyzed repos on the ecosystem map (Priority: P2)
+## Phase 4: User Story 2 - Understand the ecosystem spectrum view (Priority: P2)
 
-**Goal**: Users can see one or more successful repositories plotted on a bubble chart using stars, forks, and watchers.
+**Goal**: Users can see one or more successful repositories summarized in a spectrum-based ecosystem view using reach, builder engagement, and attention.
 
-**Independent Test**: Render the feature with one or more successful results and verify one bubble appears per plot-eligible successful repository with stars on X, forks on Y, and watchers as bubble size.
+**Independent Test**: Render the feature with one or more successful results and verify the spectrum legends and one profile card per successful repository appear without extra fetching.
 
 ### Tests for User Story 2 ⚠️
 
 > **Write these tests first, and verify they fail before implementing the story.**
 
-- [ ] T015 [P] [US2] Add chart-data tests for bubble plotting eligibility and chart coordinates in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/ecosystem-map-utils.test.ts`
-- [ ] T016 [P] [US2] Extend component tests for bubble chart rendering in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
-- [ ] T017 [US2] Add Playwright coverage for single-repo and multi-repo bubble rendering in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
+- [x] T016 [P] [US2] Add view-model tests for spectrum legends and profile-card rendering in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/ecosystem-map-utils.test.ts`
+- [x] T017 [P] [US2] Extend component tests for spectrum rendering in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
+- [x] T018 [US2] Add Playwright coverage for single-repo and multi-repo spectrum rendering in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
 
 ### Implementation for User Story 2
 
-- [ ] T018 [US2] Implement chart dataset generation in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/chart-data.ts`
-- [ ] T019 [US2] Implement the Chart.js bubble chart in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
-- [ ] T020 [US2] Handle unavailable ecosystem metrics honestly in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx` without fabricated plotted values
+- [x] T019 [US2] Implement spectrum/profile view-model generation in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/chart-data.ts`
+- [x] T020 [US2] Implement the spectrum legend and repository profile view in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
+- [x] T021 [US2] Handle unavailable ecosystem metrics honestly in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx` without fabricated derived values or rates
 
-**Checkpoint**: The ecosystem map renders a useful bubble chart for one or more successful repositories.
+**Checkpoint**: The ecosystem map renders a useful spectrum/profile view for one or more successful repositories.
 
 ---
 
-## Phase 5: User Story 3 - Understand ForkPrint ecosystem classification (Priority: P2)
+## Phase 5: User Story 3 - Understand the ecosystem spectrum profile (Priority: P2)
 
-**Goal**: Users can see ForkPrint ecosystem classifications derived from the current successful input set when multi-repo classification is possible.
+**Goal**: Users can see config-driven Reach / Builder Engagement / Attention profiles derived from exact ecosystem metrics.
 
-**Independent Test**: Render the feature with multiple successful repos and verify classifications change with the input set and use median-derived boundaries rather than hardcoded thresholds.
+**Independent Test**: Render the feature with successful repos and verify profile tiers and legends follow the shared spectrum configuration rather than inline thresholds.
 
 ### Tests for User Story 3 ⚠️
 
 > **Write these tests first, and verify they fail before implementing the story.**
 
-- [ ] T021 [P] [US3] Add classification tests for median split behavior in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/ecosystem-map-utils.test.ts`
-- [ ] T022 [P] [US3] Extend component tests for classification labels and note text in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
-- [ ] T023 [US3] Add Playwright coverage for multi-repo ForkPrint ecosystem classification in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
+- [x] T022 [P] [US3] Add profile tests for shared spectrum-band behavior in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/ecosystem-map-utils.test.ts`
+- [x] T023 [P] [US3] Extend component tests for profile labels and legend text in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
+- [x] T024 [US3] Add Playwright coverage for config-driven ecosystem profile rendering in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
 
 ### Implementation for User Story 3
 
-- [ ] T024 [US3] Implement median-split classification in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/classification.ts`
-- [ ] T025 [US3] Render ForkPrint ecosystem classification labels and legend copy in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
-- [ ] T026 [US3] Update `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx` to show the classification-aware ecosystem-map section alongside existing results/failure UI
+- [x] T025 [US3] Implement config-driven spectrum profile logic in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/classification.ts`
+- [x] T026 [US3] Render Reach / Builder Engagement / Attention profile labels and legend copy in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
+- [x] T027 [US3] Update `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx` to show the profile-aware ecosystem-map section alongside existing results/failure UI
 
-**Checkpoint**: Multi-repo analyses show median-derived ForkPrint ecosystem classification without implying official CHAOSS labels.
+**Checkpoint**: The ecosystem map shows config-driven profiles without implying official CHAOSS terminology.
 
 ---
 
-## Phase 6: User Story 4 - Inspect bubble details and single-repo behavior (Priority: P3)
+## Phase 6: User Story 4 - Inspect exact values and derived rates (Priority: P3)
 
-**Goal**: Users can inspect exact chart details and understand why classification is skipped for single-repo analyses.
+**Goal**: Users can inspect exact values and derived rates while keeping single-repo behavior fully useful.
 
-**Independent Test**: Hover or focus a plotted bubble to inspect exact values and verify that a single successful repository shows a clear “classification skipped” note instead of a fabricated label.
+**Independent Test**: Inspect the repository cards and profile content to verify exact values and derived rates, and verify that a single successful repository still receives a full profile.
 
 ### Tests for User Story 4 ⚠️
 
 > **Write these tests first, and verify they fail before implementing the story.**
 
-- [ ] T027 [P] [US4] Add component tests for tooltip/focus detail and single-repo note behavior in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
-- [ ] T028 [US4] Add Playwright coverage for tooltip details and single-repo explanatory copy in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
+- [x] T028 [P] [US4] Add component tests for exact-value detail and single-repo profile behavior in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.test.tsx`
+- [x] T029 [US4] Add Playwright coverage for derived-rate details and single-repo profile behavior in `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
 
 ### Implementation for User Story 4
 
-- [ ] T029 [US4] Implement tooltip content and accessible focus detail in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
-- [ ] T030 [US4] Implement single-repo explanatory note and classification skip behavior in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/classification.ts` and `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
+- [x] T030 [US4] Implement exact-value and derived-rate detail in `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
+- [x] T031 [US4] Implement single-repo profile behavior in `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/classification.ts` and `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`
 
-**Checkpoint**: Single-repo analyses remain useful and honest, and bubble details are inspectable.
+**Checkpoint**: Single-repo analyses remain useful, profiled, and honest, and repository details expose the derived rates.
 
 ---
 
@@ -142,12 +142,12 @@
 
 **Purpose**: Final verification, documentation alignment, and manual-checklist readiness for the feature PR.
 
-- [ ] T031 [P] Run unit/integration tests with `npm test` and confirm ecosystem-map coverage passes
-- [ ] T032 [P] Run lint with `npm run lint` and remove any dead code, TODOs, or temporary logging
-- [ ] T033 [P] Run end-to-end coverage with `npm run test:e2e` including `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
-- [ ] T034 Run `npm run build` and verify the ecosystem-map changes do not introduce production build regressions
-- [ ] T035 Update `/Users/arungupta/workspaces/forkprint/specs/005-ecosystem-map/checklists/manual-testing.md` as the feature is manually verified
-- [ ] T036 Update `/Users/arungupta/workspaces/forkprint/README.md` if the completed ecosystem-map flow changes user-facing behavior or setup
+- [x] T032 [P] Run unit/integration tests with `npm test` and confirm ecosystem-map coverage passes
+- [x] T033 [P] Run lint with `npm run lint` and remove any dead code, TODOs, or temporary logging
+- [x] T034 [P] Run end-to-end coverage with `npm run test:e2e` including `/Users/arungupta/workspaces/forkprint/e2e/ecosystem-map.spec.ts`
+- [ ] T035 Run `npm run build` and verify the ecosystem-map changes do not introduce production build regressions
+- [x] T036 Update `/Users/arungupta/workspaces/forkprint/specs/005-ecosystem-map/checklists/manual-testing.md` as the feature is manually verified
+- [x] T037 Update `/Users/arungupta/workspaces/forkprint/README.md` if the completed ecosystem-map flow changes user-facing behavior or setup
 
 ---
 
@@ -163,9 +163,9 @@
 ### User Story Dependencies
 
 - **US1 (P1)**: Starts after Foundational and delivers the first usable ecosystem-map value
-- **US2 (P2)**: Depends on US1’s visible metric/view-model work and adds chart rendering
-- **US3 (P2)**: Depends on US2’s plotted dataset and adds ForkPrint ecosystem classification
-- **US4 (P3)**: Depends on US2/US3 chart behavior and adds final tooltip/single-repo polish
+- **US2 (P2)**: Depends on US1’s visible metric/view-model work and adds the spectrum view
+- **US3 (P2)**: Depends on US2’s profile dataset and adds the config-driven ecosystem profile
+- **US4 (P3)**: Depends on US2/US3 profile behavior and adds final exact-value/rate polish
 
 ### Within Each User Story
 
@@ -177,11 +177,11 @@
 ### Parallel Opportunities
 
 - T002, T003, and T004 can run in parallel
-- T005 and T006 can run in parallel
-- T008, T009, and T010 can run in parallel
-- T015 and T016 can run in parallel
-- T021 and T022 can run in parallel
-- T031, T032, and T033 can run in parallel
+- T005, T006, and T007 can run in parallel
+- T009, T010, and T011 can run in parallel
+- T016 and T017 can run in parallel
+- T022 and T023 can run in parallel
+- T032, T033, and T034 can run in parallel
 
 ---
 
@@ -203,14 +203,14 @@ Task: "Extend client integration tests for ecosystem-map metrics rendering in co
 1. Complete Phase 1: Setup
 2. Complete Phase 2: Foundational
 3. Complete Phase 3: User Story 1
-4. Stop and validate the visible ecosystem metrics experience before adding chart rendering
+4. Stop and validate the visible ecosystem metrics experience before adding the full spectrum/profile interpretation
 
 ### Incremental Delivery
 
 1. Add visible ecosystem metrics for successful repos
-2. Add bubble-chart rendering for one or more successful repos
-3. Add ForkPrint ecosystem classification for multi-repo runs
-4. Add tooltip detail and single-repo explanatory behavior
+2. Add the spectrum/profile view for one or more successful repos
+3. Add config-driven Reach / Builder Engagement / Attention profiles
+4. Add tooltip detail and derived-rate behavior
 5. Finish with verification, manual checklist completion, and README alignment
 
 ### TDD Reminder


### PR DESCRIPTION
## Summary
- replace the earlier ecosystem-map prototype with a spectrum-first ecosystem view
- add config-driven Reach / Builder Engagement / Attention bands plus per-repo profile summaries
- align the product/spec/docs/checklists with the spectrum-based interpretation and update README

## Verification
- `npm test`
- `npm run lint`
- `npm run test:e2e`
- manual checklist completed for `P1-F05`

## Notes
- `npm run build` still fails in this environment because the existing `next/font/google` setup cannot fetch Geist fonts during build

## Related
- Implements `P1-F05`
