### PR TITLE
Reset stale result tabs when workflows change

### DIFF
--- a/components/app-shell/ResultsShell.test.tsx
+++ b/components/app-shell/ResultsShell.test.tsx
@@ -61,4 +61,38 @@ describe('ResultsShell', () => {
     expect(screen.queryByRole('tab', { name: 'Contributors' })).not.toBeInTheDocument()
     expect(screen.getByText('Organization content')).toBeInTheDocument()
   })
+
+  it('resets the active tab when the available tab set changes', async () => {
+    const { rerender } = render(
+      <ResultsShell
+        analysisPanel={<div>Analysis panel</div>}
+        overview={<div>Overview content</div>}
+        contributors={<div>Contributors content</div>}
+        activity={<div>Activity content</div>}
+        responsiveness={<div>Responsiveness content</div>}
+        healthRatios={<div>Health ratios content</div>}
+        comparison={<div>Comparison content</div>}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
+    expect(screen.getByText('Comparison content')).toBeInTheDocument()
+
+    rerender(
+      <ResultsShell
+        analysisPanel={<div>Analysis panel</div>}
+        tabs={[{ id: 'overview', label: 'Overview', status: 'implemented', description: 'Org inventory' }]}
+        overview={<div>Organization content</div>}
+        contributors={<div>Contributors content</div>}
+        activity={<div>Activity content</div>}
+        responsiveness={<div>Responsiveness content</div>}
+        healthRatios={<div>Health ratios content</div>}
+        comparison={<div>Comparison content</div>}
+      />,
+    )
+
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByText('Organization content')).toBeInTheDocument()
+    expect(screen.queryByText('Comparison content')).not.toBeInTheDocument()
+  })
 })

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import type { ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
@@ -28,6 +28,10 @@ export function ResultsShell({
   tabs = resultTabs,
 }: ResultsShellProps) {
   const [activeTab, setActiveTab] = useState<ResultTabId>('overview')
+  const currentActiveTab = useMemo(
+    () => (tabs.some((tab) => tab.id === activeTab) ? activeTab : tabs[0]?.id ?? 'overview'),
+    [activeTab, tabs],
+  )
 
   return (
     <main className="min-h-screen bg-slate-50">
@@ -60,14 +64,14 @@ export function ResultsShell({
           </section>
 
           <section aria-label="Result workspace" className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-            <ResultsTabs tabs={tabs} activeTab={activeTab} onChange={setActiveTab} />
+            <ResultsTabs tabs={tabs} activeTab={currentActiveTab} onChange={setActiveTab} />
             <div className="mt-6">
-              {activeTab === 'overview' ? overview : null}
-              {activeTab === 'contributors' ? contributors : null}
-              {activeTab === 'activity' ? activity : null}
-              {activeTab === 'responsiveness' ? responsiveness : null}
-              {activeTab === 'health-ratios' ? healthRatios : null}
-              {activeTab === 'comparison' ? comparison : null}
+              {currentActiveTab === 'overview' ? overview : null}
+              {currentActiveTab === 'contributors' ? contributors : null}
+              {currentActiveTab === 'activity' ? activity : null}
+              {currentActiveTab === 'responsiveness' ? responsiveness : null}
+              {currentActiveTab === 'health-ratios' ? healthRatios : null}
+              {currentActiveTab === 'comparison' ? comparison : null}
             </div>
           </section>
         </section>

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -268,6 +268,61 @@ describe('RepoInputClient', () => {
     expect(screen.getByRole('tab', { name: 'Contributors' })).toBeInTheDocument()
   })
 
+  it('resets a stale comparison selection when switching from repositories to organization mode', async () => {
+    const onAnalyze = vi.fn().mockResolvedValue({
+      results: [],
+      failures: [],
+      rateLimit: null,
+    })
+    const onAnalyzeOrg = vi.fn().mockResolvedValue({
+      org: 'facebook',
+      summary: {
+        totalPublicRepos: 1,
+        totalStars: 100,
+        mostStarredRepos: [{ repo: 'facebook/react', stars: 100 }],
+        mostRecentlyActiveRepos: [{ repo: 'facebook/react', pushedAt: '2026-04-02T00:00:00Z' }],
+        languageDistribution: [{ language: 'TypeScript', repoCount: 1 }],
+        archivedRepoCount: 0,
+        activeRepoCount: 1,
+      },
+      results: [
+        {
+          repo: 'facebook/react',
+          name: 'react',
+          description: 'A UI library',
+          primaryLanguage: 'TypeScript',
+          stars: 100,
+          forks: 25,
+          watchers: 10,
+          openIssues: 5,
+          pushedAt: '2026-04-02T00:00:00Z',
+          archived: false,
+          url: 'https://github.com/facebook/react',
+        },
+      ],
+      rateLimit: null,
+      failure: null,
+    })
+
+    render(<RepoInputClient hasServerToken={false} onAnalyze={onAnalyze} onAnalyzeOrg={onAnalyzeOrg} />)
+
+    await userEvent.type(screen.getByLabelText(/github personal access token/i), 'ghp_saved')
+    await userEvent.type(screen.getByRole('textbox', { name: /repository list/i }), 'facebook/react')
+    await userEvent.click(screen.getByRole('button', { name: /^analyze$/i }))
+
+    await screen.findByRole('tab', { name: 'Comparison' })
+    await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Organization' }))
+    await userEvent.type(screen.getByRole('textbox', { name: /organization input/i }), 'facebook')
+    await userEvent.click(screen.getByRole('button', { name: /^analyze$/i }))
+
+    expect(await screen.findByRole('region', { name: /org inventory view/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.queryByText(/comparison will let you evaluate multiple analyzed repositories/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'Comparison' })).not.toBeInTheDocument()
+  })
+
   it('switches the empty workspace to organization mode before any org results exist', async () => {
     render(<RepoInputClient hasServerToken />)
 


### PR DESCRIPTION
## Summary
- clamp the active results tab to the currently available tab set so stale selections like `comparison` do not survive workflow switches
- add a ResultsShell test for tab-set changes
- add a RepoInputClient regression test for switching from `Comparison` in repository mode to `Organization`

## Verification
- `npm test -- --run components/app-shell/ResultsShell.test.tsx components/repo-input/RepoInputClient.test.tsx`
- `npm run lint`

## Related
- Fixes #27
