### PR TITLE
Fix stale health score tooltip dimensions and weights

### DIFF
--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -37,7 +37,7 @@ export function MetricCard({ card }: MetricCardProps) {
         <p className="text-xs text-slate-400">Created: {card.createdAtLabel}</p>
       </div>
 
-      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Activity (30%), Responsiveness (30%), Sustainability (25%), and Documentation (15%, includes licensing, compliance & inclusive naming) — scored relative to ${hs.bracketLabel} repositories.`}>
+      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Activity (25%), Responsiveness (25%), Contributors (23%), Security (15%), and Documentation (12%, includes licensing, compliance & inclusive naming) — scored relative to ${hs.bracketLabel} repositories.`}>
         <div>
           <p className="text-xs font-medium uppercase tracking-wide">OSS Health Score</p>
           {hs.bracketLabel ? <p className="text-[10px] opacity-60">{hs.bracketLabel}</p> : null}


### PR DESCRIPTION
## Summary
- Update MetricCard tooltip to show current 5-dimension composite: Activity (25%), Responsiveness (25%), Contributors (23%), Security (15%), Documentation (12%)
- Was showing old 4-dimension weights (30/30/25/15) with "Sustainability" instead of "Contributors"

## Test plan
- [x] Hover over the OSS Health Score badge on a repo card — verify tooltip shows 5 dimensions with correct weights

🤖 Generated with [Claude Code](https://claude.com/claude-code)