### PR TITLE
Recommend CODEOWNERS/MAINTAINERS when no maintainers identified

### DIFF
--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -78,6 +78,14 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
       tab: 'contributors',
     })
   }
+  if (result.maintainerCount === 'unavailable') {
+    recommendations.push({
+      bucket: 'Sustainability',
+      percentile: sustainabilityPercentile ?? 0,
+      message: 'No maintainers could be identified. Add a CODEOWNERS file, an MAINTAINERS file, or configure repository roles so maintainer responsibility is visible to contributors and adopters.',
+      tab: 'contributors',
+    })
+  }
   if (documentation !== null) {
     for (const rec of documentation.recommendations) {
       recommendations.push({

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -82,7 +82,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
     recommendations.push({
       bucket: 'Sustainability',
       percentile: sustainabilityPercentile ?? 0,
-      message: 'No maintainers could be identified. Add a CODEOWNERS file, an MAINTAINERS file, or configure repository roles so maintainer responsibility is visible to contributors and adopters.',
+      message: 'No maintainers identified. Add a CODEOWNERS or MAINTAINERS.md file to make maintainer responsibility visible.',
       tab: 'contributors',
     })
   }


### PR DESCRIPTION
## Summary
- When `maintainerCount` is unavailable, add a sustainability recommendation to add a CODEOWNERS or MAINTAINERS.md file
- Closes #127

## Test plan
- [x] All 256 unit tests pass
- [x] Analyze a repo without CODEOWNERS/MAINTAINERS — recommendation appears in the Recommendations tab
- [x] Analyze a repo with CODEOWNERS — no maintainer recommendation shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)