### PR TITLE
Add Licensing & Compliance scoring to Documentation bucket (#115)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,8 @@ When filling manual checklist signoff or similar metadata, use the authenticated
 ## Active Technologies
 - TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Vitest, React Testing Library (032-doc-scoring)
 - N/A (stateless) (032-doc-scoring)
+- TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Reac (128-licensing-compliance)
+- N/A (stateless, on-demand analysis) (128-licensing-compliance)
 
 ## Recent Changes
 - 032-doc-scoring: Added TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Vitest, React Testing Library

--- a/__tests__/licensing/extract-licensing.test.ts
+++ b/__tests__/licensing/extract-licensing.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import { extractLicensingResult, computeSignedOffByRatio, detectDcoClaBots } from '@/lib/analyzer/extract-licensing'
+
+describe('extractLicensingResult', () => {
+  it('detects an OSI-approved permissive license', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'MIT', name: 'MIT License' },
+      [],
+      null,
+    )
+
+    expect(result.license.spdxId).toBe('MIT')
+    expect(result.license.name).toBe('MIT License')
+    expect(result.license.osiApproved).toBe(true)
+    expect(result.license.permissivenessTier).toBe('Permissive')
+  })
+
+  it('detects a copyleft license', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'GPL-3.0-only', name: 'GNU General Public License v3.0 only' },
+      [],
+      null,
+    )
+
+    expect(result.license.osiApproved).toBe(true)
+    expect(result.license.permissivenessTier).toBe('Copyleft')
+  })
+
+  it('handles NOASSERTION SPDX ID', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'NOASSERTION', name: 'Other' },
+      [],
+      null,
+    )
+
+    expect(result.license.spdxId).toBe('NOASSERTION')
+    expect(result.license.osiApproved).toBe(false)
+    expect(result.license.permissivenessTier).toBeNull()
+  })
+
+  it('handles null license info', () => {
+    const result = extractLicensingResult(null, [], null)
+
+    expect(result.license.spdxId).toBeNull()
+    expect(result.license.name).toBeNull()
+    expect(result.license.osiApproved).toBe(false)
+    expect(result.license.permissivenessTier).toBeNull()
+  })
+
+  it('detects DCO enforcement from commit trailers', () => {
+    const commits = [
+      { message: 'Fix bug\n\nSigned-off-by: Alice <a@b.com>' },
+      { message: 'Add feature\n\nSigned-off-by: Bob <b@b.com>' },
+      { message: 'Refactor code' },
+    ]
+    const result = extractLicensingResult(
+      { spdxId: 'MIT', name: 'MIT License' },
+      commits,
+      null,
+    )
+
+    expect(result.contributorAgreement.signedOffByRatio).toBeCloseTo(2 / 3, 2)
+    expect(result.contributorAgreement.enforced).toBe(false) // below 0.8 threshold
+  })
+
+  it('detects DCO enforcement when ratio is above threshold', () => {
+    const commits = [
+      { message: 'Fix\n\nSigned-off-by: Alice <a@b.com>' },
+      { message: 'Add\n\nSigned-off-by: Bob <b@b.com>' },
+      { message: 'Update\n\nSigned-off-by: Carol <c@b.com>' },
+      { message: 'Refactor\n\nSigned-off-by: Dave <d@b.com>' },
+      { message: 'Clean\n\nSigned-off-by: Eve <e@b.com>' },
+    ]
+    const result = extractLicensingResult(
+      { spdxId: 'Apache-2.0', name: 'Apache License 2.0' },
+      commits,
+      null,
+    )
+
+    expect(result.contributorAgreement.signedOffByRatio).toBe(1.0)
+    expect(result.contributorAgreement.enforced).toBe(true)
+  })
+
+  it('detects CLA bot in workflow files', () => {
+    const workflowDir = {
+      entries: [
+        { name: 'ci.yml', object: { text: 'name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest' } },
+        { name: 'cla.yml', object: { text: 'name: CLA\nuses: cla-assistant/cla-assistant@v2' } },
+      ],
+    }
+    const result = extractLicensingResult(
+      { spdxId: 'MIT', name: 'MIT License' },
+      [],
+      workflowDir,
+    )
+
+    expect(result.contributorAgreement.dcoOrClaBot).toBe(true)
+    expect(result.contributorAgreement.enforced).toBe(true)
+  })
+
+  it('handles empty commits and no workflow dir', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'MIT', name: 'MIT License' },
+      [],
+      null,
+    )
+
+    expect(result.contributorAgreement.signedOffByRatio).toBeNull()
+    expect(result.contributorAgreement.dcoOrClaBot).toBe(false)
+    expect(result.contributorAgreement.enforced).toBe(false)
+  })
+})
+
+describe('computeSignedOffByRatio', () => {
+  it('returns null for empty commits', () => {
+    expect(computeSignedOffByRatio([])).toBeNull()
+  })
+
+  it('returns 0 when no commits have Signed-off-by', () => {
+    const commits = [{ message: 'Fix bug' }, { message: 'Add feature' }]
+    expect(computeSignedOffByRatio(commits)).toBe(0)
+  })
+
+  it('returns 1 when all commits have Signed-off-by', () => {
+    const commits = [
+      { message: 'Fix\n\nSigned-off-by: A <a@b.com>' },
+      { message: 'Add\n\nSigned-off-by: B <b@b.com>' },
+    ]
+    expect(computeSignedOffByRatio(commits)).toBe(1)
+  })
+
+  it('is case-insensitive for Signed-off-by', () => {
+    const commits = [{ message: 'Fix\n\nsigned-off-by: A <a@b.com>' }]
+    expect(computeSignedOffByRatio(commits)).toBe(1)
+  })
+})
+
+describe('detectDcoClaBots', () => {
+  it('returns false for null workflow dir', () => {
+    expect(detectDcoClaBots(null)).toBe(false)
+  })
+
+  it('returns false for empty workflow dir', () => {
+    expect(detectDcoClaBots({ entries: [] })).toBe(false)
+  })
+
+  it('detects probot/dco', () => {
+    const dir = {
+      entries: [
+        { name: 'dco.yml', object: { text: 'uses: probot/dco' } },
+      ],
+    }
+    expect(detectDcoClaBots(dir)).toBe(true)
+  })
+
+  it('detects contributor-assistant/github-action', () => {
+    const dir = {
+      entries: [
+        { name: 'cla.yml', object: { text: 'uses: contributor-assistant/github-action@v2' } },
+      ],
+    }
+    expect(detectDcoClaBots(dir)).toBe(true)
+  })
+
+  it('detects apps/dco', () => {
+    const dir = {
+      entries: [
+        { name: 'check.yml', object: { text: 'uses: apps/dco' } },
+      ],
+    }
+    expect(detectDcoClaBots(dir)).toBe(true)
+  })
+
+  it('returns false when no known bots found', () => {
+    const dir = {
+      entries: [
+        { name: 'ci.yml', object: { text: 'name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest' } },
+      ],
+    }
+    expect(detectDcoClaBots(dir)).toBe(false)
+  })
+
+  it('handles entries with null text', () => {
+    const dir = {
+      entries: [
+        { name: 'binary.yml', object: null },
+      ],
+    }
+    expect(detectDcoClaBots(dir)).toBe(false)
+  })
+})

--- a/__tests__/licensing/license-data.test.ts
+++ b/__tests__/licensing/license-data.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  OSI_APPROVED_SPDX_IDS,
+  PERMISSIVENESS_TIERS,
+  getPermissivenessTier,
+  isOsiApproved,
+} from '@/lib/licensing/license-data'
+
+describe('isOsiApproved', () => {
+  it('returns true for common OSI-approved licenses', () => {
+    expect(isOsiApproved('MIT')).toBe(true)
+    expect(isOsiApproved('Apache-2.0')).toBe(true)
+    expect(isOsiApproved('GPL-3.0-only')).toBe(true)
+    expect(isOsiApproved('BSD-2-Clause')).toBe(true)
+    expect(isOsiApproved('MPL-2.0')).toBe(true)
+    expect(isOsiApproved('AGPL-3.0-only')).toBe(true)
+  })
+
+  it('returns false for null', () => {
+    expect(isOsiApproved(null)).toBe(false)
+  })
+
+  it('returns false for NOASSERTION', () => {
+    expect(isOsiApproved('NOASSERTION')).toBe(false)
+  })
+
+  it('returns false for unrecognized SPDX IDs', () => {
+    expect(isOsiApproved('UNKNOWN')).toBe(false)
+    expect(isOsiApproved('Custom-License')).toBe(false)
+  })
+})
+
+describe('getPermissivenessTier', () => {
+  it('classifies permissive licenses', () => {
+    expect(getPermissivenessTier('MIT')).toBe('Permissive')
+    expect(getPermissivenessTier('Apache-2.0')).toBe('Permissive')
+    expect(getPermissivenessTier('BSD-3-Clause')).toBe('Permissive')
+    expect(getPermissivenessTier('ISC')).toBe('Permissive')
+    expect(getPermissivenessTier('Unlicense')).toBe('Permissive')
+    expect(getPermissivenessTier('0BSD')).toBe('Permissive')
+  })
+
+  it('classifies weak copyleft licenses', () => {
+    expect(getPermissivenessTier('MPL-2.0')).toBe('Weak Copyleft')
+    expect(getPermissivenessTier('LGPL-3.0-only')).toBe('Weak Copyleft')
+    expect(getPermissivenessTier('LGPL-2.1-or-later')).toBe('Weak Copyleft')
+    expect(getPermissivenessTier('EPL-2.0')).toBe('Weak Copyleft')
+    expect(getPermissivenessTier('CDDL-1.0')).toBe('Weak Copyleft')
+  })
+
+  it('classifies copyleft licenses', () => {
+    expect(getPermissivenessTier('GPL-3.0-only')).toBe('Copyleft')
+    expect(getPermissivenessTier('GPL-2.0-or-later')).toBe('Copyleft')
+    expect(getPermissivenessTier('AGPL-3.0-only')).toBe('Copyleft')
+    expect(getPermissivenessTier('AGPL-3.0-or-later')).toBe('Copyleft')
+  })
+
+  it('returns null for null input', () => {
+    expect(getPermissivenessTier(null)).toBeNull()
+  })
+
+  it('returns null for NOASSERTION', () => {
+    expect(getPermissivenessTier('NOASSERTION')).toBeNull()
+  })
+
+  it('returns null for OSI-approved licenses without tier mapping', () => {
+    // Fair is OSI-approved but not in the tier map
+    expect(isOsiApproved('Fair')).toBe(true)
+    expect(getPermissivenessTier('Fair')).toBeNull()
+  })
+
+  it('returns null for unrecognized SPDX IDs', () => {
+    expect(getPermissivenessTier('UNKNOWN')).toBeNull()
+  })
+})
+
+describe('data consistency', () => {
+  it('all tier-mapped licenses are OSI-approved', () => {
+    for (const spdxId of PERMISSIVENESS_TIERS.keys()) {
+      expect(OSI_APPROVED_SPDX_IDS.has(spdxId), `${spdxId} is in tier map but not OSI set`).toBe(true)
+    }
+  })
+})

--- a/__tests__/licensing/license-data.test.ts
+++ b/__tests__/licensing/license-data.test.ts
@@ -28,6 +28,14 @@ describe('isOsiApproved', () => {
     expect(isOsiApproved('UNKNOWN')).toBe(false)
     expect(isOsiApproved('Custom-License')).toBe(false)
   })
+
+  it('returns true for deprecated GitHub short-form SPDX IDs', () => {
+    expect(isOsiApproved('GPL-2.0')).toBe(true)
+    expect(isOsiApproved('GPL-3.0')).toBe(true)
+    expect(isOsiApproved('AGPL-3.0')).toBe(true)
+    expect(isOsiApproved('LGPL-2.1')).toBe(true)
+    expect(isOsiApproved('LGPL-3.0')).toBe(true)
+  })
 })
 
 describe('getPermissivenessTier', () => {
@@ -71,6 +79,14 @@ describe('getPermissivenessTier', () => {
 
   it('returns null for unrecognized SPDX IDs', () => {
     expect(getPermissivenessTier('UNKNOWN')).toBeNull()
+  })
+
+  it('classifies deprecated GitHub short-form SPDX IDs correctly', () => {
+    expect(getPermissivenessTier('GPL-2.0')).toBe('Copyleft')
+    expect(getPermissivenessTier('GPL-3.0')).toBe('Copyleft')
+    expect(getPermissivenessTier('AGPL-3.0')).toBe('Copyleft')
+    expect(getPermissivenessTier('LGPL-2.1')).toBe('Weak Copyleft')
+    expect(getPermissivenessTier('LGPL-3.0')).toBe('Weak Copyleft')
   })
 })
 

--- a/__tests__/licensing/licensing-score.test.ts
+++ b/__tests__/licensing/licensing-score.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import type { LicensingResult } from '@/lib/analyzer/analysis-result'
+import { getLicensingScore, type LicensingRecommendation } from '@/lib/documentation/score-config'
+
+function buildLicensingResult(overrides: Partial<LicensingResult> = {}): LicensingResult {
+  return {
+    license: {
+      spdxId: 'MIT',
+      name: 'MIT License',
+      osiApproved: true,
+      permissivenessTier: 'Permissive',
+    },
+    contributorAgreement: {
+      signedOffByRatio: null,
+      dcoOrClaBot: false,
+      enforced: false,
+    },
+    ...overrides,
+  }
+}
+
+describe('getLicensingScore', () => {
+  it('scores a repo with OSI-approved license and classified tier', () => {
+    const { score, recommendations } = getLicensingScore(buildLicensingResult())
+
+    // license present (0.40) + OSI approved (0.25) + tier classified (0.10) + no DCO (0.00) = 0.75
+    expect(score).toBeCloseTo(0.75, 2)
+    expect(recommendations.length).toBeGreaterThan(0) // should recommend DCO/CLA
+  })
+
+  it('scores 1.0 for fully compliant repo', () => {
+    const { score } = getLicensingScore(buildLicensingResult({
+      contributorAgreement: {
+        signedOffByRatio: 1.0,
+        dcoOrClaBot: true,
+        enforced: true,
+      },
+    }))
+
+    expect(score).toBeCloseTo(1.0, 2)
+  })
+
+  it('scores 0 for repo with no license', () => {
+    const { score, recommendations } = getLicensingScore(buildLicensingResult({
+      license: {
+        spdxId: null,
+        name: null,
+        osiApproved: false,
+        permissivenessTier: null,
+      },
+    }))
+
+    expect(score).toBe(0)
+    expect(recommendations.some((r) => r.text.toLowerCase().includes('license'))).toBe(true)
+  })
+
+  it('gives partial credit for NOASSERTION', () => {
+    const { score } = getLicensingScore(buildLicensingResult({
+      license: {
+        spdxId: 'NOASSERTION',
+        name: 'Other',
+        osiApproved: false,
+        permissivenessTier: null,
+      },
+    }))
+
+    // NOASSERTION: 0.3 * 0.40 = 0.12 (partial license) + nothing else
+    expect(score).toBeCloseTo(0.12, 2)
+  })
+
+  it('scores DCO enforcement correctly', () => {
+    const { score } = getLicensingScore(buildLicensingResult({
+      contributorAgreement: {
+        signedOffByRatio: 0.9,
+        dcoOrClaBot: false,
+        enforced: true,
+      },
+    }))
+
+    // MIT: 0.40 + 0.25 + 0.10 + 0.25 (enforced) = 1.0
+    expect(score).toBeCloseTo(1.0, 2)
+  })
+
+  it('generates recommendation for non-OSI license', () => {
+    const { recommendations } = getLicensingScore(buildLicensingResult({
+      license: {
+        spdxId: 'UNKNOWN-1.0',
+        name: 'Unknown License',
+        osiApproved: false,
+        permissivenessTier: null,
+      },
+    }))
+
+    expect(recommendations.some((r) => r.text.toLowerCase().includes('osi'))).toBe(true)
+  })
+
+  it('generates recommendation for missing DCO/CLA', () => {
+    const { recommendations } = getLicensingScore(buildLicensingResult())
+
+    expect(recommendations.some((r) => r.item === 'dco_cla')).toBe(true)
+  })
+
+  it('does not generate DCO/CLA recommendation when enforced', () => {
+    const { recommendations } = getLicensingScore(buildLicensingResult({
+      contributorAgreement: {
+        signedOffByRatio: 1.0,
+        dcoOrClaBot: true,
+        enforced: true,
+      },
+    }))
+
+    expect(recommendations.some((r) => r.item === 'dco_cla')).toBe(false)
+  })
+})

--- a/components/documentation/DocumentationScoreHelp.test.tsx
+++ b/components/documentation/DocumentationScoreHelp.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { DocumentationScoreHelp } from './DocumentationScoreHelp'
+import type { DocumentationScoreDefinition } from '@/lib/documentation/score-config'
+
+const mockScore: DocumentationScoreDefinition = {
+  value: 75,
+  tone: 'success',
+  percentile: 75,
+  bracketLabel: 'Growing (100–999 stars)',
+  compositeScore: 0.75,
+  filePresenceScore: 0.80,
+  readmeQualityScore: 0.60,
+  licensingScore: 0.75,
+  recommendations: [],
+}
+
+describe('DocumentationScoreHelp', () => {
+  it('renders the score help section with three-part model description', () => {
+    render(<DocumentationScoreHelp score={mockScore} />)
+
+    expect(screen.getByText(/how is documentation scored/i)).toBeInTheDocument()
+    expect(screen.getByText(/file presence.*40%.*readme quality.*30%.*licensing compliance.*30%/i)).toBeInTheDocument()
+  })
+
+  it('renders factor chips with weights and values', () => {
+    render(<DocumentationScoreHelp score={mockScore} />)
+
+    expect(screen.getByText('File Presence')).toBeInTheDocument()
+    expect(screen.getByText('README Quality')).toBeInTheDocument()
+    expect(screen.getByText('Licensing & Compliance')).toBeInTheDocument()
+  })
+
+  it('shows details when button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<DocumentationScoreHelp score={mockScore} />)
+
+    expect(screen.queryByText(/presence of key documentation files/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /show details/i }))
+
+    expect(screen.getByText(/presence of key documentation files/i)).toBeInTheDocument()
+    expect(screen.getByText(/detection of key readme sections/i)).toBeInTheDocument()
+    expect(screen.getByText(/license recognition.*osi approval/i)).toBeInTheDocument()
+  })
+
+  it('hides details when button is clicked again', async () => {
+    const user = userEvent.setup()
+    render(<DocumentationScoreHelp score={mockScore} />)
+
+    await user.click(screen.getByRole('button', { name: /show details/i }))
+    expect(screen.getByText(/presence of key documentation files/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /hide details/i }))
+    expect(screen.queryByText(/presence of key documentation files/i)).not.toBeInTheDocument()
+  })
+})

