### PR TITLE
Detect and display dual-licensed repositories

### DIFF
--- a/__tests__/licensing/extract-licensing.test.ts
+++ b/__tests__/licensing/extract-licensing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { extractLicensingResult, computeSignedOffByRatio, detectDcoClaBots } from '@/lib/analyzer/extract-licensing'
+import { extractLicensingResult, computeSignedOffByRatio, detectDcoClaBots, parseSpdxExpression, detectLicenseFiles } from '@/lib/analyzer/extract-licensing'
 
 describe('extractLicensingResult', () => {
   it('detects an OSI-approved permissive license', () => {
@@ -187,5 +187,145 @@ describe('detectDcoClaBots', () => {
       ],
     }
     expect(detectDcoClaBots(dir)).toBe(false)
+  })
+})
+
+describe('parseSpdxExpression', () => {
+  it('parses "MIT OR Apache-2.0" expression', () => {
+    const ids = parseSpdxExpression('Licensed under MIT OR Apache-2.0', null)
+    expect(ids).toContain('MIT')
+    expect(ids).toContain('Apache-2.0')
+  })
+
+  it('parses parenthesized expression "(MIT OR Apache-2.0)"', () => {
+    const ids = parseSpdxExpression('This software is (MIT OR Apache-2.0)', null)
+    expect(ids).toContain('MIT')
+    expect(ids).toContain('Apache-2.0')
+  })
+
+  it('excludes the primary SPDX ID', () => {
+    const ids = parseSpdxExpression('MIT OR Apache-2.0', 'Apache-2.0')
+    expect(ids).toContain('MIT')
+    expect(ids).not.toContain('Apache-2.0')
+  })
+
+  it('returns empty for non-SPDX content', () => {
+    const ids = parseSpdxExpression('This is a regular LICENSE file with no SPDX expressions', null)
+    expect(ids).toEqual([])
+  })
+
+  it('ignores unknown SPDX IDs', () => {
+    const ids = parseSpdxExpression('FAKE-LICENSE OR MIT', null)
+    expect(ids).toContain('MIT')
+    expect(ids).not.toContain('FAKE-LICENSE')
+  })
+
+  it('handles multiple OR expressions', () => {
+    const ids = parseSpdxExpression('MIT OR Apache-2.0\nBSD-2-Clause OR ISC', null)
+    expect(ids).toContain('MIT')
+    expect(ids).toContain('Apache-2.0')
+    expect(ids).toContain('BSD-2-Clause')
+    expect(ids).toContain('ISC')
+  })
+})
+
+describe('detectLicenseFiles', () => {
+  it('detects LICENSE-MIT file', () => {
+    const files = [{ suffix: 'MIT', content: 'MIT License text...' }]
+    const detections = detectLicenseFiles(files, null)
+    expect(detections).toHaveLength(1)
+    expect(detections[0].spdxId).toBe('MIT')
+    expect(detections[0].osiApproved).toBe(true)
+    expect(detections[0].permissivenessTier).toBe('Permissive')
+  })
+
+  it('detects LICENSE-APACHE file', () => {
+    const files = [{ suffix: 'APACHE', content: 'Apache License 2.0 text...' }]
+    const detections = detectLicenseFiles(files, null)
+    expect(detections).toHaveLength(1)
+    expect(detections[0].spdxId).toBe('Apache-2.0')
+  })
+
+  it('skips files with null content', () => {
+    const files = [{ suffix: 'MIT', content: null }]
+    const detections = detectLicenseFiles(files, null)
+    expect(detections).toHaveLength(0)
+  })
+
+  it('skips files matching the primary SPDX ID', () => {
+    const files = [{ suffix: 'MIT', content: 'MIT License text...' }]
+    const detections = detectLicenseFiles(files, 'MIT')
+    expect(detections).toHaveLength(0)
+  })
+
+  it('detects multiple additional license files', () => {
+    const files = [
+      { suffix: 'MIT', content: 'MIT License text...' },
+      { suffix: 'APACHE', content: 'Apache License text...' },
+    ]
+    const detections = detectLicenseFiles(files, null)
+    expect(detections).toHaveLength(2)
+    expect(detections.map((d) => d.spdxId)).toEqual(['MIT', 'Apache-2.0'])
+  })
+
+  it('ignores unknown license file suffixes', () => {
+    const files = [{ suffix: 'CUSTOM', content: 'Custom license...' }]
+    const detections = detectLicenseFiles(files, null)
+    expect(detections).toHaveLength(0)
+  })
+})
+
+describe('extractLicensingResult dual-license integration', () => {
+  it('detects dual license from SPDX expression in LICENSE content', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'Apache-2.0', name: 'Apache License 2.0' },
+      [],
+      null,
+      'Licensed under the Apache License, Version 2.0 OR MIT',
+    )
+
+    expect(result.license.spdxId).toBe('Apache-2.0')
+    expect(result.additionalLicenses).toHaveLength(1)
+    expect(result.additionalLicenses[0].spdxId).toBe('MIT')
+    expect(result.additionalLicenses[0].osiApproved).toBe(true)
+    expect(result.additionalLicenses[0].permissivenessTier).toBe('Permissive')
+  })
+
+  it('detects dual license from separate license files', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'Apache-2.0', name: 'Apache License 2.0' },
+      [],
+      null,
+      null,
+      [{ suffix: 'MIT', content: 'MIT License text...' }],
+    )
+
+    expect(result.additionalLicenses).toHaveLength(1)
+    expect(result.additionalLicenses[0].spdxId).toBe('MIT')
+  })
+
+  it('deduplicates licenses found from both expression and files', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'Apache-2.0', name: 'Apache License 2.0' },
+      [],
+      null,
+      'MIT OR Apache-2.0',
+      [{ suffix: 'MIT', content: 'MIT License text...' }],
+    )
+
+    // MIT should appear only once despite being found in both expression and file
+    expect(result.additionalLicenses).toHaveLength(1)
+    expect(result.additionalLicenses[0].spdxId).toBe('MIT')
+  })
+
+  it('returns empty additionalLicenses when no dual licensing detected', () => {
+    const result = extractLicensingResult(
+      { spdxId: 'MIT', name: 'MIT License' },
+      [],
+      null,
+      'MIT License\n\nPermission is hereby granted...',
+    )
+
+    expect(result.additionalLicenses).toHaveLength(0)
   })
 })

