### PR TITLE
Add tooltip showing accepted repo input formats

### DIFF
--- a/components/repo-input/RepoInputForm.test.tsx
+++ b/components/repo-input/RepoInputForm.test.tsx
@@ -41,6 +41,48 @@ describe('RepoInputForm — US1 (valid input)', () => {
   })
 })
 
+describe('RepoInputForm — format tooltip', () => {
+  it('renders an info button for accepted formats', () => {
+    render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /accepted input formats/i })).toBeInTheDocument()
+  })
+
+  it('shows tooltip on hover with accepted formats', async () => {
+    render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)
+    const infoBtn = screen.getByRole('button', { name: /accepted input formats/i })
+    await userEvent.hover(infoBtn)
+    const tooltip = screen.getByTestId('format-tooltip')
+    expect(tooltip).toBeInTheDocument()
+    expect(tooltip).toHaveTextContent('owner/repo')
+    expect(tooltip).toHaveTextContent('https://github.com/owner/repo')
+    expect(tooltip).toHaveTextContent('.git')
+  })
+
+  it('hides tooltip on unhover', async () => {
+    render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)
+    const infoBtn = screen.getByRole('button', { name: /accepted input formats/i })
+    await userEvent.hover(infoBtn)
+    expect(screen.getByTestId('format-tooltip')).toBeInTheDocument()
+    await userEvent.unhover(infoBtn)
+    expect(screen.queryByTestId('format-tooltip')).not.toBeInTheDocument()
+  })
+
+  it('closes tooltip when clicking outside', async () => {
+    render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)
+    const infoBtn = screen.getByRole('button', { name: /accepted input formats/i })
+    await userEvent.hover(infoBtn)
+    expect(screen.getByTestId('format-tooltip')).toBeInTheDocument()
+    await userEvent.click(document.body)
+    expect(screen.queryByTestId('format-tooltip')).not.toBeInTheDocument()
+  })
+
+  it('does not show tooltip in organization mode', async () => {
+    render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: /organization/i }))
+    expect(screen.queryByRole('button', { name: /accepted input formats/i })).not.toBeInTheDocument()
+  })
+})
+
 describe('RepoInputForm — US2 (invalid input)', () => {
   it('shows inline error on empty submission', async () => {
     render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -24,7 +24,20 @@ export function RepoInputForm({
   const [orgValue, setOrgValue] = useState('')
   const [error, setError] = useState<string | null>(null)
   const repoTextareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [tooltipOpen, setTooltipOpen] = useState(false)
+  const tooltipRef = useRef<HTMLDivElement | null>(null)
   const mode = controlledMode ?? uncontrolledMode
+
+  useEffect(() => {
+    if (!tooltipOpen) return
+    function handleClickOutside(e: MouseEvent) {
+      if (tooltipRef.current && !tooltipRef.current.contains(e.target as Node)) {
+        setTooltipOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [tooltipOpen])
 
   useEffect(() => {
     if (mode !== 'repos' || !repoTextareaRef.current) return
@@ -95,6 +108,38 @@ export function RepoInputForm({
         </button>
       </div>
       {mode === 'repos' ? (
+        <div className="relative">
+          <div className="mb-1 flex items-center justify-end">
+            <div ref={tooltipRef} className="relative">
+              <button
+                type="button"
+                aria-label="Accepted input formats"
+                className="flex h-5 w-5 items-center justify-center rounded-full text-slate-400 hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                onMouseEnter={() => setTooltipOpen(true)}
+                onMouseLeave={() => setTooltipOpen(false)}
+                onTouchStart={() => setTooltipOpen((prev) => !prev)}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4" aria-hidden="true">
+                  <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0ZM8.94 6.94a.75.75 0 1 1-1.061-1.061 2.75 2.75 0 1 1 3.871 3.871.75.75 0 0 1-.25.177.75.75 0 0 0-.45.688v.19a.75.75 0 0 1-1.5 0v-.19a2.25 2.25 0 0 1 1.35-2.064A1.25 1.25 0 0 0 8.94 6.94ZM10 15a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+                </svg>
+              </button>
+              {tooltipOpen && (
+                <div
+                  role="tooltip"
+                  data-testid="format-tooltip"
+                  className="absolute right-0 top-full z-10 mt-1 w-72 rounded-lg border border-slate-200 bg-white p-3 text-sm text-slate-700 shadow-lg"
+                >
+                  <p className="mb-2 font-medium text-slate-900">Accepted formats</p>
+                  <ul className="space-y-1 font-mono text-xs">
+                    <li><span className="text-slate-500">Slug:</span> owner/repo</li>
+                    <li><span className="text-slate-500">URL:</span> https://github.com/owner/repo</li>
+                    <li><span className="text-slate-500">URL (.git):</span> https://github.com/owner/repo.git</li>
+                  </ul>
+                  <p className="mt-2 text-xs text-slate-500">Separate multiple repos with spaces, commas, or newlines.</p>
+                </div>
+              )}
+            </div>
+          </div>
         <textarea
           ref={repoTextareaRef}
           value={repoValue}
@@ -105,6 +150,7 @@ export function RepoInputForm({
           aria-label="Repository list"
           aria-describedby={error ? 'repo-input-error' : undefined}
         />
+        </div>
       ) : (
         <input
           value={orgValue}

--- a/lib/parse-repos.test.ts
+++ b/lib/parse-repos.test.ts
@@ -65,6 +65,16 @@ describe('parseRepos — valid input (US1)', () => {
     const result = parseRepos('facebook/react\nhttps://github.com/facebook/react')
     expect(result).toEqual({ valid: true, repos: ['facebook/react'] })
   })
+
+  it('extracts slug from a GitHub URL with .git suffix', () => {
+    const result = parseRepos('https://github.com/facebook/react.git')
+    expect(result).toEqual({ valid: true, repos: ['facebook/react'] })
+  })
+
+  it('extracts slug from a GitHub URL with .git suffix and trailing slash', () => {
+    const result = parseRepos('https://github.com/facebook/react.git/')
+    expect(result).toEqual({ valid: true, repos: ['facebook/react'] })
+  })
 })
 
 describe('parseRepos — invalid input (US2)', () => {

--- a/lib/parse-repos.ts
+++ b/lib/parse-repos.ts
@@ -2,7 +2,7 @@ export type ParseResult =
   | { valid: true; repos: string[] }
   | { valid: false; error: string }
 
-const GITHUB_URL_RE = /^https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+?)\/?$/
+const GITHUB_URL_RE = /^https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+?)(?:\.git)?\/?$/
 const SLUG_RE = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/
 
 function extractSlug(token: string): string {


### PR DESCRIPTION
## Summary
- Adds an info icon (?) near the repo input field that shows a tooltip on hover listing all accepted input formats: `owner/repo`, `https://github.com/owner/repo`, and `https://github.com/owner/repo.git`
- Updates the URL parser to accept `.git` suffixed GitHub URLs
- Tooltip is hover-activated on desktop, touch-togglable on mobile, and dismisses on click-outside

Closes #112

## Test plan
- [x] Hover over the `?` icon next to the repo input — tooltip appears with format list
- [x] Move mouse away — tooltip dismisses
- [x] Click outside the tooltip — it dismisses
- [x] Tooltip does not appear in Organization mode
- [x] Entering `https://github.com/owner/repo.git` is accepted and parsed correctly
- [x] Tooltip does not interfere with typing in the input box
- [x] Verify layout on narrow viewport (mobile-width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)