### PR TITLE
Add backend log viewer for in-browser debugging

### DIFF
--- a/app/api/analyze-org/route.ts
+++ b/app/api/analyze-org/route.ts
@@ -14,13 +14,20 @@ export async function POST(request: Request) {
       return Response.json({ error: 'Authentication required.' }, { status: 401 })
     }
 
+    console.log(`[analyze-org] Starting inventory for org: ${body.org}`)
+    const start = Date.now()
+
     const response = await analyzeOrgInventory({
       org: body.org,
       token,
     })
 
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1)
+    console.log(`[analyze-org] Completed in ${elapsed}s — ${response.results.length} repos found`)
+
     return Response.json(response)
-  } catch {
+  } catch (error) {
+    console.error(`[analyze-org] Request failed:`, error)
     return Response.json({ error: 'Organization inventory request failed.' }, { status: 500 })
   }
 }

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -14,13 +14,28 @@ export async function POST(request: Request) {
       return Response.json({ error: 'Authentication required.' }, { status: 401 })
     }
 
+    console.log(`[analyze] Starting analysis for ${body.repos.length} repo(s): ${body.repos.join(', ')}`)
+    const start = Date.now()
+
     const response = await analyze({
       repos: body.repos,
       token,
     })
 
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1)
+    console.log(`[analyze] Completed in ${elapsed}s — ${response.results.length} succeeded, ${response.failures.length} failed`)
+    if (response.rateLimit) {
+      console.log(`[analyze] Rate limit remaining: ${response.rateLimit.remaining}, resets at: ${response.rateLimit.resetAt}`)
+    }
+    if (response.diagnostics?.length) {
+      for (const d of response.diagnostics) {
+        console.warn(`[analyze] Diagnostic: ${d.repo} ${d.source} — ${d.message}`)
+      }
+    }
+
     return Response.json(response)
-  } catch {
+  } catch (error) {
+    console.error(`[analyze] Request failed:`, error)
     return Response.json({ error: 'Analysis request failed.' }, { status: 500 })
   }
 }

--- a/app/api/debug/logs/route.ts
+++ b/app/api/debug/logs/route.ts
@@ -1,0 +1,41 @@
+import { getEntries, installLogger, subscribe } from '@/lib/debug/logger'
+
+export const runtime = 'nodejs'
+
+export async function GET() {
+  if (process.env.NODE_ENV !== 'development') {
+    return Response.json({ error: 'Not available in production.' }, { status: 404 })
+  }
+
+  installLogger()
+
+  const encoder = new TextEncoder()
+  const stream = new ReadableStream({
+    start(controller) {
+      // Send existing entries as a batch
+      for (const entry of getEntries()) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(entry)}\n\n`))
+      }
+
+      // Stream new entries
+      const unsubscribe = subscribe((entry) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(entry)}\n\n`))
+        } catch {
+          unsubscribe()
+        }
+      })
+
+      // Clean up if client disconnects — the controller will error on enqueue
+      // and the catch block above handles unsubscribe
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { DevToolsLink } from "@/components/debug/DevToolsLink";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,7 +17,10 @@ export default function RootLayout({
       <head>
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       </head>
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        {children}
+        <DevToolsLink />
+      </body>
     </html>
   );
 }

