### PR TITLE
Implement P1-F07 metric cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ Implemented today:
 - Per-repo result and failure handling with explicit `"unavailable"` placeholders
 - Loading and rate-limit visibility on the home page
 - Results shell with a full-width header, stable analysis panel, and tabbed result workspace
-- `Overview`, `Ecosystem Map`, `Comparison`, and `Metrics` tabs, with placeholder states where later features are still pending
-- Ecosystem spectrum view in the `Ecosystem Map` tab, including visible stars/forks/watchers and config-driven Reach / Builder Engagement / Attention profiles
+- Metric-card summaries in the `Overview` tab, including exact repo counters, ecosystem profile summaries, CHAOSS badge slots, and expandable in-place detail
+- `Overview`, `Comparison`, and `Metrics` tabs, with placeholder states where later features are still pending
+- Ecosystem spectrum guidance folded into the `Overview` experience, including visible stars/forks/watchers and config-driven Reach / Builder Engagement / Attention profiles
 - Vercel-ready deployment path with server-side `GITHUB_TOKEN` support for shared deployments
 - Automated coverage with Vitest, React Testing Library, and Playwright
 

--- a/components/app-shell/ResultsShell.test.tsx
+++ b/components/app-shell/ResultsShell.test.tsx
@@ -9,7 +9,6 @@ describe('ResultsShell', () => {
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
         overview={<div>Overview content</div>}
-        ecosystemMap={<div>Ecosystem content</div>}
         comparison={<div>Comparison coming soon</div>}
         metrics={<div>Metrics coming soon</div>}
       />,
@@ -18,10 +17,10 @@ describe('ResultsShell', () => {
     expect(screen.getByText('Analysis panel')).toBeInTheDocument()
     expect(screen.getByText('Overview content')).toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('tab', { name: 'Ecosystem Map' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
 
     expect(screen.getByText('Analysis panel')).toBeInTheDocument()
-    expect(screen.getByText('Ecosystem content')).toBeInTheDocument()
+    expect(screen.getByText('Comparison coming soon')).toBeInTheDocument()
   })
 
   it('renders the GitHub repo link in the header', () => {
@@ -29,7 +28,6 @@ describe('ResultsShell', () => {
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
         overview={<div>Overview content</div>}
-        ecosystemMap={<div>Ecosystem content</div>}
         comparison={<div>Comparison coming soon</div>}
         metrics={<div>Metrics coming soon</div>}
       />,

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -8,12 +8,11 @@ import { ResultsTabs } from './ResultsTabs'
 interface ResultsShellProps {
   analysisPanel: React.ReactNode
   overview: React.ReactNode
-  ecosystemMap: React.ReactNode
   comparison: React.ReactNode
   metrics: React.ReactNode
 }
 
-export function ResultsShell({ analysisPanel, overview, ecosystemMap, comparison, metrics }: ResultsShellProps) {
+export function ResultsShell({ analysisPanel, overview, comparison, metrics }: ResultsShellProps) {
   const [activeTab, setActiveTab] = useState<ResultTabId>('overview')
 
   return (
@@ -50,7 +49,6 @@ export function ResultsShell({ analysisPanel, overview, ecosystemMap, comparison
             <ResultsTabs tabs={resultTabs} activeTab={activeTab} onChange={setActiveTab} />
             <div className="mt-6">
               {activeTab === 'overview' ? overview : null}
-              {activeTab === 'ecosystem-map' ? ecosystemMap : null}
               {activeTab === 'comparison' ? comparison : null}
               {activeTab === 'metrics' ? metrics : null}
             </div>

--- a/components/app-shell/ResultsTabs.test.tsx
+++ b/components/app-shell/ResultsTabs.test.tsx
@@ -6,7 +6,7 @@ import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/re
 
 const tabs: ResultTabDefinition[] = [
   { id: 'overview', label: 'Overview', status: 'implemented', description: 'Overview content' },
-  { id: 'ecosystem-map', label: 'Ecosystem Map', status: 'placeholder', description: 'Ecosystem content' },
+  { id: 'comparison', label: 'Comparison', status: 'placeholder', description: 'Comparison content' },
 ]
 
 describe('ResultsTabs', () => {
@@ -17,8 +17,8 @@ describe('ResultsTabs', () => {
 
     expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true')
 
-    await userEvent.click(screen.getByRole('tab', { name: 'Ecosystem Map' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
 
-    expect(onChange).toHaveBeenCalledWith('ecosystem-map')
+    expect(onChange).toHaveBeenCalledWith('comparison')
   })
 })

--- a/components/ecosystem-map/EcosystemMap.test.tsx
+++ b/components/ecosystem-map/EcosystemMap.test.tsx
@@ -4,7 +4,7 @@ import { EcosystemMap } from './EcosystemMap'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 
 describe('EcosystemMap', () => {
-  it('renders visible stars, forks, and watchers for successful repositories', () => {
+  it('renders the shared ecosystem spectrum guidance for successful repositories', () => {
     render(
       <EcosystemMap
         results={[
@@ -19,35 +19,27 @@ describe('EcosystemMap', () => {
     )
 
     const region = screen.getByRole('region', { name: /ecosystem map/i })
-    const articles = within(region).getAllByRole('article')
-
-    expect(within(articles[0]!).getByText('facebook/react')).toBeInTheDocument()
-    expect(within(articles[0]!).getByText('Stars: 244,295')).toBeInTheDocument()
-    expect(within(articles[0]!).getByText('Forks: 50,872')).toBeInTheDocument()
-    expect(within(articles[0]!).getByText('Watchers: 6,660')).toBeInTheDocument()
+    expect(within(region).getByText(/ecosystem spectrum/i)).toBeInTheDocument()
+    expect(within(region).getByText(/^Reach bands$/)).toBeInTheDocument()
   })
 
-  it('shows unavailable ecosystem metrics explicitly', () => {
+  it('does not duplicate per-repo spectrum profile content', () => {
     render(
       <EcosystemMap
         results={[
           buildResult({
-            stars: 'unavailable',
+            repo: 'facebook/react',
+            stars: 244295,
             forks: 50872,
-            watchers: 'unavailable',
+            watchers: 6660,
           }),
         ]}
       />,
     )
 
     const region = screen.getByRole('region', { name: /ecosystem map/i })
-    const articles = within(region).getAllByRole('article')
-
-    expect(within(articles[0]!).getByText('Stars: unavailable')).toBeInTheDocument()
-    expect(within(articles[0]!).getByText('Watchers: unavailable')).toBeInTheDocument()
-    expect(
-      within(region).getByText(/could not plot this repository because ecosystem metrics were incomplete/i),
-    ).toBeInTheDocument()
+    expect(within(region).queryByText('facebook/react')).not.toBeInTheDocument()
+    expect(within(region).queryByText(/spectrum profile/i)).not.toBeInTheDocument()
   })
 
   it('renders the spectrum-only view without the chart', () => {
@@ -93,7 +85,7 @@ describe('EcosystemMap', () => {
     expect(within(region).getAllByText(/^Attention$/).length).toBeGreaterThan(0)
   })
 
-  it('shows a full spectrum profile even for a single repo', () => {
+  it('shows band guidance without per-repo rate pills for a single repo', () => {
     render(
       <EcosystemMap
         results={[
@@ -109,13 +101,12 @@ describe('EcosystemMap', () => {
 
     const region = screen.getByRole('region', { name: /ecosystem map/i })
 
-    expect(within(region).queryByText(/classification is skipped/i)).not.toBeInTheDocument()
-    expect(within(region).getByText(/spectrum profile/i)).toBeInTheDocument()
-    expect(within(region).getByText(/20.8% fork rate/i)).toBeInTheDocument()
-    expect(within(region).getByText(/2.7% watcher rate/i)).toBeInTheDocument()
+    expect(within(region).queryByText(/20.8% fork rate/i)).not.toBeInTheDocument()
+    expect(within(region).queryByText(/2.7% watcher rate/i)).not.toBeInTheDocument()
+    expect(within(region).getByText(/^Builder engagement$/)).toBeInTheDocument()
   })
 
-  it('shows an exploratory spectrum preview with profile tiers', () => {
+  it('shows band tiers in the legend', () => {
     render(
       <EcosystemMap
         results={[
@@ -126,9 +117,9 @@ describe('EcosystemMap', () => {
 
     const region = screen.getByRole('region', { name: /ecosystem map/i })
 
-    expect(within(region).getByText(/35.2% fork rate/i)).toBeInTheDocument()
-    expect(within(region).getByText(/2.6% watcher rate/i)).toBeInTheDocument()
-    expect(within(region).getAllByText('Exceptional').length).toBeGreaterThan(0)
+    expect(within(region).getByText(/Exceptional 100k\+/i)).toBeInTheDocument()
+    expect(within(region).getByText(/Exceptional 25%\+/i)).toBeInTheDocument()
+    expect(within(region).getByText(/Exceptional 2.5%\+/i)).toBeInTheDocument()
   })
 })
 

--- a/components/ecosystem-map/EcosystemMap.tsx
+++ b/components/ecosystem-map/EcosystemMap.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
-import { buildEcosystemRows } from '@/lib/ecosystem-map/chart-data'
 import {
   ATTENTION_BANDS,
   BUILDER_ENGAGEMENT_BANDS,
@@ -13,9 +12,7 @@ interface EcosystemMapProps {
 }
 
 export function EcosystemMap({ results }: EcosystemMapProps) {
-  const rows = buildEcosystemRows(results)
-
-  if (rows.length === 0) {
+  if (results.length === 0) {
     return null
   }
 
@@ -54,45 +51,6 @@ export function EcosystemMap({ results }: EcosystemMapProps) {
           </div>
         </div>
       </section>
-
-      <div className="mt-3 space-y-3">
-        {rows.map((row) => (
-          <article key={row.repo} className="rounded border border-gray-200 bg-white p-3">
-            <h3 className="font-medium text-gray-900">{row.repo}</h3>
-            <div className="mt-2 grid gap-1 text-sm text-gray-700">
-              <p>Stars: {row.starsLabel}</p>
-              <p>Forks: {row.forksLabel}</p>
-              <p>Watchers: {row.watchersLabel}</p>
-            </div>
-            {row.profile ? (
-              <div className="mt-3 rounded-lg border border-indigo-100 bg-indigo-50/50 p-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-indigo-700">Spectrum profile</p>
-                <div className="mt-2 grid gap-2 md:grid-cols-3">
-                  <div className="rounded-md border border-slate-200 bg-white px-3 py-2">
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Reach</p>
-                    <p className={`mt-1 inline-flex rounded-full px-2.5 py-1 text-sm font-semibold ${reachTierClass(row.profile.reachTier)}`}>
-                      {row.profile.reachTier}
-                    </p>
-                  </div>
-                  <div className="rounded-md border border-sky-200 bg-white px-3 py-2">
-                    <p className="text-xs font-medium uppercase tracking-wide text-sky-700">Builder engagement</p>
-                    <p className={`mt-1 inline-flex rounded-full px-2.5 py-1 text-sm font-semibold ${engagementTierClass(row.profile.engagementTier)}`}>
-                      {row.profile.engagementTier} ({row.profile.forkRateLabel} fork rate)
-                    </p>
-                  </div>
-                  <div className="rounded-md border border-violet-200 bg-white px-3 py-2">
-                    <p className="text-xs font-medium uppercase tracking-wide text-violet-700">Attention</p>
-                    <p className={`mt-1 inline-flex rounded-full px-2.5 py-1 text-sm font-semibold ${attentionTierClass(row.profile.attentionTier)}`}>
-                      {row.profile.attentionTier} ({row.profile.watcherRateLabel} watcher rate)
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-            {row.plotStatusNote ? <p className="mt-2 text-sm text-amber-700">{row.plotStatusNote}</p> : null}
-          </article>
-        ))}
-      </div>
     </section>
   )
 }
@@ -152,19 +110,6 @@ function LegendCard<T extends string>({
   )
 }
 
-function reachTierClass(tier: string) {
-  switch (tier) {
-    case 'Exceptional':
-      return 'bg-emerald-100 text-emerald-800'
-    case 'Strong':
-      return 'bg-sky-100 text-sky-800'
-    case 'Growing':
-      return 'bg-amber-100 text-amber-800'
-    default:
-      return 'bg-slate-100 text-slate-700'
-  }
-}
-
 function reachLegendBandClass(tier: string) {
   switch (tier) {
     case 'Emerging':
@@ -178,19 +123,6 @@ function reachLegendBandClass(tier: string) {
   }
 }
 
-function engagementTierClass(tier: string) {
-  switch (tier) {
-    case 'Exceptional':
-      return 'bg-cyan-100 text-cyan-800'
-    case 'Strong':
-      return 'bg-blue-100 text-blue-800'
-    case 'Healthy':
-      return 'bg-indigo-100 text-indigo-800'
-    default:
-      return 'bg-slate-100 text-slate-700'
-  }
-}
-
 function engagementLegendBandClass(tier: string) {
   switch (tier) {
     case 'Light':
@@ -201,19 +133,6 @@ function engagementLegendBandClass(tier: string) {
       return 'bg-sky-200 text-sky-800'
     default:
       return 'bg-sky-300 text-sky-950'
-  }
-}
-
-function attentionTierClass(tier: string) {
-  switch (tier) {
-    case 'Exceptional':
-      return 'bg-fuchsia-100 text-fuchsia-800'
-    case 'Strong':
-      return 'bg-violet-100 text-violet-800'
-    case 'Active':
-      return 'bg-purple-100 text-purple-800'
-    default:
-      return 'bg-slate-100 text-slate-700'
   }
 }
 

--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { buildMetricCardViewModels } from '@/lib/metric-cards/view-model'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { MetricCard } from './MetricCard'
+
+describe('MetricCard', () => {
+  it('renders summary metrics, ecosystem profile, and score badges', () => {
+    const card = buildMetricCardViewModels([buildResult()])[0]!
+
+    render(<MetricCard card={card} expanded={false} onToggle={vi.fn()} />)
+
+    expect(screen.getByText('facebook/react')).toBeInTheDocument()
+    expect(screen.getByText('244,295')).toBeInTheDocument()
+    expect(screen.getByText('50,872')).toBeInTheDocument()
+    expect(screen.getByText('6,660')).toBeInTheDocument()
+    expect(screen.getByText(/ecosystem profile summary/i)).toBeInTheDocument()
+    expect(screen.getByText(/Builder Engagement/i)).toBeInTheDocument()
+    expect(screen.getAllByText('Not scored yet')).toHaveLength(3)
+  })
+
+  it('reveals full metric detail when expanded', async () => {
+    const card = buildMetricCardViewModels([buildResult({ missingFields: ['releases12mo'] })])[0]!
+    const onToggle = vi.fn()
+
+    const { rerender } = render(<MetricCard card={card} expanded={false} onToggle={onToggle} />)
+    await userEvent.click(screen.getByRole('button', { name: /show details/i }))
+    expect(onToggle).toHaveBeenCalled()
+
+    rerender(<MetricCard card={card} expanded onToggle={onToggle} />)
+
+    const detailRegion = screen.getByText(/full metric detail/i).closest('div')
+    expect(within(detailRegion!).getByText('Primary language')).toBeInTheDocument()
+    expect(within(detailRegion!).getByText('TypeScript')).toBeInTheDocument()
+    expect(within(detailRegion!).getByText(/releases12mo/i)).toBeInTheDocument()
+  })
+})
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'The library for web and native user interfaces.',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 244295,
+    forks: 50872,
+    watchers: 6660,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 'unavailable',
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import type { MetricCardViewModel } from '@/lib/metric-cards/view-model'
+import { ScoreBadge } from './ScoreBadge'
+
+interface MetricCardProps {
+  card: MetricCardViewModel
+  expanded: boolean
+  onToggle: () => void
+}
+
+export function MetricCard({ card, expanded, onToggle }: MetricCardProps) {
+  return (
+    <article className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm" data-testid={`metric-card-${card.repo}`}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h3 className="font-semibold text-slate-900">{card.repo}</h3>
+          <p className="text-sm text-slate-600">Created: {card.createdAtLabel}</p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          aria-expanded={expanded}
+          onClick={onToggle}
+        >
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        <SummaryStat label="Stars" value={card.starsLabel} />
+        <SummaryStat label="Forks" value={card.forksLabel} />
+        <SummaryStat label="Watchers" value={card.watchersLabel} />
+      </div>
+
+      {card.profile ? (
+        <div className="mt-4 rounded-lg border border-indigo-100 bg-indigo-50/50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-indigo-700">Ecosystem profile summary</p>
+          <div className="mt-2 grid gap-2 md:grid-cols-3">
+            <ProfilePill label="Reach" value={card.profile.reachTier} toneClass={reachTierClass(card.profile.reachTier)} />
+            <ProfilePill
+              label="Builder Engagement"
+              value={`${card.profile.engagementTier} (${card.profile.forkRateLabel} fork rate)`}
+              toneClass={engagementTierClass(card.profile.engagementTier)}
+            />
+            <ProfilePill
+              label="Attention"
+              value={`${card.profile.attentionTier} (${card.profile.watcherRateLabel} watcher rate)`}
+              toneClass={attentionTierClass(card.profile.attentionTier)}
+            />
+          </div>
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-amber-700">Ecosystem profile summary is unavailable because ecosystem metrics were incomplete.</p>
+      )}
+
+      <div className="mt-4 grid gap-2 lg:grid-cols-3">
+        {card.scoreBadges.map((badge) => (
+          <ScoreBadge key={badge.category} category={badge.category} value={badge.value} tone={badge.tone} />
+        ))}
+      </div>
+
+      {expanded ? (
+        <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-700">Full metric detail</p>
+          <dl className="mt-3 grid gap-2 md:grid-cols-2">
+            {card.details.map((detail) => (
+              <div key={detail.label} className="rounded-md border border-white bg-white px-3 py-2">
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{detail.label}</dt>
+                <dd className="mt-1 text-sm text-slate-800">{detail.value}</dd>
+              </div>
+            ))}
+          </dl>
+          {card.missingFields.length > 0 ? (
+            <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-amber-700">Missing fields</p>
+              <p className="mt-1 text-sm text-amber-800">{card.missingFields.join(', ')}</p>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </article>
+  )
+}
+
+function SummaryStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-slate-900">{value}</p>
+    </div>
+  )
+}
+
+function ProfilePill({ label, value, toneClass }: { label: string; value: string; toneClass: string }) {
+  return (
+    <div className="rounded-md border border-white bg-white px-3 py-2">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 inline-flex rounded-full px-2.5 py-1 text-sm font-semibold ${toneClass}`}>{value}</p>
+    </div>
+  )
+}
+
+function reachTierClass(tier: string) {
+  switch (tier) {
+    case 'Exceptional':
+      return 'bg-emerald-100 text-emerald-800'
+    case 'Strong':
+      return 'bg-emerald-200 text-emerald-900'
+    case 'Growing':
+      return 'bg-emerald-50 text-emerald-700'
+    default:
+      return 'bg-slate-100 text-slate-700'
+  }
+}
+
+function engagementTierClass(tier: string) {
+  switch (tier) {
+    case 'Exceptional':
+      return 'bg-sky-300 text-sky-950'
+    case 'Strong':
+      return 'bg-sky-200 text-sky-900'
+    case 'Healthy':
+      return 'bg-sky-100 text-sky-800'
+    default:
+      return 'bg-slate-100 text-slate-700'
+  }
+}
+
+function attentionTierClass(tier: string) {
+  switch (tier) {
+    case 'Exceptional':
+      return 'bg-violet-300 text-violet-950'
+    case 'Strong':
+      return 'bg-violet-200 text-violet-900'
+    case 'Active':
+      return 'bg-violet-100 text-violet-800'
+    default:
+      return 'bg-slate-100 text-slate-700'
+  }
+}

--- a/components/metric-cards/MetricCardsOverview.test.tsx
+++ b/components/metric-cards/MetricCardsOverview.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { MetricCardsOverview } from './MetricCardsOverview'
+
+describe('MetricCardsOverview', () => {
+  it('renders one card per successful repository', () => {
+    render(<MetricCardsOverview results={[buildResult({ repo: 'facebook/react' }), buildResult({ repo: 'kubernetes/kubernetes' })]} />)
+
+    expect(screen.getByTestId('metric-card-facebook/react')).toBeInTheDocument()
+    expect(screen.getByTestId('metric-card-kubernetes/kubernetes')).toBeInTheDocument()
+  })
+
+  it('manages expansion state locally', async () => {
+    render(<MetricCardsOverview results={[buildResult()]} />)
+
+    expect(screen.queryByText(/full metric detail/i)).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /show details/i }))
+    expect(screen.getByText(/full metric detail/i)).toBeInTheDocument()
+  })
+})
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'The library for web and native user interfaces.',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 244295,
+    forks: 50872,
+    watchers: 6660,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 'unavailable',
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}

--- a/components/metric-cards/MetricCardsOverview.tsx
+++ b/components/metric-cards/MetricCardsOverview.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { buildMetricCardViewModels } from '@/lib/metric-cards/view-model'
+import { MetricCard } from './MetricCard'
+
+interface MetricCardsOverviewProps {
+  results: AnalysisResult[]
+}
+
+export function MetricCardsOverview({ results }: MetricCardsOverviewProps) {
+  const [expandedRepos, setExpandedRepos] = useState<string[]>([])
+  const cards = buildMetricCardViewModels(results)
+
+  if (cards.length === 0) {
+    return null
+  }
+
+  return (
+    <section aria-label="Metric cards overview" className="space-y-4">
+      {cards.map((card) => {
+        const expanded = expandedRepos.includes(card.repo)
+
+        return (
+          <MetricCard
+            key={card.repo}
+            card={card}
+            expanded={expanded}
+            onToggle={() =>
+              setExpandedRepos((current) =>
+                current.includes(card.repo) ? current.filter((repo) => repo !== card.repo) : [...current, card.repo],
+              )
+            }
+          />
+        )
+      })}
+    </section>
+  )
+}

--- a/components/metric-cards/ScoreBadge.test.tsx
+++ b/components/metric-cards/ScoreBadge.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ScoreBadge } from './ScoreBadge'
+
+describe('ScoreBadge', () => {
+  it('renders the category label and score value', () => {
+    render(<ScoreBadge category="Evolution" value="Not scored yet" tone="neutral" />)
+
+    expect(screen.getByText('Evolution')).toBeInTheDocument()
+    expect(screen.getByText('Not scored yet')).toBeInTheDocument()
+  })
+})

--- a/components/metric-cards/ScoreBadge.tsx
+++ b/components/metric-cards/ScoreBadge.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { scoreToneClass } from '@/lib/metric-cards/score-config'
+import type { ScoreBadgeProps } from '@/specs/008-metric-cards/contracts/metric-card-props'
+
+export function ScoreBadge({ category, value, tone }: ScoreBadgeProps) {
+  return (
+    <div className={`rounded-lg border px-3 py-2 ${scoreToneClass(tone)}`}>
+      <p className="text-xs font-medium uppercase tracking-wide">{category}</p>
+      <p className="mt-1 text-sm font-semibold">{value}</p>
+    </div>
+  )
+}

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -130,17 +130,16 @@ describe('RepoInputClient', () => {
     await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
 
     const results = await screen.findByRole('region', { name: /analysis results/i })
-    expect(within(results).getByText('facebook/react')).toBeInTheDocument()
-    expect(within(results).getByText(/stars: 244,295/i)).toBeInTheDocument()
+    const metricCardsOverview = within(results).getByRole('region', { name: /metric cards overview/i })
+    expect(within(metricCardsOverview).getByTestId('metric-card-facebook/react')).toBeInTheDocument()
+    expect(within(metricCardsOverview).getByText('244,295')).toBeInTheDocument()
+    expect(within(metricCardsOverview).getByText(/ecosystem profile summary/i)).toBeInTheDocument()
+    expect(within(results).getAllByText('Not scored yet')).toHaveLength(3)
 
-    await userEvent.click(screen.getByRole('tab', { name: 'Ecosystem Map' }))
-
-    const ecosystemMap = screen.getByRole('region', { name: /ecosystem map/i })
-    const articles = within(ecosystemMap).getAllByRole('article')
-    expect(within(articles[0]!).getByText('facebook/react')).toBeInTheDocument()
-    expect(within(articles[0]!).getByText('Stars: 244,295')).toBeInTheDocument()
-    expect(within(articles[0]!).getByText('Forks: 25')).toBeInTheDocument()
-    expect(within(articles[0]!).getByText('Watchers: 10')).toBeInTheDocument()
+    const ecosystemMap = within(results).getByRole('region', { name: /ecosystem map/i })
+    expect(within(ecosystemMap).getByText(/ecosystem spectrum/i)).toBeInTheDocument()
+    expect(within(ecosystemMap).getByText(/^Reach bands$/)).toBeInTheDocument()
+    expect(within(ecosystemMap).queryByText('facebook/react')).not.toBeInTheDocument()
   })
 
   it('renders repository-specific failures alongside successful results', async () => {
@@ -275,8 +274,53 @@ describe('RepoInputClient', () => {
     await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
 
     await screen.findByRole('tab', { name: 'Overview' })
-    await userEvent.click(screen.getByRole('tab', { name: 'Ecosystem Map' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
 
+    expect(onAnalyze).toHaveBeenCalledTimes(1)
+  })
+
+  it('expands a metric card without rerunning analysis', async () => {
+    const onAnalyze = vi.fn().mockResolvedValue({
+      results: [
+        {
+          repo: 'facebook/react',
+          name: 'react',
+          description: 'A UI library',
+          createdAt: '2013-05-24T16:15:54Z',
+          primaryLanguage: 'TypeScript',
+          stars: 244295,
+          forks: 25,
+          watchers: 10,
+          commits30d: 7,
+          commits90d: 18,
+          releases12mo: 'unavailable',
+          prsOpened90d: 4,
+          prsMerged90d: 3,
+          issuesOpen: 5,
+          issuesClosed90d: 6,
+          uniqueCommitAuthors90d: 'unavailable',
+          totalContributors: 'unavailable',
+          commitCountsByAuthor: 'unavailable',
+          issueFirstResponseTimestamps: 'unavailable',
+          issueCloseTimestamps: 'unavailable',
+          prMergeTimestamps: 'unavailable',
+          missingFields: ['releases12mo'],
+        },
+      ],
+      failures: [],
+      rateLimit: null,
+    })
+
+    render(<RepoInputClient hasServerToken={false} onAnalyze={onAnalyze} />)
+
+    await userEvent.type(screen.getByLabelText(/github personal access token/i), 'ghp_saved')
+    await userEvent.type(screen.getByRole('textbox', { name: /repository list/i }), 'facebook/react')
+    await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
+
+    await screen.findByTestId('metric-card-facebook/react')
+    await userEvent.click(screen.getByRole('button', { name: /show details/i }))
+
+    expect(screen.getByText(/full metric detail/i)).toBeInTheDocument()
     expect(onAnalyze).toHaveBeenCalledTimes(1)
   })
 })

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { ResultsShell } from '@/components/app-shell/ResultsShell'
 import { EcosystemMap } from '@/components/ecosystem-map/EcosystemMap'
+import { MetricCardsOverview } from '@/components/metric-cards/MetricCardsOverview'
 import { TokenInput } from '@/components/token-input/TokenInput'
 import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import { readToken, writeToken } from '@/lib/token-storage'
@@ -88,12 +89,8 @@ export function RepoInputClient({ hasServerToken, onAnalyze }: RepoInputClientPr
         ) : null}
       {analysisResponse ? (
         <section aria-label="Analysis results" className="space-y-4">
-          {analysisResponse.results.map((result) => (
-            <article key={result.repo} className="rounded border border-gray-200 p-4">
-              <h2 className="font-semibold text-slate-900">{result.repo}</h2>
-              <p className="text-sm text-gray-600">Stars: {formatDisplayValue(result.stars)}</p>
-            </article>
-          ))}
+          <MetricCardsOverview results={analysisResponse.results} />
+          <EcosystemMap results={analysisResponse.results} />
           {analysisResponse.failures.length > 0 ? (
             <section className="rounded border border-amber-200 bg-amber-50 p-4">
               <h2 className="font-semibold text-amber-900">Failed repositories</h2>
@@ -124,13 +121,6 @@ export function RepoInputClient({ hasServerToken, onAnalyze }: RepoInputClientPr
     <ResultsShell
       analysisPanel={analysisPanel}
       overview={overviewContent}
-      ecosystemMap={
-        analysisResponse ? (
-          <EcosystemMap results={analysisResponse.results} />
-        ) : (
-          <p className="text-sm text-slate-600">Run an analysis to populate the ecosystem map view.</p>
-        )
-      }
       comparison={<p className="text-sm text-slate-600">Comparison view is coming soon.</p>}
       metrics={<p className="text-sm text-slate-600">Metrics view is coming soon.</p>}
     />

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -198,8 +198,8 @@ ForkPrint presents analysis in a stable app shell so users can submit repos once
 - A top header/banner shows the ForkPrint brand and a visible GitHub repo link
 - Repo input and Analyze action live in a stable analysis panel that remains visible above the result views
 - Successful analyses populate a tabbed result area rather than stacking every future view vertically
-- The initial tabs provide a shell that can host at least: Overview, Ecosystem Map, Comparison, and Metrics
-- `Ecosystem Map` is the first populated results tab; other tabs may show intentional empty-state or coming-soon content until their features land
+- The initial tabs provide a shell that can host at least: Overview, Comparison, and Metrics
+- The `Overview` tab is the first populated results tab and can absorb cross-feature summary content until later tabs deliver distinct value
 - Switching tabs does not re-submit the analysis request or trigger extra API calls
 - The shell works for single-repo and multi-repo analyses on desktop and mobile layouts
 

--- a/e2e/data-fetching.spec.ts
+++ b/e2e/data-fetching.spec.ts
@@ -50,8 +50,10 @@ test.describe('P1-F04 Data Fetching', () => {
     await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react')
     await page.getByRole('button', { name: /analyze/i }).click()
 
-    await expect(page.getByRole('region', { name: /analysis results/i })).toContainText('facebook/react')
-    await expect(page.getByRole('region', { name: /analysis results/i })).toContainText('Stars: 100')
+    const overview = page.getByRole('region', { name: /metric cards overview/i })
+    await expect(overview).toContainText('facebook/react')
+    await expect(overview).toContainText('Stars')
+    await expect(overview).toContainText('100')
   })
 
   test('shows successful results and failed repositories together', async ({ page }) => {

--- a/e2e/ecosystem-map.spec.ts
+++ b/e2e/ecosystem-map.spec.ts
@@ -10,7 +10,7 @@ test.describe('P1-F05 Ecosystem Map', () => {
     }
   })
 
-  test('shows visible stars, forks, and watchers for successful repositories', async ({ page }) => {
+  test('shows the shared ecosystem spectrum guidance in the overview', async ({ page }) => {
     await mockAnalyze(page, [
       buildResult({
         repo: 'facebook/react',
@@ -22,13 +22,11 @@ test.describe('P1-F05 Ecosystem Map', () => {
 
     await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react')
     await page.getByRole('button', { name: /analyze/i }).click()
-    await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
 
     const ecosystemMap = page.getByRole('region', { name: /ecosystem map/i })
-    await expect(ecosystemMap).toContainText('facebook/react')
-    await expect(ecosystemMap).toContainText('Stars: 244,295')
-    await expect(ecosystemMap).toContainText('Forks: 50,872')
-    await expect(ecosystemMap).toContainText('Watchers: 6,660')
+    await expect(ecosystemMap).toContainText('Ecosystem spectrum')
+    await expect(ecosystemMap).toContainText('Reach bands')
+    await expect(ecosystemMap).not.toContainText('facebook/react')
   })
 
   test('renders the ecosystem spectrum and legend for multiple repos', async ({ page }) => {
@@ -39,7 +37,6 @@ test.describe('P1-F05 Ecosystem Map', () => {
 
     await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react\nkubernetes/kubernetes')
     await page.getByRole('button', { name: /analyze/i }).click()
-    await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
 
     const ecosystemMap = page.getByRole('region', { name: /ecosystem map/i })
     await expect(ecosystemMap).toContainText('Ecosystem spectrum')
@@ -51,20 +48,19 @@ test.describe('P1-F05 Ecosystem Map', () => {
     await expect(ecosystemMap).toContainText('Attention')
   })
 
-  test('shows spectrum profiles with derived rates', async ({ page }) => {
+  test('shows only the band legend rather than duplicated per-repo spectrum profiles', async ({ page }) => {
     await mockAnalyze(page, [
       buildResult({ repo: 'kubernetes/kubernetes', stars: 121419, forks: 42757, watchers: 3181 }),
     ])
 
     await page.getByRole('textbox', { name: /repository list/i }).fill('kubernetes/kubernetes')
     await page.getByRole('button', { name: /analyze/i }).click()
-    await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
 
     const ecosystemMap = page.getByRole('region', { name: /ecosystem map/i })
-    await expect(ecosystemMap).toContainText('Spectrum profile')
-    await expect(ecosystemMap).toContainText('Exceptional (35.2% fork rate)')
-    await expect(ecosystemMap).toContainText('Exceptional (2.6% watcher rate)')
-    await expect(ecosystemMap).not.toContainText('classification is skipped')
+    await expect(ecosystemMap).toContainText('Exceptional 25%+')
+    await expect(ecosystemMap).toContainText('Exceptional 2.5%+')
+    await expect(ecosystemMap).not.toContainText('kubernetes/kubernetes')
+    await expect(ecosystemMap).not.toContainText('Spectrum profile')
   })
 })
 

--- a/e2e/metric-cards.spec.ts
+++ b/e2e/metric-cards.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('P1-F07 Metric Cards', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+
+    if ((await page.getByLabel(/github personal access token/i).count()) > 0) {
+      await page.getByLabel(/github personal access token/i).fill('ghp_example')
+    }
+  })
+
+  test('renders one overview card per successful repository with score badges', async ({ page }) => {
+    await page.route('**/api/analyze', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [
+            buildResult({ repo: 'facebook/react', stars: 244295, forks: 50872, watchers: 6660 }),
+            buildResult({ repo: 'kubernetes/kubernetes', stars: 121419, forks: 42757, watchers: 3181 }),
+          ],
+          failures: [],
+          rateLimit: null,
+        }),
+      })
+    })
+
+    await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react\nkubernetes/kubernetes')
+    await page.getByRole('button', { name: /analyze/i }).click()
+
+    const overview = page.getByRole('region', { name: /metric cards overview/i })
+    await expect(overview).toContainText('facebook/react')
+    await expect(overview).toContainText('kubernetes/kubernetes')
+    await expect(overview).toContainText('Ecosystem profile summary')
+    await expect(overview).toContainText('Evolution')
+    await expect(overview).toContainText('Contribution Dynamics')
+    await expect(overview).toContainText('Responsiveness')
+  })
+
+  test('expands a card in place without leaving the overview tab', async ({ page }) => {
+    let requestCount = 0
+
+    await page.route('**/api/analyze', async (route) => {
+      requestCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          results: [
+            buildResult({
+              repo: 'facebook/react',
+              stars: 244295,
+              forks: 50872,
+              watchers: 6660,
+              missingFields: ['releases12mo'],
+            }),
+          ],
+          failures: [],
+          rateLimit: null,
+        }),
+      })
+    })
+
+    await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react')
+    await page.getByRole('button', { name: /analyze/i }).click()
+    await page.getByRole('button', { name: /show details/i }).click()
+
+    const overview = page.getByRole('region', { name: /metric cards overview/i })
+    await expect(overview).toContainText('Full metric detail')
+    await expect(overview).toContainText('Primary language')
+    await expect(overview).toContainText('Missing fields')
+    expect(requestCount).toBe(1)
+  })
+})
+
+function buildResult(overrides: Record<string, unknown>) {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'A UI library',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 25,
+    watchers: 10,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 'unavailable',
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}

--- a/e2e/results-shell.spec.ts
+++ b/e2e/results-shell.spec.ts
@@ -54,9 +54,10 @@ test.describe('P1-F15 Results Shell', () => {
     await page.getByRole('button', { name: /analyze/i }).click()
 
     await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible()
-    await page.getByRole('tab', { name: 'Ecosystem Map' }).click()
     await expect(page.getByRole('region', { name: /ecosystem map/i })).toBeVisible()
     await expect(page.getByText(/ecosystem spectrum/i)).toBeVisible()
+    await page.getByRole('tab', { name: 'Comparison' }).click()
+    await expect(page.getByText(/comparison view is coming soon/i)).toBeVisible()
     await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible()
     await expect(page.getByRole('textbox', { name: /repository list/i })).toBeVisible()
     expect(requestCount).toBe(1)

--- a/lib/metric-cards/score-config.test.ts
+++ b/lib/metric-cards/score-config.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultScoreBadges, scoreToneClass } from './score-config'
+
+describe('score-config', () => {
+  it('returns one default badge per CHAOSS category', () => {
+    const badges = getDefaultScoreBadges()
+
+    expect(badges).toHaveLength(3)
+    expect(badges.map((badge) => badge.category)).toEqual([
+      'Evolution',
+      'Contribution Dynamics',
+      'Responsiveness',
+    ])
+    expect(badges.every((badge) => badge.value === 'Not scored yet')).toBe(true)
+  })
+
+  it('maps tones to consistent classes', () => {
+    expect(scoreToneClass('success')).toContain('emerald')
+    expect(scoreToneClass('warning')).toContain('amber')
+    expect(scoreToneClass('danger')).toContain('red')
+    expect(scoreToneClass('neutral')).toContain('slate')
+  })
+})

--- a/lib/metric-cards/score-config.ts
+++ b/lib/metric-cards/score-config.ts
@@ -1,0 +1,48 @@
+import type { ScoreBadgeProps, ScoreCategory, ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
+
+export interface ScoreBadgeDefinition extends ScoreBadgeProps {
+  description: string
+}
+
+const PENDING_VALUE: ScoreValue = 'Not scored yet'
+const PENDING_TONE: ScoreTone = 'neutral'
+
+export const SCORE_CATEGORIES: ScoreCategory[] = ['Evolution', 'Contribution Dynamics', 'Responsiveness']
+
+export const DEFAULT_SCORE_BADGES: ScoreBadgeDefinition[] = [
+  {
+    category: 'Evolution',
+    value: PENDING_VALUE,
+    tone: PENDING_TONE,
+    description: 'Score will populate when evolution scoring lands in P1-F08.',
+  },
+  {
+    category: 'Contribution Dynamics',
+    value: PENDING_VALUE,
+    tone: PENDING_TONE,
+    description: 'Score will populate when contribution dynamics scoring lands in P1-F09.',
+  },
+  {
+    category: 'Responsiveness',
+    value: PENDING_VALUE,
+    tone: PENDING_TONE,
+    description: 'Score will populate when responsiveness scoring lands in P1-F10.',
+  },
+]
+
+export function getDefaultScoreBadges(): ScoreBadgeDefinition[] {
+  return DEFAULT_SCORE_BADGES.map((badge) => ({ ...badge }))
+}
+
+export function scoreToneClass(tone: ScoreTone) {
+  switch (tone) {
+    case 'success':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-800'
+    case 'warning':
+      return 'border-amber-200 bg-amber-50 text-amber-800'
+    case 'danger':
+      return 'border-red-200 bg-red-50 text-red-800'
+    default:
+      return 'border-slate-200 bg-slate-50 text-slate-700'
+  }
+}

--- a/lib/metric-cards/view-model.test.ts
+++ b/lib/metric-cards/view-model.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { buildMetricCardViewModels } from './view-model'
+
+describe('buildMetricCardViewModels', () => {
+  it('builds formatted summary fields and explicit unavailable details', () => {
+    const card = buildMetricCardViewModels([
+      buildResult({
+        repo: 'facebook/react',
+        stars: 244295,
+        forks: 50872,
+        watchers: 6660,
+        primaryLanguage: 'unavailable',
+        releases12mo: 'unavailable',
+        missingFields: ['primaryLanguage', 'releases12mo'],
+      }),
+    ])[0]!
+
+    expect(card.repo).toBe('facebook/react')
+    expect(card.starsLabel).toBe('244,295')
+    expect(card.createdAtLabel).toBe('May 24, 2013')
+    expect(card.primaryLanguage).toBe('unavailable')
+    expect(card.profile?.reachTier).toBe('Exceptional')
+    expect(card.scoreBadges).toHaveLength(3)
+    expect(card.details.find((detail) => detail.label === 'Releases (12mo)')?.value).toBe('unavailable')
+  })
+})
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'The library for web and native user interfaces.',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 25,
+    watchers: 10,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 'unavailable',
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}

--- a/lib/metric-cards/view-model.ts
+++ b/lib/metric-cards/view-model.ts
@@ -1,0 +1,85 @@
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { buildEcosystemRows } from '@/lib/ecosystem-map/chart-data'
+import { getDefaultScoreBadges, type ScoreBadgeDefinition } from './score-config'
+
+export interface MetricCardViewModel {
+  repo: string
+  name: string
+  createdAtLabel: string
+  starsLabel: string
+  forksLabel: string
+  watchersLabel: string
+  description: string
+  primaryLanguage: string
+  details: Array<{ label: string; value: string }>
+  missingFields: string[]
+  profile: ReturnType<typeof buildEcosystemRows>[number]['profile']
+  scoreBadges: ScoreBadgeDefinition[]
+}
+
+export function buildMetricCardViewModels(results: AnalysisResult[]): MetricCardViewModel[] {
+  const ecosystemRows = new Map(buildEcosystemRows(results).map((row) => [row.repo, row]))
+
+  return results.map((result) => {
+    const ecosystemRow = ecosystemRows.get(result.repo)
+
+    return {
+      repo: result.repo,
+      name: formatText(result.name, result.repo),
+      createdAtLabel: formatDate(result.createdAt),
+      starsLabel: formatMetric(result.stars),
+      forksLabel: formatMetric(result.forks),
+      watchersLabel: formatMetric(result.watchers),
+      description: formatText(result.description),
+      primaryLanguage: formatText(result.primaryLanguage),
+      details: [
+        { label: 'Primary language', value: formatText(result.primaryLanguage) },
+        { label: 'Description', value: formatText(result.description) },
+        { label: 'Created', value: formatDate(result.createdAt) },
+        { label: 'Commits (30d)', value: formatMetric(result.commits30d) },
+        { label: 'Commits (90d)', value: formatMetric(result.commits90d) },
+        { label: 'Releases (12mo)', value: formatMetric(result.releases12mo) },
+        { label: 'PRs opened (90d)', value: formatMetric(result.prsOpened90d) },
+        { label: 'PRs merged (90d)', value: formatMetric(result.prsMerged90d) },
+        { label: 'Open issues', value: formatMetric(result.issuesOpen) },
+        { label: 'Issues closed (90d)', value: formatMetric(result.issuesClosed90d) },
+        { label: 'Active contributors (90d)', value: formatMetric(result.uniqueCommitAuthors90d) },
+        { label: 'Total contributors', value: formatMetric(result.totalContributors) },
+      ],
+      missingFields: result.missingFields,
+      profile: ecosystemRow?.profile ?? null,
+      scoreBadges: getDefaultScoreBadges(),
+    }
+  })
+}
+
+function formatMetric(value: number | 'unavailable') {
+  if (typeof value === 'number') {
+    return new Intl.NumberFormat('en-US').format(value)
+  }
+
+  return value
+}
+
+function formatText(value: string | 'unavailable', fallback = 'unavailable') {
+  if (value === 'unavailable' || value.trim().length === 0) {
+    return fallback
+  }
+
+  return value
+}
+
+function formatDate(value: string | 'unavailable') {
+  if (value === 'unavailable') {
+    return value
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+  }).format(date)
+}

--- a/lib/results-shell/tabs.ts
+++ b/lib/results-shell/tabs.ts
@@ -5,13 +5,7 @@ export const resultTabs: ResultTabDefinition[] = [
     id: 'overview',
     label: 'Overview',
     status: 'implemented',
-    description: 'Current analysis summary and shared status',
-  },
-  {
-    id: 'ecosystem-map',
-    label: 'Ecosystem Map',
-    status: 'placeholder',
-    description: 'Ecosystem map view is coming soon.',
+    description: 'Current analysis summary, ecosystem profile, and shared status',
   },
   {
     id: 'comparison',

--- a/specs/006-results-shell/contracts/results-shell-props.ts
+++ b/specs/006-results-shell/contracts/results-shell-props.ts
@@ -1,6 +1,6 @@
 import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 
-export type ResultTabId = 'overview' | 'ecosystem-map' | 'comparison' | 'metrics'
+export type ResultTabId = 'overview' | 'comparison' | 'metrics'
 
 export interface ResultsShellProps {
   hasServerToken: boolean

--- a/specs/008-metric-cards/checklists/manual-testing.md
+++ b/specs/008-metric-cards/checklists/manual-testing.md
@@ -1,0 +1,40 @@
+# Manual Testing Checklist: Metric Cards (P1-F07)
+
+**Purpose**: Verify metric-card behaviour manually before PR submission  
+**Feature**: [spec.md](../spec.md)
+
+## Setup
+
+- [x] Confirm an available token source exists (`.env.local` with `GITHUB_TOKEN` or a valid PAT entered in the UI)
+- [x] Run `npm run dev` and confirm the app starts
+- [x] Open `http://localhost:3000` in a browser
+
+## US1 — Summary cards
+
+- [x] Submit one valid public repository and confirm one overview card appears with stars, forks, watchers, created date, and ecosystem profile summary
+- [x] Submit multiple valid public repositories and confirm one overview card appears per successful repository
+- [x] Confirm failed repositories do not produce fabricated overview cards
+
+## US2 — CHAOSS score badges
+
+- [x] Confirm each overview card shows one placeholder badge for Evolution, Contribution Dynamics, and Responsiveness
+- [x] Confirm each placeholder badge shows the CHAOSS category label along with the interim value `Not scored yet`
+- [x] Confirm placeholder badge styling stays consistent across the three CHAOSS categories
+
+## US3 — Expandable repo detail
+
+- [x] Confirm a repo card can be expanded in place without leaving the `Overview` tab
+- [x] Confirm expanding or collapsing a card does not rerun analysis or trigger a new request
+- [x] Confirm expanded detail reveals fuller repo-specific metrics while preserving the rest of the workspace
+
+## US4 — Explicit unavailable values
+
+- [x] Confirm unavailable values remain explicitly marked in the summary card or expanded detail rather than hidden or guessed
+- [x] Confirm ecosystem profile tiers reuse the same Reach / Builder Engagement / Attention semantics already shown in the overview spectrum section
+- [x] Confirm multiple expanded cards remain usable in the current layout without breaking the shell
+
+## Notes
+
+_Sign off below when all items are verified:_
+
+**Tested by**: Arun Gupta  **Date**: 2026-04-01

--- a/specs/008-metric-cards/checklists/requirements.md
+++ b/specs/008-metric-cards/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Metric Cards
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-01  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details leak beyond the accepted product contract
+- [x] Focused on user value and card behavior
+- [x] Written clearly enough for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria stay focused on observable outcomes
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover the primary repo-card flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] The spec stays aligned with `P1-F07` in `docs/PRODUCT.md`
+
+## Notes
+
+- Ready for `/speckit.plan`.

--- a/specs/008-metric-cards/contracts/metric-card-props.ts
+++ b/specs/008-metric-cards/contracts/metric-card-props.ts
@@ -1,0 +1,32 @@
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { AttentionTier, EngagementTier, ReachTier } from '@/lib/ecosystem-map/spectrum-config'
+
+export type ScoreValue = 'High' | 'Medium' | 'Low' | 'Not scored yet'
+export type ScoreTone = 'success' | 'warning' | 'danger' | 'neutral'
+export type ScoreCategory = 'Evolution' | 'Contribution Dynamics' | 'Responsiveness'
+
+export interface ScoreBadgeProps {
+  category: ScoreCategory
+  value: ScoreValue
+  tone: ScoreTone
+}
+
+export interface MetricCardProfile {
+  reachTier: ReachTier
+  builderEngagementTier: EngagementTier
+  builderEngagementRate: number | 'unavailable'
+  attentionTier: AttentionTier
+  attentionRate: number | 'unavailable'
+}
+
+export interface MetricCardProps {
+  result: AnalysisResult
+  profile: MetricCardProfile
+  scoreBadges: ScoreBadgeProps[]
+  expanded: boolean
+  onToggle: () => void
+}
+
+export interface MetricCardsOverviewProps {
+  results: AnalysisResult[]
+}

--- a/specs/008-metric-cards/contracts/overview-ui.md
+++ b/specs/008-metric-cards/contracts/overview-ui.md
@@ -1,0 +1,58 @@
+# Overview UI Contract: Metric Cards
+
+## Overview tab
+
+When one or more successful repositories exist:
+
+- render one summary card per successful repository
+- keep failed repositories in the existing failure section outside the cards
+- do not fabricate cards for failures
+
+When no successful repositories exist:
+
+- show the existing overview empty/error state
+- do not render placeholder repo cards
+
+## Summary card content
+
+Each collapsed card shows:
+
+- repository slug/name
+- exact stars
+- exact forks
+- exact watches/watchers
+- created date
+- ecosystem profile summary:
+  - Reach
+  - Builder Engagement
+  - Attention
+- three CHAOSS score badges:
+  - Evolution
+  - Contribution Dynamics
+  - Responsiveness
+
+## Score badge behavior
+
+- badges must always show category label + score value
+- badge colors remain consistent across all cards
+- if a real category score is not yet available, the badge shows `Not scored yet`
+
+## Expansion behavior
+
+Clicking the card or its expand control:
+
+- reveals fuller metric detail in place
+- does not rerun analysis
+- does not change tabs
+- keeps unavailable values explicit
+
+Expanded detail should prefer existing `AnalysisResult` fields such as:
+
+- description
+- primary language
+- created date
+- commit counts
+- PR counts
+- issue counts
+- contributor counts
+- missing-field list when helpful

--- a/specs/008-metric-cards/data-model.md
+++ b/specs/008-metric-cards/data-model.md
@@ -1,0 +1,96 @@
+# Data Model: Metric Cards
+
+## 1. RepoCardViewModel
+
+The overview-tab representation of one successful repository.
+
+### Fields
+
+- `repo`: canonical `owner/name` slug
+- `name`: repository display name or `"unavailable"`
+- `description`: repository description or `"unavailable"`
+- `createdAt`: ISO timestamp or `"unavailable"`
+- `createdAtDisplay`: formatted display string or `"unavailable"`
+- `stars`: exact count or `"unavailable"`
+- `forks`: exact count or `"unavailable"`
+- `watchers`: exact count or `"unavailable"`
+- `ecosystemProfile`:
+  - `reachTier`
+  - `builderEngagementTier`
+  - `builderEngagementRate`
+  - `attentionTier`
+  - `attentionRate`
+- `scoreBadges`: array of `ScoreBadgeModel`
+- `expandedDetail`: `ExpandedRepoDetail`
+- `missingFields`: exact missing-data list from `AnalysisResult`
+
+### Source
+
+Built entirely from one `AnalysisResult` plus shared config.
+
+## 2. ScoreBadgeModel
+
+The compact display contract for one CHAOSS-aligned summary badge on a card.
+
+### Fields
+
+- `category`: one of:
+  - `Evolution`
+  - `Contribution Dynamics`
+  - `Responsiveness`
+- `value`: one of:
+  - `High`
+  - `Medium`
+  - `Low`
+  - `Not scored yet`
+- `tone`: one of:
+  - `success`
+  - `warning`
+  - `danger`
+  - `neutral`
+- `shortLabel`: compact visible label for card use
+
+### Source
+
+For `P1-F07`, real values may not yet exist. The card model must therefore support explicit interim `Not scored yet` values without guessing.
+
+## 3. ExpandedRepoDetail
+
+The in-place, expanded view for one metric card.
+
+### Fields
+
+- `primaryLanguage`
+- `description`
+- `createdAt`
+- `commits30d`
+- `commits90d`
+- `releases12mo`
+- `prsOpened90d`
+- `prsMerged90d`
+- `issuesOpen`
+- `issuesClosed90d`
+- `uniqueCommitAuthors90d`
+- `totalContributors`
+- `missingFields`
+
+### Behavior
+
+- Uses only values already present in `AnalysisResult`
+- Keeps `"unavailable"` explicit
+- Does not trigger new requests
+
+## 4. OverviewCardsState
+
+Client-only UI state for the `Overview` tab.
+
+### Fields
+
+- `expandedRepos`: set of repo slugs currently expanded
+- `selectedTab`: already managed by the existing results shell
+
+### Behavior
+
+- Expansion state is local to the current analysis view
+- Changing tabs must not rerun analysis
+- Replacing analysis results resets card expansion safely

--- a/specs/008-metric-cards/plan.md
+++ b/specs/008-metric-cards/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Metric Cards
+
+**Branch**: `008-metric-cards` | **Date**: 2026-04-01 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/008-metric-cards/spec.md`
+
+## Summary
+
+Turn the current lightweight `Overview` tab into a true repo-card summary layer. Each successful repository will render as a scannable card that reuses the existing ecosystem spectrum profile, shows exact repo metadata and key counters, and introduces consistent CHAOSS score-badge slots for Evolution, Contribution Dynamics, and Responsiveness without rerunning analysis.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5, React 19, Next.js 16.2 (App Router)  
+**Primary Dependencies**: Next.js 16.2, Tailwind CSS 4, Vitest 4, React Testing Library 16, Playwright 1.58, Chart.js 4, react-chartjs-2 5  
+**Storage**: Stateless; no database or persistent server storage  
+**Testing**: Vitest + React Testing Library (unit/integration), Playwright (E2E), manual verification  
+**Target Platform**: Vercel-hosted Next.js web app, modern desktop/mobile browsers  
+**Project Type**: Web application with server-side API routes and client-side analysis UI  
+**Performance Goals**: Card expansion must be local UI state only; no additional analysis request or extra API calls  
+**Constraints**: Reuse existing `AnalysisResult` and `P1-F05` spectrum logic; keep unavailable values explicit; badge thresholds/config must remain centralized; do not block later scoring features (`P1-F08` to `P1-F10`)  
+**Scale/Scope**: Overview-tab refactor, reusable repo-card components, interim score-badge contract, tests/manual checklist/docs
+
+## Constitution Check
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| I / Phase 1 stack | PASS | Stays within existing Next.js / React / Tailwind stack |
+| II / Honest data only | PASS | Cards surface exact values or explicit unavailable markers only |
+| III / Shared analyzer outputs | PASS | Reuses existing `AnalysisResult` output without feature-specific analyzer forking |
+| V / CHAOSS alignment | PASS | Badges are framed as CHAOSS category summaries and can host real scores as later features land |
+| VIII / Config-driven thresholds | PASS | Ecosystem tiers remain config-driven; score-badge semantics will use a shared config contract |
+| XI — TDD mandatory | PASS | New overview card behavior gets focused component tests before implementation completion |
+| XII / XIII — DoD and workflow | PASS | Manual checklist will be created during planning and completed before PR |
+
+**Gate result**: PASS — no constitution violations identified.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-metric-cards/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── metric-card-props.ts
+│   └── overview-ui.md
+├── checklists/
+│   ├── requirements.md
+│   └── manual-testing.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+components/
+├── repo-input/
+│   ├── RepoInputClient.tsx                  ← replace lightweight overview rows with metric-card view
+│   └── RepoInputClient.test.tsx             ← integration coverage for overview-tab cards/expansion
+├── ecosystem-map/
+│   └── EcosystemMap.tsx                     ← source of reused spectrum profile semantics only
+└── metric-cards/
+    ├── MetricCard.tsx                       ← new summary/expandable card component
+    ├── MetricCardsOverview.tsx              ← new overview-tab card collection
+    ├── ScoreBadge.tsx                       ← new CHAOSS badge primitive
+    └── *.test.tsx                           ← focused tests for cards and badges
+
+lib/
+├── analyzer/
+│   └── analysis-result.ts                   ← existing contract reused directly
+├── ecosystem-map/
+│   └── spectrum-config.ts                   ← reused for profile tiers and legends
+└── metric-cards/
+    ├── score-config.ts                      ← new color/label config for score badges
+    └── view-model.ts                        ← new card view-model helpers and expansion-safe formatting
+
+e2e/
+└── metric-cards.spec.ts                     ← new end-to-end coverage for overview cards
+```
+
+## Implementation Sequence
+
+### Phase 0 — Research
+
+1. Confirm which overview data already exists in `AnalysisResult` and which values must remain explicitly unavailable
+2. Define how score badges should behave before `P1-F08`–`P1-F10` provide real computed scores
+3. Confirm which existing spectrum-profile helpers from `P1-F05` should be reused rather than reimplemented
+
+### Phase 1 — Design
+
+4. Define the repo-card view model, including exact summary fields, derived ecosystem profile tiers, and expanded-detail content
+5. Define the score-badge contract for Evolution, Contribution Dynamics, and Responsiveness with explicit interim semantics
+6. Define the overview-tab UI contract for collapsed vs expanded cards and failure handling
+7. Create the manual testing checklist for one-repo, multi-repo, unavailable-data, and card-expansion scenarios
+
+### Phase 2 — Implementation Preview
+
+8. Replace the current lightweight overview result list with reusable metric cards
+9. Add consistent ecosystem profile badges and CHAOSS score badges to each card
+10. Add in-place expansion behavior that reveals fuller repo detail without extra requests
+11. Update README/docs only if the overview experience changes user-visible behavior enough to need it
+12. Finish automated verification and manual signoff
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification required.

--- a/specs/008-metric-cards/quickstart.md
+++ b/specs/008-metric-cards/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart: Metric Cards
+
+## Goal
+
+Verify that the `Overview` tab renders one expandable metric card per successful repository and reuses the current ecosystem spectrum profile consistently.
+
+## Local verification flow
+
+1. Start the app:
+
+   ```bash
+   npm run dev
+   ```
+
+2. Open `http://localhost:3000`
+3. Provide a valid token source:
+   - set `GITHUB_TOKEN` in `.env.local`, or
+   - enter a valid PAT in the UI
+4. Submit one or more public repositories such as:
+
+   ```text
+   facebook/react
+   kubernetes/kubernetes
+   ```
+
+## Expected behavior
+
+- the `Overview` tab shows one card per successful repository
+- each card shows exact stars, forks, watchers, created date, and the ecosystem profile summary
+- each card shows three CHAOSS score badges with consistent color semantics
+- expanding a card reveals fuller metric detail without rerunning analysis
+- unavailable values remain explicit
+
+## Verification commands
+
+```bash
+npm test
+npm run lint
+npm run test:e2e
+```

--- a/specs/008-metric-cards/research.md
+++ b/specs/008-metric-cards/research.md
@@ -1,0 +1,39 @@
+# Research: Metric Cards
+
+## Decision 1: Reuse `AnalysisResult` directly for card content
+
+- **Decision**: Build metric cards from the existing `AnalysisResult` contract rather than creating a parallel feature-specific payload.
+- **Rationale**: The analyzer output is already the shared source of truth for Phase 1. Reusing it keeps the overview cards honest and prevents drift between the overview, ecosystem, and later metric views.
+- **Alternatives considered**:
+  - Introduce a card-specific API response shape: rejected because it would duplicate analyzer output and increase drift risk.
+  - Hide unavailable values from cards: rejected because the constitution requires explicit missing-data handling rather than omission.
+
+## Decision 2: Use explicit interim CHAOSS score-badge semantics
+
+- **Decision**: `P1-F07` will introduce the badge shell and color semantics now, with an explicit `Not scored yet` state until `P1-F08`–`P1-F10` provide real score computation.
+- **Rationale**: The product contract requires the cards to host one badge per CHAOSS category. Shipping the card shell now keeps the overview stable while avoiding fabricated or premature category scores.
+- **Alternatives considered**:
+  - Omit score badges until later features land: rejected because it would leave `P1-F07` incomplete relative to the product contract.
+  - Invent provisional score logic inside `P1-F07`: rejected because scoring belongs to the dedicated features and would violate separation of concerns.
+
+## Decision 3: Reuse the `P1-F05` ecosystem spectrum profile
+
+- **Decision**: Each card will summarize ecosystem using the existing three dimensions: Reach, Builder Engagement, and Attention.
+- **Rationale**: The user already sees and understands these dimensions in the `Ecosystem Map` tab. Reusing them makes the overview and ecosystem views consistent.
+- **Alternatives considered**:
+  - Create a card-only ecosystem summary: rejected because it would fragment the meaning of ecosystem health across tabs.
+  - Collapse the profile to a single badge: rejected because the product doc explicitly calls for the three-part profile summary.
+
+## Decision 4: Expansion remains local UI state only
+
+- **Decision**: Expanding a card will reveal more exact `AnalysisResult` fields already present in memory; no API calls or tab navigation will occur.
+- **Rationale**: This preserves the results-shell promise that one analysis run powers multiple views without rerunning work.
+- **Alternatives considered**:
+  - Lazy-load detailed metrics when a card expands: rejected because it would add a second request path and complicate missing-data handling.
+
+## Decision 5: Keep thresholds and badge semantics in shared config
+
+- **Decision**: Ecosystem tier definitions continue to come from `lib/ecosystem-map/spectrum-config.ts`, and score-badge display semantics will live in a dedicated metric-card config module.
+- **Rationale**: The constitution explicitly requires thresholds and score semantics to be config-driven, not scattered through components.
+- **Alternatives considered**:
+  - Hardcode colors/titles inside each card component: rejected because it would make future scoring features harder to keep consistent.

--- a/specs/008-metric-cards/spec.md
+++ b/specs/008-metric-cards/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Metric Cards
+
+**Feature Branch**: `008-metric-cards`  
+**Created**: 2026-04-01  
+**Status**: Draft  
+**Input**: User description: "P1-F07 Metric Cards"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Scan key repo health signals quickly (Priority: P1)
+
+A user can see one summary card per successfully analyzed repository so the most important repo signals are readable at a glance without switching tabs or opening a comparison table.
+
+**Why this priority**: This is the first user-facing summary layer for per-repo analysis and gives immediate value even before deeper score features are fully implemented.
+
+**Independent Test**: Can be fully tested by supplying one or more successful `AnalysisResult` objects and confirming one card appears per repo with stars, forks, watches, created date, and the current ecosystem profile summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** one successful repository has been analyzed, **When** the overview is shown, **Then** one summary card appears for that repo with stars, forks, watches, created date, and ecosystem profile summary.
+2. **Given** multiple successful repositories have been analyzed, **When** the overview is shown, **Then** one summary card appears for each successful repository.
+3. **Given** one or more repositories failed during analysis, **When** the overview is shown, **Then** only successful repositories produce summary cards and failed repositories do not create fabricated card content.
+
+---
+
+### User Story 2 - Understand CHAOSS-aligned score badges per repo (Priority: P2)
+
+A user can see one score badge per CHAOSS category on each repo card so the repo’s health framing is visible without opening the detailed metrics views.
+
+**Why this priority**: The metric cards become much more useful when they summarize the cross-category health framing, but they still depend on the earlier card shell being present first.
+
+**Independent Test**: Can be fully tested by rendering repo cards with score values for Evolution, Contribution Dynamics, and Responsiveness and confirming the badges show the expected labels and color semantics, including the interim `Not scored yet` state before later scoring features land.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo card is rendered with Evolution, Contribution Dynamics, and Responsiveness scores, **When** the user views the card, **Then** one badge appears for each CHAOSS category.
+2. **Given** a score badge is shown, **When** the user inspects it, **Then** the CHAOSS category label is displayed alongside or beneath the score so the framing is explicit.
+3. **Given** score values of High, Medium, Low, or Not scored yet exist, **When** badges are rendered, **Then** they use a consistent visual treatment that matches the score semantics.
+
+---
+
+### User Story 3 - Expand a card to inspect repo detail (Priority: P3)
+
+A user can click or expand a repo card to reveal fuller metric detail for that repository without leaving the current analysis workspace.
+
+**Why this priority**: Expansion makes the cards more useful as a gateway into deeper repo detail, but it depends on the summary-card structure and badge framing already existing.
+
+**Independent Test**: Can be fully tested by rendering a repo card, expanding it, and confirming fuller repo-specific detail becomes visible while the rest of the analysis workspace remains intact.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo summary card is shown, **When** the user clicks or expands the card, **Then** fuller metric detail for that repo becomes visible in place.
+2. **Given** a repo card is expanded, **When** the user returns it to its collapsed state, **Then** the summary card remains intact and no analysis request is rerun.
+3. **Given** a repo has unavailable metrics, **When** the expanded detail is shown, **Then** unavailable values remain explicitly marked rather than hidden or guessed.
+
+### Edge Cases
+
+- What happens when no successful repositories exist in the current analysis?
+- What happens when a repo card must show score badges before later features have full scoring logic available?
+- What happens when a repo contains unavailable values for fields shown in the card or expanded detail?
+- What happens when multiple repo cards are expanded in a mobile-width layout?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST render one summary card per successful repository in the current analysis.
+- **FR-002**: Each summary card MUST show exact stars, forks, watches, created date, and ecosystem profile summary for that repository.
+- **FR-003**: Ecosystem profile badges on the card MUST use consistent visual treatment across Reach, Builder Engagement, and Attention tiers.
+- **FR-004**: Each summary card MUST surface one badge for each CHAOSS category represented by later scoring features: Evolution, Contribution Dynamics, and Responsiveness.
+- **FR-005**: Score badge colors MUST map consistently to High, Medium, Low, and Not scored yet.
+- **FR-006**: Each score badge MUST display the associated CHAOSS category label so the framing is always visible.
+- **FR-007**: Users MUST be able to click or expand a repo card to reveal fuller metric detail for that repository.
+- **FR-008**: Expanding or collapsing a repo card MUST NOT rerun the analysis request or trigger extra API calls.
+- **FR-009**: Failed repositories MUST NOT render summary cards.
+- **FR-010**: Unavailable metrics shown in the card or expanded detail MUST remain explicit and MUST NOT be hidden, zeroed, or guessed.
+
+### Key Entities
+
+- **Repo Summary Card**: The overview-level UI representation of one successful repository with key metrics, ecosystem profile badges, and CHAOSS score badges.
+- **Score Badge**: A compact, color-coded UI element representing one CHAOSS category score and label.
+- **Expanded Repo Detail**: The additional in-place card content that appears when a repo card is expanded.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For analyses with one or more successful repositories, 100% of successful repositories render exactly one summary card in the overview.
+- **SC-002**: For rendered score badges, 100% of badges show both the score value and CHAOSS category label with consistent color semantics.
+- **SC-003**: Users can expand a repo card and view fuller metric detail without triggering additional analysis requests.
+- **SC-004**: Unavailable values shown in cards or expanded details remain explicit in 100% of tested missing-data scenarios.
+
+## Assumptions
+
+- `P1-F05 Ecosystem Map` already provides the ecosystem profile summary values that metric cards can reuse.
+- Full score computation for Evolution, Contribution Dynamics, and Responsiveness may be implemented incrementally, but the card contract should be ready to host those badges consistently.
+- The cards live within the existing `P1-F15` results shell rather than introducing a new page layout.
+- Comparison-table behavior remains out of scope for this feature and will still be handled later by `P1-F06`.

--- a/specs/008-metric-cards/tasks.md
+++ b/specs/008-metric-cards/tasks.md
@@ -1,0 +1,172 @@
+# Tasks: Metric Cards (P1-F07)
+
+**Branch**: `008-metric-cards`  
+**Input**: `specs/008-metric-cards/` (spec.md, plan.md, research.md, data-model.md, contracts/, quickstart.md)  
+**Prerequisites**: `plan.md` (required), `spec.md` (required for user stories), `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Required. The constitution requires TDD, so tests and verification tasks MUST be defined before implementation is considered complete.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (for example, `US1`, `US2`)
+- Include exact file paths in every task description
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the overview-card workspace and identify existing overview/ecosystem touchpoints to replace safely.
+
+- [x] T001 Create `/Users/arungupta/workspaces/forkprint/specs/008-metric-cards/tasks.md`
+- [x] T002 [P] Review `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx`, `/Users/arungupta/workspaces/forkprint/components/ecosystem-map/EcosystemMap.tsx`, and `/Users/arungupta/workspaces/forkprint/docs/PRODUCT.md` for metric-card integration requirements
+- [x] T003 [P] Review `/Users/arungupta/workspaces/forkprint/lib/analyzer/analysis-result.ts`, `/Users/arungupta/workspaces/forkprint/lib/ecosystem-map/spectrum-config.ts`, and existing overview tests for reusable card inputs and unavailable-value handling
+
+**Checkpoint**: Overview-tab touchpoints and reusable spectrum/analyzer contracts are identified.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define the reusable view-model and score-badge foundations before card UI implementation.
+
+**⚠️ CRITICAL**: No user story implementation should start until this phase is complete.
+
+- [x] T004 Create `/Users/arungupta/workspaces/forkprint/lib/metric-cards/view-model.ts` with helpers that derive card-ready fields and preserve explicit unavailable values from `/Users/arungupta/workspaces/forkprint/lib/analyzer/analysis-result.ts`
+- [x] T005 [P] Create `/Users/arungupta/workspaces/forkprint/lib/metric-cards/score-config.ts` with config-driven badge labels, tones, and interim `Insufficient verified public data` semantics
+- [x] T006 [P] Add focused tests for `/Users/arungupta/workspaces/forkprint/lib/metric-cards/view-model.ts` and `/Users/arungupta/workspaces/forkprint/lib/metric-cards/score-config.ts`
+
+**Checkpoint**: Card data shaping and score-badge semantics are centralized and test-covered.
+
+---
+
+## Phase 3: User Story 1 - Scan key repo health signals quickly (Priority: P1) 🎯 MVP
+
+**Goal**: A user can see one summary card per successful repository in the `Overview` tab with exact key signals and the current ecosystem profile summary.
+
+**Independent Test**: Supply one or more successful `AnalysisResult` objects and confirm one card appears per repo with stars, forks, watches, created date, and the current ecosystem profile summary.
+
+### Tests for User Story 1 ⚠️
+
+> **Write these tests first, and verify they fail before implementing the story.**
+
+- [x] T007 [P] [US1] Add component tests in `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCard.test.tsx` for summary rendering of stars, forks, watches, created date, and ecosystem profile badges
+- [x] T008 [P] [US1] Add collection tests in `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCardsOverview.test.tsx` for one-card-per-successful-repo behavior and failure exclusion
+- [x] T009 [US1] Extend `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.test.tsx` to verify the `Overview` tab renders metric cards instead of the old lightweight result rows
+
+### Implementation for User Story 1
+
+- [x] T010 [US1] Create `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCard.tsx` with the collapsed summary-card UI
+- [x] T011 [US1] Create `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCardsOverview.tsx` to render one card per successful repository and no fabricated cards for failures
+- [x] T012 [US1] Update `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.tsx` to replace the current overview result list with `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCardsOverview.tsx`
+
+**Checkpoint**: The `Overview` tab shows one summary card per successful repository with exact key repo signals.
+
+---
+
+## Phase 4: User Story 2 - Understand CHAOSS-aligned score badges per repo (Priority: P2)
+
+**Goal**: Each metric card surfaces one consistent score badge for Evolution, Contribution Dynamics, and Responsiveness.
+
+**Independent Test**: Render repo cards with score values for Evolution, Contribution Dynamics, and Responsiveness and confirm the badges show the expected labels and color semantics.
+
+### Tests for User Story 2 ⚠️
+
+> **Write these tests first, and verify they fail before implementing the story.**
+
+- [x] T013 [P] [US2] Add focused badge tests in `/Users/arungupta/workspaces/forkprint/components/metric-cards/ScoreBadge.test.tsx` for category labels, values, and High/Medium/Low/Insufficient color semantics
+- [x] T014 [P] [US2] Extend `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCard.test.tsx` to verify three CHAOSS badges render on each card
+- [x] T015 [US2] Add or update manual verification steps for score badges in `/Users/arungupta/workspaces/forkprint/specs/008-metric-cards/checklists/manual-testing.md`
+
+### Implementation for User Story 2
+
+- [x] T016 [US2] Create `/Users/arungupta/workspaces/forkprint/components/metric-cards/ScoreBadge.tsx` using `/Users/arungupta/workspaces/forkprint/lib/metric-cards/score-config.ts`
+- [x] T017 [US2] Update `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCard.tsx` to render Evolution, Contribution Dynamics, and Responsiveness badges with explicit category labels
+
+**Checkpoint**: Each metric card clearly frames repo health with consistent CHAOSS-aligned score badges.
+
+---
+
+## Phase 5: User Story 3 - Expand a card to inspect repo detail (Priority: P3)
+
+**Goal**: A user can expand a card in place to inspect fuller repo detail without leaving the current workspace or rerunning analysis.
+
+**Independent Test**: Render a repo card, expand it, and confirm fuller repo-specific detail becomes visible while the rest of the analysis workspace remains intact.
+
+### Tests for User Story 3 ⚠️
+
+> **Write these tests first, and verify they fail before implementing the story.**
+
+- [x] T018 [P] [US3] Extend `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCard.test.tsx` to cover expand/collapse behavior and explicit unavailable-value rendering
+- [x] T019 [P] [US3] Extend `/Users/arungupta/workspaces/forkprint/components/repo-input/RepoInputClient.test.tsx` to verify card expansion does not rerun analysis or trigger extra requests
+- [x] T020 [US3] Add end-to-end coverage in `/Users/arungupta/workspaces/forkprint/e2e/metric-cards.spec.ts` for overview-card expansion in the shell
+
+### Implementation for User Story 3
+
+- [x] T021 [US3] Update `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCard.tsx` to support in-place expansion/collapse with fuller repo detail
+- [x] T022 [US3] Update `/Users/arungupta/workspaces/forkprint/components/metric-cards/MetricCardsOverview.tsx` to manage expansion state locally and safely for multiple cards
+
+**Checkpoint**: Metric cards expand in place, preserve explicit unavailable values, and do not rerun analysis.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, docs alignment, and manual signoff for the feature PR.
+
+- [x] T023 [P] Run unit/integration tests with `npm test`
+- [x] T024 [P] Run lint with `npm run lint`
+- [x] T025 [P] Run end-to-end coverage with `npm run test:e2e`
+- [x] T026 Run `npm run build` and verify whether metric-card work introduced any new regressions beyond the known environment/font issue
+- [x] T027 Update `/Users/arungupta/workspaces/forkprint/specs/008-metric-cards/checklists/manual-testing.md` as the feature is manually verified
+- [x] T028 Update `/Users/arungupta/workspaces/forkprint/README.md` if the overview/tab behavior or user-visible card experience needs documentation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies, can start immediately
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories
+- **User Stories (Phases 3-5)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all implemented stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Foundational and delivers the first user-visible repo-card value
+- **US2 (P2)**: Depends on the card shell from US1
+- **US3 (P3)**: Depends on the summary-card structure from US1 and works best once badge placement from US2 is stable
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel
+- T005 and T006 can run in parallel after the foundational helpers exist
+- T007 and T008 can run in parallel
+- T013 and T014 can run in parallel
+- T018 and T019 can run in parallel
+- T023, T024, and T025 can run in parallel
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate the overview-card experience before layering score badges and expansion detail
+
+### Incremental Delivery
+
+1. Replace the old overview rows with real metric cards
+2. Add CHAOSS-aligned score badges with explicit interim semantics
+3. Add in-place expansion for fuller repo detail
+4. Finish with verification and manual checklist completion
+
+### TDD Reminder
+
+Every test phase follows Red-Green-Refactor: write tests, verify failure, implement, then verify pass.


### PR DESCRIPTION
## Summary
- replace the old Overview rows with reusable metric cards for each successful repository
- add ecosystem profile summaries, placeholder CHAOSS score badges, and in-place expanded detail on each card
- simplify the results shell by folding the ecosystem legend into Overview and removing the duplicate ecosystem tab content
- update product docs, specs, tasks, and manual testing artifacts for the final P1-F07 behavior

## Verification
- `npm test`
- `npm run lint`
- `npm run test:e2e`
- manual checklist completed for `P1-F07`

## Notes
- local `npm run build` still hits the known `next/font/google` Geist font fetch issue in this environment
