### PR TITLE
Support numbered GITHUB_TOKEN env vars for multi-token calibration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,16 +5,22 @@
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
-# GitHub PAT for calibration scripts (npm run calibrate).
+# GitHub PATs for calibration scripts (npm run calibrate).
 # Generate at: https://github.com/settings/tokens → "Generate new token (classic)"
 # Required scope: public_repo (read access only) — no other scopes needed.
 #
-# Single token (simple):
-GITHUB_TOKEN=
+# Option 1 — Numbered (recommended for 3+ tokens, one per line):
+# GITHUB_TOKEN_1=ghp_...
+# GITHUB_TOKEN_2=ghp_...
+# GITHUB_TOKEN_3=ghp_...
+# GITHUB_TOKEN_4=ghp_...
+# GITHUB_TOKEN_5=ghp_...
 #
-# Multi-token round-robin (recommended — multiplies rate limit):
-# Generate additional PATs at the same URL above (one per GitHub account).
-# Add comma-separated PATs. Each additional token roughly doubles throughput.
-# GITHUB_TOKENS takes precedence over GITHUB_TOKEN when both are set.
-# Example: GITHUB_TOKENS=ghp_token1,ghp_token2,ghp_token3
-GITHUB_TOKENS=
+# Option 2 — Comma-separated (single line):
+# GITHUB_TOKENS=ghp_token1,ghp_token2,ghp_token3
+#
+# Option 3 — Single token:
+# GITHUB_TOKEN=ghp_...
+#
+# Priority: numbered → comma-separated → single.
+# Each additional token roughly doubles rate limit throughput.

--- a/docs/scoring-and-calibration.md
+++ b/docs/scoring-and-calibration.md
@@ -71,7 +71,7 @@ The calibration script (`scripts/calibrate.ts`) makes three API calls per repo:
 2. **REST contributors endpoint** — `/repos/{owner}/{name}/stats/contributors` — for `topContributorShare`. This is a separate call because contributor stats are not available via GraphQL.
 3. **Search API** — `is:pr is:open repo:{owner}/{name} updated:<DATE` with `per_page=1` — for `stalePrRatio`. Only `total_count` is needed; fetching a single result is sufficient.
 
-**Multi-token round-robin:** The script accepts `GITHUB_TOKENS` (comma-separated PATs) and round-robins across all tokens for every API call, multiplying effective rate limit capacity. Each additional token adds roughly one full token's worth of throughput.
+**Multi-token round-robin:** The script round-robins across all configured tokens for every API call, multiplying effective rate limit capacity. Each additional token adds roughly one full token's worth of throughput. Tokens can be configured as numbered env vars (`GITHUB_TOKEN_1`, `GITHUB_TOKEN_2`, ...), comma-separated (`GITHUB_TOKENS`), or a single token (`GITHUB_TOKEN`).
 
 **Retry and resilience:** All API calls are wrapped with automatic retry (up to 3 attempts with exponential backoff) for network errors (socket closures) and server errors (502, 503). Rate limit responses (403, 429) are handled by waiting for the `Retry-After` header. GraphQL responses with partial `RESOURCE_LIMITS_EXCEEDED` errors are handled gracefully — available fields are used, nulled-out fields are skipped.
 
@@ -232,10 +232,18 @@ npm run calibrate
 
 **Requirements:** Node.js 18+, at least one GitHub PAT with `public_repo` read access in `.env.local`.
 
-**Multi-token setup (recommended):** Add comma-separated PATs to `.env.local` as `GITHUB_TOKENS`. Each additional token adds roughly one full token's worth of rate limit capacity.
+**Multi-token setup (recommended):** Add PATs to `.env.local`. Each additional token adds roughly one full token's worth of rate limit capacity. 5 tokens recommended for ~800 repo calibration runs.
 
