### PR TITLE
Replace experimental org heatmap with verified public membership

### DIFF
--- a/components/contributors/ContributionBarChart.tsx
+++ b/components/contributors/ContributionBarChart.tsx
@@ -9,7 +9,7 @@ interface ContributionBarChartProps {
   items: ContributorHeatmapCell[]
   ariaLabel: string
   emptyText: string
-  tone?: 'cyan' | 'amber'
+  tone?: 'cyan' | 'amber' | 'slate'
   defaultVisibleCount?: number
   entityLabel: string
   actions?: ReactNode
@@ -46,7 +46,9 @@ export function ContributionBarChart({
   const barToneClass =
     tone === 'amber'
       ? 'bg-gradient-to-r from-amber-200 via-amber-400 to-amber-700'
-      : 'bg-gradient-to-r from-cyan-200 via-cyan-400 to-cyan-700'
+      : tone === 'slate'
+        ? 'bg-gradient-to-r from-slate-200 via-slate-400 to-slate-600'
+        : 'bg-gradient-to-r from-cyan-200 via-cyan-400 to-cyan-700'
 
   return (
     <div className="mt-4 rounded-xl border border-slate-200 bg-white p-3">

--- a/components/contributors/SustainabilityPane.test.tsx
+++ b/components/contributors/SustainabilityPane.test.tsx
@@ -49,11 +49,11 @@ describe('SustainabilityPane', () => {
             },
           ],
           experimentalHeatmap: [
-            { contributor: 'meta', commits: 7, commitsLabel: '7 attributed commits', intensity: 'max' },
-            { contributor: 'openai', commits: 3, commitsLabel: '3 attributed commits', intensity: 'high' },
+            { contributor: 'meta', commits: 7, commitsLabel: '7 commits', intensity: 'max' },
+            { contributor: 'openai', commits: 3, commitsLabel: '3 commits', intensity: 'high' },
           ],
           experimentalWarning:
-            'Best-effort estimate. Uses heuristic public GitHub organization attribution and may be incomplete or inaccurate.',
+            'Based on verified public GitHub organization memberships only. Contributors without public org membership appear as "Unaffiliated." Affiliations reflect current membership at analysis time — not historical employment at the time each commit was made. Contributors who change employers will show under their current organization.',
           missingData: ['Total contributors', 'New contributors (90d)'],
         }}
       />,
@@ -74,7 +74,7 @@ describe('SustainabilityPane', () => {
     expect(screen.queryByText('Occasional contributors')).not.toBeInTheDocument()
     expect(screen.getByText('Types of contributions')).toBeInTheDocument()
     expect(screen.getByText('Commits, Pull requests, Issues')).toBeInTheDocument()
-    expect(screen.getByText(/best-effort estimate/i)).toBeInTheDocument()
+    expect(screen.getByText(/verified public GitHub organization memberships/i)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /chaoss elephant factor reference/i })).toHaveAttribute(
       'href',
       'https://chaoss.community/kb/metric-elephant-factor/',
@@ -119,15 +119,15 @@ describe('SustainabilityPane', () => {
     expect(screen.getByRole('button', { name: /hide chart/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /hide names/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /show numbers/i })).toBeInTheDocument()
-    expect(screen.getByRole('list', { name: /attributed organization bars/i })).toBeInTheDocument()
-    expect(screen.getByLabelText(/meta 7 attributed commits/i)).toBeInTheDocument()
+    expect(screen.getByRole('list', { name: /organization contribution bars/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/meta 7 commits/i)).toBeInTheDocument()
     expect(screen.getByText('meta')).toBeInTheDocument()
-    expect(screen.queryByText('7 attributed commits')).not.toBeInTheDocument()
+    expect(screen.queryByText('7 commits')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: /show numbers/i }))
 
     expect(screen.getByRole('button', { name: /hide numbers/i })).toBeInTheDocument()
-    expect(screen.getByText('7 attributed commits')).toBeInTheDocument()
+    expect(screen.getByText('7 commits')).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: /hide names/i }))
 

--- a/components/contributors/SustainabilityPane.tsx
+++ b/components/contributors/SustainabilityPane.tsx
@@ -70,16 +70,16 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
         ))}
       </dl>
 
