### PR TITLE
Clean up RepoPulse slug rename

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,4 +1,4 @@
-# ForkPrint Constitution
+# RepoPulse Constitution
 
 **Single authoritative source of all project rules.**
 Every spec, plan, task, and line of code must comply. No exceptions.
@@ -108,7 +108,7 @@ Rules:
 
 1. P1-F05 uses a **spectrum model**, not median-derived quadrants.
 2. Axes: X = stars (reach), Y = builder engagement (`forks / stars`), bubble size = attention (`watchers / stars`).
-3. Ecosystem profile tiers are **ForkPrint-defined** and aligned to the CHAOSS ecosystem category. They are not presented as an official CHAOSS taxonomy.
+3. Ecosystem profile tiers are **RepoPulse-defined** and aligned to the CHAOSS ecosystem category. They are not presented as an official CHAOSS taxonomy.
 4. Spectrum thresholds are defined in shared configuration and read from that configuration by the UI and supporting logic.
 5. Single-repo input remains fully valid: the UI still plots and profiles the repo when verified data exists.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 RepoPulse is a CHAOSS-aligned GitHub repository health analyzer. The Phase 1 app lets you analyze one or more public repositories, explore an organization’s public repo inventory, and review results in a web dashboard. Comparison workflows and export are still on the roadmap.
 
