### PR TITLE
Replace contributor heatmaps with bar charts

### DIFF
--- a/components/contributors/ContributionBarChart.tsx
+++ b/components/contributors/ContributionBarChart.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useMemo, useState, type ReactNode } from 'react'
+import type { ContributorHeatmapCell } from '@/lib/contributors/view-model'
+
+interface ContributionBarChartProps {
+  title: string
+  description: string
+  items: ContributorHeatmapCell[]
+  ariaLabel: string
+  emptyText: string
+  tone?: 'cyan' | 'amber'
+  defaultVisibleCount?: number
+  entityLabel: string
+  actions?: ReactNode
+  collapsed?: boolean
+  showLabels?: boolean
+  showValues?: boolean
+}
+
+export function ContributionBarChart({
+  title,
+  description,
+  items,
+  ariaLabel,
+  emptyText,
+  tone = 'cyan',
+  defaultVisibleCount = 12,
+  entityLabel,
+  actions,
+  collapsed = false,
+  showLabels = true,
+  showValues = true,
+}: ContributionBarChartProps) {
+  const [expanded, setExpanded] = useState(false)
+  const visibleItems = useMemo(() => {
+    if (expanded || items.length <= defaultVisibleCount) {
+      return items
+    }
+
+    return items.slice(0, defaultVisibleCount)
+  }, [defaultVisibleCount, expanded, items])
+
+  const maxCommits = items[0]?.commits ?? 0
+  const showToggle = items.length > defaultVisibleCount
+  const barToneClass =
+    tone === 'amber'
+      ? 'bg-gradient-to-r from-amber-200 via-amber-400 to-amber-700'
+      : 'bg-gradient-to-r from-cyan-200 via-cyan-400 to-cyan-700'
+
+  return (
+    <div className="mt-4 rounded-xl border border-slate-200 bg-white p-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 sm:max-w-2xl">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{title}</p>
+          <p className="mt-1 text-xs text-slate-500">{description}</p>
+        </div>
+        {actions ? <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end">{actions}</div> : null}
+      </div>
+
+      {collapsed ? null : items.length > 0 ? (
+        <>
+          <div className="mt-3 space-y-3" role="list" aria-label={ariaLabel}>
+            {visibleItems.map((item) => {
+              const barWidth = maxCommits > 0 ? (item.commits / maxCommits) * 100 : 0
+
+              return (
+                <div key={`${item.contributor}-${item.commitsLabel}`} role="listitem" className="space-y-1">
+                  <div className="flex items-baseline justify-between gap-3">
+                    {showLabels ? (
+                      <p className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900">{item.contributor}</p>
+                    ) : (
+                      <span className="min-w-0 flex-1" aria-hidden="true" />
+                    )}
+                    {showValues ? <p className="shrink-0 text-xs text-slate-500">{item.commitsLabel}</p> : null}
+                  </div>
+                  <div className="h-2 overflow-hidden rounded-full bg-slate-100" aria-label={`${item.contributor} ${item.commitsLabel}`}>
+                    <div className={`h-full rounded-full ${barToneClass}`} style={{ width: `${barWidth}%` }} />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          {showToggle ? (
+            <div className="mt-3 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setExpanded((current) => !current)}
+                className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                aria-pressed={expanded}
+              >
+                {expanded ? `Show fewer ${entityLabel}` : `Show all ${items.length} ${entityLabel}`}
+              </button>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <p className="mt-2 text-sm text-slate-600">{emptyText}</p>
+      )}
+    </div>
+  )
+}

--- a/components/contributors/ContributorsView.test.tsx
+++ b/components/contributors/ContributorsView.test.tsx
@@ -17,7 +17,7 @@ describe('ContributorsView', () => {
     expect(within(region).getByRole('heading', { name: /sustainability/i })).toBeInTheDocument()
     expect(within(corePane).getByText('Repeat contributor ratio')).toBeInTheDocument()
     expect(within(corePane).getByText('New contributor ratio')).toBeInTheDocument()
-    expect(within(corePane).getByText(/^Contribution heatmap$/i)).toBeInTheDocument()
+    expect(within(corePane).getByText(/^Contribution chart$/i)).toBeInTheDocument()
     expect(within(region).queryByText(/later sustainability signals/i)).not.toBeInTheDocument()
   })
 
@@ -38,12 +38,12 @@ describe('ContributorsView', () => {
       />,
     )
 
-    expect(screen.getByRole('button', { name: /include bots in heatmap/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /include bots in chart/i })).toBeInTheDocument()
     expect(screen.queryByLabelText(/dependabot\[bot\] 3 commits/i)).not.toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: /include bots in heatmap/i }))
+    await userEvent.click(screen.getByRole('button', { name: /include bots in chart/i }))
 
-    expect(screen.getByRole('button', { name: /exclude bots from heatmap/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /exclude bots from chart/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/dependabot\[bot\] 3 commits/i)).toBeInTheDocument()
   })
 
@@ -57,14 +57,12 @@ describe('ContributorsView', () => {
     expect(screen.getByText(/contributor metrics from verified public data for the last 30 days/i)).toBeInTheDocument()
   })
 
-  it('uses a mobile-friendly heatmap layout when names are shown', async () => {
+  it('renders the contribution chart in a mobile-friendly stacked layout', () => {
     render(<ContributorsView results={[buildResult()]} />)
 
-    await userEvent.click(screen.getByRole('button', { name: /show names/i }))
-
-    const heatmap = screen.getByRole('list', { name: /contribution heatmap tiles/i })
-    expect(heatmap.className).toContain('grid-cols-2')
-    expect(screen.getByText('alice')).toHaveClass('break-words')
+    const chart = screen.getByRole('list', { name: /contribution activity bars/i })
+    expect(chart.className).toContain('space-y-3')
+    expect(screen.getByText('alice')).toHaveClass('truncate')
   })
 })
 

--- a/components/contributors/CoreContributorsPane.test.tsx
+++ b/components/contributors/CoreContributorsPane.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { CoreContributorsPane } from './CoreContributorsPane'
 
 describe('CoreContributorsPane', () => {
-  it('renders the core contributor metrics and compact heatmap with optional names and numbers', async () => {
+  it('renders the core contributor metrics and contribution chart with optional names and numbers', async () => {
+    const onToggleIncludeBots = vi.fn()
+
     render(
       <CoreContributorsPane
         metrics={[
@@ -25,12 +27,12 @@ describe('CoreContributorsPane', () => {
           },
         ]}
         heatmap={[
-          { contributor: 'alice', commitsLabel: '5 commits', intensity: 'max' },
-          { contributor: 'bob', commitsLabel: '2 commits', intensity: 'medium' },
+          { contributor: 'alice', commits: 5, commitsLabel: '5 commits', intensity: 'max' },
+          { contributor: 'bob', commits: 2, commitsLabel: '2 commits', intensity: 'medium' },
         ]}
         windowDays={90}
         includeBots={false}
-        onToggleIncludeBots={() => {}}
+        onToggleIncludeBots={onToggleIncludeBots}
       />,
     )
 
@@ -49,25 +51,30 @@ describe('CoreContributorsPane', () => {
     expect(screen.getByText('One-time 2')).toBeInTheDocument()
     expect(screen.getByText('Inactive 7')).toBeInTheDocument()
     expect(screen.queryByText('Contribution concentration')).not.toBeInTheDocument()
-    expect(screen.getByText(/contribution heatmap/i)).toBeInTheDocument()
-    expect(screen.getByText(/darker bubbles indicate contributor activity in the last 90 days/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /include bots in heatmap/i })).toBeInTheDocument()
-    expect(screen.getByRole('list', { name: /contribution heatmap tiles/i })).toBeInTheDocument()
-    expect(screen.queryByText('alice')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /show names/i })).toBeInTheDocument()
+    expect(screen.getByText(/contribution chart/i)).toBeInTheDocument()
+    expect(screen.getByText(/longer bars indicate contributor activity in the last 90 days/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /include bots in chart/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hide names/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /show numbers/i })).toBeInTheDocument()
+    expect(screen.getByRole('list', { name: /contribution activity bars/i })).toBeInTheDocument()
+    expect(screen.getByText('alice')).toBeInTheDocument()
     expect(screen.getByLabelText(/alice 5 commits/i)).toBeInTheDocument()
     expect(screen.queryByText('5 commits')).not.toBeInTheDocument()
+    expect(screen.getByText('12')).toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: /show names/i }))
+    await userEvent.click(screen.getByRole('button', { name: /hide names/i }))
 
-    expect(screen.getByRole('button', { name: /hide names/i })).toBeInTheDocument()
-    expect(screen.getByText('alice')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /show names/i })).toBeInTheDocument()
+    expect(screen.queryByText('alice')).not.toBeInTheDocument()
+    expect(screen.queryByText(/contributor hidden/i)).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: /show numbers/i }))
 
     expect(screen.getByRole('button', { name: /hide numbers/i })).toBeInTheDocument()
     expect(screen.getByText('5 commits')).toBeInTheDocument()
-    expect(screen.getByText('12')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /include bots in chart/i }))
+
+    expect(onToggleIncludeBots).toHaveBeenCalledTimes(1)
   })
 })

