### PR TITLE
Rename visible product branding to RepoPulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ForkPrint
+# RepoPulse
 
-ForkPrint is a CHAOSS-aligned GitHub repository health analyzer. The Phase 1 app lets you analyze one or more public repositories, explore an organization’s public repo inventory, and review results in a web dashboard. Comparison workflows and export are still on the roadmap.
+RepoPulse is a CHAOSS-aligned GitHub repository health analyzer. The Phase 1 app lets you analyze one or more public repositories, explore an organization’s public repo inventory, and review results in a web dashboard. Comparison workflows and export are still on the roadmap.
 
 Live in action: [forkprint-arun-gupta.vercel.app](https://forkprint-arun-gupta.vercel.app)
 
@@ -12,7 +12,7 @@ Live in action: [forkprint-arun-gupta.vercel.app](https://forkprint-arun-gupta.v
 
 ## Getting Started
 
-ForkPrint supports a server-side `GITHUB_TOKEN` or the browser PAT flow. For local development, you can optionally set `GITHUB_TOKEN` in `.env.local`.
+RepoPulse supports a server-side `GITHUB_TOKEN` or the browser PAT flow. For local development, you can optionally set `GITHUB_TOKEN` in `.env.local`.
 
 ```bash
 npm install

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -38,7 +38,7 @@ export function ResultsShell({
       <header className="w-full bg-sky-900 text-white">
         <div className="mx-auto flex max-w-5xl items-start justify-between gap-4 px-4 py-5">
           <div>
-            <h1 className="text-2xl font-semibold tracking-tight text-white">ForkPrint</h1>
+            <h1 className="text-2xl font-semibold tracking-tight text-white">RepoPulse</h1>
             <p className="mt-1 text-sm text-sky-100 md:text-base">
               CHAOSS-aligned GitHub repository health analyzer. Enter one or more repositories to analyze.
             </p>

--- a/components/contributors/SustainabilityPane.tsx
+++ b/components/contributors/SustainabilityPane.tsx
@@ -34,7 +34,7 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
           <div>
             <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is this scored?</p>
             <p className="mt-1 text-sm text-slate-700">
-              ForkPrint scores sustainability from recent commit concentration. Lower top-20% share means the active contributor base is more distributed.
+              RepoPulse scores sustainability from recent commit concentration. Lower top-20% share means the active contributor base is more distributed.
             </p>
           </div>
           <button

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -92,7 +92,7 @@ export function OrgInventoryView({ org, summary, results, rateLimit, onAnalyzeRe
         <section className="rounded-2xl border border-slate-200 bg-white p-6">
           <h3 className="text-lg font-semibold text-slate-900">No public repositories found</h3>
           <p className="mt-2 text-sm text-slate-600">
-            ForkPrint did not find any public repositories for this organization.
+            RepoPulse did not find any public repositories for this organization.
           </p>
         </section>
       ) : (

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -455,7 +455,7 @@ describe('RepoInputClient', () => {
     await userEvent.type(screen.getByRole('textbox', { name: /repository list/i }), 'facebook/react')
     await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
 
-    expect(warnSpy).toHaveBeenCalledWith('[ForkPrint GitHub diagnostic]', {
+    expect(warnSpy).toHaveBeenCalledWith('[RepoPulse GitHub diagnostic]', {
       repo: 'facebook/react',
       source: 'github-rest:contributors',
       message: 'GitHub REST request failed with status 403',

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -44,7 +44,7 @@ export function RepoInputClient({ hasServerToken, onAnalyze, onAnalyzeOrg }: Rep
 
     for (const diagnostic of analysisResponse.diagnostics) {
       const log = diagnostic.level === 'error' ? console.error : console.warn
-      log('[ForkPrint GitHub diagnostic]', {
+      log('[RepoPulse GitHub diagnostic]', {
         repo: diagnostic.repo,
         source: diagnostic.source,
         message: diagnostic.message,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# ForkPrint — Deployment
+# RepoPulse — Deployment
 
 Phase 1 deployment targets **Vercel**.
 
@@ -18,7 +18,7 @@ Use `.env.local` only for local development:
 GITHUB_TOKEN=
 ```
 
-If `GITHUB_TOKEN` is not set locally, ForkPrint uses the browser PAT flow.
+If `GITHUB_TOKEN` is not set locally, RepoPulse uses the browser PAT flow.
 
 Recommended GitHub token:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
-# ForkPrint — Development Workflow
+# RepoPulse — Development Workflow
 
-This document describes how to develop ForkPrint using the SpecKit / Specification-Driven Development (SDD) workflow.
+This document describes how to develop RepoPulse using the SpecKit / Specification-Driven Development (SDD) workflow.
 
 ---
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,4 +1,4 @@
-# ForkPrint — Product Definition
+# RepoPulse — Product Definition
 
 **Repo**: `arun-gupta/forkprint`  
 **Description**: CHAOSS-aligned GitHub repository health analyzer. Accepts one or more `owner/repo` inputs, fetches real public data via the GitHub GraphQL API, and produces an interactive dashboard and raw JSON output.  
@@ -6,13 +6,13 @@
 **Phase 1 Data Layer**: Next.js API Routes  
 **Development Methodology**: SpecKit / Specification-Driven Development (SDD)
 
-This document is the canonical product definition for ForkPrint. It is the source of truth for all features across all phases. `.specify/memory/constitution.md` references this document. SpecKit specs are traceable to feature IDs defined here.
+This document is the canonical product definition for RepoPulse. It is the source of truth for all features across all phases. `.specify/memory/constitution.md` references this document. SpecKit specs are traceable to feature IDs defined here.
 
 ---
 
 ## Roadmap
 
-ForkPrint is built in three phases. Phase 1 architectural decisions must not block Phases 2 or 3.
+RepoPulse is built in three phases. Phase 1 architectural decisions must not block Phases 2 or 3.
 
 - **Phase 1** — Web app (Next.js / Vercel): interactive dashboard for on-demand repo analysis
 - **Phase 2** — GitHub Action: scheduled or triggered analysis with artifact output and threshold alerting
@@ -36,11 +36,11 @@ The core analysis logic is shared across all three phases via a framework-agnost
 
 ## CHAOSS Alignment
 
-ForkPrint groups analysis into four CHAOSS-aligned reporting dimensions. These dimensions are product-level buckets, not a claim that they are the official top-level CHAOSS metric taxonomy.
+RepoPulse groups analysis into four CHAOSS-aligned reporting dimensions. These dimensions are product-level buckets, not a claim that they are the official top-level CHAOSS metric taxonomy.
 
-| ForkPrint Dimension | CHAOSS Basis | Feature | Derived Score |
+| RepoPulse Dimension | CHAOSS Basis | Feature | Derived Score |
 |---|---|---|---|
-| Ecosystem | ForkPrint repo-profile layer informed by CHAOSS-style ecosystem signals | Ecosystem Map (P1-F05) | Ecosystem profile: Reach / Builder Engagement / Attention |
+| Ecosystem | RepoPulse repo-profile layer informed by CHAOSS-style ecosystem signals | Ecosystem Map (P1-F05) | Ecosystem profile: Reach / Builder Engagement / Attention |
 | Activity | CHAOSS-aligned activity and adjacent activity-flow signals | Activity (P1-F08) | Activity score: High / Medium / Low |
 | Contributors | Contributor metrics with a dedicated Sustainability pane for resilience and organizational-risk signals | Contributors (P1-F09) | Core contributor metrics + Sustainability score |
 | Responsiveness | CHAOSS-aligned time-to-response and time-to-resolution metrics | Responsiveness (P1-F10) | Responsiveness score: High / Medium / Low |
@@ -166,7 +166,7 @@ User can authenticate with GitHub to enable data fetching.
 
 #### `[P1-F03]` Deployment
 
-ForkPrint deploys to Vercel with minimal configuration.
+RepoPulse deploys to Vercel with minimal configuration.
 
 **Acceptance criteria**
 - Deployable to Vercel with zero config
@@ -227,10 +227,10 @@ Repos are summarized in an interactive ecosystem view with a spectrum-based ecos
 
 #### `[P1-F15]` Results Shell
 
-ForkPrint presents analysis in a stable app shell so users can submit repos once and switch between result views cleanly.
+RepoPulse presents analysis in a stable app shell so users can submit repos once and switch between result views cleanly.
 
 **Acceptance criteria**
-- A top header/banner shows the ForkPrint brand and a visible GitHub repo link
+- A top header/banner shows the RepoPulse brand and a visible GitHub repo link
 - Repo input and Analyze action live in a stable analysis panel that remains visible above the result views
 - Successful analyses populate a tabbed result area rather than stacking every future view vertically
 - The shell organizes result views in a stable order with `Overview` first and domain views such as `Contributors`, `Activity`, `Responsiveness`, `Health Ratios`, and `Comparison` available as tabs
@@ -528,7 +528,7 @@ Users can take analysis results out of the UI in standard formats.
 
 #### `[P2-F01]` Scheduled Analysis
 
-ForkPrint runs as a GitHub Action on a schedule or manual trigger.
+RepoPulse runs as a GitHub Action on a schedule or manual trigger.
 
 **Acceptance criteria**
 - Action supports `schedule` (cron) and `workflow_dispatch` triggers
@@ -563,7 +563,7 @@ The action can open a GitHub Issue when health drops below a defined threshold.
 
 #### `[P3-F01]` Analyze Tool
 
-ForkPrint exposes repo health analysis as an MCP tool callable by AI assistants.
+RepoPulse exposes repo health analysis as an MCP tool callable by AI assistants.
 
 **Acceptance criteria**
 - MCP Server exposes an `analyze_repo` tool
@@ -599,7 +599,7 @@ Not specced. Captured here so Phase 1–3 decisions don't foreclose them.
 
 - `[FUT-F01]` **Historical trending** — store snapshots over time, chart metric trajectory per repo
 - `[FUT-F03]` **CHAOSS expansion** — Bus Factor, Change Request Closure Ratio, Code Coverage metrics
-- `[FUT-F04]` **Embeddable badge** — `![ForkPrint Health](https://forkprint.vercel.app/badge/owner/repo)` for READMEs
+- `[FUT-F04]` **Embeddable badge** — `![RepoPulse Health](https://forkprint.vercel.app/badge/owner/repo)` for READMEs
 - `[FUT-F05]` **Webhook mode** — trigger analysis on push or release events via GitHub webhook
 
 ---

--- a/lib/activity/score-config.ts
+++ b/lib/activity/score-config.ts
@@ -108,7 +108,7 @@ const ACTIVITY_THRESHOLDS: ActivityScoreDefinition['thresholds'] = [
 const INSUFFICIENT_SCORE: ActivityScoreDefinition = {
   value: 'Insufficient verified public data',
   tone: 'neutral',
-  description: 'ForkPrint cannot verify enough recent activity and delivery-flow data to score this repository yet.',
+  description: 'RepoPulse cannot verify enough recent activity and delivery-flow data to score this repository yet.',
   summary: 'Verified recent-flow inputs are incomplete.',
   weightedFactors: ACTIVITY_FACTORS.map((factor) => ({
     label: factor.label,

--- a/lib/contributors/score-config.ts
+++ b/lib/contributors/score-config.ts
@@ -41,7 +41,7 @@ export const SUSTAINABILITY_THRESHOLDS: SustainabilityThreshold[] = [
 const INSUFFICIENT_SCORE: SustainabilityScoreDefinition = {
   value: 'Insufficient verified public data',
   tone: 'neutral',
-  description: 'ForkPrint cannot verify enough contributor-distribution data to score sustainability yet.',
+  description: 'RepoPulse cannot verify enough contributor-distribution data to score sustainability yet.',
   concentration: 'unavailable',
   topContributorCount: 'unavailable',
   contributorCount: 'unavailable',

--- a/lib/responsiveness/score-config.ts
+++ b/lib/responsiveness/score-config.ts
@@ -108,7 +108,7 @@ const RESPONSIVENESS_THRESHOLDS: ResponsivenessScoreDefinition['thresholds'] = [
 const INSUFFICIENT_SCORE: ResponsivenessScoreDefinition = {
   value: 'Insufficient verified public data',
   tone: 'neutral',
-  description: 'ForkPrint cannot verify enough public issue and pull-request event history to score this repository yet.',
+  description: 'RepoPulse cannot verify enough public issue and pull-request event history to score this repository yet.',
   summary: 'Verified responsiveness inputs are incomplete.',
   weightedCategories: RESPONSIVENESS_CATEGORIES.map((category) => ({
     label: category.label,


### PR DESCRIPTION
## Summary
- rename the visible product branding from `ForkPrint` to `RepoPulse` across the app shell, score copy, and top-level docs
- keep the existing GitHub repository slug and deployment host unchanged for now so this stays a safe branding pass
- update the diagnostic prefix test to match the new product name

## Verification
- `npm test -- --run components/app-shell/ResultsShell.test.tsx components/repo-input/RepoInputClient.test.tsx components/contributors/SustainabilityPane.test.tsx components/org-inventory/OrgInventoryView.test.tsx`
- `npm run lint`

## Notes
- This PR updates the user-facing product name only. A GitHub repository rename to `repo-pulse` would still be a separate migration step.

## Related
- Fixes #20