-Live in action: [forkprint-arun-gupta.vercel.app](https://forkprint-arun-gupta.vercel.app)
+Live in action: [repopulse-arun-gupta.vercel.app](https://repopulse-arun-gupta.vercel.app)
 
 ## Roadmap
 

--- a/components/app-shell/ResultsShell.test.tsx
+++ b/components/app-shell/ResultsShell.test.tsx
@@ -40,7 +40,7 @@ describe('ResultsShell', () => {
     )
 
     const link = screen.getByRole('link', { name: /github repository/i })
-    expect(link).toHaveAttribute('href', 'https://github.com/arun-gupta/forkprint')
+    expect(link).toHaveAttribute('href', 'https://github.com/arun-gupta/repo-pulse')
   })
 
   it('describes both repository and organization workflows in the header', () => {

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -44,7 +44,7 @@ export function ResultsShell({
             </p>
           </div>
           <a
-            href="https://github.com/arun-gupta/forkprint"
+            href="https://github.com/arun-gupta/repo-pulse"
             target="_blank"
             rel="noreferrer"
             aria-label="GitHub repository"

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -10,7 +10,7 @@ describe('RepoInputClient', () => {
   })
 
   it('pre-populates the token field from localStorage', () => {
-    window.localStorage.setItem('forkprint_github_token', 'ghp_saved')
+    window.localStorage.setItem('repo_pulse_github_token', 'ghp_saved')
 
     render(<RepoInputClient hasServerToken={false} />)
 
@@ -26,7 +26,7 @@ describe('RepoInputClient', () => {
     await userEvent.type(screen.getByRole('textbox', { name: /repository list/i }), 'facebook/react')
     await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
 
-    expect(window.localStorage.getItem('forkprint_github_token')).toBe('ghp_saved')
+    expect(window.localStorage.getItem('repo_pulse_github_token')).toBe('ghp_saved')
     expect(onAnalyze).toHaveBeenCalledWith(['facebook/react'], 'ghp_saved')
   })
 
@@ -80,7 +80,7 @@ describe('RepoInputClient', () => {
 
   it('does not persist or use a client token when a server token is configured', async () => {
     const onAnalyze = vi.fn()
-    window.localStorage.setItem('forkprint_github_token', 'ghp_stale')
+    window.localStorage.setItem('repo_pulse_github_token', 'ghp_stale')
 
     render(<RepoInputClient hasServerToken onAnalyze={onAnalyze} />)
 
@@ -88,7 +88,7 @@ describe('RepoInputClient', () => {
     await userEvent.click(screen.getByRole('button', { name: /analyze/i }))
 
     expect(onAnalyze).toHaveBeenCalledWith(['facebook/react'], null)
-    expect(window.localStorage.getItem('forkprint_github_token')).toBe('ghp_stale')
+    expect(window.localStorage.getItem('repo_pulse_github_token')).toBe('ghp_stale')
   })
 
   it('renders returned analysis results after a successful submission', async () => {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -33,7 +33,7 @@ Recommended GitHub token:
 
 ## Vercel
 
-1. Import `arun-gupta/forkprint` into Vercel
+1. Import `arun-gupta/repo-pulse` into Vercel
 2. Keep the default Next.js framework/build settings
 3. In the Vercel project, open `Settings -> Environment Variables`
 4. Add a variable named `GITHUB_TOKEN`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,7 +6,7 @@ This document describes how to develop RepoPulse using the SpecKit / Specificati
 
 ## Prerequisites
 
-- `arun-gupta/forkprint` repo is cloned locally
+- `arun-gupta/repo-pulse` repo is cloned locally
 - `CLAUDE.md` exists — it points Claude Code to `.specify/memory/constitution.md`
 - Claude Code is running in the repo root
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,6 +1,6 @@
 # RepoPulse — Product Definition
 
-**Repo**: `arun-gupta/forkprint`  
+**Repo**: `arun-gupta/repo-pulse`  
 **Description**: CHAOSS-aligned GitHub repository health analyzer. Accepts one or more `owner/repo` inputs, fetches real public data via the GitHub GraphQL API, and produces an interactive dashboard and raw JSON output.  
 **Phase 1 Platform**: Next.js deployed on Vercel  
 **Phase 1 Data Layer**: Next.js API Routes  
@@ -599,7 +599,7 @@ Not specced. Captured here so Phase 1–3 decisions don't foreclose them.
 
 - `[FUT-F01]` **Historical trending** — store snapshots over time, chart metric trajectory per repo
 - `[FUT-F03]` **CHAOSS expansion** — Bus Factor, Change Request Closure Ratio, Code Coverage metrics
-- `[FUT-F04]` **Embeddable badge** — `![RepoPulse Health](https://forkprint.vercel.app/badge/owner/repo)` for READMEs
+- `[FUT-F04]` **Embeddable badge** — `![RepoPulse Health](https://repo-pulse.vercel.app/badge/owner/repo)` for READMEs
 - `[FUT-F05]` **Webhook mode** — trigger analysis on push or release events via GitHub webhook
 
 ---

--- a/lib/token-storage.test.ts
+++ b/lib/token-storage.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { TOKEN_STORAGE_KEY, clearToken, readToken, writeToken } from './token-storage'
+import { LEGACY_TOKEN_STORAGE_KEY, TOKEN_STORAGE_KEY, clearToken, readToken, writeToken } from './token-storage'
 
 describe('token storage', () => {
   beforeEach(() => {
@@ -17,6 +17,12 @@ describe('token storage', () => {
     expect(readToken()).toBe('ghp_example')
   })
 
+  it('reads from the legacy token key when the new key is absent', () => {
+    window.localStorage.setItem(LEGACY_TOKEN_STORAGE_KEY, 'ghp_legacy')
+
+    expect(readToken()).toBe('ghp_legacy')
+  })
+
   it('trims whitespace before storing', () => {
     writeToken('  ghp_trimmed  ')
     expect(readToken()).toBe('ghp_trimmed')
@@ -24,6 +30,7 @@ describe('token storage', () => {
 
   it('clears the token when an empty value is written', () => {
     window.localStorage.setItem(TOKEN_STORAGE_KEY, 'ghp_existing')
+    window.localStorage.setItem(LEGACY_TOKEN_STORAGE_KEY, 'ghp_legacy')
     writeToken('   ')
     expect(readToken()).toBeNull()
   })
@@ -37,6 +44,7 @@ describe('token storage', () => {
 
   it('removes the stored token explicitly', () => {
     window.localStorage.setItem(TOKEN_STORAGE_KEY, 'ghp_existing')
+    window.localStorage.setItem(LEGACY_TOKEN_STORAGE_KEY, 'ghp_legacy')
     clearToken()
     expect(readToken()).toBeNull()
   })

--- a/lib/token-storage.ts
+++ b/lib/token-storage.ts
@@ -1,8 +1,9 @@
-export const TOKEN_STORAGE_KEY = 'forkprint_github_token'
+export const TOKEN_STORAGE_KEY = 'repo_pulse_github_token'
+export const LEGACY_TOKEN_STORAGE_KEY = 'forkprint_github_token'
 
 export function readToken(): string | null {
   try {
-    return window.localStorage.getItem(TOKEN_STORAGE_KEY)
+    return window.localStorage.getItem(TOKEN_STORAGE_KEY) ?? window.localStorage.getItem(LEGACY_TOKEN_STORAGE_KEY)
   } catch {
     return null
   }
@@ -18,11 +19,13 @@ export function writeToken(value: string): void {
 
   try {
     window.localStorage.setItem(TOKEN_STORAGE_KEY, trimmed)
+    window.localStorage.removeItem(LEGACY_TOKEN_STORAGE_KEY)
   } catch {}
 }
 
 export function clearToken(): void {
   try {
     window.localStorage.removeItem(TOKEN_STORAGE_KEY)
+    window.localStorage.removeItem(LEGACY_TOKEN_STORAGE_KEY)
   } catch {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "forkprint",
+  "name": "repo-pulse",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "forkprint",
+      "name": "repo-pulse",
       "version": "0.1.0",
       "dependencies": {
         "chart.js": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "forkprint",
+  "name": "repo-pulse",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/specs/001-repo-input/spec.md
+++ b/specs/001-repo-input/spec.md
@@ -11,7 +11,7 @@
 
 ### User Story 1 — Enter repos and submit for analysis (Priority: P1)
 
-A user arrives at the ForkPrint home page and wants to analyze one or more GitHub repositories. They type or paste repo slugs (or full GitHub URLs) into a textarea and submit.
+A user arrives at the RepoPulse home page and wants to analyze one or more GitHub repositories. They type or paste repo slugs (or full GitHub URLs) into a textarea and submit.
 
 **Why this priority**: This is the entry point to the entire application. Nothing else works without it.
 

--- a/specs/002-github-pat-auth/contracts/token-storage.ts
+++ b/specs/002-github-pat-auth/contracts/token-storage.ts
@@ -6,7 +6,7 @@
  * from browser-local storage. This is the only place the storage key is defined.
  */
 
-export const TOKEN_STORAGE_KEY = 'forkprint_github_token'
+export const TOKEN_STORAGE_KEY = 'repo_pulse_github_token'
 
 /** Read the stored token. Returns null if absent or storage is unavailable. */
 export declare function readToken(): string | null

--- a/specs/002-github-pat-auth/data-model.md
+++ b/specs/002-github-pat-auth/data-model.md
@@ -9,7 +9,7 @@ Represents the PAT persisted in the browser.
 | Field       | Type     | Source         | Notes                                      |
 |-------------|----------|----------------|--------------------------------------------|
 | `value`     | `string` | User input     | Trimmed. Empty string treated as absent.   |
-| `key`       | `string` | Constant       | Always `forkprint_github_token`            |
+| `key`       | `string` | Constant       | Always `repo_pulse_github_token`           |
 
 **Lifecycle**:
 - Written to `localStorage` on form submit (if non-empty)

--- a/specs/002-github-pat-auth/plan.md
+++ b/specs/002-github-pat-auth/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Allow users to enter and persist a GitHub Personal Access Token in `localStorage` so ForkPrint can authenticate against the GitHub GraphQL API. Blocks form submission when no token is available. Hides the token input field when a server-side `GITHUB_TOKEN` is configured. Token never appears in URLs or server responses.
+Allow users to enter and persist a GitHub Personal Access Token in `localStorage` so RepoPulse can authenticate against the GitHub GraphQL API. Blocks form submission when no token is available. Hides the token input field when a server-side `GITHUB_TOKEN` is configured. Token never appears in URLs or server responses.
 
 ## Technical Context
 
@@ -90,7 +90,7 @@ tests/
 ### Step 1 — Token storage utility
 
 4. Implement `lib/token-storage.ts`
-   - Export `TOKEN_STORAGE_KEY = 'forkprint_github_token'`
+   - Export `TOKEN_STORAGE_KEY = 'repo_pulse_github_token'`
    - `readToken()`: try/catch localStorage.getItem; return null if unavailable
    - `writeToken(value)`: trim; if empty call clearToken(); else localStorage.setItem
    - `clearToken()`: localStorage.removeItem wrapped in try/catch

--- a/specs/002-github-pat-auth/research.md
+++ b/specs/002-github-pat-auth/research.md
@@ -14,7 +14,7 @@
 
 ## Decision 2: localStorage key for the token
 
-**Decision**: `forkprint_github_token`
+**Decision**: `repo_pulse_github_token`
 
 **Rationale**: Namespaced to the app, human-readable, avoids collision with other tools. Defined as a single constant in `lib/token-storage.ts` — not inlined anywhere.
 

--- a/specs/002-github-pat-auth/spec.md
+++ b/specs/002-github-pat-auth/spec.md
@@ -40,7 +40,7 @@ A user who has not entered a token (and no server-side token is configured) atte
 
 ### User Story 3 - Token Field Hidden on Server-Token Deployments (Priority: P2)
 
-When ForkPrint is deployed with a server-side `GITHUB_TOKEN`, the token input field is hidden from the UI. Users on a shared or team deployment do not need to supply their own token.
+When RepoPulse is deployed with a server-side `GITHUB_TOKEN`, the token input field is hidden from the UI. Users on a shared or team deployment do not need to supply their own token.
 
 **Why this priority**: This is a deployment-time UX concern — important for team use but not required for basic single-user functionality.
 

--- a/specs/003-data-fetching/plan.md
+++ b/specs/003-data-fetching/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement the first real analysis pipeline for ForkPrint: submit validated repos plus an available token source, fetch verified public GitHub data through a Next.js API route, and return flat per-repo analysis results with isolated failures, loading state, and rate-limit metadata. The core analyzer stays framework-agnostic so later GitHub Action and MCP phases can reuse it without duplication.
+Implement the first real analysis pipeline for RepoPulse: submit validated repos plus an available token source, fetch verified public GitHub data through a Next.js API route, and return flat per-repo analysis results with isolated failures, loading state, and rate-limit metadata. The core analyzer stays framework-agnostic so later GitHub Action and MCP phases can reuse it without duplication.
 
 ## Technical Context
 

--- a/specs/003-data-fetching/quickstart.md
+++ b/specs/003-data-fetching/quickstart.md
@@ -2,7 +2,7 @@
 
 ## What's being built
 
-The first real analysis pipeline for ForkPrint:
+The first real analysis pipeline for RepoPulse:
 - submit validated repos from the home page
 - fetch verified GitHub GraphQL data through `POST /api/analyze`
 - return flat per-repo results plus isolated failures and rate-limit metadata

--- a/specs/005-ecosystem-map/checklists/manual-testing.md
+++ b/specs/005-ecosystem-map/checklists/manual-testing.md
@@ -25,7 +25,7 @@
 
 - [x] Confirm the UI shows Reach / Builder Engagement / Attention profile tiers for successful repositories
 - [x] Confirm the spectrum legends match the shared config-driven bands shown in the UI
-- [x] Confirm the UI presents the spectrum profile as a ForkPrint interpretation aligned to CHAOSS, not official CHAOSS terminology
+- [x] Confirm the UI presents the spectrum profile as a RepoPulse interpretation aligned to CHAOSS, not official CHAOSS terminology
 
 ## US4 — Tooltip and derived-rate behavior
 

--- a/specs/005-ecosystem-map/plan.md
+++ b/specs/005-ecosystem-map/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Add the first visual analysis layer to ForkPrint by turning successful `AnalysisResult[]` data into an ecosystem-map section on the home page. The feature will show visible ecosystem metrics for each successful repository, derive a config-driven ecosystem profile across Reach / Builder Engagement / Attention, and keep the feature useful for both single-repo and multi-repo analysis.
+Add the first visual analysis layer to RepoPulse by turning successful `AnalysisResult[]` data into an ecosystem-map section on the home page. The feature will show visible ecosystem metrics for each successful repository, derive a config-driven ecosystem profile across Reach / Builder Engagement / Attention, and keep the feature useful for both single-repo and multi-repo analysis.
 
 ## Technical Context
 
@@ -26,7 +26,7 @@ Add the first visual analysis layer to ForkPrint by turning successful `Analysis
 | I / Phase 1 stack | PASS | Uses the existing Phase 1 Next.js/React/Tailwind stack without adding architecture that blocks later phases |
 | II — Verified data only | PASS | Spectrum view uses already-fetched `AnalysisResult[]`; no guessed derived rates for unavailable metrics |
 | IV — Shared analyzer boundary | PASS | No analyzer changes required beyond consuming existing flat results |
-| V / VII — CHAOSS alignment and ecosystem spectrum rules | PASS | Treat the ecosystem output as a ForkPrint profile aligned to CHAOSS; use config-driven spectrum thresholds |
+| V / VII — CHAOSS alignment and ecosystem spectrum rules | PASS | Treat the ecosystem output as a RepoPulse profile aligned to CHAOSS; use config-driven spectrum thresholds |
 | VII.5 — Single-repo behavior | PASS | Single successful repo renders profile and exact metrics without requiring a comparison set |
 | IX.5 — Flat `AnalysisResult` schema | PASS | Visualization consumes existing flat schema without transformation requirements leaking upstream |
 | XI — TDD mandatory | PASS | Classification/profile tests are written before implementation in tasks phase |

--- a/specs/005-ecosystem-map/spec.md
+++ b/specs/005-ecosystem-map/spec.md
@@ -100,7 +100,7 @@ A user can inspect exact ecosystem values from the repository cards and understa
 ### Key Entities
 
 - **Ecosystem View**: The combined legend and repository-profile presentation for successful repositories using exact stars, derived builder engagement, derived attention, and exact ecosystem metrics.
-- **Spectrum Profile**: The ForkPrint-defined ecosystem summary for one repository across Reach, Builder Engagement, and Attention tiers.
+- **Spectrum Profile**: The RepoPulse-defined ecosystem summary for one repository across Reach, Builder Engagement, and Attention tiers.
 - **Spectrum Config**: The shared threshold definition that controls Reach, Builder Engagement, and Attention bands for both UI legends and profile logic.
 - **Rate Summary**: The derived fork-rate and watcher-rate values shown in tooltips and profile detail.
 

--- a/specs/006-results-shell/contracts/tab-ui.md
+++ b/specs/006-results-shell/contracts/tab-ui.md
@@ -2,7 +2,7 @@
 
 ## Header
 
-- Shows ForkPrint title and short product framing
+- Shows RepoPulse title and short product framing
 - Shows a visible GitHub repo link in the header
 - On desktop, the GitHub link is placed in the top-right area of the header
 - On mobile, the link remains visible within the header without overlap or clipping

--- a/specs/006-results-shell/plan.md
+++ b/specs/006-results-shell/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Introduce a stable application shell for ForkPrint so analysis is submitted once and then explored through tabs instead of stacking each view vertically on the page. The shell adds a branded header with a GitHub repo link, a persistent analysis panel, and a result workspace that can host current and future views, starting with an Overview tab and an Ecosystem Map tab that will later absorb the paused `P1-F05` work.
+Introduce a stable application shell for RepoPulse so analysis is submitted once and then explored through tabs instead of stacking each view vertically on the page. The shell adds a branded header with a GitHub repo link, a persistent analysis panel, and a result workspace that can host current and future views, starting with an Overview tab and an Ecosystem Map tab that will later absorb the paused `P1-F05` work.
 
 ## Technical Context
 

--- a/specs/006-results-shell/spec.md
+++ b/specs/006-results-shell/spec.md
@@ -25,7 +25,7 @@ A user can submit repositories once and then move between result views through t
 
 ### User Story 2 - Understand the app structure at a glance (Priority: P1)
 
-A user can immediately understand that ForkPrint is an application with a stable header, a clear GitHub repo link, and a dedicated analysis workspace.
+A user can immediately understand that RepoPulse is an application with a stable header, a clear GitHub repo link, and a dedicated analysis workspace.
 
 **Why this priority**: This gives the app a durable product frame before more data views land and reduces the “prototype stack of boxes” feeling.
 
@@ -33,7 +33,7 @@ A user can immediately understand that ForkPrint is an application with a stable
 
 **Acceptance Scenarios**:
 
-1. **Given** the user loads the app, **When** the page renders, **Then** a header/banner presents the ForkPrint brand and a GitHub repo link in a predictable location.
+1. **Given** the user loads the app, **When** the page renders, **Then** a header/banner presents the RepoPulse brand and a GitHub repo link in a predictable location.
 2. **Given** the user is on desktop or mobile, **When** the shell renders, **Then** the header and analysis panel remain readable and usable without layout breakage.
 3. **Given** the user has not analyzed anything yet, **When** they view the shell, **Then** the page still feels intentional rather than like a collection of unrelated controls.
 
@@ -68,7 +68,7 @@ A user can use tabs as a stable navigation model for current and upcoming result
 ### Functional Requirements
 
 - **FR-001**: The system MUST provide a stable application shell around the analysis experience.
-- **FR-002**: The shell MUST include a top header/banner with ForkPrint branding.
+- **FR-002**: The shell MUST include a top header/banner with RepoPulse branding.
 - **FR-003**: The shell MUST include a visible GitHub repository link in the header.
 - **FR-004**: The shell MUST keep the repo input and Analyze controls in a stable analysis panel that remains available while browsing result views.
 - **FR-005**: The shell MUST provide tabs for navigating between result views after analysis.
@@ -84,7 +84,7 @@ A user can use tabs as a stable navigation model for current and upcoming result
 ### Key Entities
 
 - **Results Shell**: The stable page frame containing the header, analysis panel, and tabbed result area.
-- **Header Banner**: The top application region containing ForkPrint branding and the GitHub repo link.
+- **Header Banner**: The top application region containing RepoPulse branding and the GitHub repo link.
 - **Analysis Panel**: The stable control area containing repo input, auth controls, and the Analyze action.
 - **Result Tab**: A named navigation target for a result view such as `Overview`, `Contributors`, `Metrics`, `Responsiveness`, or `Comparison`.
 - **Placeholder View**: An intentional temporary state for a future tab that is not fully implemented yet.

--- a/specs/007-deployment/data-model.md
+++ b/specs/007-deployment/data-model.md
@@ -4,7 +4,7 @@
 
 ### DeploymentEnvironment
 
-- **Purpose**: Represents the runtime environment where ForkPrint runs
+- **Purpose**: Represents the runtime environment where RepoPulse runs
 - **Fields**:
   - `name: "local" | "vercel"`
   - `hasServerToken: boolean`

--- a/specs/007-deployment/plan.md
+++ b/specs/007-deployment/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Make ForkPrint ready for Phase 1 Vercel deployment without changing the product surface beyond deployment-specific behavior. The feature will verify zero-config Vercel deployability, document the deployment setup, preserve the existing stateless architecture, and confirm that server-side `GITHUB_TOKEN` takes precedence while the PAT field stays hidden in shared deployments.
+Make RepoPulse ready for Phase 1 Vercel deployment without changing the product surface beyond deployment-specific behavior. The feature will verify zero-config Vercel deployability, document the deployment setup, preserve the existing stateless architecture, and confirm that server-side `GITHUB_TOKEN` takes precedence while the PAT field stays hidden in shared deployments.
 
 ## Technical Context
 

--- a/specs/007-deployment/quickstart.md
+++ b/specs/007-deployment/quickstart.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Verify that ForkPrint can be prepared for a shared Vercel deployment while preserving the existing local-development and token-handling behavior.
+Verify that RepoPulse can be prepared for a shared Vercel deployment while preserving the existing local-development and token-handling behavior.
 
 ## Scenarios
 

--- a/specs/007-deployment/spec.md
+++ b/specs/007-deployment/spec.md
@@ -7,9 +7,9 @@
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Deploy ForkPrint to Vercel with minimal setup (Priority: P1)
+### User Story 1 - Deploy RepoPulse to Vercel with minimal setup (Priority: P1)
 
-A maintainer can deploy ForkPrint to Vercel with zero custom server infrastructure so the current web app can be shared outside local development.
+A maintainer can deploy RepoPulse to Vercel with zero custom server infrastructure so the current web app can be shared outside local development.
 
 **Why this priority**: The feature only delivers value if the current app can be deployed reliably in the Phase 1 hosting model defined in the product and constitution.
 
@@ -17,7 +17,7 @@ A maintainer can deploy ForkPrint to Vercel with zero custom server infrastructu
 
 **Acceptance Scenarios**:
 
-1. **Given** the current ForkPrint repo is connected to a new Vercel project, **When** the default build and runtime settings are used, **Then** the app deploys without requiring custom server infrastructure or platform-specific code changes.
+1. **Given** the current RepoPulse repo is connected to a new Vercel project, **When** the default build and runtime settings are used, **Then** the app deploys without requiring custom server infrastructure or platform-specific code changes.
 2. **Given** a successful Vercel deployment exists, **When** a user opens the deployed site, **Then** the existing Phase 1 UI loads and the analysis flow remains available.
 
 ---
@@ -74,7 +74,7 @@ A maintainer can rely on the deployed app remaining stateless and not introducin
 
 ### Key Entities
 
-- **Deployment Environment**: The runtime configuration for ForkPrint in local development or Vercel, including environment variables such as `GITHUB_TOKEN`.
+- **Deployment Environment**: The runtime configuration for RepoPulse in local development or Vercel, including environment variables such as `GITHUB_TOKEN`.
 - **Shared Deployment Token Path**: The server-side execution path that uses deployment environment variables instead of a client-supplied PAT.
 - **Deployment Setup Guide**: The user-facing documentation that explains how to configure and verify a Vercel deployment safely.
 

--- a/specs/007-deployment/tasks.md
+++ b/specs/007-deployment/tasks.md
@@ -42,9 +42,9 @@
 
 ---
 
-## Phase 3: User Story 1 - Deploy ForkPrint to Vercel with minimal setup (Priority: P1) 🎯 MVP
+## Phase 3: User Story 1 - Deploy RepoPulse to Vercel with minimal setup (Priority: P1) 🎯 MVP
 
-**Goal**: A maintainer can deploy ForkPrint to Vercel with the standard Next.js path and documented setup.
+**Goal**: A maintainer can deploy RepoPulse to Vercel with the standard Next.js path and documented setup.
 
 **Independent Test**: Review the app and deployment docs, then verify that the current project remains compatible with default Vercel deployment expectations and that setup guidance is clear.
 


### PR DESCRIPTION
## Summary
- clean up remaining slug and branding references after the GitHub repo rename to `repo-pulse`
- update package metadata, GitHub links, docs/specs, and the live README deployment URL
- migrate PAT storage to `repo_pulse_github_token` with backward-compatible fallback from the old key

## Verification
- `npm test -- --run lib/token-storage.test.ts components/app-shell/ResultsShell.test.tsx components/repo-input/RepoInputClient.test.tsx`
- `npm run lint`

## Notes
- the old `forkprint_github_token` string remains intentionally as a legacy fallback for local token migration
- `.vercel/project.json` was updated locally to match the renamed Vercel project, but that file remains gitignored and is not part of this PR