--- a/components/contributors/CoreContributorsPane.tsx
+++ b/components/contributors/CoreContributorsPane.tsx
@@ -4,6 +4,7 @@ import type { ContributorWindowDays } from '@/lib/analyzer/analysis-result'
 import { useState } from 'react'
 import { HelpLabel } from '@/components/shared/HelpLabel'
 import type { ContributorHeatmapCell, ContributorMetricRow } from '@/lib/contributors/view-model'
+import { ContributionBarChart } from './ContributionBarChart'
 
 interface CoreContributorsPaneProps {
   metrics: ContributorMetricRow[]
@@ -14,9 +15,8 @@ interface CoreContributorsPaneProps {
 }
 
 export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots, onToggleIncludeBots }: CoreContributorsPaneProps) {
-  const [showNames, setShowNames] = useState(false)
+  const [showNames, setShowNames] = useState(true)
   const [showNumbers, setShowNumbers] = useState(false)
-  const compactMode = !showNames && !showNumbers
 
   return (
     <section aria-label="Core contributors pane" className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
@@ -74,26 +74,25 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
           </div>
         ))}
       </dl>
-      <div className="mt-4 rounded-xl border border-slate-200 bg-white p-3">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0 sm:max-w-md">
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Contribution heatmap</p>
-            <p className="mt-1 text-xs text-slate-500">
-              {`Darker bubbles indicate contributor activity in the last ${windowDays} days. Detected bot accounts like `}
-              <code>dependabot[bot]</code>
-              {' or '}
-              <code>k8s-ci-robot</code>
-              {' can be included here when needed.'}
-            </p>
-          </div>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-wrap sm:flex-row sm:items-center sm:justify-end">
+      <ContributionBarChart
+        title="Contribution chart"
+        description={`Longer bars indicate contributor activity in the last ${windowDays} days. Detected bot accounts like dependabot[bot] or k8s-ci-robot can be included here when needed.`}
+        items={heatmap}
+        ariaLabel="Contribution activity bars"
+        emptyText="unavailable"
+        tone="cyan"
+        entityLabel="contributors"
+        showLabels={showNames}
+        showValues={showNumbers}
+        actions={
+          <>
             <button
               type="button"
               onClick={onToggleIncludeBots}
               className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 sm:w-auto"
               aria-pressed={includeBots}
             >
-              {includeBots ? 'Exclude bots from heatmap' : 'Include bots in heatmap'}
+              {includeBots ? 'Exclude bots from chart' : 'Include bots in chart'}
             </button>
             <button
               type="button"
@@ -111,54 +110,9 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
             >
               {showNumbers ? 'Hide numbers' : 'Show numbers'}
             </button>
-          </div>
-        </div>
-        {heatmap.length > 0 ? (
-          <div
-            className={
-              compactMode
-                ? 'mt-3 flex flex-wrap gap-1'
-                : 'mt-3 grid grid-cols-2 gap-x-3 gap-y-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8'
-            }
-            role="list"
-            aria-label="Contribution heatmap tiles"
-          >
-            {heatmap.map((cell) => (
-              <div
-                key={`${cell.contributor}-${cell.commitsLabel}`}
-                role="listitem"
-                className={compactMode ? '' : 'flex min-w-0 flex-col items-center gap-1 text-center'}
-                title={`${cell.contributor}: ${cell.commitsLabel}`}
-              >
-                <div
-                  aria-label={`${cell.contributor} ${cell.commitsLabel}`}
-                  className={`rounded-full border transition ${
-                    compactMode ? 'h-[18px] w-[18px]' : 'h-5 w-5'
-                  } ${
-                    cell.intensity === 'max'
-                      ? 'border-cyan-950 bg-cyan-950'
-                      : cell.intensity === 'higher'
-                        ? 'border-cyan-800 bg-cyan-800'
-                        : cell.intensity === 'high'
-                          ? 'border-cyan-600 bg-cyan-600'
-                          : cell.intensity === 'medium'
-                            ? 'border-cyan-400 bg-cyan-400'
-                            : cell.intensity === 'low'
-                              ? 'border-cyan-200 bg-cyan-200'
-                              : 'border-cyan-100 bg-cyan-100'
-                  }`}
-                />
-                {showNames ? (
-                  <p className="max-w-full break-words text-[10px] font-medium leading-tight text-slate-700">{cell.contributor}</p>
-                ) : null}
-                {showNumbers ? <p className="max-w-full break-words text-[10px] leading-tight text-slate-500">{cell.commitsLabel}</p> : null}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="mt-2 text-sm text-slate-600">unavailable</p>
-        )}
-      </div>
+          </>
+        }
+      />
     </section>
   )
 }

--- a/components/contributors/SustainabilityPane.test.tsx
+++ b/components/contributors/SustainabilityPane.test.tsx
@@ -47,8 +47,8 @@ describe('SustainabilityPane', () => {
             },
           ],
           experimentalHeatmap: [
-            { contributor: 'meta', commitsLabel: '7 attributed commits', intensity: 'max' },
-            { contributor: 'openai', commitsLabel: '3 attributed commits', intensity: 'high' },
+            { contributor: 'meta', commits: 7, commitsLabel: '7 attributed commits', intensity: 'max' },
+            { contributor: 'openai', commits: 3, commitsLabel: '3 attributed commits', intensity: 'high' },
           ],
           experimentalWarning:
             'Best-effort estimate. Uses heuristic public GitHub organization attribution and may be incomplete or inaccurate.',
@@ -84,8 +84,10 @@ describe('SustainabilityPane', () => {
     expect(screen.getByText('2')).toBeInTheDocument()
     expect(screen.getByText('Single-vendor dependency ratio')).toBeInTheDocument()
     expect(screen.getByText('68.0%')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /show heatmap/i })).toBeInTheDocument()
-    expect(screen.queryByRole('list', { name: /attributed organization heatmap/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /show chart/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /hide names/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /show numbers/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('list', { name: /attributed organization bars/i })).not.toBeInTheDocument()
     expect(
       screen.getByLabelText(
         /Maintainer count\. 4 maintainers or owners parsed from supported public repository files such as OWNERS, MAINTAINERS, CODEOWNERS, or GOVERNANCE\.md\./i,
@@ -113,11 +115,25 @@ describe('SustainabilityPane', () => {
     expect(screen.getByRole('button', { name: /hide thresholds/i })).toBeInTheDocument()
     expect(screen.getByText(/broadly distributed across the most active authors/i)).toBeInTheDocument()
 
-    await userEvent.click(screen.getByRole('button', { name: /show heatmap/i }))
+    await userEvent.click(screen.getByRole('button', { name: /show chart/i }))
 
-    expect(screen.getByRole('button', { name: /hide heatmap/i })).toBeInTheDocument()
-    expect(screen.getByRole('list', { name: /attributed organization heatmap/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hide chart/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hide names/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /show numbers/i })).toBeInTheDocument()
+    expect(screen.getByRole('list', { name: /attributed organization bars/i })).toBeInTheDocument()
     expect(screen.getByLabelText(/meta 7 attributed commits/i)).toBeInTheDocument()
+    expect(screen.getByText('meta')).toBeInTheDocument()
+    expect(screen.queryByText('7 attributed commits')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /show numbers/i }))
+
+    expect(screen.getByRole('button', { name: /hide numbers/i })).toBeInTheDocument()
+    expect(screen.getByText('7 attributed commits')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /hide names/i }))
+
+    expect(screen.getByRole('button', { name: /show names/i })).toBeInTheDocument()
+    expect(screen.queryByText('meta')).not.toBeInTheDocument()
   })
 
   it('hides the missing-data panel when no fields are missing', () => {

--- a/components/contributors/SustainabilityPane.tsx
+++ b/components/contributors/SustainabilityPane.tsx
@@ -5,6 +5,7 @@ import { ScoreBadge } from '@/components/metric-cards/ScoreBadge'
 import { HelpLabel } from '@/components/shared/HelpLabel'
 import { SUSTAINABILITY_THRESHOLDS } from '@/lib/contributors/score-config'
 import type { ContributorsSectionViewModel } from '@/lib/contributors/view-model'
+import { ContributionBarChart } from './ContributionBarChart'
 
 interface SustainabilityPaneProps {
   section: ContributorsSectionViewModel
@@ -13,6 +14,8 @@ interface SustainabilityPaneProps {
 export function SustainabilityPane({ section }: SustainabilityPaneProps) {
   const [showThresholds, setShowThresholds] = useState(false)
   const [showExperimentalHeatmap, setShowExperimentalHeatmap] = useState(false)
+  const [showExperimentalNames, setShowExperimentalNames] = useState(true)
+  const [showExperimentalNumbers, setShowExperimentalNumbers] = useState(false)
 
   return (
     <section aria-label="Sustainability pane" className="rounded-2xl border border-slate-200 bg-white p-4">
@@ -110,52 +113,51 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
           ))}
         </dl>
         {section.experimentalHeatmap.length > 0 ? (
-          <div className="mt-3 rounded-xl border border-amber-200 bg-white p-3">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Attributed organization heatmap</p>
-                <p className="mt-1 text-xs text-slate-500">Darker bubbles indicate more experimentally attributed recent commits.</p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setShowExperimentalHeatmap((current) => !current)}
-                className="rounded-full border border-amber-200 px-3 py-1 text-xs font-medium text-amber-900 transition hover:border-amber-300"
-                aria-pressed={showExperimentalHeatmap}
-              >
-                {showExperimentalHeatmap ? 'Hide heatmap' : 'Show heatmap'}
-              </button>
-            </div>
-            {showExperimentalHeatmap ? (
-              <div className="mt-3 grid grid-cols-4 gap-x-2 gap-y-2 sm:grid-cols-6 lg:grid-cols-8" role="list" aria-label="Attributed organization heatmap">
-                {section.experimentalHeatmap.map((cell) => (
-                  <div
-                    key={`${cell.contributor}-${cell.commitsLabel}`}
-                    role="listitem"
-                    className="flex flex-col items-center gap-1"
-                    title={`${cell.contributor}: ${cell.commitsLabel}`}
-                  >
-                    <div
-                      aria-label={`${cell.contributor} ${cell.commitsLabel}`}
-                      className={`h-4 w-4 rounded-full border ${
-                        cell.intensity === 'max'
-                          ? 'border-amber-950 bg-amber-950'
-                          : cell.intensity === 'higher'
-                            ? 'border-amber-800 bg-amber-800'
-                            : cell.intensity === 'high'
-                              ? 'border-amber-600 bg-amber-600'
-                              : cell.intensity === 'medium'
-                                ? 'border-amber-400 bg-amber-400'
-                                : cell.intensity === 'low'
-                                  ? 'border-amber-200 bg-amber-200'
-                                  : 'border-amber-100 bg-amber-100'
-                      }`}
-                    />
-                    <p className="max-w-20 text-center text-[10px] font-medium leading-tight text-slate-700">{cell.contributor}</p>
-                  </div>
-                ))}
-              </div>
-            ) : null}
-          </div>
+          <ContributionBarChart
+            title="Attributed organization chart"
+            description="Longer bars indicate more experimentally attributed recent commits."
+            items={section.experimentalHeatmap}
+            ariaLabel="Attributed organization bars"
+            emptyText="unavailable"
+            tone="amber"
+            entityLabel="organizations"
+            defaultVisibleCount={8}
+            collapsed={!showExperimentalHeatmap}
+            showLabels={showExperimentalNames}
+            showValues={showExperimentalNumbers}
+            actions={
+              <>
+                <button
+                  type="button"
+                  onClick={() => setShowExperimentalHeatmap((current) => !current)}
+                  className="rounded-full border border-amber-200 px-3 py-1 text-xs font-medium text-amber-900 transition hover:border-amber-300"
+                  aria-pressed={showExperimentalHeatmap}
+                >
+                  {showExperimentalHeatmap ? 'Hide chart' : 'Show chart'}
+                </button>
+                {showExperimentalHeatmap ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setShowExperimentalNames((current) => !current)}
+                      className="rounded-full border border-amber-200 px-3 py-1 text-xs font-medium text-amber-900 transition hover:border-amber-300"
+                      aria-pressed={showExperimentalNames}
+                    >
+                      {showExperimentalNames ? 'Hide names' : 'Show names'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowExperimentalNumbers((current) => !current)}
+                      className="rounded-full border border-amber-200 px-3 py-1 text-xs font-medium text-amber-900 transition hover:border-amber-300"
+                      aria-pressed={showExperimentalNumbers}
+                    >
+                      {showExperimentalNumbers ? 'Hide numbers' : 'Show numbers'}
+                    </button>
+                  </>
+                ) : null}
+              </>
+            }
+          />
         ) : null}
       </div>
 

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -832,7 +832,7 @@ describe('RepoInputClient', () => {
 
     expect(contributorsView).toBeInTheDocument()
     expect(screen.getByText(/top 20% contributor share/i)).toBeInTheDocument()
-    expect(within(corePane).getByText(/^Contribution heatmap$/i)).toBeInTheDocument()
+    expect(within(corePane).getByText(/^Contribution chart$/i)).toBeInTheDocument()
     expect(screen.queryByText(/later sustainability signals/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/missing data/i)).not.toBeInTheDocument()
   })

--- a/lib/contributors/view-model.ts
+++ b/lib/contributors/view-model.ts
@@ -19,6 +19,7 @@ export interface ContributorMetricRow {
 
 export interface ContributorHeatmapCell {
   contributor: string
+  commits: number
   commitsLabel: string
   intensity: 'lowest' | 'low' | 'medium' | 'high' | 'higher' | 'max'
 }
@@ -442,6 +443,7 @@ function buildHeatmap(
 
   return entries.map(([contributor, commits]) => ({
     contributor: kind === 'organization' ? contributor : formatContributorLabel(contributor),
+    commits,
     commitsLabel: `${new Intl.NumberFormat('en-US').format(commits)} ${kind === 'organization' ? 'attributed ' : ''}${commits === 1 ? 'commit' : 'commits'}`,
     intensity: getIntensity(commits, maxCommits),
   }))


### PR DESCRIPTION
## Summary
- replace the contributor and attributed-organization bubble heatmaps with a shared bar-chart visualization
- preserve the existing chart controls, including bot inclusion plus show/hide names and numbers, while cleaning up the collapsed org-chart state
- update contributor view-model data and focused tests to match the new chart treatment

## Verification
- `npm test -- --run components/contributors/CoreContributorsPane.test.tsx components/contributors/SustainabilityPane.test.tsx components/contributors/ContributorsView.test.tsx components/repo-input/RepoInputClient.test.tsx lib/contributors/view-model.test.ts`
- `npm run lint`

## Related
- Fixes #22
