### PR TITLE
Build richer security recommendations from OpenSSF Scorecard guidance

### DIFF
--- a/components/recommendations/RecommendationsView.test.tsx
+++ b/components/recommendations/RecommendationsView.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { RecommendationsView } from './RecommendationsView'
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'A UI library',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 1000,
+    forks: 25,
+    watchers: 10,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 6,
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    staleIssueRatio: 0.2,
+    medianTimeToMergeHours: 24,
+    medianTimeToCloseHours: 36,
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: {
+      defaultBranchName: 'main',
+      branchCheck: { checkType: 'branch', term: 'main', passed: true, tier: null, severity: null, replacements: [], context: null },
+      metadataChecks: [],
+    },
+    securityResult: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+describe('RecommendationsView security recommendations', () => {
+  it('renders grouped security recommendations with category headings', () => {
+    const result = buildResult({
+      securityResult: {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Dangerous-Workflow', score: 2, reason: 'dangerous patterns' },
+            { name: 'CI-Tests', score: 5, reason: 'some tests' },
+            { name: 'Fuzzing', score: 3, reason: 'no fuzzing' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      },
+    })
+    render(<RecommendationsView results={[result]} />)
+
+    expect(screen.getByText('Critical Issues')).toBeInTheDocument()
+    expect(screen.getByText('Quick Wins')).toBeInTheDocument()
+    expect(screen.getByText('Best Practices')).toBeInTheDocument()
+  })
+
+  it('shows source labels on security recommendations', () => {
+    const result = buildResult({
+      securityResult: {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Token-Permissions', score: 3, reason: 'weak' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: false, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      },
+    })
+    render(<RecommendationsView results={[result]} />)
+
+    expect(screen.getByText('OpenSSF Scorecard')).toBeInTheDocument()
+    expect(screen.getByText('Direct check')).toBeInTheDocument()
+  })
+
+  it('renders remediation hints when present', () => {
+    const result = buildResult({
+      securityResult: {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Token-Permissions', score: 3, reason: 'weak permissions' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      },
+    })
+    render(<RecommendationsView results={[result]} />)
+
+    expect(screen.getByText(/permissions: read-all/)).toBeInTheDocument()
+  })
+
+  it('renders docs links for Scorecard recommendations', () => {
+    const result = buildResult({
+      securityResult: {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Token-Permissions', score: 3, reason: 'weak' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      },
+    })
+    render(<RecommendationsView results={[result]} />)
+
+    const link = screen.getByRole('link', { name: /scorecard docs/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('checks.md'))
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+
+  it('handles recommendations with null hints gracefully', () => {
+    const result = buildResult({
+      securityResult: {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Maintained', score: 3, reason: 'low activity' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      },
+    })
+    render(<RecommendationsView results={[result]} />)
+
+    expect(screen.getByText('Maintain regular development activity')).toBeInTheDocument()
+  })
+})

--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -2,6 +2,9 @@
 
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { getHealthScore } from '@/lib/scoring/health-score'
+import { getSecurityScore } from '@/lib/security/score-config'
+import type { SecurityRecommendation } from '@/lib/security/analysis-result'
+import { CATEGORY_DEFINITIONS } from '@/lib/security/recommendation-catalog'
 
 interface RecommendationsViewProps {
   results: AnalysisResult[]
@@ -12,6 +15,99 @@ const BUCKET_COLORS: Record<string, string> = {
   Responsiveness: 'bg-purple-100 text-purple-800',
   Sustainability: 'bg-emerald-100 text-emerald-800',
   Documentation: 'bg-amber-100 text-amber-800',
+  Security: 'bg-red-100 text-red-800',
+}
+
+const RISK_COLORS: Record<string, string> = {
+  Critical: 'bg-red-100 text-red-800',
+  High: 'bg-orange-100 text-orange-800',
+  Medium: 'bg-amber-100 text-amber-800',
+  Low: 'bg-slate-100 text-slate-700',
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  scorecard: 'OpenSSF Scorecard',
+  direct_check: 'Direct check',
+}
+
+function SecurityRecommendationCard({ rec }: { rec: SecurityRecommendation }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-2">
+        <h4 className="text-sm font-semibold text-slate-900">{rec.title ?? rec.text}</h4>
+        <div className="flex shrink-0 gap-1.5">
+          {rec.riskLevel ? (
+            <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${RISK_COLORS[rec.riskLevel] ?? ''}`}>
+              {rec.riskLevel}
+            </span>
+          ) : null}
+          <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+            {SOURCE_LABELS[rec.category] ?? rec.category}
+          </span>
+        </div>
+      </div>
+      {rec.evidence ? (
+        <p className="mt-1.5 text-xs text-slate-500">{rec.evidence}</p>
+      ) : null}
+      {rec.explanation ? (
+        <p className="mt-2 text-sm text-slate-600">{rec.explanation}</p>
+      ) : null}
+      {rec.remediationHint ? (
+        <div className="mt-2 rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-800">
+          {rec.remediationHint}
+        </div>
+      ) : null}
+      {rec.docsUrl ? (
+        <a
+          href={rec.docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-block text-xs text-blue-600 underline hover:text-blue-800"
+        >
+          OpenSSF Scorecard docs
+        </a>
+      ) : null}
+    </div>
+  )
+}
+
+function SecurityRecommendationsGroup({ recommendations }: { recommendations: SecurityRecommendation[] }) {
+  // Group by category
+  const groups = new Map<string, SecurityRecommendation[]>()
+  for (const rec of recommendations) {
+    const key = rec.groupCategory ?? 'best_practices'
+    const group = groups.get(key) ?? []
+    group.push(rec)
+    groups.set(key, group)
+  }
+
+  // Sort groups by CATEGORY_DEFINITIONS order
+  const sortedGroups = CATEGORY_DEFINITIONS
+    .filter((cat) => groups.has(cat.key))
+    .map((cat) => ({ category: cat, recs: groups.get(cat.key)! }))
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex items-center gap-2">
+        <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${BUCKET_COLORS.Security}`}>
+          Security
+        </span>
+        <span className="text-xs text-slate-400">{recommendations.length} recommendation{recommendations.length !== 1 ? 's' : ''}</span>
+      </div>
+      <div className="mt-3 space-y-4">
+        {sortedGroups.map(({ category, recs }) => (
+          <div key={category.key}>
+            <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">{category.label}</h4>
+            <div className="space-y-2">
+              {recs.map((rec, i) => (
+                <SecurityRecommendationCard key={`${rec.item}-${i}`} rec={rec} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 export function RecommendationsView({ results }: RecommendationsViewProps) {
@@ -20,7 +116,16 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
       {results.map((result) => {
         const healthScore = getHealthScore(result)
 
-        if (healthScore.recommendations.length === 0) {
+        // Get enriched security recommendations directly
+        const securityRecs = result.securityResult !== 'unavailable'
+          ? getSecurityScore(result.securityResult, result.stars).recommendations
+          : []
+
+        // Non-security recommendations from health score
+        const nonSecurityRecs = healthScore.recommendations.filter((r) => r.tab !== 'security')
+
+        const totalCount = nonSecurityRecs.length + securityRecs.length
+        if (totalCount === 0) {
           return (
             <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-6">
               <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
@@ -29,13 +134,15 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
           )
         }
 
-        // Group by bucket
-        const bucketGroups = new Map<string, typeof healthScore.recommendations>()
-        for (const rec of healthScore.recommendations) {
+        // Group non-security recs by bucket
+        const bucketGroups = new Map<string, typeof nonSecurityRecs>()
+        for (const rec of nonSecurityRecs) {
           const group = bucketGroups.get(rec.bucket) ?? []
           group.push(rec)
           bucketGroups.set(rec.bucket, group)
         }
+
+        const bucketCount = bucketGroups.size + (securityRecs.length > 0 ? 1 : 0)
 
         return (
           <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
@@ -43,7 +150,7 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
               <div>
                 <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
                 <p className="mt-1 text-sm text-slate-500">
-                  {healthScore.recommendations.length} recommendation{healthScore.recommendations.length !== 1 ? 's' : ''} across {bucketGroups.size} dimension{bucketGroups.size !== 1 ? 's' : ''}
+                  {totalCount} recommendation{totalCount !== 1 ? 's' : ''} across {bucketCount} dimension{bucketCount !== 1 ? 's' : ''}
                 </p>
               </div>
             </div>
@@ -60,13 +167,17 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
                   <ul className="mt-3 space-y-2">
                     {recs.map((rec, i) => (
                       <li key={i} className="flex items-start gap-2">
-                        <span className="mt-1 text-xs text-slate-400">•</span>
+                        <span className="mt-1 text-xs text-slate-400">&bull;</span>
                         <p className="text-sm text-slate-700">{rec.message}</p>
                       </li>
                     ))}
                   </ul>
                 </div>
               ))}
+
+              {securityRecs.length > 0 ? (
+                <SecurityRecommendationsGroup recommendations={securityRecs} />
+              ) : null}
             </div>
           </div>
         )

--- a/lib/security/__tests__/recommendation-catalog.test.ts
+++ b/lib/security/__tests__/recommendation-catalog.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import { RECOMMENDATION_CATALOG, CATEGORY_DEFINITIONS, getCatalogEntry } from '@/lib/security/recommendation-catalog'
+import type { RiskLevel, RecommendationCategoryKey } from '@/lib/security/analysis-result'
+
+const EXPECTED_SCORECARD_CHECKS = [
+  'Dangerous-Workflow',
+  'Webhooks',
+  'Branch-Protection',
+  'Binary-Artifacts',
+  'Code-Review',
+  'Dependency-Update-Tool',
+  'Fuzzing',
+  'License',
+  'Maintained',
+  'Packaging',
+  'Pinned-Dependencies',
+  'SAST',
+  'Security-Policy',
+  'Signed-Releases',
+  'Token-Permissions',
+  'Vulnerabilities',
+  'CI-Tests',
+]
+
+const EXPECTED_DIRECT_CHECKS = [
+  'security_policy',
+  'dependabot',
+  'ci_cd',
+  'branch_protection',
+]
+
+const VALID_RISK_LEVELS: RiskLevel[] = ['Critical', 'High', 'Medium', 'Low']
+const VALID_CATEGORIES: RecommendationCategoryKey[] = ['critical_issues', 'quick_wins', 'workflow_hardening', 'best_practices']
+
+describe('RECOMMENDATION_CATALOG', () => {
+  it('contains entries for all 17 expected Scorecard checks', () => {
+    const scorecardKeys = RECOMMENDATION_CATALOG
+      .filter((e) => e.source === 'scorecard')
+      .map((e) => e.key)
+
+    for (const check of EXPECTED_SCORECARD_CHECKS) {
+      expect(scorecardKeys).toContain(check)
+    }
+  })
+
+  it('contains entries for all 4 direct checks', () => {
+    const directKeys = RECOMMENDATION_CATALOG
+      .filter((e) => e.source === 'direct_check')
+      .map((e) => e.key)
+
+    for (const check of EXPECTED_DIRECT_CHECKS) {
+      expect(directKeys).toContain(check)
+    }
+  })
+
+  it('has unique keys across all entries', () => {
+    const keys = RECOMMENDATION_CATALOG.map((e) => e.key)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('has all required fields on every entry', () => {
+    for (const entry of RECOMMENDATION_CATALOG) {
+      expect(entry.key).toBeTruthy()
+      expect(entry.source).toBeTruthy()
+      expect(entry.title).toBeTruthy()
+      expect(entry.riskLevel).toBeTruthy()
+      expect(entry.groupCategory).toBeTruthy()
+      expect(entry.whyItMatters).toBeTruthy()
+      expect(entry.remediation).toBeTruthy()
+    }
+  })
+
+  it('uses valid riskLevel values on every entry', () => {
+    for (const entry of RECOMMENDATION_CATALOG) {
+      expect(VALID_RISK_LEVELS).toContain(entry.riskLevel)
+    }
+  })
+
+  it('uses valid groupCategory values on every entry', () => {
+    for (const entry of RECOMMENDATION_CATALOG) {
+      expect(VALID_CATEGORIES).toContain(entry.groupCategory)
+    }
+  })
+})
+
+describe('deduplication mappings', () => {
+  it('Security-Policy maps to security_policy direct check', () => {
+    const entry = getCatalogEntry('Security-Policy')
+    expect(entry).toBeDefined()
+    expect(entry!.directCheckMapping).toBe('security_policy')
+  })
+
+  it('Dependency-Update-Tool maps to dependabot direct check', () => {
+    const entry = getCatalogEntry('Dependency-Update-Tool')
+    expect(entry).toBeDefined()
+    expect(entry!.directCheckMapping).toBe('dependabot')
+  })
+
+  it('CI-Tests maps to ci_cd direct check', () => {
+    const entry = getCatalogEntry('CI-Tests')
+    expect(entry).toBeDefined()
+    expect(entry!.directCheckMapping).toBe('ci_cd')
+  })
+
+  it('Branch-Protection maps to branch_protection direct check', () => {
+    const entry = getCatalogEntry('Branch-Protection')
+    expect(entry).toBeDefined()
+    expect(entry!.directCheckMapping).toBe('branch_protection')
+  })
+})
+
+describe('CATEGORY_DEFINITIONS', () => {
+  it('defines all 4 categories in order', () => {
+    expect(CATEGORY_DEFINITIONS).toHaveLength(4)
+    expect(CATEGORY_DEFINITIONS[0]!.key).toBe('critical_issues')
+    expect(CATEGORY_DEFINITIONS[1]!.key).toBe('quick_wins')
+    expect(CATEGORY_DEFINITIONS[2]!.key).toBe('workflow_hardening')
+    expect(CATEGORY_DEFINITIONS[3]!.key).toBe('best_practices')
+  })
+
+  it('has ascending order values', () => {
+    for (let i = 1; i < CATEGORY_DEFINITIONS.length; i++) {
+      expect(CATEGORY_DEFINITIONS[i]!.order).toBeGreaterThan(CATEGORY_DEFINITIONS[i - 1]!.order)
+    }
+  })
+})
+
+describe('getCatalogEntry', () => {
+  it('returns the entry for a known key', () => {
+    const entry = getCatalogEntry('Token-Permissions')
+    expect(entry).toBeDefined()
+    expect(entry!.key).toBe('Token-Permissions')
+  })
+
+  it('returns undefined for an unknown key', () => {
+    expect(getCatalogEntry('Unknown-Check')).toBeUndefined()
+  })
+})

--- a/lib/security/__tests__/score-config.test.ts
+++ b/lib/security/__tests__/score-config.test.ts
@@ -223,6 +223,305 @@ describe('getSecurityScore', () => {
     })
   })
 
+  describe('enriched recommendations (US1)', () => {
+    it('populates enriched fields for a Scorecard check scoring 3/10', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Token-Permissions', score: 3, reason: 'token permissions partially set' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const rec = score.recommendations.find((r) => r.item === 'Token-Permissions')
+      expect(rec).toBeDefined()
+      expect(rec!.title).toBeTruthy()
+      expect(rec!.riskLevel).toBeTruthy()
+      expect(rec!.evidence).toContain('3/10')
+      expect(rec!.explanation).toBeTruthy()
+      expect(rec!.docsUrl).toBeTruthy()
+      expect(rec!.groupCategory).toBeTruthy()
+    })
+
+    it('populates enriched fields for a direct check with detected=false', () => {
+      const score = getSecurityScore(noSignalsResult, 100)
+      const rec = score.recommendations.find((r) => r.item === 'security_policy')
+      expect(rec).toBeDefined()
+      expect(rec!.title).toBeTruthy()
+      expect(rec!.riskLevel).toBeTruthy()
+      expect(rec!.evidence).toContain('not detected')
+      expect(rec!.explanation).toBeTruthy()
+      expect(rec!.groupCategory).toBeTruthy()
+    })
+
+    it('returns zero recommendations when all Scorecard checks score 10/10 and direct checks pass', () => {
+      const perfectResult: SecurityResult = {
+        scorecard: {
+          overallScore: 10.0,
+          checks: [
+            { name: 'Security-Policy', score: 10, reason: 'policy found' },
+            { name: 'Token-Permissions', score: 10, reason: 'permissions set' },
+            { name: 'Branch-Protection', score: 10, reason: 'protected' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(perfectResult, 5000)
+      expect(score.recommendations).toHaveLength(0)
+    })
+
+    it('generates a recommendation for a Scorecard check scoring 7/10 (widened threshold)', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 7.0,
+          checks: [
+            { name: 'Token-Permissions', score: 7, reason: 'token permissions mostly set' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const rec = score.recommendations.find((r) => r.item === 'Token-Permissions')
+      expect(rec).toBeDefined()
+      expect(rec!.evidence).toContain('7/10')
+    })
+
+    it('does not generate a recommendation for indeterminate score (-1)', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 5.0,
+          checks: [
+            { name: 'Branch-Protection', score: -1, reason: 'internal error' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const rec = score.recommendations.find((r) => r.item === 'Branch-Protection')
+      expect(rec).toBeUndefined()
+    })
+
+    it('does not generate a recommendation for a check with no catalog entry', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 5.0,
+          checks: [
+            { name: 'Unknown-Future-Check', score: 3, reason: 'some reason' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const rec = score.recommendations.find((r) => r.item === 'Unknown-Future-Check')
+      expect(rec).toBeUndefined()
+    })
+
+    it('preserves backward compat: enriched recs have text field and bucket security', () => {
+      const score = getSecurityScore(noSignalsResult, 100)
+      for (const rec of score.recommendations) {
+        expect(rec.text).toBeTruthy()
+        expect(rec.bucket).toBe('security')
+      }
+    })
+  })
+
+  describe('category assignment and sorting (US2)', () => {
+    it('promotes Critical-risk check scoring 2/10 to critical_issues', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 2.0,
+          checks: [
+            { name: 'Dangerous-Workflow', score: 2, reason: 'dangerous patterns found' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const rec = score.recommendations.find((r) => r.item === 'Dangerous-Workflow')
+      expect(rec).toBeDefined()
+      expect(rec!.groupCategory).toBe('critical_issues')
+    })
+
+    it('promotes High-risk check scoring 3/10 to critical_issues', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Token-Permissions', score: 3, reason: 'weak permissions' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const rec = score.recommendations.find((r) => r.item === 'Token-Permissions')
+      expect(rec).toBeDefined()
+      expect(rec!.groupCategory).toBe('critical_issues')
+    })
+
+    it('does NOT promote High-risk check scoring 7/10 to critical_issues', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 7.0,
+          checks: [
+            { name: 'Token-Permissions', score: 7, reason: 'mostly set' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const rec = score.recommendations.find((r) => r.item === 'Token-Permissions')
+      expect(rec).toBeDefined()
+      expect(rec!.groupCategory).toBe('workflow_hardening') // default, not promoted
+    })
+
+    it('sorts recommendations by category order, then risk level, then weight', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'CI-Tests', score: 5, reason: 'some tests' }, // Low risk, quick_wins
+            { name: 'Dangerous-Workflow', score: 2, reason: 'dangerous' }, // Critical, critical_issues
+            { name: 'Fuzzing', score: 3, reason: 'no fuzzing' }, // Medium, best_practices
+            { name: 'Token-Permissions', score: 2, reason: 'weak' }, // High → critical_issues (promoted)
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: true, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const categories = score.recommendations.map((r) => r.groupCategory)
+      // critical_issues should come first, then quick_wins, then best_practices
+      const firstCritical = categories.indexOf('critical_issues')
+      const firstQuickWin = categories.indexOf('quick_wins')
+      const firstBestPractice = categories.indexOf('best_practices')
+      if (firstCritical >= 0 && firstQuickWin >= 0) {
+        expect(firstCritical).toBeLessThan(firstQuickWin)
+      }
+      if (firstQuickWin >= 0 && firstBestPractice >= 0) {
+        expect(firstQuickWin).toBeLessThan(firstBestPractice)
+      }
+    })
+  })
+
+  describe('deduplication (US3)', () => {
+    it('deduplicates Security-Policy when both Scorecard and direct check fire', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 5.0,
+          checks: [
+            { name: 'Security-Policy', score: 5, reason: 'partial policy' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: false, details: null },
+          { name: 'dependabot', detected: true, details: null },
+          { name: 'ci_cd', detected: true, details: null },
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      }
+      const score = getSecurityScore(result, 5000)
+      const secPolicyRecs = score.recommendations.filter(
+        (r) => r.item === 'Security-Policy' || r.item === 'security_policy',
+      )
+      expect(secPolicyRecs).toHaveLength(1)
+      expect(secPolicyRecs[0]!.category).toBe('scorecard') // Scorecard version preferred
+      expect(secPolicyRecs[0]!.evidence).toContain('Also confirmed')
+    })
+
+    it('deduplicates all 4 overlapping pairs', () => {
+      const result: SecurityResult = {
+        scorecard: {
+          overallScore: 3.0,
+          checks: [
+            { name: 'Security-Policy', score: 3, reason: 'weak' },
+            { name: 'Dependency-Update-Tool', score: 2, reason: 'none' },
+            { name: 'CI-Tests', score: 4, reason: 'some' },
+            { name: 'Branch-Protection', score: 1, reason: 'none' },
+          ],
+          scorecardVersion: 'v5.0.0',
+        },
+        directChecks: [
+          { name: 'security_policy', detected: false, details: null },
+          { name: 'dependabot', detected: false, details: null },
+          { name: 'ci_cd', detected: false, details: null },
+          { name: 'branch_protection', detected: false, details: null },
+        ],
+        branchProtectionEnabled: false,
+      }
+      const score = getSecurityScore(result, 5000)
+      // Should have 4 recs (Scorecard versions only), not 8
+      const directRecs = score.recommendations.filter((r) => r.category === 'direct_check')
+      expect(directRecs).toHaveLength(0)
+      expect(score.recommendations.length).toBe(4)
+    })
+  })
+
   describe('percentile and tone', () => {
     it('returns percentile when stars are available', () => {
       const score = getSecurityScore(fullScorecardResult, 5000)

--- a/lib/security/analysis-result.ts
+++ b/lib/security/analysis-result.ts
@@ -1,6 +1,16 @@
 import type { Unavailable } from '@/lib/analyzer/analysis-result'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
+export type RiskLevel = 'Critical' | 'High' | 'Medium' | 'Low'
+
+export type RecommendationCategoryKey =
+  | 'critical_issues'
+  | 'quick_wins'
+  | 'workflow_hardening'
+  | 'best_practices'
+
+export type RecommendationSource = 'scorecard' | 'direct_check'
+
 export interface ScorecardCheck {
   name: string
   score: number
@@ -29,10 +39,17 @@ export interface SecurityResult {
 
 export interface SecurityRecommendation {
   bucket: 'security'
-  category: 'scorecard' | 'direct_check'
+  category: RecommendationSource
   item: string
   weight: number
   text: string
+  title?: string
+  riskLevel?: RiskLevel
+  evidence?: string
+  explanation?: string
+  remediationHint?: string | null
+  docsUrl?: string | null
+  groupCategory?: RecommendationCategoryKey
 }
 
 export interface SecurityScoreDefinition {

--- a/lib/security/recommendation-catalog.ts
+++ b/lib/security/recommendation-catalog.ts
@@ -1,0 +1,299 @@
+import type { RiskLevel, RecommendationCategoryKey, RecommendationSource } from './analysis-result'
+
+export interface RecommendationCatalogEntry {
+  key: string
+  source: RecommendationSource
+  title: string
+  riskLevel: RiskLevel
+  groupCategory: RecommendationCategoryKey
+  whyItMatters: string
+  remediation: string
+  remediationHint: string | null
+  docsUrl: string | null
+  directCheckMapping: string | null
+}
+
+export interface RecommendationCategoryDefinition {
+  key: RecommendationCategoryKey
+  label: string
+  order: number
+}
+
+const SCORECARD_DOCS_BASE = 'https://github.com/ossf/scorecard/blob/main/docs/checks.md'
+
+export const CATEGORY_DEFINITIONS: RecommendationCategoryDefinition[] = [
+  { key: 'critical_issues', label: 'Critical Issues', order: 1 },
+  { key: 'quick_wins', label: 'Quick Wins', order: 2 },
+  { key: 'workflow_hardening', label: 'Workflow Hardening', order: 3 },
+  { key: 'best_practices', label: 'Best Practices', order: 4 },
+]
+
+export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
+  // --- Critical risk Scorecard checks ---
+  {
+    key: 'Dangerous-Workflow',
+    source: 'scorecard',
+    title: 'Fix dangerous GitHub Actions workflow patterns',
+    riskLevel: 'Critical',
+    groupCategory: 'critical_issues',
+    whyItMatters: 'Dangerous workflow patterns like untrusted code checkouts and script injection can allow attackers to execute arbitrary code in your CI/CD pipeline.',
+    remediation: 'Avoid using pull_request_target with explicit checkouts. Prevent untrusted context variables from flowing into executable code in workflow scripts.',
+    remediationHint: 'Replace `pull_request_target` triggers with `pull_request` where possible, and never pass user-controlled inputs directly into `run:` steps.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#dangerous-workflow`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Webhooks',
+    source: 'scorecard',
+    title: 'Secure webhook configurations with token authentication',
+    riskLevel: 'Critical',
+    groupCategory: 'critical_issues',
+    whyItMatters: 'Webhooks without secret token authentication allow unauthorized parties to send forged payloads, potentially triggering unintended actions.',
+    remediation: 'Enable secret token authentication in all webhook settings to verify payload authenticity.',
+    remediationHint: 'Set a webhook secret in repository Settings > Webhooks and validate the `X-Hub-Signature-256` header in your webhook handler.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#webhooks`,
+    directCheckMapping: null,
+  },
+
+  // --- High risk Scorecard checks ---
+  {
+    key: 'Branch-Protection',
+    source: 'scorecard',
+    title: 'Enforce branch protection on the default branch',
+    riskLevel: 'High',
+    groupCategory: 'workflow_hardening',
+    whyItMatters: 'Without branch protection, anyone with write access can push directly to the default branch, bypassing code review and status checks.',
+    remediation: 'Enable branch protection rules requiring pull request reviews and passing status checks before merging.',
+    remediationHint: 'Go to Settings > Branches > Add rule for your default branch. Require at least 1 reviewer and enable "Require status checks to pass."',
+    docsUrl: `${SCORECARD_DOCS_BASE}#branch-protection`,
+    directCheckMapping: 'branch_protection',
+  },
+  {
+    key: 'Binary-Artifacts',
+    source: 'scorecard',
+    title: 'Remove binary artifacts from the repository',
+    riskLevel: 'High',
+    groupCategory: 'best_practices',
+    whyItMatters: 'Binary artifacts checked into the repository cannot be easily audited for malicious content and undermine reproducible builds.',
+    remediation: 'Remove binary files from the repository and implement build-from-source processes to ensure reproducible builds.',
+    remediationHint: 'Delete checked-in binaries (`.exe`, `.dll`, `.so`, `.jar`) and add them to `.gitignore`. Build artifacts from source in CI.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#binary-artifacts`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Code-Review',
+    source: 'scorecard',
+    title: 'Require code review before merging pull requests',
+    riskLevel: 'High',
+    groupCategory: 'workflow_hardening',
+    whyItMatters: 'Without mandatory code review, unreviewed changes can introduce bugs, vulnerabilities, or malicious code into the codebase.',
+    remediation: 'Implement mandatory code reviews for all changes. Require at least one approval before merging, including from administrators.',
+    remediationHint: 'Enable "Require pull request reviews before merging" in branch protection rules and set minimum reviewers to 1+.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#code-review`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Dependency-Update-Tool',
+    source: 'scorecard',
+    title: 'Enable automated dependency updates',
+    riskLevel: 'High',
+    groupCategory: 'quick_wins',
+    whyItMatters: 'Without automated dependency updates, known vulnerabilities in dependencies go unpatched, increasing the attack surface over time.',
+    remediation: 'Enable Dependabot or Renovate to automatically create pull requests for dependency updates.',
+    remediationHint: 'Create `.github/dependabot.yml` with update schedules for your package ecosystems.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#dependency-update-tool`,
+    directCheckMapping: 'dependabot',
+  },
+  {
+    key: 'Signed-Releases',
+    source: 'scorecard',
+    title: 'Sign release artifacts to attest provenance',
+    riskLevel: 'High',
+    groupCategory: 'best_practices',
+    whyItMatters: 'Unsigned releases cannot be verified for authenticity, making it possible for attackers to distribute tampered artifacts.',
+    remediation: 'Sign releases using PGP or minisign. Attach signature files and publish SLSA provenance files with each release.',
+    remediationHint: 'Use `gpg --sign` or `cosign` to sign release artifacts, and attach `.sig` or `.pem` files to GitHub releases.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#signed-releases`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Token-Permissions',
+    source: 'scorecard',
+    title: 'Restrict GitHub Actions token permissions',
+    riskLevel: 'High',
+    groupCategory: 'workflow_hardening',
+    whyItMatters: 'Overly broad workflow token permissions increase the blast radius if a workflow is compromised, allowing attackers to modify code, create releases, or access secrets.',
+    remediation: 'Set top-level permissions to read-only and declare write permissions only at the job level when necessary.',
+    remediationHint: 'Add `permissions: read-all` at the top of workflow files and grant specific write permissions per job.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#token-permissions`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Vulnerabilities',
+    source: 'scorecard',
+    title: 'Fix known vulnerabilities in dependencies',
+    riskLevel: 'High',
+    groupCategory: 'best_practices',
+    whyItMatters: 'Open, unfixed vulnerabilities in the codebase or dependencies expose the project and its users to known exploits.',
+    remediation: 'Fix vulnerabilities promptly by updating affected dependencies. Document ignored vulnerabilities with clear rationale.',
+    remediationHint: 'Run `npm audit fix` or equivalent for your ecosystem, and review GitHub Security Advisories for your repository.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#vulnerabilities`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Maintained',
+    source: 'scorecard',
+    title: 'Maintain regular development activity',
+    riskLevel: 'High',
+    groupCategory: 'best_practices',
+    whyItMatters: 'A project without recent commits or issue activity may be abandoned, leaving known issues and vulnerabilities unaddressed.',
+    remediation: 'Maintain regular development cycles with commits and issue triage. Archive the project if it is no longer actively developed.',
+    remediationHint: null,
+    docsUrl: `${SCORECARD_DOCS_BASE}#maintained`,
+    directCheckMapping: null,
+  },
+
+  // --- Medium risk Scorecard checks ---
+  {
+    key: 'Fuzzing',
+    source: 'scorecard',
+    title: 'Adopt fuzz testing to find edge-case bugs',
+    riskLevel: 'Medium',
+    groupCategory: 'best_practices',
+    whyItMatters: 'Fuzz testing discovers edge-case bugs and memory safety issues that unit tests miss, reducing the risk of exploitable crashes.',
+    remediation: 'Integrate with OSS-Fuzz, deploy ClusterFuzzLite, or implement language-specific fuzzing functions.',
+    remediationHint: 'For Go: add `func FuzzXxx` tests. For C/C++: integrate with OSS-Fuzz. For JS/TS: use `jsfuzz` or `jazzer.js`.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#fuzzing`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Pinned-Dependencies',
+    source: 'scorecard',
+    title: 'Pin dependencies to specific versions by hash',
+    riskLevel: 'Medium',
+    groupCategory: 'workflow_hardening',
+    whyItMatters: 'Mutable dependency references (tags, branches, version ranges) can be silently changed upstream, enabling supply chain attacks.',
+    remediation: 'Pin Dockerfile base images by digest, use lock files, and pin GitHub Actions to full commit SHAs instead of tags.',
+    remediationHint: 'Replace `uses: actions/checkout@v4` with `uses: actions/checkout@<full-sha>` in workflow files.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#pinned-dependencies`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'SAST',
+    source: 'scorecard',
+    title: 'Enable static application security testing (SAST)',
+    riskLevel: 'Medium',
+    groupCategory: 'best_practices',
+    whyItMatters: 'Without SAST, source code vulnerabilities like injection flaws and buffer overflows go undetected until runtime exploitation.',
+    remediation: 'Integrate CodeQL via GitHub Actions or another SAST tool into your CI/CD pipeline to scan code on every pull request.',
+    remediationHint: 'Enable GitHub Code Scanning with CodeQL by adding the `github/codeql-action/analyze` step to your CI workflow.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#sast`,
+    directCheckMapping: null,
+  },
+  {
+    key: 'Security-Policy',
+    source: 'scorecard',
+    title: 'Add a security vulnerability disclosure policy',
+    riskLevel: 'Medium',
+    groupCategory: 'quick_wins',
+    whyItMatters: 'Without a SECURITY.md, security researchers have no clear way to report vulnerabilities responsibly, increasing the chance of public disclosure without a fix.',
+    remediation: 'Create a SECURITY.md file in the repository root with vulnerability reporting instructions, contact methods, and expected response timelines.',
+    remediationHint: 'Create `SECURITY.md` with sections: Reporting a Vulnerability, Contact, Response Timeline. GitHub also supports private vulnerability reporting.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#security-policy`,
+    directCheckMapping: 'security_policy',
+  },
+  {
+    key: 'Packaging',
+    source: 'scorecard',
+    title: 'Publish packages through official registries',
+    riskLevel: 'Medium',
+    groupCategory: 'best_practices',
+    whyItMatters: 'Publishing through official package registries with automated workflows ensures artifacts are built from reviewed source code.',
+    remediation: 'Publish via GitHub Packages or language-specific registries using automated release workflows.',
+    remediationHint: null,
+    docsUrl: `${SCORECARD_DOCS_BASE}#packaging`,
+    directCheckMapping: null,
+  },
+
+  // --- Low risk Scorecard checks ---
+  {
+    key: 'CI-Tests',
+    source: 'scorecard',
+    title: 'Run automated tests on pull requests',
+    riskLevel: 'Low',
+    groupCategory: 'quick_wins',
+    whyItMatters: 'Without automated tests on pull requests, regressions and bugs can be merged undetected.',
+    remediation: 'Add test scripts and integrate with a CI platform (GitHub Actions, Jenkins, CircleCI) to run tests on every pull request.',
+    remediationHint: 'Add a GitHub Actions workflow with `on: pull_request` that runs your test suite.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#ci-tests`,
+    directCheckMapping: 'ci_cd',
+  },
+  {
+    key: 'License',
+    source: 'scorecard',
+    title: 'Add a recognized open-source license',
+    riskLevel: 'Low',
+    groupCategory: 'quick_wins',
+    whyItMatters: 'Without a license file, the default copyright applies and users cannot legally use, modify, or distribute the code.',
+    remediation: 'Add a LICENSE file to the repository root using an SPDX-recognized identifier. Consider FSF/OSI-approved licenses.',
+    remediationHint: 'Create a `LICENSE` file at the repo root. Use `choosealicense.com` to pick an appropriate license.',
+    docsUrl: `${SCORECARD_DOCS_BASE}#license`,
+    directCheckMapping: null,
+  },
+
+  // --- Direct checks ---
+  {
+    key: 'security_policy',
+    source: 'direct_check',
+    title: 'Add a SECURITY.md vulnerability disclosure policy',
+    riskLevel: 'Medium',
+    groupCategory: 'quick_wins',
+    whyItMatters: 'Without a SECURITY.md, security researchers have no clear way to report vulnerabilities responsibly.',
+    remediation: 'Create a SECURITY.md file with vulnerability reporting instructions, contact methods, and expected response timelines.',
+    remediationHint: 'Create `SECURITY.md` at the repo root with sections for reporting process, contact info, and response expectations.',
+    docsUrl: null,
+    directCheckMapping: null,
+  },
+  {
+    key: 'dependabot',
+    source: 'direct_check',
+    title: 'Enable automated dependency updates',
+    riskLevel: 'High',
+    groupCategory: 'quick_wins',
+    whyItMatters: 'Without automated dependency updates, known vulnerabilities in dependencies go unpatched over time.',
+    remediation: 'Enable Dependabot or Renovate to automatically create pull requests for dependency updates.',
+    remediationHint: 'Create `.github/dependabot.yml` with update schedules for your package ecosystems.',
+    docsUrl: null,
+    directCheckMapping: null,
+  },
+  {
+    key: 'ci_cd',
+    source: 'direct_check',
+    title: 'Add CI/CD workflows for automated testing',
+    riskLevel: 'Low',
+    groupCategory: 'quick_wins',
+    whyItMatters: 'Without CI/CD, code changes are not automatically tested, increasing the risk of shipping bugs and regressions.',
+    remediation: 'Add GitHub Actions workflows for automated testing and CI/CD to catch issues before they reach production.',
+    remediationHint: 'Create `.github/workflows/ci.yml` with a workflow that runs your test suite on push and pull_request events.',
+    docsUrl: null,
+    directCheckMapping: null,
+  },
+  {
+    key: 'branch_protection',
+    source: 'direct_check',
+    title: 'Enable branch protection on the default branch',
+    riskLevel: 'High',
+    groupCategory: 'workflow_hardening',
+    whyItMatters: 'Without branch protection, anyone with write access can push directly to the default branch, bypassing review.',
+    remediation: 'Enable branch protection rules on the default branch to enforce code review before merging.',
+    remediationHint: 'Go to Settings > Branches > Add rule for your default branch. Require at least 1 reviewer.',
+    docsUrl: null,
+    directCheckMapping: null,
+  },
+]
+
+const catalogMap = new Map(RECOMMENDATION_CATALOG.map((e) => [e.key, e]))
+
+export function getCatalogEntry(key: string): RecommendationCatalogEntry | undefined {
+  return catalogMap.get(key)
+}

--- a/lib/security/score-config.ts
+++ b/lib/security/score-config.ts
@@ -1,6 +1,7 @@
 import type { SecurityResult, SecurityScoreDefinition, SecurityRecommendation, DirectSecurityCheck } from './analysis-result'
 import type { Unavailable } from '@/lib/analyzer/analysis-result'
 import { getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone, type PercentileSet } from '@/lib/scoring/config-loader'
+import { getCatalogEntry, CATEGORY_DEFINITIONS } from './recommendation-catalog'
 
 const SCORECARD_WEIGHT = 0.60
 const DIRECT_WEIGHT = 0.40
@@ -21,11 +22,16 @@ const MODE_B_WEIGHTS: Record<string, number> = {
   branch_protection: 0.20,
 }
 
-const RECOMMENDATION_TEXT: Record<string, string> = {
-  security_policy: 'Add a SECURITY.md file with vulnerability reporting instructions to help users report security issues responsibly.',
-  dependabot: 'Enable automated dependency updates (Dependabot or Renovate) to keep dependencies current and reduce vulnerability exposure.',
-  ci_cd: 'Add GitHub Actions workflows for automated testing and CI/CD to catch issues before they reach production.',
-  branch_protection: 'Enable branch protection rules on the default branch to enforce code review before merging.',
+const RISK_LEVEL_ORDER: Record<string, number> = {
+  Critical: 0,
+  High: 1,
+  Medium: 2,
+  Low: 3,
+}
+
+function getCategoryOrder(key: string): number {
+  const def = CATEGORY_DEFINITIONS.find((c) => c.key === key)
+  return def ? def.order : 99
 }
 
 function computeDirectCheckScore(
@@ -59,14 +65,21 @@ function generateDirectCheckRecommendations(
   for (const check of directChecks) {
     if (check.detected === false) {
       const weight = weights[check.name] ?? 0
-      const text = RECOMMENDATION_TEXT[check.name]
-      if (text) {
+      const entry = getCatalogEntry(check.name)
+      if (entry) {
         recs.push({
           bucket: 'security',
           category: 'direct_check',
           item: check.name,
           weight,
-          text,
+          text: `${entry.title}: ${entry.remediation}`,
+          title: entry.title,
+          riskLevel: entry.riskLevel,
+          evidence: `${check.name} not detected`,
+          explanation: entry.whyItMatters,
+          remediationHint: entry.remediationHint,
+          docsUrl: entry.docsUrl,
+          groupCategory: entry.groupCategory,
         })
       }
     }
@@ -115,24 +128,69 @@ export function getSecurityScore(
   // Generate recommendations
   const recommendations = generateDirectCheckRecommendations(securityResult.directChecks, weights)
 
-  // Generate scorecard-based recommendations for low scores
+  // Generate scorecard-based recommendations for any check below 10
   if (hasScorecardData) {
     const scorecard = securityResult.scorecard as Exclude<typeof securityResult.scorecard, 'unavailable'>
     for (const check of scorecard.checks) {
-      if (check.score >= 0 && check.score <= 4) {
-        recommendations.push({
-          bucket: 'security',
-          category: 'scorecard',
-          item: check.name,
-          weight: SCORECARD_WEIGHT * 0.1,
-          text: `Improve ${check.name} practices: ${check.reason}`,
-        })
-      }
+      // Skip indeterminate (-1) and perfect scores (10)
+      if (check.score < 0 || check.score >= 10) continue
+      const entry = getCatalogEntry(check.name)
+      if (!entry) continue
+      // Category promotion: Critical/High risk + score 0-4 → critical_issues
+      const effectiveCategory = (entry.riskLevel === 'Critical' || entry.riskLevel === 'High') && check.score <= 4
+        ? 'critical_issues' as const
+        : entry.groupCategory
+      recommendations.push({
+        bucket: 'security',
+        category: 'scorecard',
+        item: check.name,
+        weight: SCORECARD_WEIGHT * 0.1,
+        text: `${entry.title}: ${entry.remediation}`,
+        title: entry.title,
+        riskLevel: entry.riskLevel,
+        evidence: `${check.name} scored ${check.score}/10`,
+        explanation: entry.whyItMatters,
+        remediationHint: entry.remediationHint,
+        docsUrl: entry.docsUrl,
+        groupCategory: effectiveCategory,
+      })
     }
   }
 
-  // Sort recommendations by weight descending
-  recommendations.sort((a, b) => b.weight - a.weight)
+  // Deduplication: suppress direct-check recs when a Scorecard rec covers the same concern
+  const scorecardCoveredDirectChecks = new Set<string>()
+  for (const rec of recommendations) {
+    if (rec.category === 'scorecard') {
+      const entry = getCatalogEntry(rec.item)
+      if (entry?.directCheckMapping) {
+        scorecardCoveredDirectChecks.add(entry.directCheckMapping)
+      }
+    }
+  }
+  const deduplicatedRecs = recommendations.filter((rec) => {
+    if (rec.category === 'direct_check' && scorecardCoveredDirectChecks.has(rec.item)) {
+      // Append "Also confirmed by direct repository check" to the Scorecard version's evidence
+      const scorecardRec = recommendations.find(
+        (r) => r.category === 'scorecard' && getCatalogEntry(r.item)?.directCheckMapping === rec.item,
+      )
+      if (scorecardRec && scorecardRec.evidence && !scorecardRec.evidence.includes('Also confirmed')) {
+        scorecardRec.evidence += '. Also confirmed by direct repository check'
+      }
+      return false
+    }
+    return true
+  })
+
+  // Sort by category order, then risk level severity, then weight descending
+  deduplicatedRecs.sort((a, b) => {
+    const catOrderA = getCategoryOrder(a.groupCategory ?? '')
+    const catOrderB = getCategoryOrder(b.groupCategory ?? '')
+    if (catOrderA !== catOrderB) return catOrderA - catOrderB
+    const riskA = RISK_LEVEL_ORDER[a.riskLevel ?? ''] ?? 99
+    const riskB = RISK_LEVEL_ORDER[b.riskLevel ?? ''] ?? 99
+    if (riskA !== riskB) return riskA - riskB
+    return b.weight - a.weight
+  })
 
   // Compute percentile from calibration
   let percentile: number | null = null
@@ -163,6 +221,6 @@ export function getSecurityScore(
     scorecardScore,
     directCheckScore,
     mode,
-    recommendations,
+    recommendations: deduplicatedRecs,
   }
 }

--- a/specs/130-security-scoring/contracts/security-view-props.ts
+++ b/specs/130-security-scoring/contracts/security-view-props.ts
@@ -28,6 +28,13 @@ export interface SecurityRecommendationDisplay {
   item: string
   text: string
   weight: number
+  title?: string
+  riskLevel?: 'Critical' | 'High' | 'Medium' | 'Low'
+  evidence?: string
+  explanation?: string
+  remediationHint?: string | null
+  docsUrl?: string | null
+  groupCategory?: 'critical_issues' | 'quick_wins' | 'workflow_hardening' | 'best_practices'
 }
 
 /** Props for the SecurityView component */

--- a/specs/156-security-recommendations/checklists/manual-testing.md
+++ b/specs/156-security-recommendations/checklists/manual-testing.md
@@ -1,0 +1,43 @@
+# Manual Testing Checklist: Richer Security Recommendations
+
+**Purpose**: Verify all acceptance criteria through manual testing before opening the PR
+**Created**: 2026-04-13
+**Feature**: [spec.md](../spec.md)
+**Signed off by**: arun-gupta (2026-04-13)
+
+## US1: Structured Security Recommendations
+
+- [x] (pallets/flask) Analyze a repo with OpenSSF Scorecard data containing low-scoring checks (0-4) — verify each recommendation shows: title, source label, risk level, evidence with actual score, explanation, remediation action, and docs link. Code-Review 0/10, Branch-Protection 3/10 — all structured fields present.
+- [x] (expressjs/express) Analyze a repo missing SECURITY.md — verify direct-check recommendation shows: title, source "Direct check", risk level, evidence "not detected", explanation, remediation action. "security_policy not detected" with "Direct check" label, Medium risk, hint.
+- [x] (unit tests) Analyze a repo where all Scorecard checks score 10/10 and all direct checks pass — verify no security recommendations appear. Covered by unit test "returns zero recommendations when all Scorecard checks score 10/10 and direct checks pass" in score-config.test.ts; no real repo found with perfect scores across all checks.
+- [x] (pallets/flask) Analyze a repo with a Scorecard check scoring 7/10 — verify a recommendation is still shown with the score as evidence. Security-Policy 9/10, Pinned-Dependencies 8/10 both show recommendations.
+
+## US2: Grouped Recommendations by Category
+
+- [x] (pallets/flask) Analyze a repo with findings spanning multiple risk/score levels — verify recommendations are grouped under labeled category headings (Critical Issues, Quick Wins, Workflow Hardening, Best Practices). Critical Issues, Quick Wins, Workflow Hardening all present.
+- [x] (pallets/flask) Verify Critical Issues category appears first when present. Critical Issues is the first section.
+- [x] (expressjs/express) Verify empty categories are not displayed. No Critical Issues section shown (no High/Critical + 0-4 checks).
+- [x] (pallets/flask) Verify a High-risk check scoring 2/10 appears under "Critical Issues" (promoted). Code-Review 0/10 (High) and Branch-Protection 3/10 (High) both in Critical Issues.
+- [x] (pallets/flask) Verify a High-risk check scoring 7/10 does NOT appear under "Critical Issues". Signed-Releases 6/10 (High) stays in Best Practices, not promoted.
+
+## US3: Source Attribution and Deduplication
+
+- [x] (expressjs/express, pallets/flask) Analyze a repo with both Scorecard and direct-check findings — verify each recommendation shows a visible source label. expressjs/express: "OpenSSF Scorecard" on Pinned-Dependencies and Fuzzing, "Direct check" on security_policy. pallets/flask: "OpenSSF Scorecard" on Code-Review, Branch-Protection, etc.; "Direct check" on dependabot.
+- [x] (arun-gupta/docker-images) Analyze a repo where Scorecard is unavailable — verify all recommendations show "Direct check" label. All 3 recommendations show "Direct check" label, no "OpenSSF Scorecard" labels present.
+- [x] (pallets/flask) Verify overlapping checks (e.g., Security-Policy/security_policy) produce only one recommendation, not two. Security-Policy shows "Also confirmed by direct repository check" — single entry, deduplicated.
+
+## US4: Remediation Snippets and Documentation Links
+
+- [x] (expressjs/express, pallets/flask) Verify recommendations with remediation hints display the hint text. expressjs/express: blue hint box on security_policy, Pinned-Dependencies, Fuzzing. pallets/flask: blue hint boxes on Code-Review, Branch-Protection, dependabot, Security-Policy, Pinned-Dependencies, Signed-Releases, SAST.
+- [x] (expressjs/express, pallets/flask) Verify Scorecard-sourced recommendations include a clickable link to OpenSSF docs. expressjs/express: links on Pinned-Dependencies and Fuzzing. pallets/flask: links on all Scorecard-sourced recs.
+- [x] (expressjs/express) Verify recommendations without hints/links don't show empty hint/link sections. Direct-check rec shows no docs link (correct — direct checks have null docsUrl).
+
+## Backward Compatibility
+
+- [x] (expressjs/express, pallets/flask) Verify the Recommendations tab still shows security recommendations alongside other dimensions. Security bucket renders alongside Activity, Responsiveness, Sustainability, Documentation.
+- [x] (expressjs/express, pallets/flask) Verify security recommendations in the Recommendations tab have proper color styling (not fallback gray). expressjs/express: red "Security" badge with "3 recommendations". pallets/flask: red "Security" badge with "7 recommendations".
+
+## Notes
+
+- Repos tested: expressjs/express, pallets/flask, arun-gupta/docker-images
+- One item unchecked: "all checks 10/10" — covered by unit tests, no real repo found with perfect scores

--- a/specs/156-security-recommendations/checklists/requirements.md
+++ b/specs/156-security-recommendations/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Richer Security Recommendations
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/156-security-recommendations/contracts/security-recommendation-props.ts
+++ b/specs/156-security-recommendations/contracts/security-recommendation-props.ts
@@ -1,0 +1,81 @@
+/**
+ * Security Recommendation Contracts — enriched recommendation types
+ *
+ * Extends the existing SecurityRecommendation with structured fields
+ * for richer display in the Security tab and Recommendations view.
+ */
+
+/** Risk levels aligned with OpenSSF Scorecard documentation */
+export type RiskLevel = 'Critical' | 'High' | 'Medium' | 'Low'
+
+/** Priority-driven recommendation category keys for grouping */
+export type RecommendationCategoryKey =
+  | 'critical_issues'
+  | 'quick_wins'
+  | 'workflow_hardening'
+  | 'best_practices'
+
+/** Source of the recommendation */
+export type RecommendationSource = 'scorecard' | 'direct_check'
+
+/** A static catalog entry for a known security check */
+export interface RecommendationCatalogEntry {
+  /** Scorecard check name or direct check name */
+  key: string
+  /** Whether this covers a Scorecard check or direct check */
+  source: RecommendationSource
+  /** Descriptive, action-oriented title */
+  title: string
+  /** Risk classification from OpenSSF documentation */
+  riskLevel: RiskLevel
+  /** Which category this recommendation belongs to */
+  groupCategory: RecommendationCategoryKey
+  /** Why a low score or missing signal matters */
+  whyItMatters: string
+  /** Recommended action to address the finding */
+  remediation: string
+  /** Brief practical hint for common fixes, or null */
+  remediationHint: string | null
+  /** URL to relevant OpenSSF Scorecard check docs, or null */
+  docsUrl: string | null
+  /** Corresponding direct check name for deduplication, or null */
+  directCheckMapping: string | null
+}
+
+/** Category definition for display ordering */
+export interface RecommendationCategoryDefinition {
+  key: RecommendationCategoryKey
+  label: string
+  order: number
+}
+
+/** Enriched recommendation for UI display in the Security tab */
+export interface EnrichedSecurityRecommendationDisplay {
+  /** Descriptive action-oriented title */
+  title: string
+  /** Source label for attribution */
+  source: RecommendationSource
+  /** Risk classification */
+  riskLevel: RiskLevel
+  /** Repo-specific evidence (e.g., "Token-Permissions scored 0/10") */
+  evidence: string
+  /** Why this finding matters */
+  explanation: string
+  /** Recommended action */
+  remediation: string
+  /** Brief practical hint, or null */
+  remediationHint: string | null
+  /** Link to OpenSSF check docs, or null */
+  docsUrl: string | null
+  /** Category key for grouping */
+  groupCategory: RecommendationCategoryKey
+}
+
+/** Props for the categorized recommendations section in SecurityView */
+export interface SecurityRecommendationsSectionProps {
+  /** Recommendations grouped by category, in display order */
+  groups: Array<{
+    category: RecommendationCategoryDefinition
+    recommendations: EnrichedSecurityRecommendationDisplay[]
+  }>
+}

--- a/specs/156-security-recommendations/data-model.md
+++ b/specs/156-security-recommendations/data-model.md
@@ -1,0 +1,92 @@
+# Data Model: Richer Security Recommendations
+
+## Entities
+
+### RecommendationCatalogEntry
+
+A static catalog entry mapping a Scorecard check name or direct check name to structured recommendation metadata. Defined once, shipped with the application.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| key | string | Scorecard check name (e.g., "Token-Permissions") or direct check name (e.g., "security_policy") |
+| source | "scorecard" or "direct_check" | Whether this entry covers a Scorecard check or a direct check |
+| title | string | Descriptive, action-oriented recommendation title (e.g., "Restrict GitHub Actions token permissions") |
+| riskLevel | "Critical" or "High" or "Medium" or "Low" | Risk classification from OpenSSF Scorecard documentation |
+| groupCategory | "critical_issues" or "quick_wins" or "workflow_hardening" or "best_practices" | Which recommendation category this entry belongs to (may be overridden at generation time based on score) |
+| whyItMatters | string | Explanation of why a low score or missing signal is a risk |
+| remediation | string | Recommended action to address the finding |
+| remediationHint | string or null | Brief practical hint (e.g., "Add `permissions: read-all` at the top of workflow files") |
+| docsUrl | string or null | URL to the relevant OpenSSF Scorecard check documentation |
+| directCheckMapping | string or null | If this is a Scorecard entry, the corresponding direct check name for deduplication (e.g., "security_policy" for "Security-Policy") |
+
+### SecurityRecommendation (extended)
+
+The existing SecurityRecommendation interface extended with structured fields. All new fields are optional to preserve backward compatibility.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| bucket | "security" | Always "security" (unchanged) |
+| category | "scorecard" or "direct_check" | Source category (unchanged) |
+| item | string | Check name (unchanged) |
+| weight | number | Sorting weight (unchanged) |
+| text | string | Full recommendation text — continues to serve as the message source for HealthScoreRecommendation (unchanged) |
+| title | string or undefined | Descriptive action-oriented title (new) |
+| riskLevel | "Critical" or "High" or "Medium" or "Low" or undefined | Risk classification (new) |
+| evidence | string or undefined | Repo-specific evidence string (e.g., "Token-Permissions scored 0/10") (new) |
+| explanation | string or undefined | Why this finding matters (new) |
+| remediationHint | string or undefined | Brief practical remediation hint (new) |
+| docsUrl | string or undefined | Link to OpenSSF check documentation (new) |
+| groupCategory | "critical_issues" or "quick_wins" or "workflow_hardening" or "best_practices" or undefined | Recommendation category for grouping — computed from risk level + score (new) |
+
+### RecommendationCategory
+
+A labeled group used to organize recommendations in the UI.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| key | string | Machine-readable identifier (e.g., "quick_wins") |
+| label | string | Display label (e.g., "Quick Wins") |
+| order | number | Sort order for display (lower = first) |
+
+### Category Definitions (Static)
+
+| Key | Label | Order | Description |
+|-----|-------|-------|-------------|
+| critical_issues | Critical Issues | 1 | Critical/High risk + low score (0–4) — urgent problems needing immediate attention |
+| quick_wins | Quick Wins | 2 | Low/Medium risk or score 5–9 with a clear simple fix — easy improvements |
+| workflow_hardening | Workflow Hardening | 3 | CI/CD, branch protection, token permissions at medium scores |
+| best_practices | Best Practices | 4 | Mature security practices like fuzzing, SAST, SBOM, signed releases |
+
+## Relationships
+
+```
+RecommendationCatalog (static, keyed by check name)
+  └── entries: RecommendationCatalogEntry[]
+
+SecurityResult (from analysis)
+  ├── scorecard: ScorecardAssessment | "unavailable"
+  │     └── checks: ScorecardCheck[]
+  └── directChecks: DirectSecurityCheck[]
+
+getSecurityScore() consumes both:
+  ├── For each Scorecard check scoring below 10 → lookup catalog entry → emit enriched SecurityRecommendation
+  ├── For each missing direct check → lookup catalog entry → emit enriched SecurityRecommendation
+  ├── Deduplication: if Scorecard entry has directCheckMapping → suppress the direct-check rec
+  └── Sort: by groupCategory order, then riskLevel severity, then weight
+
+SecurityView (UI)
+  └── groups recommendations by groupCategory
+        └── renders enriched fields (title, source, riskLevel, evidence, explanation, remediation, docsUrl)
+
+HealthScoreRecommendation (unchanged)
+  └── reads rec.text as message (backward compatible)
+```
+
+## Validation Rules
+
+- RecommendationCatalogEntry.key must be unique across the catalog
+- RecommendationCatalogEntry.riskLevel must be one of: "Critical", "High", "Medium", "Low"
+- RecommendationCatalogEntry.groupCategory must be one of: "critical_issues", "quick_wins", "workflow_hardening", "best_practices"
+- SecurityRecommendation.text must always be populated (backward compatibility)
+- SecurityRecommendation.groupCategory, when present, must match a defined category key
+- Deduplication: at most one recommendation per security concern (no Scorecard + direct-check duplicates)

--- a/specs/156-security-recommendations/plan.md
+++ b/specs/156-security-recommendations/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Richer Security Recommendations
+
+**Branch**: `156-security-recommendations` | **Date**: 2026-04-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/156-security-recommendations/spec.md`
+
+## Summary
+
+Replace the generic one-line security recommendation text with structured, OpenSSF Scorecard-sourced guidance. Build a static recommendation catalog keyed by check name, extend the `SecurityRecommendation` interface with enriched fields (title, risk level, evidence, explanation, remediation, docs link, category), add deduplication for overlapping Scorecard/direct checks, and render grouped recommendations in the Security tab.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Next.js 16+)
+**Primary Dependencies**: Next.js (App Router), Tailwind CSS, React
+**Storage**: N/A (stateless)
+**Testing**: Vitest, React Testing Library
+**Target Platform**: Web (Vercel deployment)
+**Project Type**: Web application
+**Performance Goals**: No additional API calls — catalog is static, recommendations are computed from existing analysis data
+**Constraints**: Backward compatible with `HealthScoreRecommendation` pipeline (rec.text → message)
+**Scale/Scope**: 17+ Scorecard check catalog entries + 4 direct check entries
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| I. Technology Stack | PASS | No new technologies — TypeScript, Next.js, Tailwind only |
+| II. Accuracy Policy | PASS | Recommendations derived from verified Scorecard scores and direct check results; no fabrication |
+| III. Data Source Rules | PASS | No new API calls; catalog is static, evidence comes from existing SecurityResult |
+| IV. Analyzer Module Boundary | PASS | Catalog and recommendation logic live in `lib/security/` — framework-agnostic |
+| VI. Scoring Thresholds | PASS | Recommendation threshold (score 0-4) preserved from existing config |
+| IX.6 YAGNI | PASS | Catalog covers only checks that exist in the current Scorecard API; no speculative entries |
+| IX.7 Keep It Simple | PASS | Static catalog object, no dynamic fetching, no external dependencies |
+| X. Security & Hygiene | PASS | No secrets involved; docs URLs are public |
+| XI. Testing (TDD) | PASS | Tests written first for catalog, score-config changes, and SecurityView rendering |
+
+**Post-Phase 1 re-check**: All gates still pass. The design adds a static catalog module and extends an existing interface with optional fields. No constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/156-security-recommendations/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── security-recommendation-props.ts  # Enriched recommendation types
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+lib/security/
+├── recommendation-catalog.ts    # NEW — Static catalog of check → recommendation metadata
+├── analysis-result.ts           # MODIFY — Extend SecurityRecommendation with optional enriched fields
+└── score-config.ts              # MODIFY — Replace inline rec generation with catalog lookups + deduplication
+
+components/security/
+└── SecurityView.tsx             # MODIFY — Add categorized recommendations rendering section
+
+components/recommendations/
+└── RecommendationsView.tsx      # MODIFY — Add 'Security' to BUCKET_COLORS
+
+specs/130-security-scoring/contracts/
+└── security-view-props.ts       # MODIFY — Update SecurityRecommendationDisplay
+
+lib/security/__tests__/
+├── recommendation-catalog.test.ts  # NEW — Catalog completeness and validity tests
+├── score-config.test.ts            # MODIFY — Add tests for enriched recs, deduplication, categorization
+└── ...
+
+components/security/
+└── SecurityView.test.tsx        # MODIFY — Add tests for grouped recommendation rendering
+```
+
+**Structure Decision**: All changes are within the existing `lib/security/` and `components/security/` directories. One new file (`recommendation-catalog.ts`) is added to house the static catalog, keeping it separate from scoring logic per FR-014.
+
+## Complexity Tracking
+
+No constitution violations to justify. The feature is additive — extends an existing interface and adds a static catalog module.

--- a/specs/156-security-recommendations/quickstart.md
+++ b/specs/156-security-recommendations/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Richer Security Recommendations
+
+## What this feature does
+
+Replaces the generic one-line security recommendations with structured, OpenSSF-sourced guidance. Each recommendation now includes a descriptive title, risk level, repo-specific evidence, an explanation of why the finding matters, a concrete remediation action, and a link to the relevant OpenSSF Scorecard documentation. Recommendations are grouped into categories (Quick Wins, Workflow Hardening, Release Integrity, Security Process).
+
+## Key files to modify
+
+| File | Change |
+|------|--------|
+| `lib/security/recommendation-catalog.ts` | **NEW** — Static catalog of recommendation entries keyed by check name |
+| `lib/security/analysis-result.ts` | Extend `SecurityRecommendation` with optional enriched fields |
+| `lib/security/score-config.ts` | Replace inline recommendation generation with catalog lookups; add deduplication |
+| `components/security/SecurityView.tsx` | Add categorized recommendations rendering section |
+| `components/recommendations/RecommendationsView.tsx` | Add 'Security' to BUCKET_COLORS |
+| `specs/130-security-scoring/contracts/security-view-props.ts` | Update `SecurityRecommendationDisplay` with enriched fields |
+
+## Key files NOT to modify
+
+| File | Reason |
+|------|--------|
+| `lib/scoring/health-score.ts` | Reads `rec.text` — backward compatible, no changes needed |
+| `lib/security/scorecard-client.ts` | Scorecard fetching is unchanged |
+| `lib/security/direct-checks.ts` | Direct check detection is unchanged |
+| `lib/analyzer/analyze.ts` | Security analysis pipeline is unchanged |
+
+## How to verify
+
+```bash
+npm test                    # Unit tests for catalog, score-config, SecurityView
+npm run lint                # Type checking and linting
+npm run build               # Build verification
+```
+
+Then manually analyze a repo with known security findings (e.g., a repo without SECURITY.md, with low Scorecard scores) and verify:
+1. Recommendations show structured fields (title, risk, evidence, explanation, action)
+2. Recommendations are grouped by category
+3. Each recommendation shows its source (OpenSSF Scorecard or Direct check)
+4. Scorecard-sourced recommendations include docs links
+5. Overlapping checks (e.g., Security-Policy) are deduplicated
+6. The Recommendations tab still works with security items alongside other dimensions

--- a/specs/156-security-recommendations/research.md
+++ b/specs/156-security-recommendations/research.md
@@ -1,0 +1,91 @@
+# Research: Richer Security Recommendations
+
+## R1: OpenSSF Scorecard Check Catalog
+
+**Decision**: Build a static recommendation catalog keyed by Scorecard check name, derived from the published OpenSSF Scorecard checks documentation at `https://github.com/ossf/scorecard/blob/main/docs/checks.md`.
+
+**Rationale**: The Scorecard documentation provides structured risk levels, descriptions, and remediation guidance for every check. Using this as the canonical source ensures recommendations are industry-standard rather than generic or invented. A static catalog shipped with the app avoids runtime dependencies on external documentation.
+
+**Alternatives considered**:
+- Fetch checks.md at runtime: Rejected — adds latency, fragility, and a new external dependency.
+- Generate recommendations from Scorecard `reason` strings only: Rejected — reason strings are terse and vary per repo; they work as evidence but not as remediation guidance.
+- Hardcode recommendation text inline in scoring logic: Rejected — current approach, and issue #140 specifically calls for a separate structured catalog.
+
+### Scorecard Checks to Catalog (Initial Set)
+
+| Check Name | Risk Level | Default Category | Docs Anchor | Notes |
+|------------|-----------|-----------------|-------------|-------|
+| Dangerous-Workflow | Critical | Critical Issues | #dangerous-workflow | Always critical regardless of score |
+| Webhooks | Critical | Critical Issues | #webhooks | Always critical regardless of score |
+| Branch-Protection | High | Workflow Hardening | #branch-protection | → Critical Issues if score 0–4 |
+| Binary-Artifacts | High | Best Practices | #binary-artifacts | → Critical Issues if score 0–4 |
+| Code-Review | High | Workflow Hardening | #code-review | → Critical Issues if score 0–4 |
+| Dependency-Update-Tool | High | Quick Wins | #dependency-update-tool | → Critical Issues if score 0–4 |
+| Signed-Releases | High | Best Practices | #signed-releases | → Critical Issues if score 0–4 |
+| Token-Permissions | High | Workflow Hardening | #token-permissions | → Critical Issues if score 0–4 |
+| Vulnerabilities | High | Best Practices | #vulnerabilities | → Critical Issues if score 0–4 |
+| Maintained | High | Best Practices | #maintained | → Critical Issues if score 0–4 |
+| Fuzzing | Medium | Best Practices | #fuzzing | |
+| Pinned-Dependencies | Medium | Workflow Hardening | #pinned-dependencies | |
+| SAST | Medium | Best Practices | #sast | |
+| Security-Policy | Medium | Quick Wins | #security-policy | |
+| Packaging | Medium | Best Practices | #packaging | |
+| CI-Tests | Low | Quick Wins | #ci-tests | |
+| License | Low | Quick Wins | #license | |
+
+**Category override logic**: A check's default category (from the catalog) may be promoted to "Critical Issues" at recommendation generation time if the check has Critical or High risk AND scores 0–4. This means the same check can land in different categories for different repos depending on their actual score.
+
+## R2: Category Grouping Strategy
+
+**Decision**: Group recommendations into 4 priority-driven categories: Critical Issues, Quick Wins, Workflow Hardening, and Best Practices. Category assignment is determined by a combination of risk level and score, not just by domain.
+
+**Rationale**: Maintainers want to know what to fix first. Priority-driven grouping answers "what's urgent?" (Critical Issues), "what's easy?" (Quick Wins), "what hardens my pipeline?" (Workflow Hardening), and "what's the next level?" (Best Practices). This is more actionable than domain-based grouping.
+
+**Category assignment logic**:
+- **Critical Issues**: Critical or High risk AND score 0–4 — urgent problems needing immediate attention
+- **Quick Wins**: Low or Medium risk, OR score 5–9 with a clear simple fix — easy improvements with good payoff
+- **Workflow Hardening**: CI/CD, branch protection, token permissions at medium scores — pipeline and process improvements
+- **Best Practices**: Everything else — mature security practices like fuzzing, SAST, SBOM, signed releases
+
+**Alternatives considered**:
+- Group by domain (Release Integrity, Security Process, etc.): Rejected — answers "what area?" but not "what first?".
+- Group by risk level only (Critical/High/Medium/Low): Rejected — a High-risk check at 8/10 doesn't need the same urgency as one at 1/10.
+- No grouping (flat list): Rejected — current approach, and #140 explicitly calls for grouping.
+
+## R3: Deduplication Strategy for Overlapping Checks
+
+**Decision**: When both a Scorecard check and a direct check cover the same security concern, emit a single recommendation that uses the Scorecard catalog entry (richer guidance) and annotates the evidence with both sources.
+
+**Rationale**: Scorecard catalog entries have more structured guidance. Showing both would confuse users with near-identical recommendations. The mapping of overlaps is small and static.
+
+**Known overlaps**:
+- `Security-Policy` (Scorecard) ↔ `security_policy` (direct check)
+- `Dependency-Update-Tool` (Scorecard) ↔ `dependabot` (direct check)
+- `CI-Tests` (Scorecard) ↔ `ci_cd` (direct check)
+- `Branch-Protection` (Scorecard) ↔ `branch_protection` (direct check)
+
+**Alternatives considered**:
+- Show both with different labels: Rejected — adds noise without value.
+- Always prefer direct check: Rejected — Scorecard entries are richer.
+
+## R4: Recommendation Threshold
+
+**Decision**: Generate Scorecard-based recommendations for any check scoring below 10 (i.e., 0–9), as long as the catalog has an entry with remediation guidance from OpenSSF. Generate direct-check recommendations when `detected === false`. Do not generate recommendations for indeterminate (-1), unavailable checks, or perfect scores (10/10).
+
+**Rationale**: If OpenSSF has clear remediation steps for a check, users should see them regardless of whether the score is 2 or 7. The structured fields (risk level, evidence with actual score) already convey severity — a recommendation for a 7/10 check naturally reads differently from a 1/10 check because the evidence says so. Withholding guidance for 5–9 scores leaves actionable improvements invisible.
+
+**Change from existing behavior**: The current code (score-config.ts lines 122-132) only generates recommendations for scores 0–4. This feature widens the threshold to 0–9 because the enriched catalog provides meaningful, OpenSSF-sourced guidance at every sub-perfect score level.
+
+**Alternatives considered**:
+- Keep threshold at 0–4 (existing behavior): Rejected — misses actionable findings where OpenSSF has clear remediation guidance.
+- Use different language tiers (0–4 strong, 5–9 soft): Rejected — unnecessary complexity; the score evidence and risk level already communicate severity naturally.
+
+## R5: Backward Compatibility with Health Score Integration
+
+**Decision**: Extend the existing `SecurityRecommendation` interface with new optional fields rather than replacing it. The `text` field continues to serve as the `message` source in `HealthScoreRecommendation`. New fields (`title`, `riskLevel`, `evidence`, `explanation`, `remediationHint`, `docsUrl`, `groupCategory`) are additive.
+
+**Rationale**: The health-score.ts integration (lines 106-114) reads `rec.text` to populate `HealthScoreRecommendation.message`. Breaking this contract would cascade changes across the entire recommendation pipeline. Adding optional fields is non-breaking.
+
+**Alternatives considered**:
+- New interface replacing SecurityRecommendation: Rejected — unnecessary breaking change.
+- Separate enriched recommendation type only for UI: Rejected — would require dual generation paths.

--- a/specs/156-security-recommendations/spec.md
+++ b/specs/156-security-recommendations/spec.md
@@ -19,7 +19,8 @@ A maintainer analyzes their repository and sees security recommendations enriche
 
 1. **Given** a repo with OpenSSF Scorecard data where `Token-Permissions` scored 0/10, **When** the user views security recommendations, **Then** the recommendation displays a descriptive title (e.g., "Restrict GitHub Actions token permissions"), source label ("OpenSSF Scorecard"), risk level, the actual score as evidence, an explanation of why overly broad tokens are risky, a specific remediation action, and a link to the relevant OpenSSF check documentation.
 2. **Given** a repo missing `SECURITY.md` (direct check), **When** the user views security recommendations, **Then** the recommendation displays a descriptive title, source label ("Direct check"), risk level, evidence that the file was not detected, why a security policy matters, and the recommended action to add one.
-3. **Given** a repo where all Scorecard checks score 7+ and all direct checks pass, **When** the user views security recommendations, **Then** no security recommendations are shown (existing behavior preserved).
+3. **Given** a repo where all Scorecard checks score 10/10 and all direct checks pass, **When** the user views security recommendations, **Then** no security recommendations are shown.
+4. **Given** a repo where a Scorecard check scores 7/10 and the catalog has remediation guidance for it, **When** the user views security recommendations, **Then** a recommendation is shown with the actual score as evidence and the OpenSSF remediation guidance.
 
 ---
 
@@ -33,7 +34,7 @@ A maintainer sees their security recommendations organized into meaningful categ
 
 **Acceptance Scenarios**:
 
-1. **Given** a repo with findings across multiple security domains (e.g., missing security policy, low token-permissions score, no dependency updates), **When** the user views the recommendations, **Then** recommendations are grouped under category headings rather than displayed as a flat list.
+1. **Given** a repo with a Critical-risk check scoring 0/10 and a Low-risk check scoring 8/10, **When** the user views the recommendations, **Then** the critical finding appears under "Critical Issues" and the low-risk finding appears under "Quick Wins" or "Best Practices", with Critical Issues displayed first.
 2. **Given** a repo with findings in only one category, **When** the user views the recommendations, **Then** only that single category heading is shown — empty categories are not displayed.
 
 ---
@@ -82,7 +83,7 @@ A maintainer sees actionable remediation snippets or links for common security f
 - **FR-001**: Each security recommendation MUST include structured fields: a descriptive title, source label (OpenSSF Scorecard or Direct check), risk level (Critical, High, Medium, Low), evidence string, why-it-matters explanation, and recommended action text.
 - **FR-002**: Recommendations sourced from OpenSSF Scorecard checks MUST use guidance derived from the published OpenSSF Scorecard checks documentation as the baseline for title, risk level, why-it-matters, and remediation text — not generic invented guidance.
 - **FR-003**: Each Scorecard-sourced recommendation MUST include a documentation link pointing to the relevant OpenSSF Scorecard check documentation.
-- **FR-004**: Recommendations MUST be grouped into meaningful categories. The initial categories are: Quick Wins, Workflow Hardening, Release Integrity, and Security Process. Each recommendation maps to exactly one category.
+- **FR-004**: Recommendations MUST be grouped into priority-driven categories. The initial categories are: Critical Issues (Critical/High risk + low score 0–4), Quick Wins (Low/Medium risk or high score 5–9 with a clear simple fix), Workflow Hardening (CI/CD, branch protection, token permissions at medium scores), and Best Practices (mature security practices like fuzzing, SAST, SBOM, signed releases). Each recommendation maps to exactly one category based on its risk level and score.
 - **FR-005**: Empty categories (no findings in that group) MUST NOT be displayed.
 - **FR-006**: Each recommendation MUST display a source label distinguishing between "OpenSSF Scorecard" and "Direct check" origins.
 - **FR-007**: When a security concern is covered by both a Scorecard check and a direct check, the system MUST deduplicate by presenting a single recommendation that prefers the richer Scorecard-sourced version when available.

--- a/specs/156-security-recommendations/spec.md
+++ b/specs/156-security-recommendations/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Richer Security Recommendations
+
+**Feature Branch**: `156-security-recommendations`  
+**Created**: 2026-04-13  
+**Status**: Draft  
+**Input**: GitHub Issue #140 — Build richer security recommendations on top of OpenSSF Scorecard guidance
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Structured Security Recommendations (Priority: P1)
+
+A maintainer analyzes their repository and sees security recommendations enriched with risk level, evidence from the actual analysis, an explanation of why the finding matters, and a concrete recommended action — instead of generic one-line guidance.
+
+**Why this priority**: The core value proposition of #140. Without structured recommendations, the security tab is just a score display. Structured fields turn findings into actionable remediation guidance.
+
+**Independent Test**: Can be fully tested by analyzing a repo with low-scoring Scorecard checks and missing direct checks, then verifying each recommendation shows the structured fields (title, source, risk level, evidence, why it matters, recommended action, and docs link where available).
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo with OpenSSF Scorecard data where `Token-Permissions` scored 0/10, **When** the user views security recommendations, **Then** the recommendation displays a descriptive title (e.g., "Restrict GitHub Actions token permissions"), source label ("OpenSSF Scorecard"), risk level, the actual score as evidence, an explanation of why overly broad tokens are risky, a specific remediation action, and a link to the relevant OpenSSF check documentation.
+2. **Given** a repo missing `SECURITY.md` (direct check), **When** the user views security recommendations, **Then** the recommendation displays a descriptive title, source label ("Direct check"), risk level, evidence that the file was not detected, why a security policy matters, and the recommended action to add one.
+3. **Given** a repo where all Scorecard checks score 7+ and all direct checks pass, **When** the user views security recommendations, **Then** no security recommendations are shown (existing behavior preserved).
+
+---
+
+### User Story 2 - Grouped Recommendations by Category (Priority: P2)
+
+A maintainer sees their security recommendations organized into meaningful categories (e.g., Quick Wins, Workflow Hardening, Release Integrity, Security Process) so they can prioritize which group to tackle first.
+
+**Why this priority**: Grouping transforms a flat list into a structured remediation plan. It helps maintainers focus on the highest-impact cluster of fixes instead of reading recommendations one by one.
+
+**Independent Test**: Can be tested by analyzing a repo with multiple low-scoring checks spanning different categories, then verifying recommendations are grouped under labeled category headings.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo with findings across multiple security domains (e.g., missing security policy, low token-permissions score, no dependency updates), **When** the user views the recommendations, **Then** recommendations are grouped under category headings rather than displayed as a flat list.
+2. **Given** a repo with findings in only one category, **When** the user views the recommendations, **Then** only that single category heading is shown — empty categories are not displayed.
+
+---
+
+### User Story 3 - Source Attribution and Finding Distinction (Priority: P2)
+
+A maintainer can clearly distinguish between recommendations sourced from OpenSSF Scorecard findings, direct repository checks performed by RepoPulse, and unavailable signals — so they understand the origin and confidence of each finding.
+
+**Why this priority**: Transparency about where findings come from builds trust. Maintainers need to know whether a recommendation is industry-standard (Scorecard) or app-specific (direct check).
+
+**Independent Test**: Can be tested by analyzing a repo with both Scorecard and direct-check findings, then verifying each recommendation is labeled with its source.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repo with both Scorecard and direct-check findings, **When** the user views recommendations, **Then** each recommendation displays a source label distinguishing "OpenSSF Scorecard" from "Direct check".
+2. **Given** a repo where Scorecard is unavailable (direct-only mode), **When** the user views recommendations, **Then** all recommendations are labeled as "Direct check" and no Scorecard-sourced recommendations appear.
+
+---
+
+### User Story 4 - Remediation Snippets and Documentation Links (Priority: P3)
+
+A maintainer sees actionable remediation snippets or links for common security fixes, helping them go from finding to fix without needing to research the solution.
+
+**Why this priority**: Reduces friction between seeing a recommendation and acting on it. Links and snippets are the last-mile value that differentiate RepoPulse from raw Scorecard output.
+
+**Independent Test**: Can be tested by analyzing a repo with specific low-scoring checks (e.g., missing `dependabot.yml`, missing `SECURITY.md`) and verifying relevant recommendations include remediation snippets or documentation links.
+
+**Acceptance Scenarios**:
+
+1. **Given** a recommendation for a check that has a known remediation snippet (e.g., adding `permissions:` blocks to workflows), **When** the user views the recommendation, **Then** the recommendation includes a brief remediation hint describing what to do.
+2. **Given** a recommendation sourced from an OpenSSF Scorecard check, **When** the user views the recommendation, **Then** the recommendation includes a link to the relevant OpenSSF Scorecard check documentation.
+
+---
+
+### Edge Cases
+
+- What happens when a Scorecard check returns an indeterminate score (-1)? Indeterminate checks should not generate recommendations since the finding is inconclusive.
+- What happens when a direct check is `unavailable`? Unavailable checks should not generate recommendations (preserve current behavior — don't penalize what can't be measured).
+- What happens when a repo has zero findings across both Scorecard and direct checks? The existing "no recommendations" messaging should be preserved.
+- What happens when the same security concern is flagged by both Scorecard and a direct check (e.g., Branch-Protection)? The recommendation should be deduplicated, preferring the richer Scorecard-sourced version when available.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Each security recommendation MUST include structured fields: a descriptive title, source label (OpenSSF Scorecard or Direct check), risk level (Critical, High, Medium, Low), evidence string, why-it-matters explanation, and recommended action text.
+- **FR-002**: Recommendations sourced from OpenSSF Scorecard checks MUST use guidance derived from the published OpenSSF Scorecard checks documentation as the baseline for title, risk level, why-it-matters, and remediation text — not generic invented guidance.
+- **FR-003**: Each Scorecard-sourced recommendation MUST include a documentation link pointing to the relevant OpenSSF Scorecard check documentation.
+- **FR-004**: Recommendations MUST be grouped into meaningful categories. The initial categories are: Quick Wins, Workflow Hardening, Release Integrity, and Security Process. Each recommendation maps to exactly one category.
+- **FR-005**: Empty categories (no findings in that group) MUST NOT be displayed.
+- **FR-006**: Each recommendation MUST display a source label distinguishing between "OpenSSF Scorecard" and "Direct check" origins.
+- **FR-007**: When a security concern is covered by both a Scorecard check and a direct check, the system MUST deduplicate by presenting a single recommendation that prefers the richer Scorecard-sourced version when available.
+- **FR-008**: Recommendations for checks with indeterminate Scorecard scores (-1) MUST NOT be generated.
+- **FR-009**: Recommendations for direct checks with `unavailable` detection status MUST NOT be generated (preserving current behavior).
+- **FR-010**: Where applicable, recommendations MUST include brief remediation hints describing common fixes (e.g., adding workflow permissions blocks, enabling Dependabot, adding a SECURITY.md file).
+- **FR-011**: Recommendations MUST be sorted within each category by risk level (Critical first, then High, Medium, Low), with weight as a tiebreaker.
+- **FR-012**: The recommendation catalog MUST cover at minimum the following OpenSSF Scorecard checks: Branch-Protection, Binary-Artifacts, CI-Tests, Dangerous-Workflow, Pinned-Dependencies, Signed-Releases, Token-Permissions, and Security-Policy — plus all four existing direct checks.
+- **FR-013**: The existing recommendation integration with the shared Recommendations tab and health score MUST continue to work — the richer recommendation data is additive, not breaking.
+- **FR-014**: The recommendation catalog MUST be defined in a structured data source (not hardcoded in scoring logic) so entries can be reviewed and maintained independently of the recommendation engine.
+
+### Key Entities
+
+- **SecurityRecommendation**: An enriched recommendation with title, source, risk level, evidence, explanation, remediation action, category, and optional documentation link and remediation hint.
+- **RecommendationCatalog**: A structured mapping from Scorecard check names and direct check types to their baseline recommendation metadata (title, risk level, category, why-it-matters template, remediation template, docs link).
+- **RecommendationCategory**: A labeled grouping (Quick Wins, Workflow Hardening, Release Integrity, Security Process) used to organize recommendations in the UI.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every security recommendation displayed to the user includes at minimum: a descriptive title, source label, risk level, evidence, explanation, and recommended action — no recommendation falls back to the previous generic one-line format.
+- **SC-002**: Recommendations for repos with Scorecard data are grouped into at least 2 distinct categories when findings span multiple security domains.
+- **SC-003**: Users can distinguish the source of every recommendation (OpenSSF Scorecard vs. Direct check) by reading the visible label without expanding or hovering.
+- **SC-004**: At least 8 OpenSSF Scorecard checks and 4 direct checks have catalog entries with complete structured guidance.
+- **SC-005**: Duplicate recommendations for the same security concern (covered by both Scorecard and direct check) are merged into a single entry.
+- **SC-006**: The existing Recommendations tab continues to render security recommendations alongside other scoring dimensions without regression.
+
+## Assumptions
+
+- The OpenSSF Scorecard checks documentation (https://github.com/ossf/scorecard/blob/main/docs/checks.md) is the authoritative reference for Scorecard check guidance. Recommendation catalog entries are derived from this source.
+- Risk levels for Scorecard checks are informed by the risk classifications in the Scorecard documentation (Critical, High, Medium, Low).
+- The recommendation catalog is static and ships with the application — it is not fetched dynamically from the OpenSSF API at runtime.
+- The existing `SecurityRecommendation` interface will be extended (not replaced) to include the new structured fields, maintaining backward compatibility with the health score integration.
+- Category assignments for each check are determined at catalog authoring time based on the nature of the remediation, not dynamically computed.
+- Remediation hints are brief textual descriptions, not executable code snippets or full file templates.

--- a/specs/156-security-recommendations/tasks.md
+++ b/specs/156-security-recommendations/tasks.md
@@ -19,9 +19,9 @@
 
 **Purpose**: Extend types and create the recommendation catalog data source
 
-- [ ] T001 Extend `SecurityRecommendation` interface with optional enriched fields (title, riskLevel, evidence, explanation, remediationHint, docsUrl, groupCategory) in `lib/security/analysis-result.ts`
-- [ ] T002 Add `RiskLevel`, `RecommendationCategoryKey`, and `RecommendationSource` types to `lib/security/analysis-result.ts`
-- [ ] T003 Update `SecurityRecommendationDisplay` in `specs/130-security-scoring/contracts/security-view-props.ts` with enriched fields matching the extended interface
+- [x] T001 Extend `SecurityRecommendation` interface with optional enriched fields (title, riskLevel, evidence, explanation, remediationHint, docsUrl, groupCategory) in `lib/security/analysis-result.ts`
+- [x] T002 Add `RiskLevel`, `RecommendationCategoryKey`, and `RecommendationSource` types to `lib/security/analysis-result.ts`
+- [x] T003 Update `SecurityRecommendationDisplay` in `specs/130-security-scoring/contracts/security-view-props.ts` with enriched fields matching the extended interface
 
 ---
 
@@ -35,14 +35,14 @@
 
 > **Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T004 [P] Write catalog completeness tests in `lib/security/__tests__/recommendation-catalog.test.ts`: verify catalog has entries for all 17 Scorecard checks listed in research.md, all 4 direct checks, each entry has all required fields, keys are unique, riskLevel and groupCategory values are valid
-- [ ] T005 [P] Write catalog deduplication mapping tests in `lib/security/__tests__/recommendation-catalog.test.ts`: verify the 4 known overlapping Scorecard entries (Security-Policy, Dependency-Update-Tool, CI-Tests, Branch-Protection) each have a `directCheckMapping` pointing to the correct direct check name
+- [x] T004 [P] Write catalog completeness tests in `lib/security/__tests__/recommendation-catalog.test.ts`: verify catalog has entries for all 17 Scorecard checks listed in research.md, all 4 direct checks, each entry has all required fields, keys are unique, riskLevel and groupCategory values are valid
+- [x] T005 [P] Write catalog deduplication mapping tests in `lib/security/__tests__/recommendation-catalog.test.ts`: verify the 4 known overlapping Scorecard entries (Security-Policy, Dependency-Update-Tool, CI-Tests, Branch-Protection) each have a `directCheckMapping` pointing to the correct direct check name
 
 ### Implementation
 
-- [ ] T006 Create `lib/security/recommendation-catalog.ts` with the static `RECOMMENDATION_CATALOG` array containing all 17 Scorecard check entries derived from OpenSSF Scorecard checks documentation (https://github.com/ossf/scorecard/blob/main/docs/checks.md) — each entry has: key, source, title, riskLevel, groupCategory, whyItMatters, remediation, remediationHint, docsUrl, directCheckMapping
-- [ ] T007 Add 4 direct check entries to `RECOMMENDATION_CATALOG` in `lib/security/recommendation-catalog.ts` for: security_policy, dependabot, ci_cd, branch_protection — each with source "direct_check", appropriate riskLevel, groupCategory, and null docsUrl/directCheckMapping
-- [ ] T008 Export `CATEGORY_DEFINITIONS` array in `lib/security/recommendation-catalog.ts` with the 4 categories (critical_issues order 1, quick_wins order 2, workflow_hardening order 3, best_practices order 4) and a `getCatalogEntry(key: string)` lookup helper
+- [x] T006 Create `lib/security/recommendation-catalog.ts` with the static `RECOMMENDATION_CATALOG` array containing all 17 Scorecard check entries derived from OpenSSF Scorecard checks documentation (https://github.com/ossf/scorecard/blob/main/docs/checks.md) — each entry has: key, source, title, riskLevel, groupCategory, whyItMatters, remediation, remediationHint, docsUrl, directCheckMapping
+- [x] T007 Add 4 direct check entries to `RECOMMENDATION_CATALOG` in `lib/security/recommendation-catalog.ts` for: security_policy, dependabot, ci_cd, branch_protection — each with source "direct_check", appropriate riskLevel, groupCategory, and null docsUrl/directCheckMapping
+- [x] T008 Export `CATEGORY_DEFINITIONS` array in `lib/security/recommendation-catalog.ts` with the 4 categories (critical_issues order 1, quick_wins order 2, workflow_hardening order 3, best_practices order 4) and a `getCatalogEntry(key: string)` lookup helper
 
 **Checkpoint**: Catalog is complete and tested. All 21 entries pass validation. Ready for scoring integration.
 
@@ -58,20 +58,20 @@
 
 > **Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T009 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring 3/10 with a catalog entry, `getSecurityScore()` returns a recommendation with title, riskLevel, evidence containing "scored 3/10", explanation, docsUrl, and groupCategory populated
-- [ ] T010 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a direct check with detected=false and a catalog entry, `getSecurityScore()` returns a recommendation with title, riskLevel, evidence containing "not detected", explanation, and groupCategory populated
-- [ ] T011 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given all Scorecard checks scoring 10/10 and all direct checks detected, `getSecurityScore()` returns zero recommendations
-- [ ] T012 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring 7/10 with a catalog entry, `getSecurityScore()` still returns a recommendation (threshold widened from 0-4 to 0-9)
-- [ ] T013 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check with indeterminate score (-1), no recommendation is generated for that check
-- [ ] T014 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring below 10 with NO catalog entry, no recommendation is generated (catalog entry required)
-- [ ] T015 [P] [US1] Write backward compatibility test in `lib/security/__tests__/score-config.test.ts`: enriched recommendations still have `text` field populated and `bucket: 'security'` so health-score.ts integration is unbroken
+- [x] T009 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring 3/10 with a catalog entry, `getSecurityScore()` returns a recommendation with title, riskLevel, evidence containing "scored 3/10", explanation, docsUrl, and groupCategory populated
+- [x] T010 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a direct check with detected=false and a catalog entry, `getSecurityScore()` returns a recommendation with title, riskLevel, evidence containing "not detected", explanation, and groupCategory populated
+- [x] T011 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given all Scorecard checks scoring 10/10 and all direct checks detected, `getSecurityScore()` returns zero recommendations
+- [x] T012 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring 7/10 with a catalog entry, `getSecurityScore()` still returns a recommendation (threshold widened from 0-4 to 0-9)
+- [x] T013 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check with indeterminate score (-1), no recommendation is generated for that check
+- [x] T014 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring below 10 with NO catalog entry, no recommendation is generated (catalog entry required)
+- [x] T015 [P] [US1] Write backward compatibility test in `lib/security/__tests__/score-config.test.ts`: enriched recommendations still have `text` field populated and `bucket: 'security'` so health-score.ts integration is unbroken
 
 ### Implementation for User Story 1
 
-- [ ] T016 [US1] Refactor `generateDirectCheckRecommendations()` in `lib/security/score-config.ts` to look up catalog entries via `getCatalogEntry()` and populate enriched fields (title, riskLevel, evidence as "{check.name} not detected", explanation from whyItMatters, remediationHint, docsUrl, groupCategory). Compose `text` field from title + remediation for backward compat.
-- [ ] T017 [US1] Refactor Scorecard recommendation generation in `lib/security/score-config.ts` (lines 118-132) to: widen threshold from score 0-4 to score 0-9, look up catalog entries via `getCatalogEntry()`, populate enriched fields (title, riskLevel, evidence as "{check.name} scored {score}/10", explanation, remediationHint, docsUrl, groupCategory), skip checks with no catalog entry, skip indeterminate (-1) scores. Compose `text` from title + remediation.
-- [ ] T018 [US1] Remove the `RECOMMENDATION_TEXT` constant from `lib/security/score-config.ts` (lines 24-29) — replaced by catalog entries
-- [ ] T019 [US1] Verify all T009-T015 tests pass after implementation
+- [x] T016 [US1] Refactor `generateDirectCheckRecommendations()` in `lib/security/score-config.ts` to look up catalog entries via `getCatalogEntry()` and populate enriched fields (title, riskLevel, evidence as "{check.name} not detected", explanation from whyItMatters, remediationHint, docsUrl, groupCategory). Compose `text` field from title + remediation for backward compat.
+- [x] T017 [US1] Refactor Scorecard recommendation generation in `lib/security/score-config.ts` (lines 118-132) to: widen threshold from score 0-4 to score 0-9, look up catalog entries via `getCatalogEntry()`, populate enriched fields (title, riskLevel, evidence as "{check.name} scored {score}/10", explanation, remediationHint, docsUrl, groupCategory), skip checks with no catalog entry, skip indeterminate (-1) scores. Compose `text` from title + remediation.
+- [x] T018 [US1] Remove the `RECOMMENDATION_TEXT` constant from `lib/security/score-config.ts` (lines 24-29) — replaced by catalog entries
+- [x] T019 [US1] Verify all T009-T015 tests pass after implementation
 
 **Checkpoint**: `getSecurityScore()` returns enriched recommendations with all structured fields. `text` backward compat preserved. Threshold widened to 0-9.
 
@@ -87,18 +87,18 @@
 
 > **Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T020 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a Critical-risk Scorecard check scoring 2/10, its groupCategory is "critical_issues" (promoted from default)
-- [ ] T021 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a High-risk Scorecard check scoring 3/10, its groupCategory is "critical_issues" (promoted from default)
-- [ ] T022 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a High-risk Scorecard check scoring 7/10, its groupCategory stays at its catalog default (NOT promoted to critical_issues)
-- [ ] T023 [P] [US2] Write sorting test in `lib/security/__tests__/score-config.test.ts`: recommendations are sorted by category order (critical_issues first, then quick_wins, workflow_hardening, best_practices), then by riskLevel severity within each category, then by weight
-- [ ] T024 [P] [US2] Write UI test in `components/security/SecurityView.test.tsx`: given recommendations spanning 3 categories, SecurityView renders 3 category sections with correct headings in display order, with empty categories omitted
+- [x] T020 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a Critical-risk Scorecard check scoring 2/10, its groupCategory is "critical_issues" (promoted from default)
+- [x] T021 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a High-risk Scorecard check scoring 3/10, its groupCategory is "critical_issues" (promoted from default)
+- [x] T022 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a High-risk Scorecard check scoring 7/10, its groupCategory stays at its catalog default (NOT promoted to critical_issues)
+- [x] T023 [P] [US2] Write sorting test in `lib/security/__tests__/score-config.test.ts`: recommendations are sorted by category order (critical_issues first, then quick_wins, workflow_hardening, best_practices), then by riskLevel severity within each category, then by weight
+- [x] T024 [P] [US2] Write UI test in `components/security/SecurityView.test.tsx`: given recommendations spanning 3 categories, SecurityView renders 3 category sections with correct headings in display order, with empty categories omitted
 
 ### Implementation for User Story 2
 
-- [ ] T025 [US2] Add category promotion logic to recommendation generation in `lib/security/score-config.ts`: after looking up catalog entry's default groupCategory, promote to "critical_issues" if riskLevel is Critical/High AND score is 0-4
-- [ ] T026 [US2] Update recommendation sorting in `lib/security/score-config.ts` to sort by: (1) category order (using CATEGORY_DEFINITIONS), (2) riskLevel severity (Critical > High > Medium > Low), (3) weight descending
-- [ ] T027 [US2] Add categorized recommendations rendering section to `components/security/SecurityView.tsx`: group recommendations by groupCategory, render each non-empty group under a labeled heading using CATEGORY_DEFINITIONS labels, display in category order
-- [ ] T028 [US2] Verify all T020-T024 tests pass after implementation
+- [x] T025 [US2] Add category promotion logic to recommendation generation in `lib/security/score-config.ts`: after looking up catalog entry's default groupCategory, promote to "critical_issues" if riskLevel is Critical/High AND score is 0-4
+- [x] T026 [US2] Update recommendation sorting in `lib/security/score-config.ts` to sort by: (1) category order (using CATEGORY_DEFINITIONS), (2) riskLevel severity (Critical > High > Medium > Low), (3) weight descending
+- [x] T027 [US2] Add categorized recommendations rendering section to `components/security/SecurityView.tsx`: group recommendations by groupCategory, render each non-empty group under a labeled heading using CATEGORY_DEFINITIONS labels, display in category order
+- [x] T028 [US2] Verify all T020-T024 tests pass after implementation
 
 **Checkpoint**: Recommendations are grouped into priority-driven categories. Critical Issues show first. Empty categories are hidden.
 
@@ -114,15 +114,15 @@
 
 > **Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T029 [P] [US3] Write deduplication test in `lib/security/__tests__/score-config.test.ts`: given Security-Policy Scorecard check scoring 5/10 AND security_policy direct check detected=false, only one recommendation is emitted (Scorecard version preferred) with evidence noting both sources
-- [ ] T030 [P] [US3] Write deduplication test for all 4 overlapping pairs in `lib/security/__tests__/score-config.test.ts`: Security-Policy/security_policy, Dependency-Update-Tool/dependabot, CI-Tests/ci_cd, Branch-Protection/branch_protection
-- [ ] T031 [P] [US3] Write UI test in `components/security/SecurityView.test.tsx`: each rendered recommendation card shows a visible source label ("OpenSSF Scorecard" or "Direct check") without requiring hover or expansion
+- [x] T029 [P] [US3] Write deduplication test in `lib/security/__tests__/score-config.test.ts`: given Security-Policy Scorecard check scoring 5/10 AND security_policy direct check detected=false, only one recommendation is emitted (Scorecard version preferred) with evidence noting both sources
+- [x] T030 [P] [US3] Write deduplication test for all 4 overlapping pairs in `lib/security/__tests__/score-config.test.ts`: Security-Policy/security_policy, Dependency-Update-Tool/dependabot, CI-Tests/ci_cd, Branch-Protection/branch_protection
+- [x] T031 [P] [US3] Write UI test in `components/security/SecurityView.test.tsx`: each rendered recommendation card shows a visible source label ("OpenSSF Scorecard" or "Direct check") without requiring hover or expansion
 
 ### Implementation for User Story 3
 
-- [ ] T032 [US3] Add deduplication logic to `getSecurityScore()` in `lib/security/score-config.ts`: after generating all Scorecard recommendations, collect the set of direct check names that are covered by Scorecard entries with `directCheckMapping`. Suppress direct-check recommendations for those names. For deduplicated entries, append "Also confirmed by direct repository check" to evidence.
-- [ ] T033 [US3] Add source label rendering to the recommendation cards in `components/security/SecurityView.tsx`: display "OpenSSF Scorecard" or "Direct check" as a visible badge/label on each recommendation, using the `category` field
-- [ ] T034 [US3] Verify all T029-T031 tests pass after implementation
+- [x] T032 [US3] Add deduplication logic to `getSecurityScore()` in `lib/security/score-config.ts`: after generating all Scorecard recommendations, collect the set of direct check names that are covered by Scorecard entries with `directCheckMapping`. Suppress direct-check recommendations for those names. For deduplicated entries, append "Also confirmed by direct repository check" to evidence.
+- [x] T033 [US3] Add source label rendering to the recommendation cards in `components/security/SecurityView.tsx`: display "OpenSSF Scorecard" or "Direct check" as a visible badge/label on each recommendation, using the `category` field
+- [x] T034 [US3] Verify all T029-T031 tests pass after implementation
 
 **Checkpoint**: Source attribution is visible on every recommendation. Duplicates are merged.
 
@@ -138,15 +138,15 @@
 
 > **Write these tests FIRST, ensure they FAIL before implementation**
 
-- [ ] T035 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with a non-null remediationHint, the hint text is rendered in the recommendation card
-- [ ] T036 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with a non-null docsUrl, a clickable link to the OpenSSF Scorecard docs is rendered
-- [ ] T037 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with null remediationHint and null docsUrl, no hint section or link is rendered (graceful absence)
+- [x] T035 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with a non-null remediationHint, the hint text is rendered in the recommendation card
+- [x] T036 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with a non-null docsUrl, a clickable link to the OpenSSF Scorecard docs is rendered
+- [x] T037 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with null remediationHint and null docsUrl, no hint section or link is rendered (graceful absence)
 
 ### Implementation for User Story 4
 
-- [ ] T038 [US4] Add remediation hint rendering to recommendation cards in `components/security/SecurityView.tsx`: when `remediationHint` is non-null, render it as a distinct visual element (e.g., a light-background tip box) below the main remediation text
-- [ ] T039 [US4] Add documentation link rendering to recommendation cards in `components/security/SecurityView.tsx`: when `docsUrl` is non-null, render a clickable "OpenSSF Scorecard docs" link that opens in a new tab
-- [ ] T040 [US4] Verify all T035-T037 tests pass after implementation
+- [x] T038 [US4] Add remediation hint rendering to recommendation cards in `components/security/SecurityView.tsx`: when `remediationHint` is non-null, render it as a distinct visual element (e.g., a light-background tip box) below the main remediation text
+- [x] T039 [US4] Add documentation link rendering to recommendation cards in `components/security/SecurityView.tsx`: when `docsUrl` is non-null, render a clickable "OpenSSF Scorecard docs" link that opens in a new tab
+- [x] T040 [US4] Verify all T035-T037 tests pass after implementation
 
 **Checkpoint**: Recommendations show remediation hints and docs links where available.
 
@@ -156,10 +156,10 @@
 
 **Purpose**: Fix the missing Security color, ensure backward compat, and final validation
 
-- [ ] T041 [P] Add `Security: 'bg-red-100 text-red-800'` to `BUCKET_COLORS` in `components/recommendations/RecommendationsView.tsx`
-- [ ] T042 [P] Write integration test in `lib/security/__tests__/score-config.test.ts`: verify that enriched recommendations produced by `getSecurityScore()` are consumable by `getHealthScore()` — the `text` field maps to `HealthScoreRecommendation.message` without errors
-- [ ] T043 Run `npm test` and verify all existing + new tests pass
-- [ ] T044 Run `npm run lint` and `npm run build` to verify no type errors or build failures
+- [x] T041 [P] Add `Security: 'bg-red-100 text-red-800'` to `BUCKET_COLORS` in `components/recommendations/RecommendationsView.tsx`
+- [x] T042 [P] Write integration test in `lib/security/__tests__/score-config.test.ts`: verify that enriched recommendations produced by `getSecurityScore()` are consumable by `getHealthScore()` — the `text` field maps to `HealthScoreRecommendation.message` without errors
+- [x] T043 Run `npm test` and verify all existing + new tests pass
+- [x] T044 Run `npm run lint` and `npm run build` to verify no type errors or build failures
 - [ ] T045 Run quickstart.md manual verification: analyze a repo with known security findings and verify all 6 verification steps from quickstart.md
 
 ---

--- a/specs/156-security-recommendations/tasks.md
+++ b/specs/156-security-recommendations/tasks.md
@@ -1,0 +1,254 @@
+# Tasks: Richer Security Recommendations
+
+**Input**: Design documents from `/specs/156-security-recommendations/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Required — constitution Section XI mandates TDD (Red-Green-Refactor).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Extend types and create the recommendation catalog data source
+
+- [ ] T001 Extend `SecurityRecommendation` interface with optional enriched fields (title, riskLevel, evidence, explanation, remediationHint, docsUrl, groupCategory) in `lib/security/analysis-result.ts`
+- [ ] T002 Add `RiskLevel`, `RecommendationCategoryKey`, and `RecommendationSource` types to `lib/security/analysis-result.ts`
+- [ ] T003 Update `SecurityRecommendationDisplay` in `specs/130-security-scoring/contracts/security-view-props.ts` with enriched fields matching the extended interface
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the static recommendation catalog — all user stories depend on this
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+### Tests
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T004 [P] Write catalog completeness tests in `lib/security/__tests__/recommendation-catalog.test.ts`: verify catalog has entries for all 17 Scorecard checks listed in research.md, all 4 direct checks, each entry has all required fields, keys are unique, riskLevel and groupCategory values are valid
+- [ ] T005 [P] Write catalog deduplication mapping tests in `lib/security/__tests__/recommendation-catalog.test.ts`: verify the 4 known overlapping Scorecard entries (Security-Policy, Dependency-Update-Tool, CI-Tests, Branch-Protection) each have a `directCheckMapping` pointing to the correct direct check name
+
+### Implementation
+
+- [ ] T006 Create `lib/security/recommendation-catalog.ts` with the static `RECOMMENDATION_CATALOG` array containing all 17 Scorecard check entries derived from OpenSSF Scorecard checks documentation (https://github.com/ossf/scorecard/blob/main/docs/checks.md) — each entry has: key, source, title, riskLevel, groupCategory, whyItMatters, remediation, remediationHint, docsUrl, directCheckMapping
+- [ ] T007 Add 4 direct check entries to `RECOMMENDATION_CATALOG` in `lib/security/recommendation-catalog.ts` for: security_policy, dependabot, ci_cd, branch_protection — each with source "direct_check", appropriate riskLevel, groupCategory, and null docsUrl/directCheckMapping
+- [ ] T008 Export `CATEGORY_DEFINITIONS` array in `lib/security/recommendation-catalog.ts` with the 4 categories (critical_issues order 1, quick_wins order 2, workflow_hardening order 3, best_practices order 4) and a `getCatalogEntry(key: string)` lookup helper
+
+**Checkpoint**: Catalog is complete and tested. All 21 entries pass validation. Ready for scoring integration.
+
+---
+
+## Phase 3: User Story 1 - Structured Security Recommendations (Priority: P1) MVP
+
+**Goal**: Every security recommendation includes structured fields (title, source, risk level, evidence, explanation, remediation action, docs link) instead of generic one-line text.
+
+**Independent Test**: Analyze a repo with low-scoring Scorecard checks and missing direct checks; verify each recommendation shows all structured fields.
+
+### Tests for User Story 1
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T009 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring 3/10 with a catalog entry, `getSecurityScore()` returns a recommendation with title, riskLevel, evidence containing "scored 3/10", explanation, docsUrl, and groupCategory populated
+- [ ] T010 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a direct check with detected=false and a catalog entry, `getSecurityScore()` returns a recommendation with title, riskLevel, evidence containing "not detected", explanation, and groupCategory populated
+- [ ] T011 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given all Scorecard checks scoring 10/10 and all direct checks detected, `getSecurityScore()` returns zero recommendations
+- [ ] T012 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring 7/10 with a catalog entry, `getSecurityScore()` still returns a recommendation (threshold widened from 0-4 to 0-9)
+- [ ] T013 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check with indeterminate score (-1), no recommendation is generated for that check
+- [ ] T014 [P] [US1] Write test in `lib/security/__tests__/score-config.test.ts`: given a Scorecard check scoring below 10 with NO catalog entry, no recommendation is generated (catalog entry required)
+- [ ] T015 [P] [US1] Write backward compatibility test in `lib/security/__tests__/score-config.test.ts`: enriched recommendations still have `text` field populated and `bucket: 'security'` so health-score.ts integration is unbroken
+
+### Implementation for User Story 1
+
+- [ ] T016 [US1] Refactor `generateDirectCheckRecommendations()` in `lib/security/score-config.ts` to look up catalog entries via `getCatalogEntry()` and populate enriched fields (title, riskLevel, evidence as "{check.name} not detected", explanation from whyItMatters, remediationHint, docsUrl, groupCategory). Compose `text` field from title + remediation for backward compat.
+- [ ] T017 [US1] Refactor Scorecard recommendation generation in `lib/security/score-config.ts` (lines 118-132) to: widen threshold from score 0-4 to score 0-9, look up catalog entries via `getCatalogEntry()`, populate enriched fields (title, riskLevel, evidence as "{check.name} scored {score}/10", explanation, remediationHint, docsUrl, groupCategory), skip checks with no catalog entry, skip indeterminate (-1) scores. Compose `text` from title + remediation.
+- [ ] T018 [US1] Remove the `RECOMMENDATION_TEXT` constant from `lib/security/score-config.ts` (lines 24-29) — replaced by catalog entries
+- [ ] T019 [US1] Verify all T009-T015 tests pass after implementation
+
+**Checkpoint**: `getSecurityScore()` returns enriched recommendations with all structured fields. `text` backward compat preserved. Threshold widened to 0-9.
+
+---
+
+## Phase 4: User Story 2 - Grouped Recommendations by Category (Priority: P2)
+
+**Goal**: Recommendations are organized into priority-driven categories (Critical Issues, Quick Wins, Workflow Hardening, Best Practices) with dynamic promotion based on risk level + score.
+
+**Independent Test**: Analyze a repo with findings spanning multiple risk/score combinations; verify recommendations are grouped under correct category headings in the correct display order.
+
+### Tests for User Story 2
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T020 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a Critical-risk Scorecard check scoring 2/10, its groupCategory is "critical_issues" (promoted from default)
+- [ ] T021 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a High-risk Scorecard check scoring 3/10, its groupCategory is "critical_issues" (promoted from default)
+- [ ] T022 [P] [US2] Write category assignment test in `lib/security/__tests__/score-config.test.ts`: given a High-risk Scorecard check scoring 7/10, its groupCategory stays at its catalog default (NOT promoted to critical_issues)
+- [ ] T023 [P] [US2] Write sorting test in `lib/security/__tests__/score-config.test.ts`: recommendations are sorted by category order (critical_issues first, then quick_wins, workflow_hardening, best_practices), then by riskLevel severity within each category, then by weight
+- [ ] T024 [P] [US2] Write UI test in `components/security/SecurityView.test.tsx`: given recommendations spanning 3 categories, SecurityView renders 3 category sections with correct headings in display order, with empty categories omitted
+
+### Implementation for User Story 2
+
+- [ ] T025 [US2] Add category promotion logic to recommendation generation in `lib/security/score-config.ts`: after looking up catalog entry's default groupCategory, promote to "critical_issues" if riskLevel is Critical/High AND score is 0-4
+- [ ] T026 [US2] Update recommendation sorting in `lib/security/score-config.ts` to sort by: (1) category order (using CATEGORY_DEFINITIONS), (2) riskLevel severity (Critical > High > Medium > Low), (3) weight descending
+- [ ] T027 [US2] Add categorized recommendations rendering section to `components/security/SecurityView.tsx`: group recommendations by groupCategory, render each non-empty group under a labeled heading using CATEGORY_DEFINITIONS labels, display in category order
+- [ ] T028 [US2] Verify all T020-T024 tests pass after implementation
+
+**Checkpoint**: Recommendations are grouped into priority-driven categories. Critical Issues show first. Empty categories are hidden.
+
+---
+
+## Phase 5: User Story 3 - Source Attribution and Finding Distinction (Priority: P2)
+
+**Goal**: Each recommendation is clearly labeled with its source (OpenSSF Scorecard or Direct check).
+
+**Independent Test**: Analyze a repo with both Scorecard and direct-check findings; verify each recommendation shows a visible source label.
+
+### Tests for User Story 3
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T029 [P] [US3] Write deduplication test in `lib/security/__tests__/score-config.test.ts`: given Security-Policy Scorecard check scoring 5/10 AND security_policy direct check detected=false, only one recommendation is emitted (Scorecard version preferred) with evidence noting both sources
+- [ ] T030 [P] [US3] Write deduplication test for all 4 overlapping pairs in `lib/security/__tests__/score-config.test.ts`: Security-Policy/security_policy, Dependency-Update-Tool/dependabot, CI-Tests/ci_cd, Branch-Protection/branch_protection
+- [ ] T031 [P] [US3] Write UI test in `components/security/SecurityView.test.tsx`: each rendered recommendation card shows a visible source label ("OpenSSF Scorecard" or "Direct check") without requiring hover or expansion
+
+### Implementation for User Story 3
+
+- [ ] T032 [US3] Add deduplication logic to `getSecurityScore()` in `lib/security/score-config.ts`: after generating all Scorecard recommendations, collect the set of direct check names that are covered by Scorecard entries with `directCheckMapping`. Suppress direct-check recommendations for those names. For deduplicated entries, append "Also confirmed by direct repository check" to evidence.
+- [ ] T033 [US3] Add source label rendering to the recommendation cards in `components/security/SecurityView.tsx`: display "OpenSSF Scorecard" or "Direct check" as a visible badge/label on each recommendation, using the `category` field
+- [ ] T034 [US3] Verify all T029-T031 tests pass after implementation
+
+**Checkpoint**: Source attribution is visible on every recommendation. Duplicates are merged.
+
+---
+
+## Phase 6: User Story 4 - Remediation Snippets and Documentation Links (Priority: P3)
+
+**Goal**: Recommendations include brief remediation hints and clickable links to OpenSSF Scorecard check documentation.
+
+**Independent Test**: Analyze a repo with low-scoring checks; verify recommendations with catalog hints show them, and Scorecard-sourced recommendations link to the correct docs page.
+
+### Tests for User Story 4
+
+> **Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T035 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with a non-null remediationHint, the hint text is rendered in the recommendation card
+- [ ] T036 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with a non-null docsUrl, a clickable link to the OpenSSF Scorecard docs is rendered
+- [ ] T037 [P] [US4] Write UI test in `components/security/SecurityView.test.tsx`: given a recommendation with null remediationHint and null docsUrl, no hint section or link is rendered (graceful absence)
+
+### Implementation for User Story 4
+
+- [ ] T038 [US4] Add remediation hint rendering to recommendation cards in `components/security/SecurityView.tsx`: when `remediationHint` is non-null, render it as a distinct visual element (e.g., a light-background tip box) below the main remediation text
+- [ ] T039 [US4] Add documentation link rendering to recommendation cards in `components/security/SecurityView.tsx`: when `docsUrl` is non-null, render a clickable "OpenSSF Scorecard docs" link that opens in a new tab
+- [ ] T040 [US4] Verify all T035-T037 tests pass after implementation
+
+**Checkpoint**: Recommendations show remediation hints and docs links where available.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Fix the missing Security color, ensure backward compat, and final validation
+
+- [ ] T041 [P] Add `Security: 'bg-red-100 text-red-800'` to `BUCKET_COLORS` in `components/recommendations/RecommendationsView.tsx`
+- [ ] T042 [P] Write integration test in `lib/security/__tests__/score-config.test.ts`: verify that enriched recommendations produced by `getSecurityScore()` are consumable by `getHealthScore()` — the `text` field maps to `HealthScoreRecommendation.message` without errors
+- [ ] T043 Run `npm test` and verify all existing + new tests pass
+- [ ] T044 Run `npm run lint` and `npm run build` to verify no type errors or build failures
+- [ ] T045 Run quickstart.md manual verification: analyze a repo with known security findings and verify all 6 verification steps from quickstart.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — types only, can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (types must exist for catalog)
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (catalog must exist for lookups)
+- **User Story 2 (Phase 4)**: Depends on Phase 3 (enriched recs must exist for grouping)
+- **User Story 3 (Phase 5)**: Depends on Phase 3 (enriched recs must exist for deduplication)
+- **User Story 4 (Phase 6)**: Depends on Phase 3 (enriched recs must exist for UI rendering)
+- **Polish (Phase 7)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational only — core MVP
+- **US2 (P2)**: Depends on US1 — needs enriched recs with groupCategory
+- **US3 (P2)**: Depends on US1 — needs enriched recs with category field for source labels + deduplication
+- **US4 (P3)**: Depends on US1 — needs enriched recs with remediationHint and docsUrl
+
+**Note**: US2 and US3 are both P2 and can run in parallel once US1 is complete (they modify different concerns: grouping vs. source attribution). US4 can also run in parallel with US2/US3.
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation (TDD per constitution XI)
+- Implementation follows test specifications
+- All tests must pass before checkpoint
+
+### Parallel Opportunities
+
+- T004, T005 can run in parallel (different test concerns, same file)
+- T009–T015 can all run in parallel (independent test cases)
+- T020–T024 can all run in parallel (independent test cases)
+- T029–T031 can all run in parallel (independent test cases)
+- T035–T037 can all run in parallel (independent test cases)
+- T041, T042 can run in parallel (different files)
+- US2, US3, US4 can run in parallel after US1 (if team capacity allows)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all tests in parallel (TDD — write first, verify they fail):
+T009: Scorecard check 3/10 → enriched recommendation fields
+T010: Direct check not detected → enriched recommendation fields
+T011: All checks perfect → zero recommendations
+T012: Scorecard check 7/10 → still generates recommendation (widened threshold)
+T013: Indeterminate score → no recommendation
+T014: No catalog entry → no recommendation
+T015: Backward compat → text field + bucket:'security' preserved
+
+# Then implement sequentially:
+T016: Refactor direct check recommendation generation
+T017: Refactor Scorecard recommendation generation
+T018: Remove old RECOMMENDATION_TEXT constant
+T019: Verify all tests pass
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Type extensions
+2. Complete Phase 2: Recommendation catalog
+3. Complete Phase 3: User Story 1 (enriched structured recommendations)
+4. **STOP and VALIDATE**: Test — every recommendation has structured fields, backward compat works
+5. This alone delivers the core value of #140
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Foundation ready (types + catalog)
+2. Add US1 → Structured recommendations (MVP!)
+3. Add US2 → Priority-driven grouping
+4. Add US3 → Source attribution + deduplication
+5. Add US4 → Remediation hints + docs links
+6. Polish → Security color fix, integration test, manual verification
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent concerns, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Constitution XI mandates TDD — all test tasks must complete before implementation tasks
+- The `text` field on SecurityRecommendation MUST remain populated for backward compat with health-score.ts
+- Catalog entries are derived from OpenSSF Scorecard checks.md — not invented


### PR DESCRIPTION
## Summary

Closes #140

- Build a 21-entry static recommendation catalog (17 OpenSSF Scorecard checks + 4 direct checks) derived from [OpenSSF Scorecard checks.md](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
- Each recommendation now includes: title, risk level, evidence (actual score), explanation, remediation hint, and docs link — replacing generic one-line text
- Widen recommendation threshold from score 0-4 to 0-9 (any sub-perfect score with OpenSSF remediation guidance)
- Priority-driven category grouping: Critical Issues, Quick Wins, Workflow Hardening, Best Practices
- Dynamic category promotion: Critical/High risk + score 0-4 automatically promoted to Critical Issues
- Deduplication for 4 overlapping Scorecard/direct check pairs (Security-Policy, Dependency-Update-Tool, CI-Tests, Branch-Protection)
- Enriched rendering in the Recommendations tab with source labels, risk badges, hint boxes, and OpenSSF docs links
- Security bucket color fix in RecommendationsView (was fallback gray, now red)

## Test plan

- [x] (pallets/flask) Analyze a repo with low-scoring Scorecard checks — verify structured fields on each recommendation
- [x] (expressjs/express) Analyze a repo missing SECURITY.md — verify "Direct check" label and "not detected" evidence
- [x] (pallets/flask) Verify Critical Issues category appears first with promoted High-risk checks scoring 0-4
- [x] (expressjs/express) Verify empty categories are not displayed
- [x] (pallets/flask) Verify Signed-Releases 6/10 (High) stays in Best Practices, not promoted to Critical Issues
- [x] (pallets/flask) Verify Security-Policy deduplication — single entry with "Also confirmed by direct repository check"
- [x] (arun-gupta/docker-images) Analyze a repo where Scorecard is unavailable — verify all recs show "Direct check" label
- [x] (expressjs/express, pallets/flask) Verify remediation hints (blue boxes) and OpenSSF docs links render correctly
- [x] (expressjs/express, pallets/flask) Verify Security bucket in Recommendations tab has red color styling
- [x] Run `npm test` — 444 tests pass across 64 test files
- [x] Run `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)