### PR TITLE
Move user badge into banner with GitHub avatar

### DIFF
--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -5,6 +5,7 @@ import { getCalibrationMeta } from '@/lib/scoring/config-loader'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import type { ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
+import { UserBadge } from '@/components/auth/UserBadge'
 import { ResultsTabs } from './ResultsTabs'
 
 interface ResultsShellProps {
@@ -89,12 +90,14 @@ export function ResultsShell({
               target="_blank"
               rel="noreferrer"
               aria-label="GitHub repository"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-sky-700 bg-sky-950/25 text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-sky-700 bg-sky-950/25 text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
             >
-            <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current">
-              <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.47c.53.1.72-.23.72-.52v-1.85c-2.94.64-3.56-1.25-3.56-1.25-.48-1.2-1.16-1.52-1.16-1.52-.95-.65.07-.64.07-.64 1.06.08 1.62 1.08 1.62 1.08.94 1.61 2.46 1.15 3.06.88.1-.68.37-1.15.67-1.42-2.35-.27-4.82-1.17-4.82-5.2 0-1.15.41-2.1 1.08-2.84-.11-.27-.47-1.37.1-2.86 0 0 .88-.28 2.89 1.08a9.98 9.98 0 0 1 5.26 0c2.01-1.36 2.89-1.08 2.89-1.08.57 1.49.21 2.59.1 2.86.67.74 1.08 1.69 1.08 2.84 0 4.04-2.48 4.93-4.84 5.19.38.33.72.98.72 1.98v2.93c0 .29.19.63.73.52A10.5 10.5 0 0 0 12 1.5Z" />
-            </svg>
-          </a>
+              <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current">
+                <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.47c.53.1.72-.23.72-.52v-1.85c-2.94.64-3.56-1.25-3.56-1.25-.48-1.2-1.16-1.52-1.16-1.52-.95-.65.07-.64.07-.64 1.06.08 1.62 1.08 1.62 1.08.94 1.61 2.46 1.15 3.06.88.1-.68.37-1.15.67-1.42-2.35-.27-4.82-1.17-4.82-5.2 0-1.15.41-2.1 1.08-2.84-.11-.27-.47-1.37.1-2.86 0 0 .88-.28 2.89 1.08a9.98 9.98 0 0 1 5.26 0c2.01-1.36 2.89-1.08 2.89-1.08.57 1.49.21 2.59.1 2.86.67.74 1.08 1.69 1.08 2.84 0 4.04-2.48 4.93-4.84 5.19.38.33.72.98.72 1.98v2.93c0 .29.19.63.73.52A10.5 10.5 0 0 0 12 1.5Z" />
+              </svg>
+            </a>
+            <div className="h-6 w-px bg-sky-700" />
+            <UserBadge />
           </div>
         </div>
       </header>

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from './AuthContext'
 import { SignInButton } from './SignInButton'
-import { UserBadge } from './UserBadge'
 
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const { session, signIn } = useAuth()
@@ -63,13 +62,6 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     )
   }
 
-  return (
-    <div className="flex min-h-screen flex-col">
-      <header className="flex items-center justify-between border-b border-slate-200 px-6 py-3">
-        <span className="text-sm font-semibold text-slate-900">RepoPulse</span>
-        <UserBadge />
-      </header>
-      <main className="flex-1">{children}</main>
-    </div>
-  )
+  return <>{children}</>
+
 }

--- a/components/auth/UserBadge.tsx
+++ b/components/auth/UserBadge.tsx
@@ -15,14 +15,18 @@ export function UserBadge({ onSignOut }: UserBadgeProps) {
   }
 
   return (
-    <div className="flex items-center gap-3">
-      <span className="text-sm text-slate-700">
-        Signed in as <span className="font-medium text-slate-900">{session?.username}</span>
-      </span>
+    <div className="flex items-center gap-2">
+      <img
+        src={`https://github.com/${session?.username}.png`}
+        alt=""
+        className="h-7 w-7 rounded-full border border-sky-600"
+        aria-hidden="true"
+      />
+      <span className="text-xs font-medium text-white">{session?.username}</span>
       <button
         type="button"
         onClick={handleSignOut}
-        className="text-xs text-slate-500 underline-offset-2 hover:text-slate-700 hover:underline"
+        className="ml-1 text-xs text-sky-300 underline-offset-2 hover:text-white hover:underline"
       >
         Sign out
       </button>


### PR DESCRIPTION
## Summary
- Remove the separate top header bar ("RepoPulse" text + sign-out controls)
- Move user badge into the blue banner, right side, separated by a vertical divider
- Show GitHub avatar next to username with sign-out link
- Saves vertical space by consolidating into a single header area

## Test plan
- [x] No separate header bar appears above the blue banner
- [x] User avatar, username, and sign-out link appear in the blue banner (right side)
- [x] Scoring Methodology and GitHub icon still render correctly
- [x] Sign out works from the banner
- [x] Layout looks correct on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)