-      <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-3">
+      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
         <div className="flex flex-col gap-1">
-          <p className="text-xs font-medium uppercase tracking-wide text-amber-900">Experimental</p>
-          <p className="text-sm text-amber-900">{section.experimentalWarning}</p>
-          <p className="text-sm text-amber-900">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-900">Organization Affiliation</p>
+          <p className="text-sm text-slate-600">{section.experimentalWarning}</p>
+          <p className="text-sm text-slate-600">
             <a
               href="https://chaoss.community/kb/metric-elephant-factor/"
               target="_blank"
               rel="noreferrer"
-              className="font-medium underline underline-offset-2"
+              className="font-medium text-slate-700 underline underline-offset-2"
             >
               CHAOSS Elephant Factor reference
             </a>
@@ -87,7 +87,7 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
         </div>
         <dl className="mt-3 grid gap-3 md:grid-cols-2">
           {section.experimentalMetrics.map((metric) => (
-            <div key={metric.label} className="rounded-xl border border-amber-200 bg-white p-3">
+            <div key={metric.label} className="rounded-xl border border-slate-200 bg-white p-3">
               <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
                 <HelpLabel label={metric.label} helpText={metric.hoverText} />
               </dt>
@@ -97,12 +97,12 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
         </dl>
         {section.experimentalHeatmap.length > 0 ? (
           <ContributionBarChart
-            title="Attributed organization chart"
-            description="Longer bars indicate more experimentally attributed recent commits."
+            title="Organization contribution chart"
+            description="Longer bars indicate more recent commits attributed via verified public GitHub organization membership."
             items={section.experimentalHeatmap}
-            ariaLabel="Attributed organization bars"
+            ariaLabel="Organization contribution bars"
             emptyText="—"
-            tone="amber"
+            tone="slate"
             entityLabel="organizations"
             defaultVisibleCount={8}
             collapsed={!showExperimentalHeatmap}
@@ -113,7 +113,7 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
                 <button
                   type="button"
                   onClick={() => setShowExperimentalHeatmap((current) => !current)}
-                  className="rounded-full border border-amber-200 px-3 py-1 text-xs font-medium text-amber-900 transition hover:border-amber-300"
+                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400"
                   aria-pressed={showExperimentalHeatmap}
                 >
                   {showExperimentalHeatmap ? 'Hide chart' : 'Show chart'}
@@ -123,7 +123,7 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
                     <button
                       type="button"
                       onClick={() => setShowExperimentalNames((current) => !current)}
-                      className="rounded-full border border-amber-200 px-3 py-1 text-xs font-medium text-amber-900 transition hover:border-amber-300"
+                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400"
                       aria-pressed={showExperimentalNames}
                     >
                       {showExperimentalNames ? 'Hide names' : 'Show names'}
@@ -131,7 +131,7 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
                     <button
                       type="button"
                       onClick={() => setShowExperimentalNumbers((current) => !current)}
-                      className="rounded-full border border-amber-200 px-3 py-1 text-xs font-medium text-amber-900 transition hover:border-amber-300"
+                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400"
                       aria-pressed={showExperimentalNumbers}
                     >
                       {showExperimentalNumbers ? 'Hide numbers' : 'Show numbers'}

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -1218,7 +1218,7 @@ async function buildExperimentalOrganizationCommitCountsByWindow(
   }
 
   let rateLimit: RateLimitState | null = null
-  const organizationByLogin = new Map<string, string | null>()
+  const organizationsByLogin = new Map<string, string[]>()
 
   for (const login of uniqueLogins) {
     const response = await fetchPublicUserOrganizations(token, login).catch((error) => ({
@@ -1228,16 +1228,15 @@ async function buildExperimentalOrganizationCommitCountsByWindow(
     rateLimit = response.rateLimit ?? rateLimit
 
     if (response.data === 'unavailable') {
-      organizationByLogin.set(login, null)
+      organizationsByLogin.set(login, [])
       continue
     }
 
-    const [org] = response.data
-    organizationByLogin.set(login, org ?? null)
+    organizationsByLogin.set(login, response.data)
   }
 
   return {
-    data: buildExperimentalMetricsByWindow(recentCommitNodes, organizationByLogin, now),
+    data: buildExperimentalMetricsByWindow(recentCommitNodes, organizationsByLogin, now),
     rateLimit,
   }
 }
@@ -1382,7 +1381,7 @@ function createUnavailableContributorWindowMetrics(): Record<ContributorWindowDa
 
 function buildExperimentalMetricsByWindow(
   recentCommitNodes: CommitNode[],
-  organizationByLogin: Map<string, string | null>,
+  organizationsByLogin: Map<string, string[]>,
   now: Date,
 ): Record<ContributorWindowDays, ContributorWindowMetrics> {
   return Object.fromEntries(
@@ -1421,14 +1420,31 @@ function buildExperimentalMetricsByWindow(
           continue
         }
 
-        const org = organizationByLogin.get(login) ?? null
-        if (!org) {
+        const orgs = organizationsByLogin.get(login) ?? []
+        if (orgs.length === 0) {
           unattributedAuthors.add(actorKey)
           continue
         }
 
         attributedAuthors.add(actorKey)
-        commitCountsByExperimentalOrg.set(org, (commitCountsByExperimentalOrg.get(org) ?? 0) + 1)
+        // Attribute commit to all public organizations the contributor belongs to
+        for (const org of orgs) {
+          commitCountsByExperimentalOrg.set(org, (commitCountsByExperimentalOrg.get(org) ?? 0) + 1)
+        }
+      }
+
+      // Include unaffiliated commits in the org map for transparent reporting
+      if (unattributedAuthors.size > 0 && sawResolvableAuthor) {
+        let unaffiliatedCommits = 0
+        for (const node of windowNodes) {
+          const actorKey = getCommitActorKey(node)
+          if (actorKey && unattributedAuthors.has(actorKey)) {
+            unaffiliatedCommits++
+          }
+        }
+        if (unaffiliatedCommits > 0) {
+          commitCountsByExperimentalOrg.set('Unaffiliated', unaffiliatedCommits)
+        }
       }
 
       return [

--- a/lib/analyzer/analyzer.test.ts
+++ b/lib/analyzer/analyzer.test.ts
@@ -683,7 +683,7 @@ describe('analyze', () => {
     expect(result.results[0]?.missingFields).toContain('maintainerCount')
   })
 
-  it('keeps verified-organization metrics unavailable when contributors do not resolve to exactly one public organization', async () => {
+  it('shows Unaffiliated in org metrics when contributors have no public organization', async () => {
     fetchPublicUserOrganizationsMock.mockResolvedValueOnce({
       data: [],
       rateLimit: { remaining: 4995, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
@@ -737,9 +737,8 @@ describe('analyze', () => {
     })
 
     expect(result.results[0]).toMatchObject({
-      commitCountsByExperimentalOrg: 'unavailable',
+      commitCountsByExperimentalOrg: { Unaffiliated: 1 },
     })
-    expect(result.results[0]?.missingFields).toContain('commitCountsByExperimentalOrg')
   })
 
   it('degrades experimental org attribution when a user organization lookup fails', async () => {

--- a/lib/contributors/view-model.test.ts
+++ b/lib/contributors/view-model.test.ts
@@ -111,7 +111,7 @@ describe('contributors/view-model', () => {
     expect(section.experimentalMetrics.find((metric) => metric.label === 'Elephant Factor')?.value).toBe('1')
     expect(section.experimentalMetrics.find((metric) => metric.label === 'Single-vendor dependency ratio')?.value).toBe('63.6%')
     expect(section.experimentalHeatmap.map((cell) => cell.contributor)).toEqual(['meta', 'openai', 'vercel'])
-    expect(section.experimentalHeatmap[0]?.commitsLabel).toBe('7 attributed commits')
+    expect(section.experimentalHeatmap[0]?.commitsLabel).toBe('7 commits')
   })
 
   it('keeps unavailable contributor values explicit', () => {

--- a/lib/contributors/view-model.ts
+++ b/lib/contributors/view-model.ts
@@ -122,7 +122,7 @@ export function buildContributorsViewModels(
         },
       ],
       experimentalWarning:
-        'Best-effort estimate. Uses heuristic public GitHub organization attribution and may be incomplete or inaccurate.',
+        'Based on verified public GitHub organization memberships only. Contributors without public org membership appear as "Unaffiliated." Affiliations reflect current membership at analysis time — not historical employment at the time each commit was made. Contributors who change employers will show under their current organization.',
       missingData: buildMissingDataList(
         result,
         windowMetrics,
@@ -346,7 +346,11 @@ function computeElephantFactor(commitCountsByExperimentalOrg: Record<string, num
     return 'unavailable'
   }
 
-  const counts = Object.values(commitCountsByExperimentalOrg).filter((count) => count > 0).sort((a, b) => b - a)
+  // Exclude "Unaffiliated" — it's not a real organization
+  const counts = Object.entries(commitCountsByExperimentalOrg)
+    .filter(([org, count]) => org !== 'Unaffiliated' && count > 0)
+    .map(([, count]) => count)
+    .sort((a, b) => b - a)
   if (counts.length === 0) {
     return 'unavailable'
   }
@@ -371,7 +375,10 @@ function computeSingleVendorDependencyRatio(
     return 'unavailable'
   }
 
-  const counts = Object.values(commitCountsByExperimentalOrg).filter((count) => count > 0)
+  // Exclude "Unaffiliated" — it's not a real organization
+  const counts = Object.entries(commitCountsByExperimentalOrg)
+    .filter(([org, count]) => org !== 'Unaffiliated' && count > 0)
+    .map(([, count]) => count)
   if (counts.length === 0) {
     return 'unavailable'
   }
@@ -453,7 +460,7 @@ function buildHeatmap(
   return entries.map(([contributor, commits]) => ({
     contributor: kind === 'organization' ? contributor : formatContributorLabel(contributor),
     commits,
-    commitsLabel: `${new Intl.NumberFormat('en-US').format(commits)} ${kind === 'organization' ? 'attributed ' : ''}${commits === 1 ? 'commit' : 'commits'}`,
+    commitsLabel: `${new Intl.NumberFormat('en-US').format(commits)} ${commits === 1 ? 'commit' : 'commits'}`,
     intensity: getIntensity(commits, maxCommits),
   }))
 }


### PR DESCRIPTION
## Summary
- Uses **all** public GitHub organization memberships per contributor (previously only the first)
- Adds explicit **"Unaffiliated"** category for contributors without public org membership, shown transparently in the heatmap
- Excludes "Unaffiliated" from Elephant Factor and Single-vendor ratio (not a real organization)
- Replaces amber "Experimental" styling with standard slate "Organization Affiliation" section
- Adds transparency callout documenting exactly what "verified" means and the maintainer mobility limitation

### Transparency callout
> Based on verified public GitHub organization memberships only. Contributors without public org membership appear as "Unaffiliated." Affiliations reflect current membership at analysis time — not historical employment at the time each commit was made. Contributors who change employers will show under their current organization.

Closes #13

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] All tests pass (`npx vitest run` — 249 pass, 1 pre-existing failure on main)
- [ ] Organization Affiliation section renders with slate styling (not amber)
- [ ] Heatmap shows "Unaffiliated" category for contributors without public org membership
- [ ] Elephant Factor and Single-vendor ratio exclude "Unaffiliated" from calculations
- [ ] Transparency callout visible in the Organization Affiliation section
- [ ] Contributors with multiple public orgs attribute commits to all orgs

🤖 Generated with [Claude Code](https://claude.com/claude-code)