--- a/__tests__/licensing/licensing-score.test.ts
+++ b/__tests__/licensing/licensing-score.test.ts
@@ -10,6 +10,7 @@ function buildLicensingResult(overrides: Partial<LicensingResult> = {}): Licensi
       osiApproved: true,
       permissivenessTier: 'Permissive',
     },
+    additionalLicenses: [],
     contributorAgreement: {
       signedOffByRatio: null,
       dcoOrClaBot: false,
@@ -110,5 +111,39 @@ describe('getLicensingScore', () => {
     }))
 
     expect(recommendations.some((r) => r.item === 'dco_cla')).toBe(false)
+  })
+
+  it('counts OSI approval from additional licenses when primary is not OSI', () => {
+    const { score } = getLicensingScore(buildLicensingResult({
+      license: {
+        spdxId: 'UNKNOWN-1.0',
+        name: 'Unknown License',
+        osiApproved: false,
+        permissivenessTier: null,
+      },
+      additionalLicenses: [
+        { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+      ],
+    }))
+
+    // license present (0.40) + OSI from additional (0.25) + tier from additional (0.10) = 0.75
+    expect(score).toBeCloseTo(0.75, 2)
+  })
+
+  it('counts tier classification from additional licenses', () => {
+    const { score } = getLicensingScore(buildLicensingResult({
+      license: {
+        spdxId: 'UNKNOWN-1.0',
+        name: 'Unknown License',
+        osiApproved: false,
+        permissivenessTier: null,
+      },
+      additionalLicenses: [
+        { spdxId: 'Apache-2.0', name: 'Apache License 2.0', osiApproved: true, permissivenessTier: 'Permissive' },
+      ],
+    }))
+
+    // license present (0.40) + OSI (0.25) + tier (0.10) = 0.75
+    expect(score).toBeCloseTo(0.75, 2)
   })
 })

