### PR TITLE
Redesign landing page to communicate value proposition clearly

### DIFF
--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -50,14 +50,49 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
         <div className="text-center">
           <img src="/repo-pulse-banner.png" alt="RepoPulse" className="mx-auto h-40 rounded-xl shadow-lg" />
           <h1 className="mt-6 text-3xl font-bold text-slate-900">RepoPulse</h1>
-          <p className="mt-2 text-lg text-slate-600">Measure the health of your open source projects</p>
+          <p className="mt-2 text-lg text-slate-600">Know the real health of any open source project — in seconds</p>
         </div>
-        <div className="max-w-md text-center text-sm text-slate-500 space-y-2">
-          <p>Get percentile-based scores for <span className="font-medium text-slate-700">Activity</span>, <span className="font-medium text-slate-700">Responsiveness</span>, <span className="font-medium text-slate-700">Contributors</span>, <span className="font-medium text-slate-700">Security</span>, and <span className="font-medium text-slate-700">Documentation</span> — calibrated against 1,600+ real GitHub repositories.</p>
-          <p>Analyze any public repo, compare side-by-side, and see exactly where it ranks.</p>
+
+        <div className="max-w-lg space-y-4">
+          <p className="text-center text-sm text-slate-600">
+            RepoPulse computes a single <span className="font-semibold text-slate-800">OSS Health Score</span> from
+            five dimensions — scored as percentiles against 1,600+ real GitHub repositories in the same star bracket.
+          </p>
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Activity</p>
+              <p className="mt-0.5 text-xs text-slate-600">PR throughput, issue flow, commit cadence, release frequency</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Responsiveness</p>
+              <p className="mt-0.5 text-xs text-slate-600">Response times, resolution speed, backlog health</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Contributors</p>
+              <p className="mt-0.5 text-xs text-slate-600">Contributor concentration, repeat and new contributor mix</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Security</p>
+              <p className="mt-0.5 text-xs text-slate-600">OpenSSF Scorecard, dependency automation, branch protection</p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 sm:col-span-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Documentation</p>
+              <p className="mt-0.5 text-xs text-slate-600">Key project files, README quality, licensing compliance, inclusive naming</p>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-slate-500">
+            <span>Compare up to 4 repos side-by-side</span>
+            <span className="text-slate-300">|</span>
+            <span>Browse repos by GitHub org</span>
+            <span className="text-slate-300">|</span>
+            <span>Export as JSON or Markdown</span>
+          </div>
         </div>
+
         <SignInButton />
-        <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 transition">View scoring baseline</a>
+        <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 transition">View scoring methodology</a>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Replace generic tagline with direct benefit: "Know the real health of any open source project — in seconds"
- Show all 5 scoring dimensions (Activity, Responsiveness, Contributors, Security, Documentation) in a card grid with brief descriptions
- Add key capability callouts: multi-repo comparison, org inventory, export
- Rename "View scoring baseline" → "View scoring methodology"

Closes #151

## Test plan
- [x] Visit the landing page (signed out) — verify the 5 dimension cards are visible with descriptions
- [x] Verify the tagline reads "Know the real health of any open source project — in seconds"
- [x] Verify the capability line shows: Compare up to 4 repos, Browse by org, Export
- [x] Verify "View scoring methodology" link opens in a new tab
- [x] Verify Sign in with GitHub button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)