### PR TITLE
Hotfix: OAuth callback redirects to correct host in all environments

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -10,7 +10,8 @@ export async function GET(request: Request) {
   const code = url.searchParams.get('code')
   const state = url.searchParams.get('state')
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
+  const { origin } = new URL(request.url)
+  const appUrl = origin
 
   // Handle user denial or GitHub error
   if (error) {


### PR DESCRIPTION
## Problem

The Vercel production deployment was redirecting users back to `http://localhost:3000` after GitHub OAuth authorization, making sign-in impossible on the live app.

## Diagnosis

Worked through several hypotheses before finding root cause:

1. **GitHub OAuth App callback URL misconfigured** — ruled out; the production OAuth App had `https://repopulse-arun-gupta.vercel.app/api/auth/callback` correctly set.
2. **Wrong `GITHUB_CLIENT_ID` in Vercel env vars** — ruled out; confirmed via the GitHub authorize URL in the browser address bar that the client ID matched the production OAuth App exactly.
3. **Browser/cookie cache** — ruled out; same behavior in a fresh incognito window after revoking all user tokens on the OAuth App.
4. **Stale Vercel deployment** — ruled out; the current production deployment was built from the correct commit (merged PR #38).
5. **Root cause found** — reading `app/api/auth/callback/route.ts`, line 13:

```ts
const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'
```

`NEXT_PUBLIC_APP_URL` was never set in Vercel, so the callback route always redirected to `http://localhost:3000` regardless of where the request came from. GitHub's callback URL was correct, but *our* callback route was then redirecting to localhost.

## Fix

Derive the app URL from `request.url` (the actual URL the server received) instead of an env var:

```ts
const { origin } = new URL(request.url)
const appUrl = origin
```

This works correctly in all environments — `http://localhost:3000` locally, `https://repopulse-arun-gupta.vercel.app` in production — with no configuration required.

## Test plan

- [ ] Merge and verify Vercel redeploys automatically
- [ ] Open `https://repopulse-arun-gupta.vercel.app` → click "Sign in with GitHub" → confirm redirect goes to GitHub (not localhost) → confirm successful sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)