### PR TITLE
Refresh repository input examples

### DIFF
--- a/components/repo-input/RepoInputForm.test.tsx
+++ b/components/repo-input/RepoInputForm.test.tsx
@@ -10,6 +10,15 @@ describe('RepoInputForm — US1 (valid input)', () => {
     expect(screen.getByRole('button', { name: /analyze/i })).toBeInTheDocument()
   })
 
+  it('shows seeded examples for the accepted repository input styles', () => {
+    render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'placeholder',
+      'facebook/react\ngithub.com/kubernetes/kubernetes\nhttps://github.com/pytorch/pytorch',
+    )
+  })
+
   it('calls onSubmit with parsed slugs on valid input', async () => {
     const onSubmit = vi.fn()
     render(<RepoInputForm onSubmitRepos={onSubmit} onSubmitOrg={vi.fn()} />)

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -82,7 +82,7 @@ export function RepoInputForm({ onSubmitRepos, onSubmitOrg, mode: controlledMode
         <textarea
           value={repoValue}
           onChange={(e) => setRepoValue(e.target.value)}
-          placeholder={'facebook/react\ntorvalds/linux\nhttps://github.com/microsoft/typescript'}
+          placeholder={'facebook/react\ngithub.com/kubernetes/kubernetes\nhttps://github.com/pytorch/pytorch'}
           rows={5}
           className="w-full rounded border border-slate-300 bg-white p-2 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
           aria-label="Repository list"


### PR DESCRIPTION
## Summary
- refresh the seeded repository examples in the input textarea
- make the accepted input styles clearer with slug, host-path, and full URL examples
- add a focused form test to keep the placeholder aligned with the supported formats

## Verification
- `npm test -- --run components/repo-input/RepoInputForm.test.tsx`

## Related
- Fixes #26
