### PR TITLE
Update app headline for organization workflow

### DIFF
--- a/components/app-shell/ResultsShell.test.tsx
+++ b/components/app-shell/ResultsShell.test.tsx
@@ -43,6 +43,26 @@ describe('ResultsShell', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/arun-gupta/forkprint')
   })
 
+  it('describes both repository and organization workflows in the header', () => {
+    render(
+      <ResultsShell
+        analysisPanel={<div>Analysis panel</div>}
+        overview={<div>Overview content</div>}
+        contributors={<div>Contributors coming soon</div>}
+        activity={<div>Activity coming soon</div>}
+        responsiveness={<div>Responsiveness coming soon</div>}
+        healthRatios={<div>Health ratios coming soon</div>}
+        comparison={<div>Comparison coming soon</div>}
+      />,
+    )
+
+    expect(
+      screen.getByText(
+        /chaoss-aligned github health analyzer for repository analysis and organization inventory browsing/i,
+      ),
+    ).toBeInTheDocument()
+  })
+
   it('supports a custom tab set for alternate workflows like org inventory', () => {
     render(
       <ResultsShell

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -40,7 +40,7 @@ export function ResultsShell({
           <div>
             <h1 className="text-2xl font-semibold tracking-tight text-white">ForkPrint</h1>
             <p className="mt-1 text-sm text-sky-100 md:text-base">
-              CHAOSS-aligned GitHub repository health analyzer. Enter one or more repositories to analyze.
+              CHAOSS-aligned GitHub health analyzer for repository analysis and organization inventory browsing.
             </p>
           </div>
           <a


### PR DESCRIPTION
## Summary
- update the app-shell hero copy so it reflects both repository analysis and organization inventory browsing
- add a focused shell test to keep the headline aligned with both workflows

## Verification
- `npm test -- --run components/app-shell/ResultsShell.test.tsx`

## Related
- Fixes #25
