### PR TITLE
Fix tab bar wrapping with overflow menu

### DIFF
--- a/components/app-shell/ResultsShell.test.tsx
+++ b/components/app-shell/ResultsShell.test.tsx
@@ -105,6 +105,8 @@ describe('ResultsShell', () => {
       />,
     )
 
+    // Comparison is in the overflow menu
+    await userEvent.click(screen.getByRole('button', { name: /More/ }))
     await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
     expect(screen.getByText('Comparison content')).toBeInTheDocument()
 
@@ -128,7 +130,7 @@ describe('ResultsShell', () => {
     expect(screen.queryByText('Comparison content')).not.toBeInTheDocument()
   })
 
-  it('supports opening on an initial active tab', () => {
+  it('supports opening on an initial active tab', async () => {
     render(
       <ResultsShell
         initialActiveTab="comparison"
@@ -144,6 +146,8 @@ describe('ResultsShell', () => {
       />,
     )
 
+    // Comparison is in the overflow — button shows "Comparison" when active
+    await userEvent.click(screen.getByRole('button', { name: /Comparison/ }))
     expect(screen.getByRole('tab', { name: 'Comparison' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByText('Comparison content')).toBeInTheDocument()
   })

--- a/components/app-shell/ResultsShell.test.tsx
+++ b/components/app-shell/ResultsShell.test.tsx
@@ -13,6 +13,7 @@ describe('ResultsShell', () => {
         activity={<div>Activity coming soon</div>}
         responsiveness={<div>Responsiveness coming soon</div>}
         documentation={<div>Documentation coming soon</div>}
+        security={<div>Security coming soon</div>}
         recommendations={<div>Recommendations coming soon</div>}
         comparison={<div>Comparison coming soon</div>}
       />,
@@ -36,6 +37,7 @@ describe('ResultsShell', () => {
         activity={<div>Activity coming soon</div>}
         responsiveness={<div>Responsiveness coming soon</div>}
         documentation={<div>Documentation coming soon</div>}
+        security={<div>Security coming soon</div>}
         recommendations={<div>Recommendations coming soon</div>}
         comparison={<div>Comparison coming soon</div>}
       />,
@@ -54,6 +56,7 @@ describe('ResultsShell', () => {
         activity={<div>Activity coming soon</div>}
         responsiveness={<div>Responsiveness coming soon</div>}
         documentation={<div>Documentation coming soon</div>}
+        security={<div>Security coming soon</div>}
         recommendations={<div>Recommendations coming soon</div>}
         comparison={<div>Comparison coming soon</div>}
       />,
@@ -76,6 +79,7 @@ describe('ResultsShell', () => {
         activity={<div>Activity coming soon</div>}
         responsiveness={<div>Responsiveness coming soon</div>}
         documentation={<div>Documentation coming soon</div>}
+        security={<div>Security coming soon</div>}
         recommendations={<div>Recommendations coming soon</div>}
         comparison={<div>Comparison coming soon</div>}
       />,
@@ -94,6 +98,9 @@ describe('ResultsShell', () => {
         contributors={<div>Contributors content</div>}
         activity={<div>Activity content</div>}
         responsiveness={<div>Responsiveness content</div>}
+        documentation={<div>Documentation content</div>}
+        security={<div>Security content</div>}
+        recommendations={<div>Recommendations content</div>}
         comparison={<div>Comparison content</div>}
       />,
     )
@@ -109,6 +116,9 @@ describe('ResultsShell', () => {
         contributors={<div>Contributors content</div>}
         activity={<div>Activity content</div>}
         responsiveness={<div>Responsiveness content</div>}
+        documentation={<div>Documentation content</div>}
+        security={<div>Security content</div>}
+        recommendations={<div>Recommendations content</div>}
         comparison={<div>Comparison content</div>}
       />,
     )
@@ -127,6 +137,9 @@ describe('ResultsShell', () => {
         contributors={<div>Contributors content</div>}
         activity={<div>Activity content</div>}
         responsiveness={<div>Responsiveness content</div>}
+        documentation={<div>Documentation content</div>}
+        security={<div>Security content</div>}
+        recommendations={<div>Recommendations content</div>}
         comparison={<div>Comparison content</div>}
       />,
     )

--- a/components/app-shell/ResultsTabs.test.tsx
+++ b/components/app-shell/ResultsTabs.test.tsx
@@ -66,8 +66,14 @@ describe('ResultsTabs', () => {
     await userEvent.click(screen.getByRole('button', { name: /More/ }))
     await userEvent.click(screen.getByRole('button', { name: /Show all/ }))
 
-    // Now all 8 tabs are visible as inline tab buttons
+    // Now all 8 tabs are visible as inline tab buttons with a Show less button
     expect(screen.getAllByRole('tab')).toHaveLength(8)
     expect(screen.queryByRole('button', { name: /More/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Show less/ })).toBeInTheDocument()
+
+    // Click Show less — collapses back to 6 tabs + More dropdown
+    await userEvent.click(screen.getByRole('button', { name: /Show less/ }))
+    expect(screen.getAllByRole('tab')).toHaveLength(6)
+    expect(screen.getByRole('button', { name: /More/ })).toBeInTheDocument()
   })
 })

--- a/components/app-shell/ResultsTabs.test.tsx
+++ b/components/app-shell/ResultsTabs.test.tsx
@@ -31,7 +31,7 @@ describe('ResultsTabs', () => {
     expect(screen.queryByRole('tab', { name: 'Metrics' })).not.toBeInTheDocument()
   })
 
-  it('shows overflow tabs in a More menu when tab count exceeds visible limit', async () => {
+  it('shows overflow tabs in a More menu and supports Show all', async () => {
     const manyTabs: ResultTabDefinition[] = [
       { id: 'overview', label: 'Overview', status: 'implemented', description: '' },
       { id: 'contributors', label: 'Contributors', status: 'placeholder', description: '' },
@@ -41,24 +41,33 @@ describe('ResultsTabs', () => {
       { id: 'security', label: 'Security', status: 'implemented', description: '' },
       { id: 'recommendations', label: 'Recommendations', status: 'implemented', description: '' },
       { id: 'comparison', label: 'Comparison', status: 'implemented', description: '' },
-      { id: 'comparison', label: 'Extra Tab', status: 'implemented', description: '' },
     ]
     const onChange = vi.fn()
 
     render(<ResultsTabs tabs={manyTabs} activeTab="overview" onChange={onChange} />)
 
-    // First 8 tabs are visible directly
+    // First 6 tabs are visible directly
     expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: 'Comparison' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Security' })).toBeInTheDocument()
 
     // Overflow tabs are hidden until More is clicked
-    expect(screen.queryByRole('tab', { name: 'Extra Tab' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'Recommendations' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'Comparison' })).not.toBeInTheDocument()
 
+    // Open dropdown and select a tab
     await userEvent.click(screen.getByRole('button', { name: /More/ }))
+    expect(screen.getByRole('tab', { name: 'Recommendations' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Comparison' })).toBeInTheDocument()
 
-    expect(screen.getByRole('tab', { name: 'Extra Tab' })).toBeInTheDocument()
-
-    await userEvent.click(screen.getByRole('tab', { name: 'Extra Tab' }))
+    await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
     expect(onChange).toHaveBeenCalledWith('comparison')
+
+    // Open dropdown again and click Show all — all tabs become inline
+    await userEvent.click(screen.getByRole('button', { name: /More/ }))
+    await userEvent.click(screen.getByRole('button', { name: /Show all/ }))
+
+    // Now all 8 tabs are visible as inline tab buttons
+    expect(screen.getAllByRole('tab')).toHaveLength(8)
+    expect(screen.queryByRole('button', { name: /More/ })).not.toBeInTheDocument()
   })
 })

--- a/components/app-shell/ResultsTabs.test.tsx
+++ b/components/app-shell/ResultsTabs.test.tsx
@@ -30,4 +30,35 @@ describe('ResultsTabs', () => {
     expect(screen.queryByRole('tab', { name: 'Health Ratios' })).not.toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: 'Metrics' })).not.toBeInTheDocument()
   })
+
+  it('shows overflow tabs in a More menu when tab count exceeds visible limit', async () => {
+    const manyTabs: ResultTabDefinition[] = [
+      { id: 'overview', label: 'Overview', status: 'implemented', description: '' },
+      { id: 'contributors', label: 'Contributors', status: 'placeholder', description: '' },
+      { id: 'activity', label: 'Activity', status: 'placeholder', description: '' },
+      { id: 'responsiveness', label: 'Responsiveness', status: 'implemented', description: '' },
+      { id: 'documentation', label: 'Documentation', status: 'implemented', description: '' },
+      { id: 'security', label: 'Security', status: 'implemented', description: '' },
+      { id: 'recommendations', label: 'Recommendations', status: 'implemented', description: '' },
+      { id: 'comparison', label: 'Comparison', status: 'implemented', description: '' },
+      { id: 'comparison', label: 'Extra Tab', status: 'implemented', description: '' },
+    ]
+    const onChange = vi.fn()
+
+    render(<ResultsTabs tabs={manyTabs} activeTab="overview" onChange={onChange} />)
+
+    // First 8 tabs are visible directly
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Comparison' })).toBeInTheDocument()
+
+    // Overflow tabs are hidden until More is clicked
+    expect(screen.queryByRole('tab', { name: 'Extra Tab' })).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /More/ }))
+
+    expect(screen.getByRole('tab', { name: 'Extra Tab' })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Extra Tab' }))
+    expect(onChange).toHaveBeenCalledWith('comparison')
+  })
 })

--- a/components/app-shell/ResultsTabs.tsx
+++ b/components/app-shell/ResultsTabs.tsx
@@ -9,14 +9,17 @@ interface ResultsTabsProps {
   onChange: (tabId: ResultTabId) => void
 }
 
-const VISIBLE_COUNT = 8
+const COLLAPSED_COUNT = 6
 
 export function ResultsTabs({ tabs, activeTab, onChange }: ResultsTabsProps) {
   const [menuOpen, setMenuOpen] = useState(false)
+  const [expanded, setExpanded] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
-  const visibleTabs = tabs.slice(0, VISIBLE_COUNT)
-  const overflowTabs = tabs.slice(VISIBLE_COUNT)
+  const hasOverflow = tabs.length > COLLAPSED_COUNT
+  const showAll = expanded || !hasOverflow
+  const visibleTabs = showAll ? tabs : tabs.slice(0, COLLAPSED_COUNT)
+  const overflowTabs = showAll ? [] : tabs.slice(COLLAPSED_COUNT)
   const activeOverflowTab = overflowTabs.find((t) => t.id === activeTab)
 
   useEffect(() => {
@@ -77,6 +80,17 @@ export function ResultsTabs({ tabs, activeTab, onChange }: ResultsTabsProps) {
                   {tab.label}
                 </button>
               ))}
+              <div className="my-1 border-t border-slate-100" />
+              <button
+                type="button"
+                className="block w-full px-4 py-2 text-left text-xs font-medium text-slate-500 hover:bg-slate-50"
+                onClick={() => {
+                  setExpanded(true)
+                  setMenuOpen(false)
+                }}
+              >
+                Show all
+              </button>
             </div>
           )}
         </div>

--- a/components/app-shell/ResultsTabs.tsx
+++ b/components/app-shell/ResultsTabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
 import type { ResultTabDefinition, ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 
 interface ResultsTabsProps {
@@ -8,26 +9,97 @@ interface ResultsTabsProps {
   onChange: (tabId: ResultTabId) => void
 }
 
+const VISIBLE_COUNT = 8
+
 export function ResultsTabs({ tabs, activeTab, onChange }: ResultsTabsProps) {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  const visibleTabs = tabs.slice(0, VISIBLE_COUNT)
+  const overflowTabs = tabs.slice(VISIBLE_COUNT)
+  const activeOverflowTab = overflowTabs.find((t) => t.id === activeTab)
+
+  useEffect(() => {
+    if (!menuOpen) return
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [menuOpen])
+
   return (
-    <div role="tablist" aria-label="Result views" className="flex flex-wrap gap-2">
-      {tabs.map((tab) => (
-        <button
-          key={tab.id}
-          role="tab"
-          type="button"
-          data-tab-id={tab.id}
-          aria-selected={tab.id === activeTab}
-          className={
-            tab.id === activeTab
-              ? 'rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white'
-              : 'rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700'
-          }
-          onClick={() => onChange(tab.id)}
-        >
-          {tab.label}
-        </button>
+    <div role="tablist" aria-label="Result views" className="flex flex-wrap items-center gap-1.5">
+      {visibleTabs.map((tab) => (
+        <TabButton key={tab.id} tab={tab} active={tab.id === activeTab} onClick={() => onChange(tab.id)} />
       ))}
+
+      {overflowTabs.length > 0 && (
+        <div className="relative" ref={menuRef}>
+          <button
+            type="button"
+            aria-haspopup="true"
+            aria-expanded={menuOpen}
+            className={
+              activeOverflowTab
+                ? 'inline-flex items-center gap-1 rounded-full bg-slate-900 px-2.5 py-1.5 text-sm font-medium text-white'
+                : 'inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1.5 text-sm font-medium text-slate-700'
+            }
+            onClick={() => setMenuOpen((o) => !o)}
+          >
+            {activeOverflowTab ? activeOverflowTab.label : 'More'}
+            <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+
+          {menuOpen && (
+            <div className="absolute left-0 top-full z-10 mt-1 min-w-[10rem] rounded-lg border border-slate-200 bg-white py-1 shadow-lg">
+              {overflowTabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  role="tab"
+                  type="button"
+                  data-tab-id={tab.id}
+                  aria-selected={tab.id === activeTab}
+                  className={
+                    tab.id === activeTab
+                      ? 'block w-full px-4 py-2 text-left text-sm font-medium text-slate-900 bg-slate-100'
+                      : 'block w-full px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-50'
+                  }
+                  onClick={() => {
+                    onChange(tab.id)
+                    setMenuOpen(false)
+                  }}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
+  )
+}
+
+function TabButton({ tab, active, onClick }: { tab: ResultTabDefinition; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      role="tab"
+      type="button"
+      data-tab-id={tab.id}
+      aria-selected={active}
+      className={
+        active
+          ? 'whitespace-nowrap rounded-full bg-slate-900 px-2.5 py-1.5 text-sm font-medium text-white'
+          : 'whitespace-nowrap rounded-full border border-slate-300 bg-white px-2.5 py-1.5 text-sm font-medium text-slate-700'
+      }
+      onClick={onClick}
+    >
+      {tab.label}
+    </button>
   )
 }

--- a/components/app-shell/ResultsTabs.tsx
+++ b/components/app-shell/ResultsTabs.tsx
@@ -39,6 +39,16 @@ export function ResultsTabs({ tabs, activeTab, onChange }: ResultsTabsProps) {
         <TabButton key={tab.id} tab={tab} active={tab.id === activeTab} onClick={() => onChange(tab.id)} />
       ))}
 
+      {expanded && hasOverflow && (
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1.5 text-sm font-medium text-slate-700"
+          onClick={() => setExpanded(false)}
+        >
+          Show less
+        </button>
+      )}
+
       {overflowTabs.length > 0 && (
         <div className="relative" ref={menuRef}>
           <button

--- a/components/app-shell/ResultsTabs.tsx
+++ b/components/app-shell/ResultsTabs.tsx
@@ -42,7 +42,7 @@ export function ResultsTabs({ tabs, activeTab, onChange }: ResultsTabsProps) {
       {expanded && hasOverflow && (
         <button
           type="button"
-          className="inline-flex items-center gap-1 rounded-full border border-slate-300 bg-white px-2.5 py-1.5 text-sm font-medium text-slate-700"
+          className="px-1 py-1.5 text-xs font-medium text-slate-500 hover:text-slate-700"
           onClick={() => setExpanded(false)}
         >
           Show less

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -99,6 +99,8 @@ describe('RepoInputClient', () => {
     await userEvent.type(screen.getByRole('textbox', { name: /repository list/i }), 'facebook/react nvidia/topograph')
     await userEvent.click(screen.getByRole('button', { name: /^analyze$/i }))
 
+    // Comparison is in the overflow menu
+    await userEvent.click(screen.getByRole('button', { name: /More/ }))
     await userEvent.click(await screen.findByRole('tab', { name: 'Comparison' }))
     expect(await screen.findByRole('region', { name: /comparison view/i })).toBeInTheDocument()
   })
@@ -209,8 +211,9 @@ describe('RepoInputClient', () => {
     expect(screen.getByText(/enter a github organization slug or org url above/i)).toBeInTheDocument()
   })
 
-  it('shows the comparison tab with a placeholder before any analysis results exist', () => {
+  it('shows the comparison tab in the overflow menu before any analysis results exist', async () => {
     renderWithAuth(<RepoInputClient />)
+    await userEvent.click(screen.getByRole('button', { name: /More/ }))
     expect(screen.getByRole('tab', { name: 'Comparison' })).toBeInTheDocument()
   })
 

--- a/lib/results-shell/tabs.ts
+++ b/lib/results-shell/tabs.ts
@@ -16,8 +16,8 @@ export const resultTabs: ResultTabDefinition[] = [
   {
     id: 'activity',
     label: 'Activity',
-    status: 'placeholder',
-    description: 'Activity metrics and scoring are coming soon.',
+    status: 'implemented',
+    description: 'Activity metrics, scoring, and detailed repo flow signals.',
   },
   {
     id: 'responsiveness',
@@ -26,10 +26,22 @@ export const resultTabs: ResultTabDefinition[] = [
     description: 'Response-time, backlog-health, and engagement signals from public issue and PR activity.',
   },
   {
+    id: 'documentation',
+    label: 'Documentation',
+    status: 'implemented',
+    description: 'Documentation file presence, README quality, and improvement recommendations.',
+  },
+  {
     id: 'security',
     label: 'Security',
     status: 'implemented',
     description: 'Security posture including OpenSSF Scorecard checks, dependency automation, and branch protection.',
+  },
+  {
+    id: 'recommendations',
+    label: 'Recommendations',
+    status: 'implemented',
+    description: 'Actionable recommendations across all scoring dimensions.',
   },
   {
     id: 'comparison',


### PR DESCRIPTION
## Summary
- Show first 6 tabs inline; remaining tabs go into a **"More" dropdown** (fixes #137)
- Dropdown includes a **"Show all"** option that expands all tabs inline
- Expanded view shows a **"Show less"** button to collapse back to the overflow layout
- "More" button shows the active tab's label when the selection is in the overflow group
- Sync `tabs.ts` default tab list with actual runtime tabs (adds Documentation, Recommendations; marks Activity as implemented)

## Test plan
- [x] Verify first 6 tabs (Overview through Security) render inline without wrapping
- [x] Verify "More" dropdown shows Recommendations and Comparison
- [x] Verify clicking a tab in "More" switches content and closes the menu
- [x] Verify "More" button shows the active tab label when an overflow tab is selected (e.g., "Comparison ▾")
- [x] Verify clicking "Show all" in the dropdown expands all 8 tabs inline and removes the dropdown
- [x] Verify "Show less" button appears in expanded view and collapses back to 6 tabs + More
- [x] Verify dropdown closes on outside click

🤖 Generated with [Claude Code](https://claude.com/claude-code)