--- a/components/documentation/DocumentationView.test.tsx
+++ b/components/documentation/DocumentationView.test.tsx
@@ -53,6 +53,7 @@ function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
     },
     licensingResult: {
       license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+      additionalLicenses: [],
       contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
     },
     missingFields: [],
@@ -77,6 +78,7 @@ describe('DocumentationView', () => {
       render(<DocumentationView results={[buildResult({
         licensingResult: {
           license: { spdxId: 'GPL-3.0-only', name: 'GNU General Public License v3.0 only', osiApproved: true, permissivenessTier: 'Copyleft' },
+          additionalLicenses: [],
           contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
         },
       })]} />)
@@ -89,6 +91,7 @@ describe('DocumentationView', () => {
       render(<DocumentationView results={[buildResult({
         licensingResult: {
           license: { spdxId: 'MPL-2.0', name: 'Mozilla Public License 2.0', osiApproved: true, permissivenessTier: 'Weak Copyleft' },
+          additionalLicenses: [],
           contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
         },
       })]} />)
@@ -101,6 +104,7 @@ describe('DocumentationView', () => {
       render(<DocumentationView results={[buildResult({
         licensingResult: {
           license: { spdxId: null, name: null, osiApproved: false, permissivenessTier: null },
+          additionalLicenses: [],
           contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
         },
       })]} />)
@@ -120,6 +124,7 @@ describe('DocumentationView', () => {
       render(<DocumentationView results={[buildResult({
         licensingResult: {
           license: { spdxId: 'Apache-2.0', name: 'Apache License 2.0', osiApproved: true, permissivenessTier: 'Permissive' },
+          additionalLicenses: [],
           contributorAgreement: { signedOffByRatio: 0.95, dcoOrClaBot: true, enforced: true },
         },
       })]} />)
@@ -139,12 +144,37 @@ describe('DocumentationView', () => {
       render(<DocumentationView results={[buildResult({
         licensingResult: {
           license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+          additionalLicenses: [],
           contributorAgreement: { signedOffByRatio: 0.1, dcoOrClaBot: false, enforced: false },
         },
       })]} />)
 
       const licensingPane = screen.getByRole('region', { name: /licensing/i })
       expect(within(licensingPane).getByText(/not detected/i)).toBeInTheDocument()
+    })
+
+    it('renders dual-licensed repo with additional licenses', () => {
+      render(<DocumentationView results={[buildResult({
+        licensingResult: {
+          license: { spdxId: 'Apache-2.0', name: 'Apache License 2.0', osiApproved: true, permissivenessTier: 'Permissive' },
+          additionalLicenses: [
+            { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+          ],
+          contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
+        },
+      })]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).getByText('Apache License 2.0')).toBeInTheDocument()
+      expect(within(licensingPane).getByText('MIT License')).toBeInTheDocument()
+      expect(within(licensingPane).getByText(/dual-licensed/i)).toBeInTheDocument()
+    })
+
+    it('does not show dual-licensed label for single license', () => {
+      render(<DocumentationView results={[buildResult()]} />)
+
+      const licensingPane = screen.getByRole('region', { name: /licensing/i })
+      expect(within(licensingPane).queryByText(/dual-licensed/i)).not.toBeInTheDocument()
     })
   })
 })

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -36,8 +36,9 @@ function LicensingPane({ licensingResult }: { licensingResult: LicensingResult |
     )
   }
 
-  const { license, contributorAgreement } = licensingResult
+  const { license, additionalLicenses, contributorAgreement } = licensingResult
   const hasLicense = license.spdxId !== null
+  const isDualLicensed = additionalLicenses.length > 0
 
   return (
     <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
@@ -50,14 +51,34 @@ function LicensingPane({ licensingResult }: { licensingResult: LicensingResult |
           </span>
           <div className="min-w-0">
             {hasLicense ? (
-              <p className="text-sm font-medium text-slate-900">
-                {license.name} <span className="font-normal text-slate-400">({license.spdxId})</span>
-              </p>
+              <>
+                <p className="text-sm font-medium text-slate-900">
+                  {license.name} <span className="font-normal text-slate-400">({license.spdxId})</span>
+                </p>
+                {isDualLicensed ? (
+                  <p className="mt-0.5 text-xs text-slate-500">Dual-licensed</p>
+                ) : null}
+              </>
             ) : (
               <p className="text-sm font-medium text-slate-400">No license detected</p>
             )}
           </div>
         </li>
+
+        {/* Additional licenses */}
+        {additionalLicenses.map((addLicense) => (
+          <li key={addLicense.spdxId} className="flex items-start gap-2">
+            <span className="mt-0.5 text-sm text-emerald-600">✓</span>
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-slate-900">
+                {addLicense.name ?? addLicense.spdxId} <span className="font-normal text-slate-400">({addLicense.spdxId})</span>
+              </p>
+              {addLicense.permissivenessTier ? (
+                <p className="mt-0.5 text-xs text-slate-500">{addLicense.permissivenessTier}</p>
+              ) : null}
+            </div>
+          </li>
+        ))}
 
         {/* OSI Approval */}
         {hasLicense ? (

--- a/lib/analyzer/analysis-result.ts
+++ b/lib/analyzer/analysis-result.ts
@@ -70,6 +70,7 @@ export interface ContributorAgreementSignal {
 
 export interface LicensingResult {
   license: LicenseDetection
+  additionalLicenses: LicenseDetection[]
   contributorAgreement: ContributorAgreementSignal
 }
 

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -19,7 +19,7 @@ import { CONTRIBUTOR_WINDOW_DAYS } from './analysis-result'
 import { queryGitHubGraphQL } from './github-graphql'
 import { fetchContributorCount, fetchMaintainerCount, fetchPublicUserOrganizations } from './github-rest'
 import { REPO_COMMIT_AND_RELEASES_QUERY, REPO_ACTIVITY_COUNTS_QUERY, REPO_COMMIT_HISTORY_PAGE_QUERY, REPO_OVERVIEW_QUERY, REPO_RESPONSIVENESS_METADATA_QUERY, buildResponsivenessDetailQuery } from './queries'
-import { extractLicensingResult } from './extract-licensing'
+import { extractLicensingResult, type LicenseFileInfo } from './extract-licensing'
 
 interface DocBlob {
   text?: string
@@ -47,6 +47,9 @@ interface RepoOverviewResponse {
     docLicenseMd?: DocBlob | null
     docLicenseTxt?: DocBlob | null
     docCopying?: DocBlob | null
+    docLicenseMit?: DocBlob | null
+    docLicenseApache?: DocBlob | null
+    docLicenseBsd?: DocBlob | null
     docContributing?: DocBlob | null
     docContributingRst?: DocBlob | null
     docContributingTxt?: DocBlob | null
@@ -644,11 +647,26 @@ function buildAnalysisResult(
     medianTimeToCloseHours: activityMetricsByWindow[90].medianTimeToCloseHours,
     documentationResult: extractDocumentationResult(overview.repository),
     licensingResult: overview.repository
-      ? extractLicensingResult(
-          overview.repository.licenseInfo ?? null,
-          recentCommitNodes.filter((n): n is CommitNode & { message: string } => typeof n.message === 'string'),
-          overview.repository.workflowDir ?? null,
-        )
+      ? (() => {
+          const repo = overview.repository
+          // Collect license file content for SPDX expression parsing
+          const licenseFileContent =
+            repo.docLicense?.text ?? repo.docLicenseMd?.text ?? repo.docLicenseTxt?.text ??
+            repo.docLicenseRst?.text ?? repo.docCopying?.text ?? null
+          // Collect additional license files (LICENSE-MIT, LICENSE-APACHE, etc.)
+          const additionalLicenseFiles: LicenseFileInfo[] = [
+            { suffix: 'MIT', content: repo.docLicenseMit?.text ?? null },
+            { suffix: 'APACHE', content: repo.docLicenseApache?.text ?? null },
+            { suffix: 'BSD', content: repo.docLicenseBsd?.text ?? null },
+          ]
+          return extractLicensingResult(
+            repo.licenseInfo ?? null,
+            recentCommitNodes.filter((n): n is CommitNode & { message: string } => typeof n.message === 'string'),
+            repo.workflowDir ?? null,
+            licenseFileContent,
+            additionalLicenseFiles,
+          )
+        })()
       : 'unavailable',
     issueFirstResponseTimestamps,
     issueCloseTimestamps,
@@ -664,7 +682,7 @@ function extractDocumentationResult(repo: RepoOverviewResponse['repository']): D
     aliases.find((a) => a != null) ?? null
 
   const readmeBlob = findFirst(repo.docReadmeMd, repo.docReadmeLower, repo.docReadmeRst, repo.docReadmeTxt, repo.docReadmePlain)
-  const licenseBlob = findFirst(repo.docLicense, repo.docLicenseMd, repo.docLicenseTxt, repo.docLicenseRst, repo.docCopying)
+  const licenseBlob = findFirst(repo.docLicense, repo.docLicenseMd, repo.docLicenseTxt, repo.docLicenseRst, repo.docCopying, repo.docLicenseMit, repo.docLicenseApache, repo.docLicenseBsd)
   const contributingBlob = findFirst(repo.docContributing, repo.docContributingRst, repo.docContributingTxt)
   const codeOfConductBlob = findFirst(repo.docCodeOfConduct, repo.docCodeOfConductRst, repo.docCodeOfConductTxt)
   const securityBlob = findFirst(repo.docSecurity, repo.docSecurityRst)
@@ -676,6 +694,7 @@ function extractDocumentationResult(repo: RepoOverviewResponse['repository']): D
   ]
   const licensePathMap: [string, DocBlob | null | undefined][] = [
     ['LICENSE', repo.docLicense], ['LICENSE.md', repo.docLicenseMd], ['LICENSE.txt', repo.docLicenseTxt], ['LICENSE.rst', repo.docLicenseRst], ['COPYING', repo.docCopying],
+    ['LICENSE-MIT', repo.docLicenseMit], ['LICENSE-APACHE', repo.docLicenseApache], ['LICENSE-BSD', repo.docLicenseBsd],
   ]
   const contributingPathMap: [string, DocBlob | null | undefined][] = [
     ['CONTRIBUTING.md', repo.docContributing], ['CONTRIBUTING.rst', repo.docContributingRst], ['CONTRIBUTING.txt', repo.docContributingTxt],

--- a/lib/analyzer/extract-licensing.ts
+++ b/lib/analyzer/extract-licensing.ts
@@ -1,5 +1,5 @@
-import type { LicensingResult } from '@/lib/analyzer/analysis-result'
-import { isOsiApproved, getPermissivenessTier } from '@/lib/licensing/license-data'
+import type { LicenseDetection, LicensingResult } from '@/lib/analyzer/analysis-result'
+import { isOsiApproved, getPermissivenessTier, OSI_APPROVED_SPDX_IDS } from '@/lib/licensing/license-data'
 
 const SIGNED_OFF_BY_RE = /^signed-off-by:\s/im
 
@@ -11,6 +11,23 @@ const DCO_CLA_BOT_PATTERNS = [
 ]
 
 const SIGNED_OFF_BY_RATIO_THRESHOLD = 0.8
+
+/**
+ * Regex to match SPDX license expression operators (OR / AND) between SPDX IDs.
+ * Captures patterns like "MIT OR Apache-2.0", "(MIT OR Apache-2.0)", etc.
+ * Only supports simple disjunctions — not nested expressions.
+ */
+const SPDX_EXPRESSION_RE = /\(?\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s+OR\s+([A-Za-z0-9][A-Za-z0-9._-]*)\s*\)?/gi
+
+/**
+ * Maps well-known license file suffixes to their likely SPDX IDs.
+ * Used when a repo has LICENSE-MIT, LICENSE-APACHE, etc.
+ */
+const LICENSE_FILE_SPDX_MAP: Record<string, { spdxId: string; name: string }> = {
+  'MIT': { spdxId: 'MIT', name: 'MIT License' },
+  'APACHE': { spdxId: 'Apache-2.0', name: 'Apache License 2.0' },
+  'BSD': { spdxId: 'BSD-3-Clause', name: 'BSD 3-Clause License' },
+}
 
 interface LicenseInfo {
   spdxId: string | null
@@ -28,6 +45,59 @@ interface WorkflowEntry {
 
 interface WorkflowDir {
   entries: WorkflowEntry[]
+}
+
+export interface LicenseFileInfo {
+  /** e.g. 'MIT', 'APACHE', 'BSD' — the suffix after LICENSE- */
+  suffix: string
+  content: string | null
+}
+
+function buildLicenseDetection(spdxId: string, name: string | null): LicenseDetection {
+  return {
+    spdxId,
+    name,
+    osiApproved: isOsiApproved(spdxId),
+    permissivenessTier: getPermissivenessTier(spdxId),
+  }
+}
+
+/**
+ * Parses SPDX license expressions like "MIT OR Apache-2.0" from license file content.
+ * Returns additional SPDX IDs found (excludes the primary license already detected by GitHub).
+ */
+export function parseSpdxExpression(content: string, primarySpdxId: string | null): string[] {
+  const ids = new Set<string>()
+  let match: RegExpExecArray | null
+  const re = new RegExp(SPDX_EXPRESSION_RE.source, SPDX_EXPRESSION_RE.flags)
+  while ((match = re.exec(content)) !== null) {
+    const [, left, right] = match
+    if (left && OSI_APPROVED_SPDX_IDS.has(left)) ids.add(left)
+    if (right && OSI_APPROVED_SPDX_IDS.has(right)) ids.add(right)
+  }
+  // Remove the primary license — it's already the main detection
+  if (primarySpdxId) ids.delete(primarySpdxId)
+  return Array.from(ids)
+}
+
+/**
+ * Detects additional licenses from LICENSE-MIT, LICENSE-APACHE, etc. files.
+ * Returns LicenseDetection entries for each additional license file found.
+ */
+export function detectLicenseFiles(
+  files: LicenseFileInfo[],
+  primarySpdxId: string | null,
+): LicenseDetection[] {
+  const detections: LicenseDetection[] = []
+  for (const file of files) {
+    if (!file.content) continue
+    const mapping = LICENSE_FILE_SPDX_MAP[file.suffix]
+    if (!mapping) continue
+    // Skip if this is the same as the primary license
+    if (mapping.spdxId === primarySpdxId) continue
+    detections.push(buildLicenseDetection(mapping.spdxId, mapping.name))
+  }
+  return detections
 }
 
 export function computeSignedOffByRatio(commits: CommitNode[]): number | null {
@@ -52,6 +122,8 @@ export function extractLicensingResult(
   licenseInfo: LicenseInfo | null | undefined,
   commits: CommitNode[],
   workflowDir: WorkflowDir | null,
+  licenseFileContent?: string | null,
+  additionalLicenseFiles?: LicenseFileInfo[],
 ): LicensingResult {
   const spdxId = licenseInfo?.spdxId ?? null
   const name = licenseInfo?.name ?? null
@@ -60,6 +132,26 @@ export function extractLicensingResult(
   const dcoOrClaBot = detectDcoClaBots(workflowDir)
   const enforced = dcoOrClaBot || (signedOffByRatio !== null && signedOffByRatio >= SIGNED_OFF_BY_RATIO_THRESHOLD)
 
+  // Detect additional licenses from SPDX expressions in LICENSE content
+  const additionalLicenses: LicenseDetection[] = []
+  if (licenseFileContent) {
+    const extraIds = parseSpdxExpression(licenseFileContent, spdxId)
+    for (const id of extraIds) {
+      additionalLicenses.push(buildLicenseDetection(id, null))
+    }
+  }
+
+  // Detect additional licenses from separate license files (LICENSE-MIT, LICENSE-APACHE, etc.)
+  if (additionalLicenseFiles) {
+    const fileDetections = detectLicenseFiles(additionalLicenseFiles, spdxId)
+    for (const det of fileDetections) {
+      // Avoid duplicates (e.g., if SPDX expression already found the same license)
+      if (!additionalLicenses.some((l) => l.spdxId === det.spdxId)) {
+        additionalLicenses.push(det)
+      }
+    }
+  }
+
   return {
     license: {
       spdxId,
@@ -67,6 +159,7 @@ export function extractLicensingResult(
       osiApproved: isOsiApproved(spdxId),
       permissivenessTier: getPermissivenessTier(spdxId),
     },
+    additionalLicenses,
     contributorAgreement: {
       signedOffByRatio,
       dcoOrClaBot,

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -27,17 +27,20 @@ export const REPO_OVERVIEW_QUERY = `
       docReadmeRst: object(expression: "HEAD:README.rst") { ... on Blob { text } }
       docReadmeTxt: object(expression: "HEAD:README.txt") { ... on Blob { text } }
       docReadmePlain: object(expression: "HEAD:README") { ... on Blob { text } }
-      docLicense: object(expression: "HEAD:LICENSE") { ... on Blob { oid } }
-      docLicenseMd: object(expression: "HEAD:LICENSE.md") { ... on Blob { oid } }
-      docLicenseTxt: object(expression: "HEAD:LICENSE.txt") { ... on Blob { oid } }
-      docCopying: object(expression: "HEAD:COPYING") { ... on Blob { oid } }
+      docLicense: object(expression: "HEAD:LICENSE") { ... on Blob { oid text } }
+      docLicenseMd: object(expression: "HEAD:LICENSE.md") { ... on Blob { oid text } }
+      docLicenseTxt: object(expression: "HEAD:LICENSE.txt") { ... on Blob { oid text } }
+      docCopying: object(expression: "HEAD:COPYING") { ... on Blob { oid text } }
+      docLicenseMit: object(expression: "HEAD:LICENSE-MIT") { ... on Blob { oid text } }
+      docLicenseApache: object(expression: "HEAD:LICENSE-APACHE") { ... on Blob { oid text } }
+      docLicenseBsd: object(expression: "HEAD:LICENSE-BSD") { ... on Blob { oid text } }
       docContributing: object(expression: "HEAD:CONTRIBUTING.md") { ... on Blob { oid } }
       docContributingRst: object(expression: "HEAD:CONTRIBUTING.rst") { ... on Blob { oid } }
       docContributingTxt: object(expression: "HEAD:CONTRIBUTING.txt") { ... on Blob { oid } }
       docCodeOfConduct: object(expression: "HEAD:CODE_OF_CONDUCT.md") { ... on Blob { oid } }
       docCodeOfConductRst: object(expression: "HEAD:CODE_OF_CONDUCT.rst") { ... on Blob { oid } }
       docCodeOfConductTxt: object(expression: "HEAD:CODE_OF_CONDUCT.txt") { ... on Blob { oid } }
-      docLicenseRst: object(expression: "HEAD:LICENSE.rst") { ... on Blob { oid } }
+      docLicenseRst: object(expression: "HEAD:LICENSE.rst") { ... on Blob { oid text } }
       docSecurity: object(expression: "HEAD:SECURITY.md") { ... on Blob { oid } }
       docSecurityRst: object(expression: "HEAD:SECURITY.rst") { ... on Blob { oid } }
       docChangelog: object(expression: "HEAD:CHANGELOG.md") { ... on Blob { oid } }

--- a/lib/documentation/score-config.test.ts
+++ b/lib/documentation/score-config.test.ts
@@ -26,16 +26,19 @@ function buildDocResult(overrides: Partial<DocumentationResult> = {}): Documenta
 
 const fullLicensing: LicensingResult = {
   license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+  additionalLicenses: [],
   contributorAgreement: { signedOffByRatio: 1.0, dcoOrClaBot: true, enforced: true },
 }
 
 const noLicensing: LicensingResult = {
   license: { spdxId: null, name: null, osiApproved: false, permissivenessTier: null },
+  additionalLicenses: [],
   contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
 }
 
 const partialLicensing: LicensingResult = {
   license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+  additionalLicenses: [],
   contributorAgreement: { signedOffByRatio: null, dcoOrClaBot: false, enforced: false },
 }
 

--- a/lib/documentation/score-config.ts
+++ b/lib/documentation/score-config.ts
@@ -82,7 +82,12 @@ export function getLicensingScore(licensingResult: LicensingResult): {
   const recommendations: LicensingRecommendation[] = []
   let score = 0
 
-  const { license, contributorAgreement } = licensingResult
+  const { license, additionalLicenses, contributorAgreement } = licensingResult
+
+  // For scoring, consider all licenses (primary + additional)
+  const allLicenses = [license, ...additionalLicenses]
+  const anyOsiApproved = allLicenses.some((l) => l.osiApproved)
+  const anyTierClassified = allLicenses.some((l) => l.permissivenessTier !== null)
 
   // License present
   if (license.spdxId && license.spdxId !== 'NOASSERTION') {
@@ -106,8 +111,8 @@ export function getLicensingScore(licensingResult: LicensingResult): {
     })
   }
 
-  // OSI approved
-  if (license.osiApproved) {
+  // OSI approved — any license being OSI-approved counts
+  if (anyOsiApproved) {
     score += LICENSING_WEIGHTS.osiApproved
   } else if (license.spdxId && license.spdxId !== 'NOASSERTION') {
     recommendations.push({
@@ -119,8 +124,8 @@ export function getLicensingScore(licensingResult: LicensingResult): {
     })
   }
 
-  // Tier classified
-  if (license.permissivenessTier) {
+  // Tier classified — any license being classified counts
+  if (anyTierClassified) {
     score += LICENSING_WEIGHTS.tierClassified
   }
 


### PR DESCRIPTION
## Summary
- Detects dual-licensed repos via SPDX expression parsing (`MIT OR Apache-2.0`) in LICENSE file content and separate license files (`LICENSE-MIT`, `LICENSE-APACHE`, `LICENSE-BSD`)
- Displays all detected licenses in the Licensing pane with individual permissiveness tiers and a "Dual-licensed" label
- Scoring considers all licenses for OSI approval and tier classification

## Test plan
- [x] `rust-lang/rust` — shows Apache-2.0 + MIT via LICENSE-APACHE and LICENSE-MIT files
- [x] `serde-rs/serde` — shows Apache-2.0 + MIT
- [x] `tokio-rs/tokio` — shows Apache-2.0 + MIT
- [x] `nickel-org/nickel.rs` — shows MIT + Apache-2.0
- [x] `BurntSushi/ripgrep` — shows Unlicense + MIT
- [x] Single-licensed repos (e.g., `facebook/react`) still show single license without dual-license label
- [x] All 335 tests pass (20 new tests for SPDX parsing, license file detection, scoring, and UI)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)