--- a/components/debug/DevToolsLink.tsx
+++ b/components/debug/DevToolsLink.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+interface LogEntry {
+  timestamp: string
+  level: 'info' | 'warn' | 'error'
+  message: string
+}
+
+const levelColors: Record<string, string> = {
+  info: 'text-blue-400',
+  warn: 'text-yellow-400',
+  error: 'text-red-400',
+}
+
+export function DevToolsLink() {
+  if (process.env.NODE_ENV !== 'development') return null
+
+  return <LogPanel />
+}
+
+function LogPanel() {
+  const [open, setOpen] = useState(false)
+  const [entries, setEntries] = useState<LogEntry[]>([])
+  const [connected, setConnected] = useState(false)
+  const [filter, setFilter] = useState<string>('')
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const eventSource = new EventSource('/api/debug/logs')
+
+    eventSource.onopen = () => setConnected(true)
+
+    eventSource.onmessage = (event) => {
+      const entry = JSON.parse(event.data) as LogEntry
+      setEntries((prev) => {
+        const next = [...prev, entry]
+        return next.length > 500 ? next.slice(-500) : next
+      })
+    }
+
+    eventSource.onerror = () => {
+      setConnected(false)
+      eventSource.close()
+    }
+
+    return () => eventSource.close()
+  }, [open])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [entries])
+
+  const filtered = filter ? entries.filter((e) => e.level === filter) : entries
+
+  if (!open) {
+    return (
+      <div className="fixed bottom-2 right-2 z-50">
+        <button
+          onClick={() => setOpen(true)}
+          className="rounded bg-gray-800 px-2 py-1 text-xs text-gray-400 hover:text-white"
+        >
+          Logs
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="fixed bottom-0 right-0 z-50 w-[600px] max-w-full h-80 flex flex-col bg-gray-950 border border-gray-700 rounded-tl-lg shadow-2xl font-mono text-sm">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800">
+        <div className="flex items-center gap-3">
+          <span className="text-gray-100 font-bold text-xs">Backend Logs</span>
+          <span
+            className={`inline-block w-2 h-2 rounded-full ${connected ? 'bg-green-500' : 'bg-red-500'}`}
+            title={connected ? 'Connected' : 'Disconnected'}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          {['', 'info', 'warn', 'error'].map((level) => (
+            <button
+              key={level}
+              onClick={() => setFilter(level)}
+              className={`px-2 py-0.5 rounded text-xs ${
+                filter === level
+                  ? 'bg-gray-700 text-white'
+                  : 'bg-gray-800 text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              {level || 'all'}
+            </button>
+          ))}
+          <button
+            onClick={() => setEntries([])}
+            className="px-2 py-0.5 rounded text-xs bg-gray-800 text-gray-400 hover:text-gray-200"
+          >
+            clear
+          </button>
+          <button
+            onClick={() => setOpen(false)}
+            className="px-2 py-0.5 rounded text-xs bg-gray-800 text-gray-400 hover:text-gray-200"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-0.5">
+        {filtered.length === 0 && (
+          <p className="text-gray-500">No log entries yet.</p>
+        )}
+        {filtered.map((entry, i) => (
+          <div key={i} className="flex gap-3">
+            <span className="text-gray-600 shrink-0">
+              {new Date(entry.timestamp).toLocaleTimeString()}
+            </span>
+            <span className={`shrink-0 uppercase w-12 ${levelColors[entry.level]}`}>
+              {entry.level}
+            </span>
+            <span className="text-gray-300 break-all">{entry.message}</span>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  )
+}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register() {
+  if (process.env.NODE_ENV === 'development') {
+    const { installLogger } = await import('@/lib/debug/logger')
+    installLogger()
+  }
+}

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -293,8 +293,10 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
 
   for (const repo of input.repos) {
     const [owner, name] = repo.split('/')
+    const repoStart = Date.now()
 
     try {
+      console.log(`[analyzer] ${repo} — fetching overview`)
       const overview = await queryGitHubGraphQL<RepoOverviewResponse>(input.token, REPO_OVERVIEW_QUERY, {
         owner,
         name,
@@ -302,6 +304,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
       latestRateLimit = overview.rateLimit ?? latestRateLimit
 
       if (!overview.data.repository) {
+        console.warn(`[analyzer] ${repo} — not found, skipping`)
         failures.push({
           repo,
           reason: 'Repository could not be analyzed.',
@@ -334,6 +337,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
       const repoSearch = `${owner}/${name}`
 
       // Pass 1: Commit history + releases (lightweight — no search queries)
+      console.log(`[analyzer] ${repo} — pass 1: commit history + releases`)
       const commitAndReleases = await queryGitHubGraphQL<RepoCommitAndReleasesResponse>(input.token, REPO_COMMIT_AND_RELEASES_QUERY, {
         owner,
         name,
@@ -346,6 +350,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
       latestRateLimit = commitAndReleases.rateLimit ?? latestRateLimit
 
       // Pass 2: Search-based PR/issue counts (may hit RESOURCE_LIMITS_EXCEEDED)
+      console.log(`[analyzer] ${repo} — pass 2: activity counts (search-based)`)
       const searchVariables = {
         prsOpened30Query: buildSearchQuery(repoSearch, 'is:pr', 'created', since30),
         prsOpened60Query: buildSearchQuery(repoSearch, 'is:pr', 'created', since60),
@@ -391,6 +396,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
         rateLimit: latestRateLimit,
       }
 
+      console.log(`[analyzer] ${repo} — fetching responsiveness metrics`)
       const responsiveness = await fetchResponsivenessTwoPass(
         input.token,
         {
@@ -409,6 +415,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
       )
       latestRateLimit = responsiveness.rateLimit ?? latestRateLimit
 
+      console.log(`[analyzer] ${repo} — fetching contributor + maintainer counts`)
       const contributorCount = await fetchContributorCount(input.token, owner, name).catch((error) => {
         latestRateLimit = extractRateLimitFromError(error) ?? latestRateLimit
         diagnostics.push(buildDiagnostic(repo, 'github-rest:contributors', error))
@@ -431,6 +438,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
       })
       latestRateLimit = maintainerCount.rateLimit ?? latestRateLimit
 
+      console.log(`[analyzer] ${repo} — collecting commit history`)
       const commitHistory = await collectRecentCommitHistory({
         token: input.token,
         owner,
@@ -463,7 +471,11 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
           experimentalOrgAttribution.data,
         ),
       )
+      const repoElapsed = ((Date.now() - repoStart) / 1000).toFixed(1)
+      console.log(`[analyzer] ${repo} — done in ${repoElapsed}s`)
     } catch (error) {
+      const repoElapsed = ((Date.now() - repoStart) / 1000).toFixed(1)
+      console.error(`[analyzer] ${repo} — failed after ${repoElapsed}s:`, error)
       latestRateLimit = latestRateLimit ?? extractRateLimitFromError(error)
       diagnostics.push(buildDiagnostic(repo, 'analyze', error, 'error'))
       failures.push(buildFailure(repo, error))

--- a/lib/debug/logger.test.ts
+++ b/lib/debug/logger.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Each test gets a fresh module instance
+async function freshLogger() {
+  vi.resetModules()
+  return await import('./logger')
+}
+
+describe('debug logger', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('captures console.log as info entries', async () => {
+    const { installLogger, getEntries } = await freshLogger()
+    installLogger()
+    console.log('test message')
+    const entries = getEntries()
+    expect(entries.length).toBeGreaterThanOrEqual(1)
+    const last = entries[entries.length - 1]
+    expect(last.level).toBe('info')
+    expect(last.message).toBe('test message')
+    expect(last.timestamp).toBeTruthy()
+  })
+
+  it('captures console.warn as warn entries', async () => {
+    const { installLogger, getEntries } = await freshLogger()
+    installLogger()
+    console.warn('warning')
+    const entries = getEntries()
+    const last = entries[entries.length - 1]
+    expect(last.level).toBe('warn')
+    expect(last.message).toBe('warning')
+  })
+
+  it('captures console.error as error entries', async () => {
+    const { installLogger, getEntries } = await freshLogger()
+    installLogger()
+    console.error('bad thing')
+    const entries = getEntries()
+    const last = entries[entries.length - 1]
+    expect(last.level).toBe('error')
+    expect(last.message).toBe('bad thing')
+  })
+
+  it('stringifies non-string arguments', async () => {
+    const { installLogger, getEntries } = await freshLogger()
+    installLogger()
+    console.log('obj:', { key: 'value' })
+    const entries = getEntries()
+    const last = entries[entries.length - 1]
+    expect(last.message).toBe('obj: {"key":"value"}')
+  })
+
+  it('notifies subscribers of new entries', async () => {
+    const { installLogger, subscribe } = await freshLogger()
+    installLogger()
+    const received: unknown[] = []
+    subscribe((entry) => received.push(entry))
+    console.log('sub test')
+    expect(received.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('unsubscribe stops notifications', async () => {
+    const { installLogger, subscribe } = await freshLogger()
+    installLogger()
+    const received: unknown[] = []
+    const unsub = subscribe((entry) => received.push(entry))
+    unsub()
+    console.log('after unsub')
+    expect(received).toHaveLength(0)
+  })
+})

--- a/lib/debug/logger.ts
+++ b/lib/debug/logger.ts
@@ -1,0 +1,56 @@
+type LogLevel = 'info' | 'warn' | 'error'
+
+export interface LogEntry {
+  timestamp: string
+  level: LogLevel
+  message: string
+}
+
+const MAX_ENTRIES = 500
+
+const entries: LogEntry[] = []
+const listeners = new Set<(entry: LogEntry) => void>()
+
+function addEntry(level: LogLevel, args: unknown[]) {
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message: args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '),
+  }
+  entries.push(entry)
+  if (entries.length > MAX_ENTRIES) entries.shift()
+  for (const listener of listeners) listener(entry)
+}
+
+export function getEntries(): LogEntry[] {
+  return [...entries]
+}
+
+export function subscribe(listener: (entry: LogEntry) => void): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+let installed = false
+
+export function installLogger() {
+  if (installed) return
+  installed = true
+
+  const originalLog = console.log
+  const originalWarn = console.warn
+  const originalError = console.error
+
+  console.log = (...args: unknown[]) => {
+    addEntry('info', args)
+    originalLog.apply(console, args)
+  }
+  console.warn = (...args: unknown[]) => {
+    addEntry('warn', args)
+    originalWarn.apply(console, args)
+  }
+  console.error = (...args: unknown[]) => {
+    addEntry('error', args)
+    originalError.apply(console, args)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a dev-only log panel (bottom-right popup) that streams backend `console.log/warn/error` to the browser via SSE
- Adds structured logging to the analyzer pipeline so each analysis step (overview, commit history, activity counts, responsiveness, contributors) is visible in real time with timing
- Only active in development mode — zero production impact (no bundle size, no runtime overhead)
- Closes #122

## Files added
- `lib/debug/logger.ts` — Ring buffer logger with pub/sub, intercepts console methods
- `lib/debug/logger.test.ts` — 6 unit tests
- `app/api/debug/logs/route.ts` — SSE endpoint (returns 404 in production)
- `components/debug/DevToolsLink.tsx` — Popup log panel with level filtering, clear, auto-scroll
- `instrumentation.ts` — Installs logger on server startup in dev mode

## Test plan
- [x] Run `npm run dev`, click "Logs" button in bottom-right corner — panel opens
- [x] Analyze a repo — log entries stream in real time showing each analysis step with timing
- [x] Filter by level (info/warn/error) — only matching entries shown
- [x] Click "clear" — entries are cleared
- [x] Click "✕" — panel closes
- [x] `npm run build` succeeds — no debug routes in production bundle behavior
- [x] All 262 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)