-```
-GITHUB_TOKENS=ghp_token1,ghp_token2,ghp_token3
+```bash
+# Numbered (recommended for 3+ tokens):
+GITHUB_TOKEN_1=ghp_...
+GITHUB_TOKEN_2=ghp_...
+GITHUB_TOKEN_3=ghp_...
+GITHUB_TOKEN_4=ghp_...
+GITHUB_TOKEN_5=ghp_...
+
+# Or comma-separated (single line):
+# GITHUB_TOKENS=ghp_token1,ghp_token2,ghp_token3
 ```
 
 The script checkpoints to `scripts/calibrate-checkpoint.json` after every batch. If interrupted (network errors, rate limits), re-running resumes from where it left off. Delete the checkpoint file to start fresh.

--- a/scripts/calibrate.ts
+++ b/scripts/calibrate.ts
@@ -22,14 +22,37 @@ import { existsSync, readFileSync, writeFileSync } from 'fs'
 loadEnvConfig(process.cwd())
 
 // ─── Token pool ───────────────────────────────────────────────────────────────
+//
+// Priority: GITHUB_TOKEN_1/2/3/... (numbered) → GITHUB_TOKENS (comma-separated) → GITHUB_TOKEN (single)
 
-const rawTokens = (process.env.GITHUB_TOKENS ?? process.env.GITHUB_TOKEN ?? '')
-  .split(',')
-  .map((t) => t.trim())
-  .filter(Boolean)
+function collectTokens(): string[] {
+  // 1. Numbered: GITHUB_TOKEN_1, GITHUB_TOKEN_2, ...
+  const numbered: string[] = []
+  for (const [key, value] of Object.entries(process.env)) {
+    if (/^GITHUB_TOKEN_\d+$/i.test(key) && value?.trim()) {
+      numbered.push(value.trim())
+    }
+  }
+  if (numbered.length > 0) return numbered
+
+  // 2. Comma-separated: GITHUB_TOKENS
+  if (process.env.GITHUB_TOKENS) {
+    const tokens = process.env.GITHUB_TOKENS.split(',').map((t) => t.trim()).filter(Boolean)
+    if (tokens.length > 0) return tokens
+  }
+
+  // 3. Single: GITHUB_TOKEN
+  if (process.env.GITHUB_TOKEN?.trim()) {
+    return [process.env.GITHUB_TOKEN.trim()]
+  }
+
+  return []
+}
+
+const rawTokens = collectTokens()
 
 if (rawTokens.length === 0) {
-  console.error('No GitHub tokens found. Set GITHUB_TOKENS or GITHUB_TOKEN in .env.local')
+  console.error('No GitHub tokens found. Set GITHUB_TOKEN_1, GITHUB_TOKEN_2, ... or GITHUB_TOKENS or GITHUB_TOKEN in .env.local')
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary

Closes #95

Adds support for numbered env vars (`GITHUB_TOKEN_1`, `GITHUB_TOKEN_2`, ...) as a cleaner alternative to the comma-separated `GITHUB_TOKENS` format when using 3+ tokens.

### Before
```bash
GITHUB_TOKENS=ghp_very_long_token_1,ghp_very_long_token_2,ghp_very_long_token_3,ghp_very_long_token_4,ghp_very_long_token_5
```

### After
```bash
GITHUB_TOKEN_1=ghp_...
GITHUB_TOKEN_2=ghp_...
GITHUB_TOKEN_3=ghp_...
GITHUB_TOKEN_4=ghp_...
GITHUB_TOKEN_5=ghp_...
```

### Priority order
1. `GITHUB_TOKEN_1`, `GITHUB_TOKEN_2`, ... (numbered)
2. `GITHUB_TOKENS` (comma-separated, backward compatible)
3. `GITHUB_TOKEN` (single token fallback)

### Files changed
- `scripts/calibrate.ts` — `collectTokens()` function with priority logic
- `.env.example` — documents all three formats
- `docs/scoring-and-calibration.md` — updated multi-token setup instructions

## Test plan

- [x] `npm run test` — all 250 tests pass
- [x] `npm run build` — no type errors
- [x] Numbered tokens collected from env vars
- [x] Backward compatible with `GITHUB_TOKENS` and `GITHUB_TOKEN`
- [x] Script logs token count on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)