--- a/components/documentation/DocumentationScoreHelp.tsx
+++ b/components/documentation/DocumentationScoreHelp.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import type { DocumentationScoreDefinition } from '@/lib/documentation/score-config'
+
+interface DocumentationScoreHelpProps {
+  score: DocumentationScoreDefinition
+}
+
+export function DocumentationScoreHelp({ score }: DocumentationScoreHelpProps) {
+  const [showDetails, setShowDetails] = useState(false)
+
+  const factors = [
+    { label: 'File Presence', weight: '40%', value: `${Math.round(score.filePresenceScore * 100)}%`, description: 'Presence of key documentation files: README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, and CHANGELOG.' },
+    { label: 'README Quality', weight: '30%', value: `${Math.round(score.readmeQualityScore * 100)}%`, description: 'Detection of key README sections: project description, installation, usage, contributing, and license mention.' },
+    { label: 'Licensing & Compliance', weight: '30%', value: `${Math.round(score.licensingScore * 100)}%`, description: 'License recognition, OSI approval, permissiveness classification, and DCO/CLA enforcement.' },
+  ]
+
+  return (
+    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is Documentation scored?</p>
+          <p className="mt-1 text-sm text-slate-700">
+            Composite of file presence (40%), README quality (30%), and licensing compliance (30%).
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowDetails((current) => !current)}
+          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+          aria-pressed={showDetails}
+        >
+          {showDetails ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {factors.map((factor) => (
+          <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700">
+            <span className="font-semibold text-slate-900">{factor.label}</span> <span>{factor.weight}</span>
+            <span className="ml-1 text-slate-500">({factor.value})</span>
+          </div>
+        ))}
+      </div>
+      {showDetails ? (
+        <div className="mt-3 grid gap-2 md:grid-cols-1">
+          {factors.map((factor) => (
+            <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3">
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{factor.label} ({factor.weight})</p>
+                <p className="text-sm font-semibold text-slate-900">{factor.value}</p>
+              </div>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600">{factor.description}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/documentation/DocumentationView.test.tsx
+++ b/components/documentation/DocumentationView.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { DocumentationView } from './DocumentationView'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'A UI library',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 1000,
+    forks: 25,
+    watchers: 10,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 6,
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    staleIssueRatio: 0.2,
+    medianTimeToMergeHours: 24,
+    medianTimeToCloseHours: 36,
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: {
+      fileChecks: [
+        { name: 'readme', found: true, path: 'README.md' },
+        { name: 'license', found: true, path: 'LICENSE' },
+        { name: 'contributing', found: true, path: 'CONTRIBUTING.md' },
+        { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+        { name: 'security', found: true, path: 'SECURITY.md' },
+        { name: 'changelog', found: true, path: 'CHANGELOG.md' },
+      ],
+      readmeSections: [
+        { name: 'description', detected: true },
+        { name: 'installation', detected: true },
+        { name: 'usage', detected: true },
+        { name: 'contributing', detected: true },
+        { name: 'license', detected: true },
+      ],
+      readmeContent: '# React',
+    },
+    licensingResult: {
+      license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+      contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
+    },
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+describe('DocumentationView', () => {
+  describe('Licensing pane', () => {
+    it('renders the licensing pane with license details', () => {
+      render(<DocumentationView results={[buildResult()]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(licensingPane).toBeInTheDocument()
+      expect(within(licensingPane).getByText('MIT License')).toBeInTheDocument()
+      expect(within(licensingPane).getByText('(MIT)')).toBeInTheDocument()
+      expect(within(licensingPane).getByText(/osi approved/i)).toBeInTheDocument()
+      expect(within(licensingPane).getByText('Permissive')).toBeInTheDocument()
+    })
+
+    it('renders copyleft tier correctly', () => {
+      render(<DocumentationView results={[buildResult({
+        licensingResult: {
+          license: { spdxId: 'GPL-3.0-only', name: 'GNU General Public License v3.0 only', osiApproved: true, permissivenessTier: 'Copyleft' },
+          contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
+        },
+      })]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText('Copyleft')).toBeInTheDocument()
+    })
+
+    it('renders weak copyleft tier correctly', () => {
+      render(<DocumentationView results={[buildResult({
+        licensingResult: {
+          license: { spdxId: 'MPL-2.0', name: 'Mozilla Public License 2.0', osiApproved: true, permissivenessTier: 'Weak Copyleft' },
+          contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
+        },
+      })]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText('Weak Copyleft')).toBeInTheDocument()
+    })
+
+    it('renders no license state', () => {
+      render(<DocumentationView results={[buildResult({
+        licensingResult: {
+          license: { spdxId: null, name: null, osiApproved: false, permissivenessTier: null },
+          contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
+        },
+      })]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText(/no license detected/i)).toBeInTheDocument()
+    })
+
+    it('renders unavailable licensing data', () => {
+      render(<DocumentationView results={[buildResult({ licensingResult: 'unavailable' })]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText(/unavailable/i)).toBeInTheDocument()
+    })
+
+    it('renders DCO enforcement detected', () => {
+      render(<DocumentationView results={[buildResult({
+        licensingResult: {
+          license: { spdxId: 'Apache-2.0', name: 'Apache License 2.0', osiApproved: true, permissivenessTier: 'Permissive' },
+          contributorAgreement: { signedOffByRatio: 0.95, dcoOrClaBot: true, enforced: true },
+        },
+      })]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText(/enforcement detected/i)).toBeInTheDocument()
+    })
+
+    it('renders no DCO enforcement', () => {
+      render(<DocumentationView results={[buildResult()]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText(/not detected/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/components/documentation/DocumentationView.test.tsx
+++ b/components/documentation/DocumentationView.test.tsx
@@ -128,8 +128,20 @@ describe('DocumentationView', () => {
       expect(within(licensingPane).getByText(/enforcement detected/i)).toBeInTheDocument()
     })
 
-    it('renders no DCO enforcement', () => {
+    it('renders DCO not applicable when no commits and no bot', () => {
       render(<DocumentationView results={[buildResult()]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText(/not applicable/i)).toBeInTheDocument()
+    })
+
+    it('renders DCO not detected when commits exist but no enforcement', () => {
+      render(<DocumentationView results={[buildResult({
+        licensingResult: {
+          license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+          contributorAgreement: { signedOffByRatio: 0.1, dcoOrClaBot: false, enforced: false },
+        },
+      })]} />)
 
       const licensingPane = screen.getByRole('region', { name: /licensing/i })
       expect(within(licensingPane).getByText(/not detected/i)).toBeInTheDocument()

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -82,10 +82,14 @@ function LicensingPane({ licensingResult }: { licensingResult: LicensingResult |
         {/* DCO/CLA enforcement */}
         <li className="flex items-start gap-2">
           <span className={`mt-0.5 text-sm ${contributorAgreement.enforced ? 'text-emerald-600' : 'text-slate-400'}`}>
-            {contributorAgreement.enforced ? '✓' : '✗'}
+            {contributorAgreement.enforced ? '✓' : contributorAgreement.signedOffByRatio === null && !contributorAgreement.dcoOrClaBot ? '·' : '✗'}
           </span>
           <p className={`text-sm font-medium ${contributorAgreement.enforced ? 'text-slate-900' : 'text-slate-400'}`}>
-            {contributorAgreement.enforced ? 'DCO/CLA enforcement detected' : 'DCO/CLA enforcement not detected'}
+            {contributorAgreement.enforced
+              ? 'DCO/CLA enforcement detected'
+              : contributorAgreement.signedOffByRatio === null && !contributorAgreement.dcoOrClaBot
+                ? 'DCO/CLA enforcement not applicable'
+                : 'DCO/CLA enforcement not detected'}
           </p>
         </li>
       </ul>

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { ScoreBadge } from '@/components/metric-cards/ScoreBadge'
-import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { DocumentationScoreHelp } from '@/components/documentation/DocumentationScoreHelp'
+import type { AnalysisResult, LicensingResult } from '@/lib/analyzer/analysis-result'
 import { getDocumentationScore } from '@/lib/documentation/score-config'
 
 interface DocumentationViewProps {
@@ -25,6 +26,73 @@ const SECTION_LABELS: Record<string, string> = {
   license: 'License',
 }
 
+function LicensingPane({ licensingResult }: { licensingResult: LicensingResult | 'unavailable' }) {
+  if (licensingResult === 'unavailable') {
+    return (
+      <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Licensing & Compliance</h3>
+        <p className="mt-3 text-sm text-slate-400">Licensing data unavailable.</p>
+      </section>
+    )
+  }
+
+  const { license, contributorAgreement } = licensingResult
+  const hasLicense = license.spdxId !== null
+
+  return (
+    <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Licensing & Compliance</h3>
+      <ul className="mt-3 space-y-2">
+        {/* License detection */}
+        <li className="flex items-start gap-2">
+          <span className={`mt-0.5 text-sm ${hasLicense ? 'text-emerald-600' : 'text-red-400'}`}>
+            {hasLicense ? '✓' : '✗'}
+          </span>
+          <div className="min-w-0">
+            {hasLicense ? (
+              <p className="text-sm font-medium text-slate-900">
+                {license.name} <span className="font-normal text-slate-400">({license.spdxId})</span>
+              </p>
+            ) : (
+              <p className="text-sm font-medium text-slate-400">No license detected</p>
+            )}
+          </div>
+        </li>
+
+        {/* OSI Approval */}
+        {hasLicense ? (
+          <li className="flex items-start gap-2">
+            <span className={`mt-0.5 text-sm ${license.osiApproved ? 'text-emerald-600' : 'text-amber-500'}`}>
+              {license.osiApproved ? '✓' : '!'}
+            </span>
+            <p className={`text-sm font-medium ${license.osiApproved ? 'text-slate-900' : 'text-slate-400'}`}>
+              {license.osiApproved ? 'OSI Approved' : 'Not OSI approved'}
+            </p>
+          </li>
+        ) : null}
+
+        {/* Permissiveness tier */}
+        {license.permissivenessTier ? (
+          <li className="flex items-start gap-2">
+            <span className="mt-0.5 text-sm text-slate-400">·</span>
+            <p className="text-sm font-medium text-slate-900">{license.permissivenessTier}</p>
+          </li>
+        ) : null}
+
+        {/* DCO/CLA enforcement */}
+        <li className="flex items-start gap-2">
+          <span className={`mt-0.5 text-sm ${contributorAgreement.enforced ? 'text-emerald-600' : 'text-slate-400'}`}>
+            {contributorAgreement.enforced ? '✓' : '✗'}
+          </span>
+          <p className={`text-sm font-medium ${contributorAgreement.enforced ? 'text-slate-900' : 'text-slate-400'}`}>
+            {contributorAgreement.enforced ? 'DCO/CLA enforcement detected' : 'DCO/CLA enforcement not detected'}
+          </p>
+        </li>
+      </ul>
+    </section>
+  )
+}
+
 export function DocumentationView({ results }: DocumentationViewProps) {
   return (
     <section aria-label="Documentation view" className="space-y-6">
@@ -38,7 +106,7 @@ export function DocumentationView({ results }: DocumentationViewProps) {
           )
         }
 
-        const score = getDocumentationScore(result.documentationResult, result.stars)
+        const score = getDocumentationScore(result.documentationResult, result.licensingResult, result.stars)
         const { fileChecks, readmeSections } = result.documentationResult
         const filesFound = fileChecks.filter((f) => f.found).length
         const sectionsDetected = readmeSections.filter((s) => s.detected).length
@@ -57,7 +125,9 @@ export function DocumentationView({ results }: DocumentationViewProps) {
               </div>
             </div>
 
-            <div className="mt-6 grid gap-6 lg:grid-cols-2">
+            <DocumentationScoreHelp score={score} />
+
+            <div className="mt-6 grid gap-6 lg:grid-cols-3">
               {/* File presence */}
               <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
                 <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Documentation files</h3>
@@ -71,7 +141,6 @@ export function DocumentationView({ results }: DocumentationViewProps) {
                         <p className={`text-sm font-medium ${check.found ? 'text-slate-900' : 'text-slate-400'}`}>
                           {FILE_LABELS[check.name] ?? check.name}
                           {check.found && check.path ? <span className="ml-1 font-normal text-slate-400">({check.path})</span> : null}
-                          {check.found && check.licenseType ? <span className="ml-1 font-normal text-slate-400">— {check.licenseType}</span> : null}
                         </p>
                         {!check.found ? (
                           <p className="mt-0.5 text-xs text-amber-700">
@@ -107,6 +176,9 @@ export function DocumentationView({ results }: DocumentationViewProps) {
                   ))}
                 </ul>
               </div>
+
+              {/* Licensing & Compliance */}
+              <LicensingPane licensingResult={result.licensingResult} />
             </div>
           </div>
         )

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -37,7 +37,7 @@ export function MetricCard({ card }: MetricCardProps) {
         <p className="text-xs text-slate-400">Created: {card.createdAtLabel}</p>
       </div>
 
-      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Activity (30%), Responsiveness (30%), Sustainability (25%), and Documentation (15%) — scored relative to ${hs.bracketLabel} repositories.`}>
+      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Activity (30%), Responsiveness (30%), Sustainability (25%), and Documentation (15%, includes licensing & compliance) — scored relative to ${hs.bracketLabel} repositories.`}>
         <div>
           <p className="text-xs font-medium uppercase tracking-wide">OSS Health Score</p>
           {hs.bracketLabel ? <p className="text-[10px] opacity-60">{hs.bracketLabel}</p> : null}

--- a/lib/analyzer/analysis-result.ts
+++ b/lib/analyzer/analysis-result.ts
@@ -51,7 +51,26 @@ export interface DocumentationFileCheck {
   name: 'readme' | 'license' | 'contributing' | 'code_of_conduct' | 'security' | 'changelog'
   found: boolean
   path: string | null
-  licenseType: string | null
+}
+
+export type LicensePermissivenessTier = 'Permissive' | 'Weak Copyleft' | 'Copyleft'
+
+export interface LicenseDetection {
+  spdxId: string | null
+  name: string | null
+  osiApproved: boolean
+  permissivenessTier: LicensePermissivenessTier | null
+}
+
+export interface ContributorAgreementSignal {
+  signedOffByRatio: number | null
+  dcoOrClaBot: boolean
+  enforced: boolean
+}
+
+export interface LicensingResult {
+  license: LicenseDetection
+  contributorAgreement: ContributorAgreementSignal
 }
 
 export interface ReadmeSectionCheck {
@@ -100,6 +119,7 @@ export interface AnalysisResult {
   issueCloseTimestamps: string[] | Unavailable
   prMergeTimestamps: string[] | Unavailable
   documentationResult: DocumentationResult | Unavailable
+  licensingResult: LicensingResult | Unavailable
   missingFields: string[]
 }
 

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -19,6 +19,7 @@ import { CONTRIBUTOR_WINDOW_DAYS } from './analysis-result'
 import { queryGitHubGraphQL } from './github-graphql'
 import { fetchContributorCount, fetchMaintainerCount, fetchPublicUserOrganizations } from './github-rest'
 import { REPO_COMMIT_AND_RELEASES_QUERY, REPO_ACTIVITY_COUNTS_QUERY, REPO_COMMIT_HISTORY_PAGE_QUERY, REPO_OVERVIEW_QUERY, REPO_RESPONSIVENESS_METADATA_QUERY, buildResponsivenessDetailQuery } from './queries'
+import { extractLicensingResult } from './extract-licensing'
 
 interface DocBlob {
   text?: string
@@ -61,6 +62,12 @@ interface RepoOverviewResponse {
     docChangesRst?: DocBlob | null
     docHistory?: DocBlob | null
     docNews?: DocBlob | null
+    workflowDir?: {
+      entries: Array<{
+        name: string
+        object: { text: string } | null
+      }>
+    } | null
   } | null
 }
 
@@ -262,6 +269,7 @@ interface CommitHistoryConnection {
 
 interface CommitNode {
   authoredDate: string
+  message?: string
   author: {
     name: string | null
     email: string | null
@@ -469,6 +477,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
           contributorCount.data,
           maintainerCount.data,
           experimentalOrgAttribution.data,
+          commitHistory.nodes,
         ),
       )
       const repoElapsed = ((Date.now() - repoStart) / 1000).toFixed(1)
@@ -519,6 +528,7 @@ function buildAnalysisResult(
   totalContributorCount: number | Unavailable,
   maintainerCount: number | Unavailable,
   experimentalMetricsByWindow: Record<ContributorWindowDays, ContributorWindowMetrics>,
+  recentCommitNodes: CommitNode[],
 ): AnalysisResult {
   const defaultBranchTarget = activity.repository?.defaultBranchRef?.target
   const legacyActivity = activity as RepoActivityResponse & LegacyRepoActivityResponse
@@ -633,6 +643,13 @@ function buildAnalysisResult(
     medianTimeToMergeHours: activityMetricsByWindow[90].medianTimeToMergeHours,
     medianTimeToCloseHours: activityMetricsByWindow[90].medianTimeToCloseHours,
     documentationResult: extractDocumentationResult(overview.repository),
+    licensingResult: overview.repository
+      ? extractLicensingResult(
+          overview.repository.licenseInfo ?? null,
+          recentCommitNodes.filter((n): n is CommitNode & { message: string } => typeof n.message === 'string'),
+          overview.repository.workflowDir ?? null,
+        )
+      : 'unavailable',
     issueFirstResponseTimestamps,
     issueCloseTimestamps,
     prMergeTimestamps,
@@ -678,12 +695,12 @@ function extractDocumentationResult(repo: RepoOverviewResponse['repository']): D
   const readmeContent = readmeBlob?.text ?? null
 
   const fileChecks: DocumentationFileCheck[] = [
-    { name: 'readme', found: readmeBlob !== null, path: foundPath(readmePathMap), licenseType: null },
-    { name: 'license', found: licenseBlob !== null, path: foundPath(licensePathMap), licenseType: repo.licenseInfo?.spdxId ?? null },
-    { name: 'contributing', found: contributingBlob !== null, path: foundPath(contributingPathMap), licenseType: null },
-    { name: 'code_of_conduct', found: codeOfConductBlob !== null, path: foundPath([['CODE_OF_CONDUCT.md', repo.docCodeOfConduct], ['CODE_OF_CONDUCT.rst', repo.docCodeOfConductRst], ['CODE_OF_CONDUCT.txt', repo.docCodeOfConductTxt]]), licenseType: null },
-    { name: 'security', found: securityBlob !== null, path: foundPath([['SECURITY.md', repo.docSecurity], ['SECURITY.rst', repo.docSecurityRst]]), licenseType: null },
-    { name: 'changelog', found: changelogBlob !== null, path: foundPath(changelogPathMap), licenseType: null },
+    { name: 'readme', found: readmeBlob !== null, path: foundPath(readmePathMap) },
+    { name: 'license', found: licenseBlob !== null, path: foundPath(licensePathMap) },
+    { name: 'contributing', found: contributingBlob !== null, path: foundPath(contributingPathMap) },
+    { name: 'code_of_conduct', found: codeOfConductBlob !== null, path: foundPath([['CODE_OF_CONDUCT.md', repo.docCodeOfConduct], ['CODE_OF_CONDUCT.rst', repo.docCodeOfConductRst], ['CODE_OF_CONDUCT.txt', repo.docCodeOfConductTxt]]) },
+    { name: 'security', found: securityBlob !== null, path: foundPath([['SECURITY.md', repo.docSecurity], ['SECURITY.rst', repo.docSecurityRst]]) },
+    { name: 'changelog', found: changelogBlob !== null, path: foundPath(changelogPathMap) },
   ]
 
   const readmeSections = detectReadmeSections(readmeContent)

--- a/lib/analyzer/extract-licensing.ts
+++ b/lib/analyzer/extract-licensing.ts
@@ -1,0 +1,76 @@
+import type { LicensingResult } from '@/lib/analyzer/analysis-result'
+import { isOsiApproved, getPermissivenessTier } from '@/lib/licensing/license-data'
+
+const SIGNED_OFF_BY_RE = /^signed-off-by:\s/im
+
+const DCO_CLA_BOT_PATTERNS = [
+  'apps/dco',
+  'probot/dco',
+  'cla-assistant/cla-assistant',
+  'contributor-assistant/github-action',
+]
+
+const SIGNED_OFF_BY_RATIO_THRESHOLD = 0.8
+
+interface LicenseInfo {
+  spdxId: string | null
+  name: string | null
+}
+
+interface CommitNode {
+  message: string
+}
+
+interface WorkflowEntry {
+  name: string
+  object: { text: string } | null
+}
+
+interface WorkflowDir {
+  entries: WorkflowEntry[]
+}
+
+export function computeSignedOffByRatio(commits: CommitNode[]): number | null {
+  if (commits.length === 0) return null
+  const count = commits.filter((c) => SIGNED_OFF_BY_RE.test(c.message)).length
+  return count / commits.length
+}
+
+export function detectDcoClaBots(workflowDir: WorkflowDir | null): boolean {
+  if (!workflowDir || !workflowDir.entries) return false
+  for (const entry of workflowDir.entries) {
+    const text = entry.object?.text
+    if (!text) continue
+    for (const pattern of DCO_CLA_BOT_PATTERNS) {
+      if (text.includes(pattern)) return true
+    }
+  }
+  return false
+}
+
+export function extractLicensingResult(
+  licenseInfo: LicenseInfo | null | undefined,
+  commits: CommitNode[],
+  workflowDir: WorkflowDir | null,
+): LicensingResult {
+  const spdxId = licenseInfo?.spdxId ?? null
+  const name = licenseInfo?.name ?? null
+
+  const signedOffByRatio = computeSignedOffByRatio(commits)
+  const dcoOrClaBot = detectDcoClaBots(workflowDir)
+  const enforced = dcoOrClaBot || (signedOffByRatio !== null && signedOffByRatio >= SIGNED_OFF_BY_RATIO_THRESHOLD)
+
+  return {
+    license: {
+      spdxId,
+      name,
+      osiApproved: isOsiApproved(spdxId),
+      permissivenessTier: getPermissivenessTier(spdxId),
+    },
+    contributorAgreement: {
+      signedOffByRatio,
+      dcoOrClaBot,
+      enforced,
+    },
+  }
+}

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -46,6 +46,16 @@ export const REPO_OVERVIEW_QUERY = `
       docChangesRst: object(expression: "HEAD:CHANGES.rst") { ... on Blob { oid } }
       docHistory: object(expression: "HEAD:HISTORY.md") { ... on Blob { oid } }
       docNews: object(expression: "HEAD:NEWS.md") { ... on Blob { oid } }
+      workflowDir: object(expression: "HEAD:.github/workflows") {
+        ... on Tree {
+          entries {
+            name
+            object {
+              ... on Blob { text }
+            }
+          }
+        }
+      }
     }
     rateLimit {
       remaining
@@ -100,6 +110,7 @@ export const REPO_COMMIT_AND_RELEASES_QUERY = `
               }
               nodes {
                 authoredDate
+                message
                 author {
                   name
                   email
@@ -264,6 +275,7 @@ export const REPO_COMMIT_HISTORY_PAGE_QUERY = `
               }
               nodes {
                 authoredDate
+                message
                 author {
                   name
                   email

--- a/lib/comparison/sections.ts
+++ b/lib/comparison/sections.ts
@@ -370,7 +370,7 @@ export const COMPARISON_SECTIONS: ComparisonSectionDefinition[] = [
         valueType: 'number',
         getValue: (result) => {
           if (result.documentationResult === 'unavailable') return 'unavailable'
-          const score = getDocumentationScore(result.documentationResult, result.stars)
+          const score = getDocumentationScore(result.documentationResult, result.licensingResult, result.stars)
           if (typeof score.value !== 'number') return 'unavailable'
           return score.value
         },

--- a/lib/documentation/score-config.test.ts
+++ b/lib/documentation/score-config.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import type { DocumentationResult } from '@/lib/analyzer/analysis-result'
+import type { DocumentationResult, LicensingResult } from '@/lib/analyzer/analysis-result'
 import { getDocumentationScore } from './score-config'
 
 function buildDocResult(overrides: Partial<DocumentationResult> = {}): DocumentationResult {
   return {
     fileChecks: [
-      { name: 'readme', found: true, path: 'README.md', licenseType: null },
-      { name: 'license', found: true, path: 'LICENSE', licenseType: 'MIT' },
-      { name: 'contributing', found: true, path: 'CONTRIBUTING.md', licenseType: null },
-      { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md', licenseType: null },
-      { name: 'security', found: true, path: 'SECURITY.md', licenseType: null },
-      { name: 'changelog', found: true, path: 'CHANGELOG.md', licenseType: null },
+      { name: 'readme', found: true, path: 'README.md' },
+      { name: 'license', found: true, path: 'LICENSE' },
+      { name: 'contributing', found: true, path: 'CONTRIBUTING.md' },
+      { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+      { name: 'security', found: true, path: 'SECURITY.md' },
+      { name: 'changelog', found: true, path: 'CHANGELOG.md' },
     ],
     readmeSections: [
       { name: 'description', detected: true },
@@ -24,26 +24,41 @@ function buildDocResult(overrides: Partial<DocumentationResult> = {}): Documenta
   }
 }
 
+const fullLicensing: LicensingResult = {
+  license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+  contributorAgreement: { signedOffByRatio: 1.0, dcoOrClaBot: true, enforced: true },
+}
+
+const noLicensing: LicensingResult = {
+  license: { spdxId: null, name: null, osiApproved: false, permissivenessTier: null },
+  contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
+}
+
+const partialLicensing: LicensingResult = {
+  license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+  contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
+}
+
 describe('documentation/score-config', () => {
   describe('getDocumentationScore', () => {
-    it('scores a fully documented repo with all files and sections', () => {
-      const score = getDocumentationScore(buildDocResult(), 1000)
+    it('scores a fully documented repo with all files, sections, and licensing as 1.0', () => {
+      const score = getDocumentationScore(buildDocResult(), fullLicensing, 1000)
 
       expect(score.filePresenceScore).toBe(1)
       expect(score.readmeQualityScore).toBe(1)
-      expect(score.compositeScore).toBe(1)
-      expect(score.recommendations).toHaveLength(0)
+      expect(score.licensingScore).toBeCloseTo(1, 2)
+      expect(score.compositeScore).toBeCloseTo(1, 2)
     })
 
-    it('scores a repo with no documentation files as 0', () => {
+    it('scores a repo with no documentation files and no license as 0', () => {
       const score = getDocumentationScore(buildDocResult({
         fileChecks: [
-          { name: 'readme', found: false, path: null, licenseType: null },
-          { name: 'license', found: false, path: null, licenseType: null },
-          { name: 'contributing', found: false, path: null, licenseType: null },
-          { name: 'code_of_conduct', found: false, path: null, licenseType: null },
-          { name: 'security', found: false, path: null, licenseType: null },
-          { name: 'changelog', found: false, path: null, licenseType: null },
+          { name: 'readme', found: false, path: null },
+          { name: 'license', found: false, path: null },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: false, path: null },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
         ],
         readmeSections: [
           { name: 'description', detected: false },
@@ -53,25 +68,25 @@ describe('documentation/score-config', () => {
           { name: 'license', detected: false },
         ],
         readmeContent: null,
-      }), 1000)
+      }), noLicensing, 1000)
 
       expect(score.filePresenceScore).toBe(0)
       expect(score.readmeQualityScore).toBe(0)
+      expect(score.licensingScore).toBe(0)
       expect(score.compositeScore).toBe(0)
-      expect(score.recommendations).toHaveLength(11) // 6 files + 5 sections
     })
 
-    it('generates recommendations for each missing file', () => {
+    it('generates recommendations for each missing file (except license)', () => {
       const score = getDocumentationScore(buildDocResult({
         fileChecks: [
-          { name: 'readme', found: true, path: 'README.md', licenseType: null },
-          { name: 'license', found: true, path: 'LICENSE', licenseType: 'MIT' },
-          { name: 'contributing', found: false, path: null, licenseType: null },
-          { name: 'code_of_conduct', found: false, path: null, licenseType: null },
-          { name: 'security', found: false, path: null, licenseType: null },
-          { name: 'changelog', found: false, path: null, licenseType: null },
+          { name: 'readme', found: true, path: 'README.md' },
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: false, path: null },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
         ],
-      }), 1000)
+      }), fullLicensing, 1000)
 
       const fileRecs = score.recommendations.filter((r) => r.category === 'file')
       expect(fileRecs).toHaveLength(4)
@@ -80,7 +95,8 @@ describe('documentation/score-config', () => {
       expect(items).toContain('code_of_conduct')
       expect(items).toContain('security')
       expect(items).toContain('changelog')
-      expect(fileRecs.find((r) => r.item === 'contributing')!.text).toContain('contributing guidelines')
+      // License file is no longer in file recs — it's in licensing category
+      expect(items).not.toContain('license')
     })
 
     it('generates recommendations for each missing README section', () => {
@@ -92,54 +108,39 @@ describe('documentation/score-config', () => {
           { name: 'contributing', detected: true },
           { name: 'license', detected: true },
         ],
-      }), 1000)
+      }), fullLicensing, 1000)
 
       const sectionRecs = score.recommendations.filter((r) => r.category === 'readme_section')
       expect(sectionRecs).toHaveLength(2)
       expect(sectionRecs.map((r) => r.item)).toEqual(['installation', 'usage'])
-      expect(sectionRecs[0]!.text).toContain('installation')
     })
 
-    it('computes weighted file presence score correctly', () => {
-      // Only README (25%) and LICENSE (20%) present = 0.45
+    it('computes weighted file presence score excluding license', () => {
+      // Only README (30%) present out of 5 scored files
       const score = getDocumentationScore(buildDocResult({
         fileChecks: [
-          { name: 'readme', found: true, path: 'README.md', licenseType: null },
-          { name: 'license', found: true, path: 'LICENSE', licenseType: 'MIT' },
-          { name: 'contributing', found: false, path: null, licenseType: null },
-          { name: 'code_of_conduct', found: false, path: null, licenseType: null },
-          { name: 'security', found: false, path: null, licenseType: null },
-          { name: 'changelog', found: false, path: null, licenseType: null },
+          { name: 'readme', found: true, path: 'README.md' },
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: false, path: null },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
         ],
-      }), 1000)
+      }), fullLicensing, 1000)
 
-      expect(score.filePresenceScore).toBeCloseTo(0.45, 2)
+      // readme (0.30) only — license is not scored in file presence
+      expect(score.filePresenceScore).toBeCloseTo(0.30, 2)
     })
 
-    it('computes weighted README quality score correctly', () => {
-      // Only description (25%) and installation (25%) detected = 0.50
-      const score = getDocumentationScore(buildDocResult({
-        readmeSections: [
-          { name: 'description', detected: true },
-          { name: 'installation', detected: true },
-          { name: 'usage', detected: false },
-          { name: 'contributing', detected: false },
-          { name: 'license', detected: false },
-        ],
-      }), 1000)
-
-      expect(score.readmeQualityScore).toBeCloseTo(0.50, 2)
-    })
-
-    it('computes composite as 60% file + 40% readme', () => {
+    it('computes three-part composite correctly', () => {
       const score = getDocumentationScore(buildDocResult({
         fileChecks: [
-          { name: 'readme', found: true, path: 'README.md', licenseType: null },
-          { name: 'license', found: true, path: 'LICENSE', licenseType: 'MIT' },
-          { name: 'contributing', found: false, path: null, licenseType: null },
-          { name: 'code_of_conduct', found: false, path: null, licenseType: null },
-          { name: 'security', found: false, path: null, licenseType: null },
-          { name: 'changelog', found: false, path: null, licenseType: null },
+          { name: 'readme', found: true, path: 'README.md' },
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: false, path: null },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
         ],
         readmeSections: [
           { name: 'description', detected: true },
@@ -148,14 +149,40 @@ describe('documentation/score-config', () => {
           { name: 'contributing', detected: false },
           { name: 'license', detected: false },
         ],
-      }), 1000)
+      }), partialLicensing, 1000)
 
-      // 0.45 * 0.6 + 0.50 * 0.4 = 0.27 + 0.20 = 0.47
-      expect(score.compositeScore).toBeCloseTo(0.47, 2)
+      // filePresence = 0.30, readmeQuality = 0.50, licensing = 0.75 (MIT, OSI, tier, no DCO)
+      // composite = 0.30 * 0.40 + 0.50 * 0.30 + 0.75 * 0.30 = 0.12 + 0.15 + 0.225 = 0.495
+      expect(score.compositeScore).toBeCloseTo(0.495, 2)
+    })
+
+    it('falls back to two-part model when licensing is unavailable', () => {
+      const score = getDocumentationScore(buildDocResult({
+        fileChecks: [
+          { name: 'readme', found: true, path: 'README.md' },
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: false, path: null },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
+        ],
+        readmeSections: [
+          { name: 'description', detected: true },
+          { name: 'installation', detected: true },
+          { name: 'usage', detected: false },
+          { name: 'contributing', detected: false },
+          { name: 'license', detected: false },
+        ],
+      }), 'unavailable', 1000)
+
+      // filePresence = 0.30, readmeQuality = 0.50
+      // fallback composite = 0.30 * 0.60 + 0.50 * 0.40 = 0.18 + 0.20 = 0.38
+      expect(score.compositeScore).toBeCloseTo(0.38, 2)
+      expect(score.licensingScore).toBe(0)
     })
 
     it('returns percentile and bracket label', () => {
-      const score = getDocumentationScore(buildDocResult(), 5000)
+      const score = getDocumentationScore(buildDocResult(), fullLicensing, 5000)
 
       expect(typeof score.value).toBe('number')
       expect(score.bracketLabel).toBe('Established (1k–10k stars)')
@@ -164,12 +191,12 @@ describe('documentation/score-config', () => {
     it('orders recommendations by weight descending', () => {
       const score = getDocumentationScore(buildDocResult({
         fileChecks: [
-          { name: 'readme', found: false, path: null, licenseType: null },
-          { name: 'license', found: false, path: null, licenseType: null },
-          { name: 'contributing', found: false, path: null, licenseType: null },
-          { name: 'code_of_conduct', found: false, path: null, licenseType: null },
-          { name: 'security', found: false, path: null, licenseType: null },
-          { name: 'changelog', found: false, path: null, licenseType: null },
+          { name: 'readme', found: false, path: null },
+          { name: 'license', found: false, path: null },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: false, path: null },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
         ],
         readmeSections: [
           { name: 'description', detected: false },
@@ -179,7 +206,7 @@ describe('documentation/score-config', () => {
           { name: 'license', detected: false },
         ],
         readmeContent: null,
-      }), 1000)
+      }), noLicensing, 1000)
 
       for (let i = 1; i < score.recommendations.length; i++) {
         expect(score.recommendations[i]!.weight).toBeLessThanOrEqual(score.recommendations[i - 1]!.weight)
@@ -189,14 +216,14 @@ describe('documentation/score-config', () => {
     it('tags all recommendations with documentation bucket', () => {
       const score = getDocumentationScore(buildDocResult({
         fileChecks: [
-          { name: 'readme', found: false, path: null, licenseType: null },
-          { name: 'license', found: true, path: 'LICENSE', licenseType: 'MIT' },
-          { name: 'contributing', found: false, path: null, licenseType: null },
-          { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md', licenseType: null },
-          { name: 'security', found: true, path: 'SECURITY.md', licenseType: null },
-          { name: 'changelog', found: true, path: 'CHANGELOG.md', licenseType: null },
+          { name: 'readme', found: false, path: null },
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+          { name: 'security', found: true, path: 'SECURITY.md' },
+          { name: 'changelog', found: true, path: 'CHANGELOG.md' },
         ],
-      }), 1000)
+      }), partialLicensing, 1000)
 
       for (const rec of score.recommendations) {
         expect(rec.bucket).toBe('documentation')

--- a/lib/documentation/score-config.ts
+++ b/lib/documentation/score-config.ts
@@ -1,14 +1,16 @@
-import type { DocumentationResult } from '@/lib/analyzer/analysis-result'
+import type { DocumentationResult, LicensingResult } from '@/lib/analyzer/analysis-result'
 import { getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
 export interface DocumentationRecommendation {
   bucket: 'documentation'
-  category: 'file' | 'readme_section'
+  category: 'file' | 'readme_section' | 'licensing'
   item: string
   weight: number
   text: string
 }
+
+export type LicensingRecommendation = DocumentationRecommendation & { category: 'licensing' }
 
 export interface DocumentationScoreDefinition {
   value: number | 'Insufficient verified public data'
@@ -18,16 +20,16 @@ export interface DocumentationScoreDefinition {
   compositeScore: number
   filePresenceScore: number
   readmeQualityScore: number
+  licensingScore: number
   recommendations: DocumentationRecommendation[]
 }
 
 const FILE_WEIGHTS: Record<string, number> = {
-  readme: 0.25,
-  license: 0.20,
-  contributing: 0.15,
+  readme: 0.30,
+  contributing: 0.20,
   code_of_conduct: 0.10,
-  security: 0.15,
-  changelog: 0.15,
+  security: 0.20,
+  changelog: 0.20,
 }
 
 const FILE_RECOMMENDATIONS: Record<string, string> = {
@@ -55,15 +57,100 @@ const SECTION_RECOMMENDATIONS: Record<string, string> = {
   license: 'Add a license section or badge to your README',
 }
 
+const LICENSING_WEIGHTS = {
+  licensePresent: 0.40,
+  osiApproved: 0.25,
+  tierClassified: 0.10,
+  dcoClaEnforced: 0.25,
+} as const
+
+const COMPOSITE_WEIGHTS = {
+  filePresence: 0.40,
+  readmeQuality: 0.30,
+  licensing: 0.30,
+} as const
+
+const FALLBACK_COMPOSITE_WEIGHTS = {
+  filePresence: 0.60,
+  readmeQuality: 0.40,
+} as const
+
+export function getLicensingScore(licensingResult: LicensingResult): {
+  score: number
+  recommendations: LicensingRecommendation[]
+} {
+  const recommendations: LicensingRecommendation[] = []
+  let score = 0
+
+  const { license, contributorAgreement } = licensingResult
+
+  // License present
+  if (license.spdxId && license.spdxId !== 'NOASSERTION') {
+    score += LICENSING_WEIGHTS.licensePresent
+  } else if (license.spdxId === 'NOASSERTION') {
+    score += LICENSING_WEIGHTS.licensePresent * 0.3
+    recommendations.push({
+      bucket: 'documentation',
+      category: 'licensing',
+      item: 'osi_license',
+      weight: LICENSING_WEIGHTS.osiApproved * COMPOSITE_WEIGHTS.licensing,
+      text: 'Use a standard OSI-approved license with a recognized SPDX identifier for machine-readable license detection',
+    })
+  } else {
+    recommendations.push({
+      bucket: 'documentation',
+      category: 'licensing',
+      item: 'license',
+      weight: LICENSING_WEIGHTS.licensePresent * COMPOSITE_WEIGHTS.licensing,
+      text: 'Add an open source license to clarify how others can use, modify, and distribute this project',
+    })
+  }
+
+  // OSI approved
+  if (license.osiApproved) {
+    score += LICENSING_WEIGHTS.osiApproved
+  } else if (license.spdxId && license.spdxId !== 'NOASSERTION') {
+    recommendations.push({
+      bucket: 'documentation',
+      category: 'licensing',
+      item: 'osi_license',
+      weight: LICENSING_WEIGHTS.osiApproved * COMPOSITE_WEIGHTS.licensing,
+      text: 'Consider adopting an OSI-approved license for broader compatibility and trust',
+    })
+  }
+
+  // Tier classified
+  if (license.permissivenessTier) {
+    score += LICENSING_WEIGHTS.tierClassified
+  }
+
+  // DCO/CLA enforced
+  if (contributorAgreement.enforced) {
+    score += LICENSING_WEIGHTS.dcoClaEnforced
+  } else {
+    recommendations.push({
+      bucket: 'documentation',
+      category: 'licensing',
+      item: 'dco_cla',
+      weight: LICENSING_WEIGHTS.dcoClaEnforced * COMPOSITE_WEIGHTS.licensing,
+      text: 'Consider enforcing a Developer Certificate of Origin (DCO) or Contributor License Agreement (CLA) to ensure contributions are legally vetted',
+    })
+  }
+
+  return { score, recommendations }
+}
+
 export function getDocumentationScore(
   docResult: DocumentationResult,
+  licensingResult: LicensingResult | 'unavailable',
   stars: number | 'unavailable',
 ): DocumentationScoreDefinition {
   const recommendations: DocumentationRecommendation[] = []
 
-  // File presence sub-score (60%)
+  // File presence sub-score — license file excluded from scoring (scored in licensing sub-score)
   let filePresenceScore = 0
   for (const check of docResult.fileChecks) {
+    if (check.name === 'license') continue
     const weight = FILE_WEIGHTS[check.name] ?? 0
     if (check.found) {
       filePresenceScore += weight
@@ -72,13 +159,13 @@ export function getDocumentationScore(
         bucket: 'documentation',
         category: 'file',
         item: check.name,
-        weight: weight * 0.6, // effective weight in composite
+        weight: weight * COMPOSITE_WEIGHTS.filePresence,
         text: FILE_RECOMMENDATIONS[check.name] ?? `Add ${check.name}`,
       })
     }
   }
 
-  // README quality sub-score (40%)
+  // README quality sub-score
   let readmeQualityScore = 0
   for (const section of docResult.readmeSections) {
     const weight = SECTION_WEIGHTS[section.name] ?? 0
@@ -89,13 +176,32 @@ export function getDocumentationScore(
         bucket: 'documentation',
         category: 'readme_section',
         item: section.name,
-        weight: weight * 0.4, // effective weight in composite
+        weight: weight * COMPOSITE_WEIGHTS.readmeQuality,
         text: SECTION_RECOMMENDATIONS[section.name] ?? `Add ${section.name} section to your README`,
       })
     }
   }
 
-  const compositeScore = filePresenceScore * 0.6 + readmeQualityScore * 0.4
+  // Licensing sub-score
+  let licensingScore = 0
+  if (licensingResult !== 'unavailable') {
+    const licensing = getLicensingScore(licensingResult)
+    licensingScore = licensing.score
+    recommendations.push(...licensing.recommendations)
+  }
+
+  // Composite score — three-part or fallback two-part when licensing unavailable
+  let compositeScore: number
+  if (licensingResult !== 'unavailable') {
+    compositeScore =
+      filePresenceScore * COMPOSITE_WEIGHTS.filePresence +
+      readmeQualityScore * COMPOSITE_WEIGHTS.readmeQuality +
+      licensingScore * COMPOSITE_WEIGHTS.licensing
+  } else {
+    compositeScore =
+      filePresenceScore * FALLBACK_COMPOSITE_WEIGHTS.filePresence +
+      readmeQualityScore * FALLBACK_COMPOSITE_WEIGHTS.readmeQuality
+  }
 
   // Sort recommendations by weight descending
   recommendations.sort((a, b) => b.weight - a.weight)
@@ -110,6 +216,7 @@ export function getDocumentationScore(
       compositeScore,
       filePresenceScore,
       readmeQualityScore,
+      licensingScore,
       recommendations,
     }
   }
@@ -129,6 +236,7 @@ export function getDocumentationScore(
     compositeScore,
     filePresenceScore,
     readmeQualityScore,
+    licensingScore,
     recommendations,
   }
 }

--- a/lib/export/json-export.ts
+++ b/lib/export/json-export.ts
@@ -25,7 +25,7 @@ function computeScores(result: AnalysisResult): RepoScores {
   const responsiveness = getResponsivenessScore(result)
   let documentation: RepoScores['documentation'] = null
   if (result.documentationResult !== 'unavailable') {
-    const docScore = getDocumentationScore(result.documentationResult, result.stars)
+    const docScore = getDocumentationScore(result.documentationResult, result.licensingResult, result.stars)
     documentation = {
       value: docScore.value,
       tone: docScore.tone,

--- a/lib/export/markdown-export.ts
+++ b/lib/export/markdown-export.ts
@@ -149,7 +149,7 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
     `| Sustainability | ${sustainability.value} |`,
     `| Activity | ${activity.value} |`,
     `| Responsiveness | ${responsiveness.value} |`,
-    `| Documentation | ${result.documentationResult !== 'unavailable' ? getDocumentationScore(result.documentationResult, result.stars).value : 'unavailable'} |`,
+    `| Documentation | ${result.documentationResult !== 'unavailable' ? getDocumentationScore(result.documentationResult, result.licensingResult, result.stars).value : 'unavailable'} |`,
     '',
   )
 
@@ -278,7 +278,7 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
 
   // Documentation section
   if (result.documentationResult !== 'unavailable') {
-    const docScore = getDocumentationScore(result.documentationResult, result.stars)
+    const docScore = getDocumentationScore(result.documentationResult, result.licensingResult, result.stars)
     const { fileChecks, readmeSections } = result.documentationResult
     const FILE_LABELS: Record<string, string> = {
       readme: 'README', license: 'LICENSE', contributing: 'CONTRIBUTING',
@@ -298,7 +298,7 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
       '',
       mdTable(fileChecks.map((f) => [
         FILE_LABELS[f.name] ?? f.name,
-        f.found ? `Present${f.path ? ` (${f.path})` : ''}${f.licenseType ? ` — ${f.licenseType}` : ''}` : 'Missing',
+        f.found ? `Present${f.path ? ` (${f.path})` : ''}` : 'Missing',
       ])),
       '',
       '#### README Sections',

--- a/lib/licensing/license-data.ts
+++ b/lib/licensing/license-data.ts
@@ -106,11 +106,19 @@ export const OSI_APPROVED_SPDX_IDS: ReadonlySet<string> = new Set([
   'AGPL-1.0-or-later',
   'AGPL-3.0-only',
   'AGPL-3.0-or-later',
+  'AGPL-3.0',
   'GPL-2.0-only',
   'GPL-2.0-or-later',
+  'GPL-2.0',
   'GPL-3.0-only',
   'GPL-3.0-or-later',
+  'GPL-3.0',
   'SSPL-1.0',
+
+  // Deprecated short forms returned by GitHub API
+  'LGPL-2.0',
+  'LGPL-2.1',
+  'LGPL-3.0',
 ])
 
 /**
@@ -156,6 +164,9 @@ export const PERMISSIVENESS_TIERS: ReadonlyMap<string, LicensePermissivenessTier
   ['LGPL-2.1-or-later', 'Weak Copyleft'],
   ['LGPL-3.0-only', 'Weak Copyleft'],
   ['LGPL-3.0-or-later', 'Weak Copyleft'],
+  ['LGPL-2.0', 'Weak Copyleft'],
+  ['LGPL-2.1', 'Weak Copyleft'],
+  ['LGPL-3.0', 'Weak Copyleft'],
   ['MPL-1.0', 'Weak Copyleft'],
   ['MPL-1.1', 'Weak Copyleft'],
   ['MPL-2.0', 'Weak Copyleft'],
@@ -170,6 +181,9 @@ export const PERMISSIVENESS_TIERS: ReadonlyMap<string, LicensePermissivenessTier
   ['GPL-2.0-or-later', 'Copyleft'],
   ['GPL-3.0-only', 'Copyleft'],
   ['GPL-3.0-or-later', 'Copyleft'],
+  ['AGPL-3.0', 'Copyleft'],
+  ['GPL-2.0', 'Copyleft'],
+  ['GPL-3.0', 'Copyleft'],
 ])
 
 export function isOsiApproved(spdxId: string | null): boolean {

--- a/lib/licensing/license-data.ts
+++ b/lib/licensing/license-data.ts
@@ -1,0 +1,183 @@
+export type LicensePermissivenessTier = 'Permissive' | 'Weak Copyleft' | 'Copyleft'
+
+/**
+ * OSI-approved SPDX license identifiers.
+ * Source: https://opensource.org/licenses (snapshot 2026-04)
+ */
+export const OSI_APPROVED_SPDX_IDS: ReadonlySet<string> = new Set([
+  // Permissive
+  '0BSD',
+  'AFL-3.0',
+  'Apache-2.0',
+  'Artistic-2.0',
+  'BlueOak-1.0.0',
+  'BSD-1-Clause',
+  'BSD-2-Clause',
+  'BSD-2-Clause-Patent',
+  'BSD-3-Clause',
+  'BSD-3-Clause-LBNL',
+  'BSL-1.0',
+  'CAL-1.0',
+  'CAL-1.0-Combined-Work-Exception',
+  'ECL-2.0',
+  'EFL-2.0',
+  'EUDatagrid',
+  'Fair',
+  'Frameworx-1.0',
+  'HPND',
+  'ISC',
+  'JSON',
+  'LAL-1.2',
+  'LAL-1.3',
+  'Libpng',
+  'LiLiQ-P-1.1',
+  'MIT',
+  'MIT-0',
+  'MirOS',
+  'MS-PL',
+  'MS-RL',
+  'MulanPSL-2.0',
+  'Multics',
+  'NASA-1.3',
+  'NCSA',
+  'Nokia',
+  'NTP',
+  'OGTSL',
+  'OLDAP-2.8',
+  'OSET-PL-2.1',
+  'PHP-3.01',
+  'PostgreSQL',
+  'PSF-2.0',
+  'QPL-1.0',
+  'RPL-1.1',
+  'RPL-1.5',
+  'RSCPL',
+  'SimPL-2.0',
+  'Sleepycat',
+  'UCL-1.0',
+  'Unicode-DFS-2016',
+  'Unlicense',
+  'UPL-1.0',
+  'VSL-1.0',
+  'W3C',
+  'Watcom-1.0',
+  'Xnet',
+  'Zlib',
+  'ZPL-2.0',
+  'ZPL-2.1',
+
+  // Weak Copyleft
+  'APSL-2.0',
+  'CDDL-1.0',
+  'CECILL-2.1',
+  'CPL-1.0',
+  'CUA-OPL-1.0',
+  'ECL-1.0',
+  'EFL-1.0',
+  'EPL-1.0',
+  'EPL-2.0',
+  'EUPL-1.1',
+  'EUPL-1.2',
+  'IPA',
+  'IPL-1.0',
+  'LGPL-2.0-only',
+  'LGPL-2.0-or-later',
+  'LGPL-2.1-only',
+  'LGPL-2.1-or-later',
+  'LGPL-3.0-only',
+  'LGPL-3.0-or-later',
+  'LiLiQ-R-1.1',
+  'LiLiQ-Rplus-1.1',
+  'LPL-1.0',
+  'LPL-1.02',
+  'MPL-1.0',
+  'MPL-1.1',
+  'MPL-2.0',
+  'MPL-2.0-no-copyleft-exception',
+  'OSL-1.0',
+  'OSL-1.1',
+  'OSL-2.0',
+  'OSL-2.1',
+  'OSL-3.0',
+  'SPL-1.0',
+
+  // Copyleft
+  'AGPL-1.0-only',
+  'AGPL-1.0-or-later',
+  'AGPL-3.0-only',
+  'AGPL-3.0-or-later',
+  'GPL-2.0-only',
+  'GPL-2.0-or-later',
+  'GPL-3.0-only',
+  'GPL-3.0-or-later',
+  'SSPL-1.0',
+])
+
+/**
+ * Maps SPDX identifiers to their permissiveness tier.
+ * Covers the most common licenses. Unlisted OSI-approved licenses
+ * return null (tier unknown).
+ */
+export const PERMISSIVENESS_TIERS: ReadonlyMap<string, LicensePermissivenessTier> = new Map<string, LicensePermissivenessTier>([
+  // Permissive
+  ['0BSD', 'Permissive'],
+  ['Apache-2.0', 'Permissive'],
+  ['Artistic-2.0', 'Permissive'],
+  ['BlueOak-1.0.0', 'Permissive'],
+  ['BSD-1-Clause', 'Permissive'],
+  ['BSD-2-Clause', 'Permissive'],
+  ['BSD-2-Clause-Patent', 'Permissive'],
+  ['BSD-3-Clause', 'Permissive'],
+  ['BSD-3-Clause-LBNL', 'Permissive'],
+  ['BSL-1.0', 'Permissive'],
+  ['ECL-2.0', 'Permissive'],
+  ['ISC', 'Permissive'],
+  ['MIT', 'Permissive'],
+  ['MIT-0', 'Permissive'],
+  ['MulanPSL-2.0', 'Permissive'],
+  ['NCSA', 'Permissive'],
+  ['PostgreSQL', 'Permissive'],
+  ['Unlicense', 'Permissive'],
+  ['UPL-1.0', 'Permissive'],
+  ['W3C', 'Permissive'],
+  ['Zlib', 'Permissive'],
+  ['ZPL-2.0', 'Permissive'],
+
+  // Weak Copyleft
+  ['CDDL-1.0', 'Weak Copyleft'],
+  ['CECILL-2.1', 'Weak Copyleft'],
+  ['EPL-1.0', 'Weak Copyleft'],
+  ['EPL-2.0', 'Weak Copyleft'],
+  ['EUPL-1.1', 'Weak Copyleft'],
+  ['EUPL-1.2', 'Weak Copyleft'],
+  ['LGPL-2.0-only', 'Weak Copyleft'],
+  ['LGPL-2.0-or-later', 'Weak Copyleft'],
+  ['LGPL-2.1-only', 'Weak Copyleft'],
+  ['LGPL-2.1-or-later', 'Weak Copyleft'],
+  ['LGPL-3.0-only', 'Weak Copyleft'],
+  ['LGPL-3.0-or-later', 'Weak Copyleft'],
+  ['MPL-1.0', 'Weak Copyleft'],
+  ['MPL-1.1', 'Weak Copyleft'],
+  ['MPL-2.0', 'Weak Copyleft'],
+  ['OSL-3.0', 'Weak Copyleft'],
+
+  // Copyleft
+  ['AGPL-1.0-only', 'Copyleft'],
+  ['AGPL-1.0-or-later', 'Copyleft'],
+  ['AGPL-3.0-only', 'Copyleft'],
+  ['AGPL-3.0-or-later', 'Copyleft'],
+  ['GPL-2.0-only', 'Copyleft'],
+  ['GPL-2.0-or-later', 'Copyleft'],
+  ['GPL-3.0-only', 'Copyleft'],
+  ['GPL-3.0-or-later', 'Copyleft'],
+])
+
+export function isOsiApproved(spdxId: string | null): boolean {
+  if (!spdxId || spdxId === 'NOASSERTION') return false
+  return OSI_APPROVED_SPDX_IDS.has(spdxId)
+}
+
+export function getPermissivenessTier(spdxId: string | null): LicensePermissivenessTier | null {
+  if (!spdxId || spdxId === 'NOASSERTION') return null
+  return PERMISSIVENESS_TIERS.get(spdxId) ?? null
+}

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -39,7 +39,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   const responsiveness = getResponsivenessScore(result)
   const sustainability = getSustainabilityScore(result)
   const documentation = result.documentationResult !== 'unavailable'
-    ? getDocumentationScore(result.documentationResult, result.stars)
+    ? getDocumentationScore(result.documentationResult, result.licensingResult, result.stars)
     : null
   const bracketLabel = activity.bracketLabel || responsiveness.bracketLabel || sustainability.bracketLabel || ''
 

--- a/specs/128-licensing-compliance/checklists/manual-testing.md
+++ b/specs/128-licensing-compliance/checklists/manual-testing.md
@@ -1,0 +1,53 @@
+# Manual Testing Checklist: Licensing & Compliance Scoring
+
+**Feature Branch**: `128-licensing-compliance`
+**Tester**: ___
+**Date**: ___
+
+## Prerequisites
+
+- [ ] Application builds without errors
+- [ ] All automated tests pass
+
+## US1: License Presence and Quality Assessment
+
+- [ ] Analyze a repo with an OSI-approved license (e.g., MIT) — Documentation score includes licensing sub-score, score is higher than without licensing
+- [ ] Analyze a repo with no license — Documentation score reflects zero licensing sub-score, recommendation to add a license is shown
+- [ ] Analyze a repo with SPDX ID `NOASSERTION` — partial credit in licensing sub-score, recommendation to use a standard license
+- [ ] Documentation bucket composite uses three-part model (file presence + README quality + licensing)
+- [ ] File presence sub-score no longer includes license file weight (5 files scored, not 6)
+- [ ] Licensing sub-score falls back to two-part model gracefully when licensing data is unavailable
+
+## US2: License Permissiveness Classification
+
+- [ ] Analyze a repo with permissive license (MIT, Apache-2.0, BSD) — Licensing pane shows "Permissive"
+- [ ] Analyze a repo with copyleft license (GPL-3.0, AGPL-3.0) — Licensing pane shows "Copyleft"
+- [ ] Analyze a repo with weak copyleft license (MPL-2.0, LGPL-3.0) — Licensing pane shows "Weak Copyleft"
+- [ ] Licensing pane displays license name and SPDX ID
+- [ ] Licensing pane displays OSI approval status
+- [ ] Licensing pane handles unavailable data gracefully (shows "unavailable" state)
+
+## US3: DCO/CLA Enforcement Detection
+
+- [ ] Analyze a repo with Signed-off-by commit trailers — Licensing pane shows DCO enforcement detected
+- [ ] Analyze a repo with DCO/CLA bot in GitHub Actions workflows — Licensing pane shows enforcement detected
+- [ ] Analyze a repo with no enforcement signals — Licensing pane shows "Not detected" with recommendation
+- [ ] Empty repo (zero commits) — DCO/CLA shows "not applicable", not penalized
+
+## Score Integration
+
+- [ ] Health score tooltip still shows correct bucket weights (Activity 30%, Responsiveness 30%, Sustainability 25%, Documentation 15%)
+- [ ] Documentation score help component explains three-part model
+- [ ] Summary line in Documentation tab includes licensing signal count
+
+## Edge Cases
+
+- [ ] Repo with dual licensing — uses primary license from GitHub's licenseInfo
+- [ ] Repo where workflows are not accessible — falls back to commit trailer analysis only
+- [ ] Multiple repos analyzed — each shows independent licensing data in Documentation tab
+
+## Sign-off
+
+- [ ] All items above verified
+- **Signed off by**: ___
+- **Date**: ___

--- a/specs/128-licensing-compliance/checklists/manual-testing.md
+++ b/specs/128-licensing-compliance/checklists/manual-testing.md
@@ -6,33 +6,33 @@
 
 ## Prerequisites
 
-- [ ] Application builds without errors
-- [ ] All automated tests pass
+- [x] Application builds without errors
+- [x] All automated tests pass *(312 tests, 54 files)*
 
 ## US1: License Presence and Quality Assessment
 
-- [ ] Analyze a repo with an OSI-approved license (e.g., MIT) — Documentation score includes licensing sub-score, score is higher than without licensing
-- [ ] Analyze a repo with no license — Documentation score reflects zero licensing sub-score, recommendation to add a license is shown
-- [ ] Analyze a repo with SPDX ID `NOASSERTION` — partial credit in licensing sub-score, recommendation to use a standard license
-- [ ] Documentation bucket composite uses three-part model (file presence + README quality + licensing)
-- [ ] File presence sub-score no longer includes license file weight (5 files scored, not 6)
-- [ ] Licensing sub-score falls back to two-part model gracefully when licensing data is unavailable
+- [x] Analyze a repo with an OSI-approved license — Documentation score includes licensing sub-score, score is higher than without licensing *(Test with `arun-gupta/repo-pulse` — Apache-2.0)*
+- [x] Analyze a repo with no license — Documentation score reflects zero licensing sub-score, recommendation to add a license is shown *(Test with `arun-gupta/docker-images` — no license)*
+- [x] Analyze a repo with SPDX ID `NOASSERTION` — partial credit in licensing sub-score, recommendation to use a standard license *(Test with `donnemartin/system-design-primer` — NOASSERTION)*
+- [x] Documentation bucket composite uses three-part model (file presence + README quality + licensing) *(Click "Show details" below Documentation score badge on any repo)*
+- [x] File presence sub-score no longer includes license file weight (5 files scored, not 6)
+- [x] Licensing sub-score falls back to two-part model gracefully when licensing data is unavailable *(Verified via unit test T017 — cannot be triggered via UI)*
 
 ## US2: License Permissiveness Classification
 
-- [ ] Analyze a repo with permissive license (MIT, Apache-2.0, BSD) — Licensing pane shows "Permissive"
-- [ ] Analyze a repo with copyleft license (GPL-3.0, AGPL-3.0) — Licensing pane shows "Copyleft"
-- [ ] Analyze a repo with weak copyleft license (MPL-2.0, LGPL-3.0) — Licensing pane shows "Weak Copyleft"
-- [ ] Licensing pane displays license name and SPDX ID
-- [ ] Licensing pane displays OSI approval status
-- [ ] Licensing pane handles unavailable data gracefully (shows "unavailable" state)
+- [x] Analyze a repo with permissive license (MIT, Apache-2.0, BSD) — Licensing pane shows "Permissive" *(Tested with `arun-gupta/repo-pulse` — Apache-2.0)*
+- [x] Analyze a repo with copyleft license (GPL-3.0, AGPL-3.0) — Licensing pane shows "Copyleft" *(Tested with `justjavac/free-programming-books-zh_CN` — GPL-3.0)*
+- [x] Analyze a repo with weak copyleft license (MPL-2.0, LGPL-3.0) — Licensing pane shows "Weak Copyleft" *(Tested with `syncthing/syncthing` — MPL-2.0)*
+- [x] Licensing pane displays license name and SPDX ID *(Verified across all repos above)*
+- [x] Licensing pane displays OSI approval status *(Verified across all repos above)*
+- [x] Licensing pane handles unavailable data gracefully (shows "unavailable" state) *(Verified via component test — cannot be triggered via UI)*
 
 ## US3: DCO/CLA Enforcement Detection
 
 - [ ] Analyze a repo with Signed-off-by commit trailers — Licensing pane shows DCO enforcement detected
 - [ ] Analyze a repo with DCO/CLA bot in GitHub Actions workflows — Licensing pane shows enforcement detected
 - [ ] Analyze a repo with no enforcement signals — Licensing pane shows "Not detected" with recommendation
-- [ ] Empty repo (zero commits) — DCO/CLA shows "not applicable", not penalized
+- [ ] Empty repo (zero commits) — DCO/CLA shows "not applicable", not penalized *(Verified via unit test — cannot be triggered via UI)*
 
 ## Score Integration
 

--- a/specs/128-licensing-compliance/checklists/manual-testing.md
+++ b/specs/128-licensing-compliance/checklists/manual-testing.md
@@ -29,25 +29,25 @@
 
 ## US3: DCO/CLA Enforcement Detection
 
-- [ ] Analyze a repo with Signed-off-by commit trailers — Licensing pane shows DCO enforcement detected
-- [ ] Analyze a repo with DCO/CLA bot in GitHub Actions workflows — Licensing pane shows enforcement detected
-- [ ] Analyze a repo with no enforcement signals — Licensing pane shows "Not detected" with recommendation
-- [ ] Empty repo (zero commits) — DCO/CLA shows "not applicable", not penalized *(Verified via unit test — cannot be triggered via UI)*
+- [x] Analyze a repo with Signed-off-by commit trailers — Licensing pane shows DCO enforcement detected *(Tested with `buildroot/buildroot` — 20/20 Signed-off-by)*
+- [x] Analyze a repo with DCO/CLA bot in GitHub Actions workflows — Licensing pane shows enforcement detected *(Tested with `langfuse/langfuse` — cla-assistant workflow)*
+- [x] Analyze a repo with no enforcement signals — Licensing pane shows "Not detected" with recommendation *(Tested with `arun-gupta/repo-pulse`)*
+- [x] Empty repo (zero commits) — DCO/CLA shows "not applicable", not penalized *(Verified via unit test — cannot be triggered via UI)*
 
 ## Score Integration
 
-- [ ] Health score tooltip still shows correct bucket weights (Activity 30%, Responsiveness 30%, Sustainability 25%, Documentation 15%)
-- [ ] Documentation score help component explains three-part model
-- [ ] Summary line in Documentation tab includes licensing signal count
+- [x] Health score tooltip still shows correct bucket weights (Activity 30%, Responsiveness 30%, Sustainability 25%, Documentation 15%)
+- [x] Documentation score help component explains three-part model
+- [x] Summary line in Documentation tab includes licensing signal count
 
 ## Edge Cases
 
-- [ ] Repo with dual licensing — uses primary license from GitHub's licenseInfo
-- [ ] Repo where workflows are not accessible — falls back to commit trailer analysis only
-- [ ] Multiple repos analyzed — each shows independent licensing data in Documentation tab
+- [x] Repo with dual licensing — uses primary license from GitHub's licenseInfo *(Tested with `rust-lang/rust` — shows Apache-2.0 only; dual-license detection deferred to #131)*
+- [x] Repo where workflows are not accessible — falls back to commit trailer analysis only *(Tested with `buildroot/buildroot` — DCO detected via Signed-off-by trailers, no DCO/CLA bot in workflows)*
+- [x] Multiple repos analyzed — each shows independent licensing data in Documentation tab
 
 ## Sign-off
 
-- [ ] All items above verified
-- **Signed off by**: ___
-- **Date**: ___
+- [x] All items above verified
+- **Signed off by**: arun-gupta
+- **Date**: 2026-04-12

--- a/specs/128-licensing-compliance/checklists/requirements.md
+++ b/specs/128-licensing-compliance/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Licensing & Compliance Scoring
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation
+- Architecture decision: Licensing is a sub-score within Documentation bucket (not a standalone 5th bucket)
+- UI decision: Licensing pane added to Documentation tab (no new tab)
+- Out-of-scope boundaries: dependency license scanning, copyright notice parsing
+- Overall health score bucket weights remain unchanged

--- a/specs/128-licensing-compliance/contracts/documentation-score.md
+++ b/specs/128-licensing-compliance/contracts/documentation-score.md
@@ -1,0 +1,48 @@
+# Contract: Documentation Score — Three-Part Model
+
+## Context
+
+The Documentation bucket score changes from a two-part composite (file presence 60%, README quality 40%) to a three-part composite (file presence 40%, README quality 30%, licensing compliance 30%).
+
+## Contract
+
+### DocumentationScoreDefinition (updated)
+
+```typescript
+{
+  value: number | 'Insufficient verified public data'
+  tone: ScoreTone
+  percentile: number | null
+  bracketLabel: string | null
+  compositeScore: number          // weighted composite of 3 sub-scores
+  filePresenceScore: number       // 0.0–1.0, from 5 files (license removed)
+  readmeQualityScore: number      // 0.0–1.0, unchanged
+  licensingScore: number          // 0.0–1.0, NEW
+  recommendations: DocumentationRecommendation[]
+}
+```
+
+### Composite formula
+
+```
+compositeScore = filePresenceScore * 0.40
+               + readmeQualityScore * 0.30
+               + licensingScore * 0.30
+```
+
+### Recommendation categories
+
+Existing categories: `'file'`, `'readme_section'`
+New category: `'licensing'`
+
+### Function signature (updated)
+
+```typescript
+getDocumentationScore(
+  docResult: DocumentationResult,
+  licensingResult: LicensingResult | 'unavailable',
+  stars: number | 'unavailable'
+): DocumentationScoreDefinition
+```
+
+The `licensingResult` parameter is new. When `'unavailable'`, the licensing sub-score is excluded and the composite falls back to the two-part model (file presence + README quality only).

--- a/specs/128-licensing-compliance/contracts/licensing-result.md
+++ b/specs/128-licensing-compliance/contracts/licensing-result.md
@@ -1,0 +1,47 @@
+# Contract: LicensingResult in AnalysisResult
+
+## Context
+
+The `AnalysisResult` interface is the shared data contract between the analyzer module and all consumers (web UI, future GitHub Action, future MCP server). Adding `licensingResult` must maintain backward compatibility.
+
+## Contract
+
+### New field on AnalysisResult
+
+```typescript
+licensingResult: LicensingResult | 'unavailable'
+```
+
+### LicensingResult shape
+
+```typescript
+{
+  license: {
+    spdxId: string | null
+    name: string | null
+    osiApproved: boolean
+    permissivenessTier: 'Permissive' | 'Weak Copyleft' | 'Copyleft' | null
+  }
+  contributorAgreement: {
+    signedOffByRatio: number | null
+    dcoOrClaBot: boolean
+    enforced: boolean
+  }
+}
+```
+
+### When unavailable
+
+If the overview query fails or license data cannot be extracted, `licensingResult` is set to `'unavailable'`. Consumers must handle this case.
+
+## Backward Compatibility
+
+- `DocumentationFileCheck` for license continues to have `found: boolean` and `path: string | null` for file presence display.
+- The `licenseType` field on `DocumentationFileCheck` is removed — consumers should read `licensingResult.license.spdxId` instead.
+- The `DocumentationResult` type is unchanged structurally.
+
+## Consumers
+
+- **Documentation score-config**: Reads `licensingResult` to compute the licensing sub-score.
+- **DocumentationView**: Reads `licensingResult` to render the Licensing pane.
+- **Health score tooltip**: No change needed (bucket weights unchanged).

--- a/specs/128-licensing-compliance/data-model.md
+++ b/specs/128-licensing-compliance/data-model.md
@@ -1,0 +1,133 @@
+# Data Model: Licensing & Compliance Scoring
+
+## New Types
+
+### LicensePermissivenessTier
+
+Classifies a detected license by its permissiveness level.
+
+- Values: `Permissive`, `Weak Copyleft`, `Copyleft`
+- Derived from: SPDX ID lookup against static tier mapping
+
+### LicenseDetection
+
+Captures the license identified for a repository.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| spdxId | string or null | SPDX short identifier from GitHub API |
+| name | string or null | Human-readable license name from GitHub API |
+| osiApproved | boolean | Whether the SPDX ID is in the OSI-approved set |
+| permissivenessTier | LicensePermissivenessTier or null | Tier classification (null if SPDX ID unrecognized) |
+
+- Source: `repository.licenseInfo` GraphQL field (already fetched)
+- `osiApproved` and `permissivenessTier` derived from static config lookup
+
+### ContributorAgreementSignal
+
+Captures DCO/CLA enforcement status.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| signedOffByRatio | number or null | Ratio of recent commits with `Signed-off-by:` trailers (0.0–1.0) |
+| dcoOrClaBot | boolean | Whether a DCO/CLA bot action was found in workflow files |
+| enforced | boolean | Whether contributor agreement enforcement is detected (derived) |
+
+- `signedOffByRatio`: Computed from `message` field on recent commit nodes
+- `dcoOrClaBot`: Computed from workflow tree query, checking for known action references
+- `enforced`: `true` if `signedOffByRatio >= threshold` OR `dcoOrClaBot === true`
+
+### LicensingResult
+
+Top-level licensing analysis result, added to the existing AnalysisResult.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| license | LicenseDetection | License detection data |
+| contributorAgreement | ContributorAgreementSignal | DCO/CLA enforcement signals |
+
+## Modified Types
+
+### DocumentationFileCheck (existing)
+
+**Change**: Remove `licenseType` field. License SPDX data moves to `LicensingResult.license.spdxId`.
+
+The `license` entry remains in `fileChecks` for file presence scoring (found/not found), but the SPDX metadata is no longer carried on this type.
+
+### DocumentationResult (existing)
+
+**No structural change**. File checks and README sections remain as-is. The license file check stays in `fileChecks` for backward compatibility but its weight in the file presence sub-score is redistributed to other files.
+
+### AnalysisResult (existing)
+
+**Change**: Add `licensingResult` field.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| licensingResult | LicensingResult or Unavailable | Licensing & compliance analysis data |
+
+### DocumentationScoreDefinition (existing)
+
+**Change**: Add `licensingScore` field to expose the third sub-score.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| licensingScore | number | Licensing compliance sub-score (0.0–1.0) |
+
+Existing fields `filePresenceScore` and `readmeQualityScore` remain unchanged.
+
+## Scoring Model
+
+### Documentation Bucket — Three-Part Composite
+
+```
+compositeScore = filePresenceScore * 0.40
+               + readmeQualityScore * 0.30
+               + licensingScore * 0.30
+```
+
+### File Presence Sub-Score — Updated Weights
+
+License file check removed from scoring (still checked for presence display). Remaining files redistributed:
+
+| File | Old Weight | New Weight |
+|------|-----------|------------|
+| readme | 0.25 | 0.30 |
+| contributing | 0.15 | 0.20 |
+| code_of_conduct | 0.10 | 0.10 |
+| security | 0.15 | 0.20 |
+| changelog | 0.15 | 0.20 |
+| license | 0.20 | *(removed from scoring)* |
+
+### Licensing Sub-Score — Weighted Signals
+
+| Signal | Weight | Score Logic |
+|--------|--------|-------------|
+| License present (SPDX detected) | 0.40 | 1.0 if spdxId non-null and not NOASSERTION; 0.3 if NOASSERTION; 0.0 if null |
+| OSI approved | 0.25 | 1.0 if osiApproved; 0.0 otherwise |
+| Permissiveness classified | 0.10 | 1.0 if tier is non-null; 0.0 otherwise (informational, all tiers score equally) |
+| DCO/CLA enforced | 0.25 | 1.0 if enforced; 0.0 otherwise |
+
+## Static Configuration
+
+### OSI-Approved License Set
+
+A `Set<string>` of ~110 SPDX identifiers recognized as OSI-approved. Source: https://opensource.org/licenses (snapshot, updated manually as needed).
+
+### Permissiveness Tier Map
+
+A `Map<string, LicensePermissivenessTier>` mapping SPDX identifiers to their tier. Covers the ~30 most common licenses. Unlisted OSI-approved licenses default to `null` (tier unknown).
+
+### DCO/CLA Bot Action Identifiers
+
+A `Set<string>` of known GitHub Action references for DCO/CLA enforcement:
+- `apps/dco`
+- `probot/dco`
+- `cla-assistant/cla-assistant`
+- `contributor-assistant/github-action`
+
+### Configurable Thresholds
+
+| Threshold | Default | Description |
+|-----------|---------|-------------|
+| signedOffByRatioThreshold | 0.8 | Minimum ratio of commits with Signed-off-by to consider DCO enforced |

--- a/specs/128-licensing-compliance/plan.md
+++ b/specs/128-licensing-compliance/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Licensing & Compliance Scoring
+
+**Branch**: `128-licensing-compliance` | **Date**: 2026-04-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/128-licensing-compliance/spec.md`
+
+## Summary
+
+Add Licensing & Compliance as a third sub-score within the Documentation scoring bucket. The feature enriches the existing license file presence check with OSI approval detection, permissiveness tier classification, and DCO/CLA enforcement detection. A new Licensing pane in the Documentation tab displays these signals. The Documentation bucket's internal weighting shifts from a two-part model (file presence 60%, README quality 40%) to a three-part model (file presence, README quality, licensing compliance).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Next.js 16+)
+**Primary Dependencies**: Next.js (App Router), Tailwind CSS, React
+**Storage**: N/A (stateless, on-demand analysis)
+**Testing**: Vitest, React Testing Library
+**Target Platform**: Web (Vercel deployment)
+**Project Type**: Web application (Next.js App Router)
+**Performance Goals**: No additional API calls for license detection (SPDX ID already fetched). DCO/CLA detection adds commit message field to existing query and a new workflow file query (1-2 additional GraphQL requests).
+**Constraints**: Must comply with constitution's 1-3 GraphQL requests per repo guideline. Commit message bodies increase query payload size.
+**Scale/Scope**: Scoring logic change affects all analyzed repositories.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| I. Technology Stack | PASS | No new tech — uses existing TypeScript, Next.js, Tailwind |
+| II. Accuracy Policy | PASS | All data from GitHub GraphQL API. Missing data marked "unavailable". No estimation or fabrication. |
+| III. Data Source Rules | PASS | Primary source is GraphQL `licenseInfo`. Commit messages and workflow files also via GraphQL. No new REST calls needed. |
+| IV. Analyzer Module Boundary | PASS | New scoring logic is framework-agnostic, lives in `lib/`. No Next.js imports in analyzer. |
+| V. CHAOSS Alignment | PASS | No new CHAOSS category. Licensing enriches the existing Documentation dimension. |
+| VI. Scoring Thresholds | PASS | Thresholds in configuration, not hardcoded. |
+| IX. Feature Scope Rules | PASS | YAGNI: only signals defined in spec. No dependency scanning or copyright parsing. |
+| X. Security & Hygiene | PASS | No new secrets. Token usage unchanged. |
+| XI. Testing | PASS | TDD: tests first, then implementation. Vitest + RTL. |
+| XII. Definition of Done | PASS | Manual testing checklist, linting, no TODOs required. |
+| XIII. Development Workflow | PASS | Feature branch, PR workflow. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/128-licensing-compliance/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+lib/
+├── analyzer/
+│   ├── analysis-result.ts    # MODIFY: Add LicensingResult interface
+│   ├── analyze.ts            # MODIFY: Extract licensing data, DCO/CLA signals
+│   └── queries.ts            # MODIFY: Add commit message field, workflow file query
+├── documentation/
+│   └── score-config.ts       # MODIFY: Three-part scoring model
+├── licensing/
+│   └── license-data.ts       # NEW: OSI license list, permissiveness tiers
+└── scoring/
+    ├── health-score.ts        # MODIFY: Update tooltip text
+    └── calibration-data.json  # MODIFY: Re-calibrate documentation percentiles
+
+components/
+├── documentation/
+│   ├── DocumentationView.tsx  # MODIFY: Add Licensing pane
+│   └── DocumentationScoreHelp.tsx  # NEW: Three-part score explanation
+
+__tests__/
+├── licensing/
+│   ├── license-data.test.ts          # NEW: OSI list, tier classification tests
+│   └── licensing-score.test.ts       # NEW: Licensing sub-score calculation tests
+├── documentation/
+│   └── score-config.test.ts          # MODIFY: Update for three-part model
+└── components/
+    └── DocumentationView.test.tsx     # MODIFY: Test Licensing pane rendering
+```
+
+**Structure Decision**: No new top-level directories. Licensing data config lives in `lib/licensing/` (new). Scoring logic stays in `lib/documentation/score-config.ts` since licensing is a sub-score within Documentation. UI additions stay in `components/documentation/`.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/128-licensing-compliance/quickstart.md
+++ b/specs/128-licensing-compliance/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Licensing & Compliance Scoring
+
+## What this feature does
+
+Adds licensing and compliance signals to the Documentation health score bucket. Users see a new Licensing pane in the Documentation tab showing:
+- License name, SPDX ID, and OSI approval status
+- Permissiveness tier (Permissive / Weak Copyleft / Copyleft)
+- DCO/CLA enforcement detection
+- Actionable recommendations for missing signals
+
+## Key files to understand
+
+| File | Purpose |
+|------|---------|
+| `lib/analyzer/queries.ts` | GraphQL queries — add `message` to commit nodes, add workflow tree query |
+| `lib/analyzer/analyze.ts` | Data extraction — build `LicensingResult` from API response |
+| `lib/analyzer/analysis-result.ts` | Types — add `LicensingResult`, update `AnalysisResult` |
+| `lib/licensing/license-data.ts` | **New** — OSI license set, permissiveness tier map |
+| `lib/documentation/score-config.ts` | Scoring — three-part composite, licensing sub-score logic |
+| `components/documentation/DocumentationView.tsx` | UI — add Licensing pane |
+| `components/documentation/DocumentationScoreHelp.tsx` | **New** — score explanation component |
+
+## Implementation order
+
+1. **Static data** (`lib/licensing/license-data.ts`): OSI set + tier map. Fully testable in isolation.
+2. **Types** (`analysis-result.ts`): Add `LicensingResult` interface and field on `AnalysisResult`.
+3. **Data collection** (`queries.ts` + `analyze.ts`): Add commit `message` field, workflow tree query, extract licensing data.
+4. **Scoring** (`score-config.ts`): Three-part model, licensing sub-score, updated file weights.
+5. **UI** (`DocumentationView.tsx`, `DocumentationScoreHelp.tsx`): Licensing pane, updated help section.
+6. **Calibration** (`calibration-data.json`): Re-sample percentile anchors with updated formula.
+
+## Testing approach
+
+- **Unit tests first** (TDD per constitution): license classification, tier lookup, score calculation, DCO ratio detection.
+- **Component tests**: Licensing pane rendering with various data states (OSI license, no license, NOASSERTION, DCO detected, etc.).
+- **Integration**: Full analyzer flow with mocked GraphQL responses including licensing data.
+
+## What NOT to change
+
+- Overall health score bucket weights (Activity 30%, Responsiveness 30%, Sustainability 25%, Documentation 15%) — unchanged.
+- Other scoring buckets — no modifications needed.
+- Tab structure — no new tab; licensing lives inside the Documentation tab.

--- a/specs/128-licensing-compliance/research.md
+++ b/specs/128-licensing-compliance/research.md
@@ -1,0 +1,87 @@
+# Research: Licensing & Compliance Scoring
+
+## R1: How to detect OSI-approved licenses from SPDX ID
+
+**Decision**: Maintain a static lookup set of OSI-approved SPDX identifiers.
+
+**Rationale**: The SPDX license list is stable (updated ~2x/year). A static set avoids runtime API calls and is trivially testable. GitHub's `licenseInfo.spdxId` returns the SPDX short identifier (e.g., `MIT`, `Apache-2.0`, `GPL-3.0-only`). Cross-referencing against the OSI list is a simple `Set.has()` check.
+
+**Alternatives considered**:
+- Fetching from SPDX API at runtime: Unnecessary network dependency for a slowly-changing list.
+- Using GitHub's `licenseInfo.isSpdxApproved` field: This field does not exist in the GitHub GraphQL API.
+
+## R2: How to classify license permissiveness tiers
+
+**Decision**: Static mapping from SPDX ID to tier: `Permissive`, `Weak Copyleft`, `Copyleft`.
+
+**Rationale**: The permissiveness classification is well-established and stable. Common mappings:
+- **Permissive**: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, Unlicense, 0BSD, Zlib, BSL-1.0
+- **Weak Copyleft**: MPL-2.0, LGPL-2.1-only, LGPL-2.1-or-later, LGPL-3.0-only, LGPL-3.0-or-later, EPL-2.0, CDDL-1.0
+- **Copyleft**: GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later, EUPL-1.2, OSL-3.0
+
+Licenses not in any tier default to `null` (unclassified) — the system reports OSI status separately.
+
+**Alternatives considered**:
+- Binary permissive/copyleft split: Too coarse. Weak copyleft (MPL, LGPL) has meaningfully different enterprise implications than strong copyleft (GPL, AGPL).
+- Granular 5-tier model: Over-engineering for the current need.
+
+## R3: How to detect DCO/CLA enforcement
+
+**Decision**: Two-signal approach — commit trailer analysis + workflow file inspection.
+
+### Signal 1: Signed-off-by commit trailers
+
+**Approach**: Add the `message` field to the existing commit history query nodes. Check recent commits (last 100, already fetched in `REPO_COMMIT_AND_RELEASES_QUERY`) for `Signed-off-by:` trailers.
+
+**Metric**: Ratio of recent commits containing `Signed-off-by:` trailers. A ratio above a configurable threshold (e.g., 0.8) indicates DCO enforcement.
+
+**Cost**: Adding `message` to existing commit nodes increases payload size but requires no additional API call.
+
+### Signal 2: Workflow file inspection
+
+**Approach**: Query `.github/workflows/` directory contents via GraphQL `object(expression: "HEAD:.github/workflows")` tree query. Check YAML filenames and, where feasible, file content for known DCO/CLA action references:
+- `apps/dco` (GitHub App)
+- `probot/dco` (legacy)
+- `cla-assistant/cla-assistant`
+- `contributor-assistant/github-action`
+- `dco-action`
+
+**Cost**: One additional GraphQL request to fetch workflow directory tree + selective blob reads. This stays within the constitution's 1-3 requests guideline (the workflow query can be bundled with the overview query or run as a lightweight supplementary request).
+
+**Alternatives considered**:
+- REST API for workflow files: Constitution prefers GraphQL. REST is supplementary only.
+- Checking only commit trailers: Misses projects that use CLA bots but don't require Signed-off-by.
+- Checking only workflow files: Misses projects that enforce DCO via git hooks or policy without a bot.
+
+## R4: Documentation bucket weight redistribution
+
+**Decision**: Three-part model with weights: file presence 40%, README quality 30%, licensing compliance 30%.
+
+**Rationale**: 
+- Currently: file presence 60% + README quality 40%.
+- Licensing compliance is a substantial new signal dimension (4 sub-signals) — deserves equal or near-equal weight to README quality.
+- File presence drops from 60% to 40% because the license file check moves out of it (it was 20% of file presence, so effective loss is 12 percentage points, partially compensated by the 5 remaining files redistributing weights).
+- 40/30/30 gives licensing meaningful impact (~4.5% of overall score = 30% of 15%) vs the current ~3%.
+
+**Alternatives considered**:
+- 50/25/25: Under-weights licensing signals.
+- 33/33/34: Over-weights file presence relative to the richer licensing analysis.
+- Keeping 60/40 and nesting licensing inside file presence: Buries licensing signals; defeats the purpose of the feature.
+
+## R5: Impact on existing calibration data
+
+**Decision**: Re-calibrate the `documentationScore` percentile sets in `calibration-data.json` after implementation.
+
+**Rationale**: The composite formula changes (three-part model instead of two-part). Existing percentile anchors (p25/p50/p75/p90) were calibrated against the old formula. New anchors must be derived from real repository data using the updated formula.
+
+**Approach**: Use the existing calibration sampling script (from issue #52 work) to re-sample repositories and compute new percentile distributions. This is a post-implementation calibration step, not a blocking dependency.
+
+## R6: GraphQL query cost analysis
+
+**Decision**: Acceptable — adds `message` field to existing commit nodes + one new tree query for workflow files.
+
+**Details**:
+- `message` on commit nodes: Already fetching 100 commit nodes. Adding `message` field is a trivial payload increase, no extra API call.
+- Workflow tree query: `object(expression: "HEAD:.github/workflows") { ... on Tree { entries { name, object { ... on Blob { text } } } }` — one query, fetches all workflow file names and content.
+- Can be combined into the existing `REPO_OVERVIEW_QUERY` to stay within the 1-3 request budget.
+- Total: 0-1 additional API calls (0 if bundled into overview query).

--- a/specs/128-licensing-compliance/spec.md
+++ b/specs/128-licensing-compliance/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Licensing & Compliance Scoring
+
+**Feature Branch**: `128-licensing-compliance`  
+**Created**: 2026-04-12  
+**Status**: Draft  
+**Input**: GitHub Issue #115 — Add Licensing & Compliance scoring to health score
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - License Presence and Quality Assessment (Priority: P1)
+
+A user analyzing a repository sees licensing details within the Documentation tab that reflect whether the project has a recognized, machine-readable license. This is the most fundamental signal: without a clear license, the project cannot be safely adopted.
+
+**Why this priority**: License presence is the single most important compliance signal. A project without a recognized license is legally ambiguous and unadoptable in enterprise settings.
+
+**Independent Test**: Can be tested by analyzing repos with known license states (MIT-licensed, unlicensed, custom license text) and verifying the score reflects license quality.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with an OSI-approved license detected by GitHub (valid SPDX ID), **When** the user views the Documentation tab, **Then** the Licensing pane shows a high sub-score for license presence and recognition.
+2. **Given** a repository with no license file or no detected license, **When** the user views the Documentation tab, **Then** the Licensing pane shows a zero sub-score and the user sees a recommendation to add a license.
+3. **Given** a repository where GitHub detects a license but the SPDX ID is `NOASSERTION` or unrecognized, **When** the user views the Documentation tab, **Then** the Licensing pane reflects partial credit (license file exists but is not machine-readable or OSI-approved) and a recommendation to use a standard license.
+
+---
+
+### User Story 2 - License Permissiveness Classification (Priority: P2)
+
+A user evaluating a repository for enterprise adoption sees whether the license is permissive (MIT, Apache-2.0, BSD) or copyleft (GPL, AGPL, LGPL, MPL) within the Licensing pane. This classification helps users quickly assess adoption friction.
+
+**Why this priority**: Permissiveness tier is a key enterprise adoption signal, but it only matters when a license is actually present (depends on P1 signal data).
+
+**Independent Test**: Can be tested by analyzing repos with known permissive and copyleft licenses and verifying the classification is displayed correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with a permissive OSI-approved license (e.g., MIT, Apache-2.0, BSD-2-Clause), **When** the user views the Licensing pane, **Then** the license is classified as "Permissive."
+2. **Given** a repository with a copyleft license (e.g., GPL-3.0, AGPL-3.0), **When** the user views the Licensing pane, **Then** the license is classified as "Copyleft."
+3. **Given** a repository with a weak copyleft license (e.g., MPL-2.0, LGPL-3.0), **When** the user views the Licensing pane, **Then** the license is classified as "Weak Copyleft."
+
+---
+
+### User Story 3 - DCO/CLA Enforcement Detection (Priority: P3)
+
+A user sees whether the project enforces contributor agreements (DCO or CLA) within the Licensing pane, signaling that contributions are legally vetted. This is a strong governance signal for enterprise-maintained or foundation-backed projects.
+
+**Why this priority**: DCO/CLA enforcement is a valuable compliance signal but is less universally applicable than license presence — many healthy projects do not use formal contributor agreements.
+
+**Independent Test**: Can be tested by analyzing repos with known DCO bot configurations, CLA enforcement workflows, or Signed-off-by commit trailers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository whose recent commits consistently include `Signed-off-by` trailers, **When** the user views the Licensing pane, **Then** the system reports DCO enforcement as detected.
+2. **Given** a repository with a GitHub Actions workflow referencing a known DCO or CLA bot action, **When** the user views the Licensing pane, **Then** the system reports CLA/DCO enforcement as detected.
+3. **Given** a repository with no contributor agreement enforcement signals, **When** the user views the Licensing pane, **Then** the system reports no enforcement detected and provides a recommendation to consider adding DCO or CLA enforcement.
+
+---
+
+### Edge Cases
+
+- What happens when a repo has multiple LICENSE files (e.g., dual licensing)? The system uses the primary license detected by GitHub via `licenseInfo.spdxId`.
+- What happens when the SPDX ID is `NOASSERTION`? Treated as "license present but unrecognized" — partial credit, with a recommendation to adopt a standard OSI-approved license.
+- What happens when GitHub detects a license but no LICENSE file exists at the repo root? The system relies on GitHub's `licenseInfo` detection; file placement is not independently verified.
+- What happens when a repo has zero commits (empty repo)? DCO/CLA signals are scored as "not applicable" rather than penalized.
+- What happens when GitHub Actions workflows are not accessible? DCO/CLA detection falls back to commit trailer analysis only; missing workflow data does not penalize the score.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect whether a repository has a license recognized by GitHub (`licenseInfo.spdxId` is non-null and not `NOASSERTION`).
+- **FR-002**: System MUST determine whether the detected license is OSI-approved based on the SPDX identifier.
+- **FR-003**: System MUST classify detected licenses into permissiveness tiers: Permissive, Weak Copyleft, or Copyleft, based on the SPDX identifier.
+- **FR-004**: System MUST check recent commits for `Signed-off-by` trailer presence as a DCO enforcement signal.
+- **FR-005**: System MUST check GitHub Actions workflow files for references to known DCO/CLA bot actions as a contributor agreement enforcement signal.
+- **FR-006**: System MUST compute a composite Licensing & Compliance sub-score from weighted sub-signals: license presence/recognition, OSI approval, permissiveness classification, and DCO/CLA enforcement.
+- **FR-007**: System MUST produce actionable recommendations when licensing signals are missing or weak (e.g., no license, non-OSI license, no contributor agreement enforcement).
+- **FR-008**: System MUST integrate the Licensing & Compliance sub-score as a third component within the Documentation bucket, alongside the existing file presence and README quality sub-scores.
+- **FR-009**: System MUST rebalance the Documentation bucket's internal weights to accommodate three sub-scores (file presence, README quality, and licensing compliance) while preserving the Documentation bucket's existing weight in the overall health score.
+- **FR-010**: System MUST replace the existing license file presence check in the Documentation file presence sub-score with the richer licensing sub-score to avoid double-counting license signals.
+- **FR-011**: System MUST redistribute the weight previously assigned to the license file check within file presence across the remaining documentation files (README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG).
+- **FR-012**: System MUST display licensing details in a dedicated Licensing pane within the Documentation tab, showing: license name, SPDX ID, OSI approval status, permissiveness tier, and DCO/CLA enforcement status.
+- **FR-013**: System MUST update the Documentation score tooltip and help section to reflect the three-part scoring model (file presence, README quality, licensing compliance).
+- **FR-014**: When license data is unavailable from the GitHub API, the system MUST mark the licensing sub-score as `"Insufficient verified public data"` per the constitution's accuracy policy.
+- **FR-015**: When the licensing sub-score has insufficient data, the system MUST compute the Documentation bucket score from the remaining two sub-scores (file presence and README quality) rather than penalizing the repository.
+
+### Key Entities
+
+- **License Detection Result**: The license identified by GitHub for a repository — includes SPDX ID, name, whether it is OSI-approved, and its permissiveness tier.
+- **Contributor Agreement Signal**: Whether DCO or CLA enforcement is detected — derived from commit trailers and workflow file analysis.
+- **Licensing & Compliance Sub-Score**: A composite score combining license quality and contributor agreement signals, integrated as one of three sub-scores within the Documentation bucket.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every analyzed repository displays licensing details (or an explicit "insufficient data" indicator) within the Documentation tab's Licensing pane.
+- **SC-002**: Repositories with OSI-approved, machine-readable licenses score measurably higher in the Documentation bucket than repositories with no license or unrecognized licenses.
+- **SC-003**: Users can distinguish between permissive and copyleft-licensed projects at a glance from the Licensing pane.
+- **SC-004**: Repositories with active DCO/CLA enforcement score higher in the Documentation bucket than those without, all else being equal.
+- **SC-005**: The Documentation bucket score changes to reflect the new three-part model (file presence + README quality + licensing compliance).
+- **SC-006**: At least one actionable recommendation is generated for any repository missing a license or lacking contributor agreement enforcement.
+
+## Health Score Integration
+
+### Documentation Bucket — Three-Part Model
+
+The Documentation bucket currently uses a two-part scoring model: file presence (60%) and README quality (40%). This feature adds a third sub-score — Licensing & Compliance — creating a three-part model. The exact sub-score weights are deferred to the planning phase but the structure is:
+
+1. **File Presence** — presence of key documentation files (README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG). The license file check moves out of this sub-score and into the Licensing sub-score.
+2. **README Quality** — detection of key sections (description, installation, usage, contributing, license mention).
+3. **Licensing & Compliance** — license recognition, OSI approval, permissiveness tier, and DCO/CLA enforcement.
+
+### Impact on Scores
+
+- The overall health score weights (Activity 30%, Responsiveness 30%, Sustainability 25%, Documentation 15%) remain unchanged.
+- Within the Documentation bucket, licensing signals gain significantly more influence than the current ~3% effective weight (20% of the file presence sub-score's 60% share).
+- Repositories with strong licensing practices (OSI-approved license + DCO/CLA enforcement) see a Documentation score boost.
+- Repositories with no license see a larger Documentation score penalty than before, since the licensing sub-score contributes more than a single file presence check did.
+- The file presence sub-score is simplified (5 files instead of 6) and its internal weights are redistributed.
+
+### UI Display
+
+The Documentation tab gains a **Licensing pane** displayed alongside the existing documentation files and README sections views. The Licensing pane shows:
+
+- License name and SPDX identifier
+- OSI approval status (approved / not approved / no license)
+- Permissiveness tier (Permissive / Weak Copyleft / Copyleft / N/A)
+- DCO/CLA enforcement status (detected / not detected)
+- Licensing sub-score contribution to the Documentation bucket
+- Actionable recommendations for missing or weak signals
+
+The Documentation score help section is updated to explain the three-part model.
+
+## Assumptions
+
+- The GitHub GraphQL API `licenseInfo.spdxId` field is the authoritative source for license detection. The system does not independently parse LICENSE file content beyond what GitHub provides.
+- The list of OSI-approved SPDX identifiers and their permissiveness tiers is maintained as a static configuration within the analyzer, not fetched from an external API at runtime.
+- DCO/CLA detection via commit trailers uses a sample of recent commits (consistent with existing commit-fetching patterns in the analyzer), not the full commit history.
+- Workflow file analysis for DCO/CLA bots is limited to `.github/workflows/` YAML files accessible via the GitHub API.
+- Dependency license compatibility scanning is explicitly out of scope for this feature (deferred to a separate issue).
+- Copyright notice completeness checking is out of scope — the system does not parse LICENSE file text content for copyright headers.
+- Licensing & Compliance is integrated as a sub-score within the existing Documentation bucket, not as a standalone 5th bucket. The overall health score bucket weights remain unchanged.
+- The existing calibration infrastructure (star-bracket percentile interpolation) continues to work with the Documentation bucket — no new top-level calibration is needed.

--- a/specs/128-licensing-compliance/tasks.md
+++ b/specs/128-licensing-compliance/tasks.md
@@ -1,0 +1,208 @@
+# Tasks: Licensing & Compliance Scoring
+
+**Input**: Design documents from `/specs/128-licensing-compliance/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included — constitution mandates TDD (Red-Green-Refactor).
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Static data and type definitions that all user stories depend on
+
+- [ ] T001 [P] Create OSI-approved license set and permissiveness tier map in lib/licensing/license-data.ts
+- [ ] T002 [P] Create unit tests for license-data (OSI lookup, tier classification, edge cases) in __tests__/licensing/license-data.test.ts
+- [ ] T003 Add LicensingResult, LicenseDetection, and ContributorAgreementSignal interfaces to lib/analyzer/analysis-result.ts
+- [ ] T004 Add licensingResult field (LicensingResult | Unavailable) to AnalysisResult interface in lib/analyzer/analysis-result.ts
+
+---
+
+## Phase 2: Foundational (Data Collection)
+
+**Purpose**: Extend the analyzer to collect licensing and compliance data from the GitHub API. MUST complete before any scoring or UI work.
+
+- [ ] T005 Add `message` field to commit history nodes in REPO_COMMIT_AND_RELEASES_QUERY in lib/analyzer/queries.ts
+- [ ] T006 Add workflow tree query field (`object(expression: "HEAD:.github/workflows")`) to REPO_OVERVIEW_QUERY in lib/analyzer/queries.ts
+- [ ] T007 Write unit tests for licensing data extraction (license detection, Signed-off-by parsing, workflow bot detection) in __tests__/licensing/extract-licensing.test.ts
+- [ ] T008 Implement extractLicensingResult() in lib/analyzer/analyze.ts — extract license SPDX ID, OSI approval, permissiveness tier from overview query response
+- [ ] T009 Implement Signed-off-by trailer detection in lib/analyzer/analyze.ts — parse commit messages, compute signedOffByRatio
+- [ ] T010 Implement DCO/CLA bot detection in lib/analyzer/analyze.ts — scan workflow tree entries for known bot action references
+- [ ] T011 Wire extractLicensingResult() into the main analyze() function, populating licensingResult on AnalysisResult in lib/analyzer/analyze.ts
+- [ ] T012 Remove licenseType field from DocumentationFileCheck interface in lib/analyzer/analysis-result.ts and update all references in lib/analyzer/analyze.ts and components/documentation/DocumentationView.tsx
+
+**Checkpoint**: Analyzer now produces LicensingResult for every analyzed repo. All downstream consumers can read licensing data.
+
+---
+
+## Phase 3: User Story 1 — License Presence and Quality Assessment (Priority: P1) 🎯 MVP
+
+**Goal**: Documentation score reflects license quality via a three-part composite model. Users see licensing signals affect the Documentation bucket score.
+
+**Independent Test**: Analyze a repo with MIT license → Documentation score includes licensing sub-score. Analyze a repo with no license → score is lower, recommendation generated.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T013 [P] [US1] Write unit tests for three-part Documentation composite formula (40/30/30 weights) in __tests__/documentation/score-config.test.ts
+- [ ] T014 [P] [US1] Write unit tests for licensing sub-score calculation (license present, OSI approved, tier classified, DCO enforced) in __tests__/licensing/licensing-score.test.ts
+- [ ] T015 [P] [US1] Write unit tests for updated file presence weights (5 files, license removed from scoring) in __tests__/documentation/score-config.test.ts
+- [ ] T016 [P] [US1] Write unit tests for licensing recommendation generation (no license, non-OSI, no DCO) in __tests__/licensing/licensing-score.test.ts
+- [ ] T017 [P] [US1] Write unit test for fallback to two-part model when licensingResult is unavailable in __tests__/documentation/score-config.test.ts
+
+### Implementation for User Story 1
+
+- [ ] T018 [US1] Implement getLicensingScore() function computing weighted licensing sub-score in lib/documentation/score-config.ts
+- [ ] T019 [US1] Update FILE_WEIGHTS in lib/documentation/score-config.ts — remove license entry, redistribute weights across 5 remaining files (readme 0.30, contributing 0.20, code_of_conduct 0.10, security 0.20, changelog 0.20)
+- [ ] T020 [US1] Update getDocumentationScore() signature to accept licensingResult parameter in lib/documentation/score-config.ts
+- [ ] T021 [US1] Update composite formula to three-part model (filePresence * 0.40 + readmeQuality * 0.30 + licensing * 0.30) with fallback to two-part when licensing unavailable in lib/documentation/score-config.ts
+- [ ] T022 [US1] Add licensingScore field to DocumentationScoreDefinition interface in lib/documentation/score-config.ts
+- [ ] T023 [US1] Generate licensing recommendations (no license, non-OSI license, no DCO/CLA) in lib/documentation/score-config.ts
+- [ ] T024 [US1] Update getHealthScore() call site to pass licensingResult to getDocumentationScore() in lib/scoring/health-score.ts
+
+**Checkpoint**: Documentation bucket score now incorporates licensing signals. All scoring tests pass.
+
+---
+
+## Phase 4: User Story 2 — License Permissiveness Classification (Priority: P2)
+
+**Goal**: Users see the permissiveness tier (Permissive / Weak Copyleft / Copyleft) displayed in the Documentation tab's Licensing pane.
+
+**Independent Test**: Analyze a repo with Apache-2.0 → Licensing pane shows "Permissive". Analyze a repo with GPL-3.0 → shows "Copyleft".
+
+### Tests for User Story 2
+
+- [ ] T025 [P] [US2] Write component tests for Licensing pane rendering (license name, SPDX ID, OSI badge, permissiveness tier) in __tests__/components/DocumentationView.test.tsx
+- [ ] T026 [P] [US2] Write component tests for Licensing pane with missing/unavailable data states in __tests__/components/DocumentationView.test.tsx
+
+### Implementation for User Story 2
+
+- [ ] T027 [US2] Add Licensing pane to DocumentationView — display license name, SPDX ID, OSI approval status, and permissiveness tier in components/documentation/DocumentationView.tsx
+- [ ] T028 [US2] Style Licensing pane with presence indicators (✓/✗), tier badge, and recommendation text consistent with existing file/section panes in components/documentation/DocumentationView.tsx
+- [ ] T029 [US2] Handle unavailable/missing licensing data gracefully in the Licensing pane (show "unavailable" state) in components/documentation/DocumentationView.tsx
+
+**Checkpoint**: Documentation tab shows Licensing pane with license details and permissiveness tier.
+
+---
+
+## Phase 5: User Story 3 — DCO/CLA Enforcement Detection (Priority: P3)
+
+**Goal**: Users see DCO/CLA enforcement status in the Licensing pane. Repos with active enforcement score higher.
+
+**Independent Test**: Analyze a repo with Signed-off-by trailers → Licensing pane shows "DCO enforcement detected". Analyze a repo with no enforcement → shows "Not detected" with recommendation.
+
+### Tests for User Story 3
+
+- [ ] T030 [P] [US3] Write component tests for DCO/CLA enforcement display in Licensing pane (detected/not detected states) in __tests__/components/DocumentationView.test.tsx
+- [ ] T031 [P] [US3] Write component test for enforcement recommendation display in __tests__/components/DocumentationView.test.tsx
+
+### Implementation for User Story 3
+
+- [ ] T032 [US3] Add DCO/CLA enforcement section to Licensing pane — show Signed-off-by ratio, bot detection status, and enforcement verdict in components/documentation/DocumentationView.tsx
+- [ ] T033 [US3] Add enforcement recommendation text when not detected in components/documentation/DocumentationView.tsx
+
+**Checkpoint**: Licensing pane shows full compliance picture — license quality + permissiveness + DCO/CLA enforcement.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Score help component, tooltip updates, and cleanup
+
+- [ ] T034 [P] Create DocumentationScoreHelp component explaining three-part model (file presence, README quality, licensing compliance) in components/documentation/DocumentationScoreHelp.tsx
+- [ ] T035 [P] Write component tests for DocumentationScoreHelp in __tests__/components/DocumentationScoreHelp.test.tsx
+- [ ] T036 Wire DocumentationScoreHelp into DocumentationView below the score badge in components/documentation/DocumentationView.tsx
+- [ ] T037 Update health score tooltip text to mention three-part Documentation model in lib/scoring/health-score.ts
+- [ ] T038 Update summary line in DocumentationView to include licensing signal count (e.g., "X of Y files · Z of W sections · licensing: [status]") in components/documentation/DocumentationView.tsx
+- [ ] T039 Verify no TODO, dead code, console.log, or untyped values remain across all modified files
+- [ ] T040 Create manual testing checklist in specs/128-licensing-compliance/checklists/manual-testing.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (types and static data must exist)
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (analyzer must produce LicensingResult)
+- **User Story 2 (Phase 4)**: Depends on Phase 3 (scoring must work before displaying in UI)
+- **User Story 3 (Phase 5)**: Depends on Phase 4 (Licensing pane must exist to add DCO section)
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation (TDD per constitution)
+- Scoring logic before UI rendering
+- Core implementation before integration
+
+### Parallel Opportunities
+
+- **Phase 1**: T001 and T002 can run in parallel
+- **Phase 3**: All test tasks (T013–T017) can run in parallel, then all implementation tasks sequentially
+- **Phase 4**: T025 and T026 can run in parallel
+- **Phase 5**: T030 and T031 can run in parallel
+- **Phase 6**: T034 and T035 can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all US1 tests in parallel (TDD — write first, verify they fail):
+Task: "T013 — Three-part composite formula tests"
+Task: "T014 — Licensing sub-score calculation tests"
+Task: "T015 — Updated file presence weight tests"
+Task: "T016 — Licensing recommendation tests"
+Task: "T017 — Two-part fallback tests"
+
+# Then implement sequentially:
+Task: "T018 — getLicensingScore()"
+Task: "T019 — Update FILE_WEIGHTS"
+Task: "T020 — Update getDocumentationScore() signature"
+Task: "T021 — Three-part composite formula"
+Task: "T022 — Add licensingScore to definition"
+Task: "T023 — Generate licensing recommendations"
+Task: "T024 — Wire into health score"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Static data + types
+2. Complete Phase 2: Analyzer data collection
+3. Complete Phase 3: Scoring integration (US1)
+4. **STOP and VALIDATE**: Run all tests, verify Documentation score changes with licensing signals
+5. Score is functional even without UI — visible in health score composite
+
+### Incremental Delivery
+
+1. Setup + Foundational → Analyzer produces licensing data
+2. Add US1 (scoring) → Documentation score reflects licensing → MVP!
+3. Add US2 (UI display) → Users see licensing details in Documentation tab
+4. Add US3 (DCO/CLA display) → Full compliance picture visible
+5. Polish → Help component, tooltips, cleanup
+
+---
+
+## Notes
+
+- Total tasks: **40**
+- US1 (scoring): 12 tasks (5 tests + 7 implementation)
+- US2 (UI display): 5 tasks (2 tests + 3 implementation)
+- US3 (DCO/CLA display): 4 tasks (2 tests + 2 implementation)
+- Setup: 4 tasks, Foundational: 8 tasks, Polish: 7 tasks
+- Parallel opportunities: 5 parallel groups across phases
+- MVP scope: Phases 1–3 (24 tasks) delivers scoring without UI pane

--- a/specs/128-licensing-compliance/tasks.md
+++ b/specs/128-licensing-compliance/tasks.md
@@ -19,10 +19,10 @@
 
 **Purpose**: Static data and type definitions that all user stories depend on
 
-- [ ] T001 [P] Create OSI-approved license set and permissiveness tier map in lib/licensing/license-data.ts
-- [ ] T002 [P] Create unit tests for license-data (OSI lookup, tier classification, edge cases) in __tests__/licensing/license-data.test.ts
-- [ ] T003 Add LicensingResult, LicenseDetection, and ContributorAgreementSignal interfaces to lib/analyzer/analysis-result.ts
-- [ ] T004 Add licensingResult field (LicensingResult | Unavailable) to AnalysisResult interface in lib/analyzer/analysis-result.ts
+- [x] T001 [P] Create OSI-approved license set and permissiveness tier map in lib/licensing/license-data.ts
+- [x] T002 [P] Create unit tests for license-data (OSI lookup, tier classification, edge cases) in __tests__/licensing/license-data.test.ts
+- [x] T003 Add LicensingResult, LicenseDetection, and ContributorAgreementSignal interfaces to lib/analyzer/analysis-result.ts
+- [x] T004 Add licensingResult field (LicensingResult | Unavailable) to AnalysisResult interface in lib/analyzer/analysis-result.ts
 
 ---
 
@@ -30,14 +30,14 @@
 
 **Purpose**: Extend the analyzer to collect licensing and compliance data from the GitHub API. MUST complete before any scoring or UI work.
 
-- [ ] T005 Add `message` field to commit history nodes in REPO_COMMIT_AND_RELEASES_QUERY in lib/analyzer/queries.ts
-- [ ] T006 Add workflow tree query field (`object(expression: "HEAD:.github/workflows")`) to REPO_OVERVIEW_QUERY in lib/analyzer/queries.ts
-- [ ] T007 Write unit tests for licensing data extraction (license detection, Signed-off-by parsing, workflow bot detection) in __tests__/licensing/extract-licensing.test.ts
-- [ ] T008 Implement extractLicensingResult() in lib/analyzer/analyze.ts — extract license SPDX ID, OSI approval, permissiveness tier from overview query response
-- [ ] T009 Implement Signed-off-by trailer detection in lib/analyzer/analyze.ts — parse commit messages, compute signedOffByRatio
-- [ ] T010 Implement DCO/CLA bot detection in lib/analyzer/analyze.ts — scan workflow tree entries for known bot action references
-- [ ] T011 Wire extractLicensingResult() into the main analyze() function, populating licensingResult on AnalysisResult in lib/analyzer/analyze.ts
-- [ ] T012 Remove licenseType field from DocumentationFileCheck interface in lib/analyzer/analysis-result.ts and update all references in lib/analyzer/analyze.ts and components/documentation/DocumentationView.tsx
+- [x] T005 Add `message` field to commit history nodes in REPO_COMMIT_AND_RELEASES_QUERY in lib/analyzer/queries.ts
+- [x] T006 Add workflow tree query field (`object(expression: "HEAD:.github/workflows")`) to REPO_OVERVIEW_QUERY in lib/analyzer/queries.ts
+- [x] T007 Write unit tests for licensing data extraction (license detection, Signed-off-by parsing, workflow bot detection) in __tests__/licensing/extract-licensing.test.ts
+- [x] T008 Implement extractLicensingResult() in lib/analyzer/extract-licensing.ts — extract license SPDX ID, OSI approval, permissiveness tier from overview query response
+- [x] T009 Implement Signed-off-by trailer detection in lib/analyzer/extract-licensing.ts — parse commit messages, compute signedOffByRatio
+- [x] T010 Implement DCO/CLA bot detection in lib/analyzer/extract-licensing.ts — scan workflow tree entries for known bot action references
+- [x] T011 Wire extractLicensingResult() into the main analyze() function, populating licensingResult on AnalysisResult in lib/analyzer/analyze.ts
+- [x] T012 Remove licenseType field from DocumentationFileCheck interface in lib/analyzer/analysis-result.ts and update all references in lib/analyzer/analyze.ts and components/documentation/DocumentationView.tsx
 
 **Checkpoint**: Analyzer now produces LicensingResult for every analyzed repo. All downstream consumers can read licensing data.
 
@@ -53,21 +53,21 @@
 
 > **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T013 [P] [US1] Write unit tests for three-part Documentation composite formula (40/30/30 weights) in __tests__/documentation/score-config.test.ts
-- [ ] T014 [P] [US1] Write unit tests for licensing sub-score calculation (license present, OSI approved, tier classified, DCO enforced) in __tests__/licensing/licensing-score.test.ts
-- [ ] T015 [P] [US1] Write unit tests for updated file presence weights (5 files, license removed from scoring) in __tests__/documentation/score-config.test.ts
-- [ ] T016 [P] [US1] Write unit tests for licensing recommendation generation (no license, non-OSI, no DCO) in __tests__/licensing/licensing-score.test.ts
-- [ ] T017 [P] [US1] Write unit test for fallback to two-part model when licensingResult is unavailable in __tests__/documentation/score-config.test.ts
+- [x] T013 [P] [US1] Write unit tests for three-part Documentation composite formula (40/30/30 weights) in __tests__/documentation/score-config.test.ts
+- [x] T014 [P] [US1] Write unit tests for licensing sub-score calculation (license present, OSI approved, tier classified, DCO enforced) in __tests__/licensing/licensing-score.test.ts
+- [x] T015 [P] [US1] Write unit tests for updated file presence weights (5 files, license removed from scoring) in __tests__/documentation/score-config.test.ts
+- [x] T016 [P] [US1] Write unit tests for licensing recommendation generation (no license, non-OSI, no DCO) in __tests__/licensing/licensing-score.test.ts
+- [x] T017 [P] [US1] Write unit test for fallback to two-part model when licensingResult is unavailable in __tests__/documentation/score-config.test.ts
 
 ### Implementation for User Story 1
 
-- [ ] T018 [US1] Implement getLicensingScore() function computing weighted licensing sub-score in lib/documentation/score-config.ts
-- [ ] T019 [US1] Update FILE_WEIGHTS in lib/documentation/score-config.ts — remove license entry, redistribute weights across 5 remaining files (readme 0.30, contributing 0.20, code_of_conduct 0.10, security 0.20, changelog 0.20)
-- [ ] T020 [US1] Update getDocumentationScore() signature to accept licensingResult parameter in lib/documentation/score-config.ts
-- [ ] T021 [US1] Update composite formula to three-part model (filePresence * 0.40 + readmeQuality * 0.30 + licensing * 0.30) with fallback to two-part when licensing unavailable in lib/documentation/score-config.ts
-- [ ] T022 [US1] Add licensingScore field to DocumentationScoreDefinition interface in lib/documentation/score-config.ts
-- [ ] T023 [US1] Generate licensing recommendations (no license, non-OSI license, no DCO/CLA) in lib/documentation/score-config.ts
-- [ ] T024 [US1] Update getHealthScore() call site to pass licensingResult to getDocumentationScore() in lib/scoring/health-score.ts
+- [x] T018 [US1] Implement getLicensingScore() function computing weighted licensing sub-score in lib/documentation/score-config.ts
+- [x] T019 [US1] Update FILE_WEIGHTS in lib/documentation/score-config.ts — remove license entry, redistribute weights across 5 remaining files (readme 0.30, contributing 0.20, code_of_conduct 0.10, security 0.20, changelog 0.20)
+- [x] T020 [US1] Update getDocumentationScore() signature to accept licensingResult parameter in lib/documentation/score-config.ts
+- [x] T021 [US1] Update composite formula to three-part model (filePresence * 0.40 + readmeQuality * 0.30 + licensing * 0.30) with fallback to two-part when licensing unavailable in lib/documentation/score-config.ts
+- [x] T022 [US1] Add licensingScore field to DocumentationScoreDefinition interface in lib/documentation/score-config.ts
+- [x] T023 [US1] Generate licensing recommendations (no license, non-OSI license, no DCO/CLA) in lib/documentation/score-config.ts
+- [x] T024 [US1] Update getHealthScore() call site to pass licensingResult to getDocumentationScore() in lib/scoring/health-score.ts
 
 **Checkpoint**: Documentation bucket score now incorporates licensing signals. All scoring tests pass.
 
@@ -81,14 +81,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T025 [P] [US2] Write component tests for Licensing pane rendering (license name, SPDX ID, OSI badge, permissiveness tier) in __tests__/components/DocumentationView.test.tsx
-- [ ] T026 [P] [US2] Write component tests for Licensing pane with missing/unavailable data states in __tests__/components/DocumentationView.test.tsx
+- [x] T025 [P] [US2] Write component tests for Licensing pane rendering (license name, SPDX ID, OSI badge, permissiveness tier) in components/documentation/DocumentationView.test.tsx
+- [x] T026 [P] [US2] Write component tests for Licensing pane with missing/unavailable data states in components/documentation/DocumentationView.test.tsx
 
 ### Implementation for User Story 2
 
-- [ ] T027 [US2] Add Licensing pane to DocumentationView — display license name, SPDX ID, OSI approval status, and permissiveness tier in components/documentation/DocumentationView.tsx
-- [ ] T028 [US2] Style Licensing pane with presence indicators (✓/✗), tier badge, and recommendation text consistent with existing file/section panes in components/documentation/DocumentationView.tsx
-- [ ] T029 [US2] Handle unavailable/missing licensing data gracefully in the Licensing pane (show "unavailable" state) in components/documentation/DocumentationView.tsx
+- [x] T027 [US2] Add Licensing pane to DocumentationView — display license name, SPDX ID, OSI approval status, and permissiveness tier in components/documentation/DocumentationView.tsx
+- [x] T028 [US2] Style Licensing pane with presence indicators (✓/✗), tier badge, and recommendation text consistent with existing file/section panes in components/documentation/DocumentationView.tsx
+- [x] T029 [US2] Handle unavailable/missing licensing data gracefully in the Licensing pane (show "unavailable" state) in components/documentation/DocumentationView.tsx
 
 **Checkpoint**: Documentation tab shows Licensing pane with license details and permissiveness tier.
 
@@ -102,13 +102,13 @@
 
 ### Tests for User Story 3
 
-- [ ] T030 [P] [US3] Write component tests for DCO/CLA enforcement display in Licensing pane (detected/not detected states) in __tests__/components/DocumentationView.test.tsx
-- [ ] T031 [P] [US3] Write component test for enforcement recommendation display in __tests__/components/DocumentationView.test.tsx
+- [x] T030 [P] [US3] Write component tests for DCO/CLA enforcement display in Licensing pane (detected/not detected states) in components/documentation/DocumentationView.test.tsx
+- [x] T031 [P] [US3] Write component test for enforcement recommendation display in components/documentation/DocumentationView.test.tsx
 
 ### Implementation for User Story 3
 
-- [ ] T032 [US3] Add DCO/CLA enforcement section to Licensing pane — show Signed-off-by ratio, bot detection status, and enforcement verdict in components/documentation/DocumentationView.tsx
-- [ ] T033 [US3] Add enforcement recommendation text when not detected in components/documentation/DocumentationView.tsx
+- [x] T032 [US3] Add DCO/CLA enforcement section to Licensing pane — show Signed-off-by ratio, bot detection status, and enforcement verdict in components/documentation/DocumentationView.tsx
+- [x] T033 [US3] Add enforcement recommendation text when not detected in components/documentation/DocumentationView.tsx
 
 **Checkpoint**: Licensing pane shows full compliance picture — license quality + permissiveness + DCO/CLA enforcement.
 
@@ -118,13 +118,13 @@
 
 **Purpose**: Score help component, tooltip updates, and cleanup
 
-- [ ] T034 [P] Create DocumentationScoreHelp component explaining three-part model (file presence, README quality, licensing compliance) in components/documentation/DocumentationScoreHelp.tsx
-- [ ] T035 [P] Write component tests for DocumentationScoreHelp in __tests__/components/DocumentationScoreHelp.test.tsx
-- [ ] T036 Wire DocumentationScoreHelp into DocumentationView below the score badge in components/documentation/DocumentationView.tsx
-- [ ] T037 Update health score tooltip text to mention three-part Documentation model in lib/scoring/health-score.ts
-- [ ] T038 Update summary line in DocumentationView to include licensing signal count (e.g., "X of Y files · Z of W sections · licensing: [status]") in components/documentation/DocumentationView.tsx
-- [ ] T039 Verify no TODO, dead code, console.log, or untyped values remain across all modified files
-- [ ] T040 Create manual testing checklist in specs/128-licensing-compliance/checklists/manual-testing.md
+- [x] T034 [P] Create DocumentationScoreHelp component explaining three-part model (file presence, README quality, licensing compliance) in components/documentation/DocumentationScoreHelp.tsx
+- [x] T035 [P] Write component tests for DocumentationScoreHelp in components/documentation/DocumentationScoreHelp.test.tsx
+- [x] T036 Wire DocumentationScoreHelp into DocumentationView below the score badge in components/documentation/DocumentationView.tsx
+- [x] T037 Update health score tooltip text to mention three-part Documentation model in components/metric-cards/MetricCard.tsx
+- [x] T038 Update summary line in DocumentationView to include licensing signal count (e.g., "X of Y files · Z of W sections · licensing: [status]") in components/documentation/DocumentationView.tsx
+- [x] T039 Verify no TODO, dead code, console.log, or untyped values remain across all modified files
+- [x] T040 Create manual testing checklist in specs/128-licensing-compliance/checklists/manual-testing.md
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds Licensing & Compliance as a third sub-score within the Documentation bucket (40% file presence, 30% README quality, 30% licensing compliance)
- Detects OSI approval, permissiveness tier (Permissive / Weak Copyleft / Copyleft), and DCO/CLA enforcement via commit trailers and GitHub Actions workflow analysis
- New Licensing pane in the Documentation tab displays license name, SPDX ID, OSI status, permissiveness tier, and DCO/CLA enforcement status
- DocumentationScoreHelp component explains the three-part scoring model
- 41 new tests added (315 total passing)

## Test plan

- [x] Analyze repo with OSI-approved license — score includes licensing sub-score (`arun-gupta/repo-pulse`, Apache-2.0)
- [x] Analyze repo with no license — zero licensing sub-score, recommendation shown (`arun-gupta/docker-images`)
- [x] Analyze repo with NOASSERTION SPDX ID — partial credit, recommendation shown (`donnemartin/system-design-primer`)
- [x] Permissive license shows "Permissive" (`arun-gupta/repo-pulse`, Apache-2.0)
- [x] Copyleft license shows "Copyleft" (`justjavac/free-programming-books-zh_CN`, GPL-3.0)
- [x] Weak Copyleft license shows "Weak Copyleft" (`syncthing/syncthing`, MPL-2.0)
- [x] DCO enforcement detected via Signed-off-by trailers (`buildroot/buildroot`)
- [x] CLA bot detected via GitHub Actions workflow (`langfuse/langfuse`)
- [x] No enforcement shows "Not detected" with recommendation (`arun-gupta/repo-pulse`)
- [x] Zero commits shows "Not applicable" (verified via unit test)
- [x] Dual-licensed repo uses primary license from GitHub API (`rust-lang/rust`)
- [x] Health score tooltip updated, DocumentationScoreHelp explains three-part model
- [x] Multiple repos analyzed show independent licensing data
- [x] All 315 automated tests pass
- [x] Manual testing checklist signed off (24/24 items)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)