### PR TITLE
Add stable reference IDs to recommendations (SEC-1, DOC-3, etc.)

### DIFF
--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -5,6 +5,7 @@ import { getHealthScore } from '@/lib/scoring/health-score'
 import { getSecurityScore } from '@/lib/security/score-config'
 import type { SecurityRecommendation } from '@/lib/security/analysis-result'
 import { CATEGORY_DEFINITIONS } from '@/lib/security/recommendation-catalog'
+import { assignReferenceIds, resolveReferenceId } from '@/lib/recommendations/reference-id'
 
 interface RecommendationsViewProps {
   results: AnalysisResult[]
@@ -30,11 +31,16 @@ const SOURCE_LABELS: Record<string, string> = {
   direct_check: 'Direct check',
 }
 
-function SecurityRecommendationCard({ rec }: { rec: SecurityRecommendation }) {
+function SecurityRecommendationCard({ rec, referenceId }: { rec: SecurityRecommendation; referenceId?: string }) {
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-4">
       <div className="flex items-start justify-between gap-2">
-        <h4 className="text-sm font-semibold text-slate-900">{rec.title ?? rec.text}</h4>
+        <h4 className="text-sm font-semibold text-slate-900">
+          {referenceId ? (
+            <span className="mr-1.5 inline-flex rounded bg-slate-200 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-500">{referenceId}</span>
+          ) : null}
+          {rec.title ?? rec.text}
+        </h4>
         <div className="flex shrink-0 gap-1.5">
           {rec.riskLevel ? (
             <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${RISK_COLORS[rec.riskLevel] ?? ''}`}>
@@ -72,19 +78,25 @@ function SecurityRecommendationCard({ rec }: { rec: SecurityRecommendation }) {
 }
 
 function SecurityRecommendationsGroup({ recommendations }: { recommendations: SecurityRecommendation[] }) {
+  // Resolve catalog IDs — each rec's `item` field is the catalog key
+  const withIds = recommendations.map((rec, i) => ({
+    rec,
+    referenceId: resolveReferenceId(rec.item, 'Security', i + 1),
+  }))
+
   // Group by category
-  const groups = new Map<string, SecurityRecommendation[]>()
-  for (const rec of recommendations) {
-    const key = rec.groupCategory ?? 'best_practices'
+  const groups = new Map<string, typeof withIds>()
+  for (const entry of withIds) {
+    const key = entry.rec.groupCategory ?? 'best_practices'
     const group = groups.get(key) ?? []
-    group.push(rec)
+    group.push(entry)
     groups.set(key, group)
   }
 
   // Sort groups by CATEGORY_DEFINITIONS order
   const sortedGroups = CATEGORY_DEFINITIONS
     .filter((cat) => groups.has(cat.key))
-    .map((cat) => ({ category: cat, recs: groups.get(cat.key)! }))
+    .map((cat) => ({ category: cat, entries: groups.get(cat.key)! }))
 
   return (
     <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
@@ -95,12 +107,12 @@ function SecurityRecommendationsGroup({ recommendations }: { recommendations: Se
         <span className="text-xs text-slate-400">{recommendations.length} recommendation{recommendations.length !== 1 ? 's' : ''}</span>
       </div>
       <div className="mt-3 space-y-4">
-        {sortedGroups.map(({ category, recs }) => (
+        {sortedGroups.map(({ category, entries }) => (
           <div key={category.key}>
             <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">{category.label}</h4>
             <div className="space-y-2">
-              {recs.map((rec, i) => (
-                <SecurityRecommendationCard key={`${rec.item}-${i}`} rec={rec} />
+              {entries.map(({ rec, referenceId }) => (
+                <SecurityRecommendationCard key={`${rec.item}-${referenceId}`} rec={rec} referenceId={referenceId} />
               ))}
             </div>
           </div>
@@ -134,9 +146,12 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
           )
         }
 
+        // Assign reference IDs to non-security recs
+        const nonSecurityWithIds = assignReferenceIds(nonSecurityRecs)
+
         // Group non-security recs by bucket
-        const bucketGroups = new Map<string, typeof nonSecurityRecs>()
-        for (const rec of nonSecurityRecs) {
+        const bucketGroups = new Map<string, typeof nonSecurityWithIds>()
+        for (const rec of nonSecurityWithIds) {
           const group = bucketGroups.get(rec.bucket) ?? []
           group.push(rec)
           bucketGroups.set(rec.bucket, group)
@@ -167,7 +182,7 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
                   <ul className="mt-3 space-y-2">
                     {recs.map((rec, i) => (
                       <li key={i} className="flex items-start gap-2">
-                        <span className="mt-1 text-xs text-slate-400">&bull;</span>
+                        <span className="shrink-0 rounded bg-slate-200 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-500">{rec.referenceId}</span>
                         <p className="text-sm text-slate-700">{rec.message}</p>
                       </li>
                     ))}

--- a/lib/export/json-export.ts
+++ b/lib/export/json-export.ts
@@ -5,7 +5,10 @@ import { getSustainabilityScore } from '@/lib/contributors/score-config'
 import { buildContributorsViewModels } from '@/lib/contributors/view-model'
 import { buildHealthRatioRows } from '@/lib/health-ratios/view-model'
 import { getDocumentationScore } from '@/lib/documentation/score-config'
+import { assignReferenceIds, resolveReferenceId } from '@/lib/recommendations/reference-id'
 import { getResponsivenessScore } from '@/lib/responsiveness/score-config'
+import { getHealthScore } from '@/lib/scoring/health-score'
+import { getSecurityScore } from '@/lib/security/score-config'
 
 export interface JsonExportResult {
   blob: Blob
@@ -74,6 +77,32 @@ function computeContributors(result: AnalysisResult) {
   }
 }
 
+function computeRecommendations(result: AnalysisResult) {
+  const healthScore = getHealthScore(result)
+  const nonSecurityRecs = healthScore.recommendations.filter((r) => r.tab !== 'security')
+  const securityRecs = result.securityResult !== 'unavailable'
+    ? getSecurityScore(result.securityResult, result.stars).recommendations
+    : []
+
+  const nonSecurityWithIds = assignReferenceIds(nonSecurityRecs).map((r) => ({
+    referenceId: r.referenceId,
+    bucket: r.bucket,
+    message: r.message,
+  }))
+
+  const securityWithIds = securityRecs.map((rec, i) => ({
+    referenceId: resolveReferenceId(rec.item, 'Security', i + 1),
+    bucket: 'Security',
+    title: rec.title ?? rec.text,
+    riskLevel: rec.riskLevel,
+    category: rec.category,
+    evidence: rec.evidence,
+    remediationHint: rec.remediationHint,
+  }))
+
+  return [...nonSecurityWithIds, ...securityWithIds]
+}
+
 function computeComparison(results: AnalysisResult[]) {
   if (results.length < 2) return undefined
   return buildComparisonSections(results).map((section) => ({
@@ -103,6 +132,7 @@ export function buildJsonExport(response: AnalyzeResponse): JsonExportResult {
       scores: computeScores(result),
       contributors: computeContributors(result),
       healthRatios: computeHealthRatios(result),
+      recommendations: computeRecommendations(result),
     })),
     comparison: computeComparison(response.results),
   }

--- a/lib/export/markdown-export.ts
+++ b/lib/export/markdown-export.ts
@@ -7,7 +7,10 @@ import { getDocumentationScore } from '@/lib/documentation/score-config'
 import { buildContributorsViewModels } from '@/lib/contributors/view-model'
 import { buildSpectrumProfile } from '@/lib/ecosystem-map/classification'
 import { buildHealthRatioRows } from '@/lib/health-ratios/view-model'
+import { assignReferenceIds, resolveReferenceId } from '@/lib/recommendations/reference-id'
 import { formatHours, formatPercentage, getResponsivenessScore } from '@/lib/responsiveness/score-config'
+import { getHealthScore } from '@/lib/scoring/health-score'
+import { getSecurityScore } from '@/lib/security/score-config'
 import { encodeRepos } from '@/lib/export/shareable-url'
 
 export interface MarkdownExportResult {
@@ -331,6 +334,35 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
       })),
       '',
     )
+  }
+
+  // Recommendations section
+  const healthScore = getHealthScore(result)
+  const nonSecurityRecs = healthScore.recommendations.filter((r) => r.tab !== 'security')
+  const securityRecs = result.securityResult !== 'unavailable'
+    ? getSecurityScore(result.securityResult, result.stars).recommendations
+    : []
+
+  if (nonSecurityRecs.length > 0 || securityRecs.length > 0) {
+    lines.push('### Recommendations', '')
+
+    if (nonSecurityRecs.length > 0) {
+      const withIds = assignReferenceIds(nonSecurityRecs)
+      for (const rec of withIds) {
+        lines.push(`- **${rec.referenceId}** — ${rec.message}`)
+      }
+      lines.push('')
+    }
+
+    if (securityRecs.length > 0) {
+      for (const [i, rec] of securityRecs.entries()) {
+        const refId = resolveReferenceId(rec.item, 'Security', i + 1)
+        const title = rec.title ?? rec.text
+        const risk = rec.riskLevel ? ` [${rec.riskLevel}]` : ''
+        lines.push(`- **${refId}**${risk} — ${title}`)
+      }
+      lines.push('')
+    }
   }
 
   if (result.missingFields.length > 0) {

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { RECOMMENDATION_CATALOG, getCatalogId, getCatalogEntryByKey } from '../catalog'
+
+describe('RECOMMENDATION_CATALOG', () => {
+  it('has no duplicate IDs', () => {
+    const ids = RECOMMENDATION_CATALOG.map((e) => e.id)
+    expect(ids.length).toBe(new Set(ids).size)
+  })
+
+  it('has no duplicate keys', () => {
+    const keys = RECOMMENDATION_CATALOG.map((e) => e.key)
+    expect(keys.length).toBe(new Set(keys).size)
+  })
+
+  it('contains entries for all five buckets', () => {
+    const buckets = new Set(RECOMMENDATION_CATALOG.map((e) => e.bucket))
+    expect(buckets).toEqual(new Set(['Security', 'Activity', 'Responsiveness', 'Sustainability', 'Documentation']))
+  })
+
+  it('IDs follow the PREFIX-N pattern', () => {
+    for (const entry of RECOMMENDATION_CATALOG) {
+      expect(entry.id).toMatch(/^[A-Z]{3}-\d+$/)
+    }
+  })
+
+  it('IDs use the correct prefix for their bucket', () => {
+    const prefixMap: Record<string, string> = {
+      Security: 'SEC', Activity: 'ACT', Responsiveness: 'RSP',
+      Sustainability: 'SUS', Documentation: 'DOC',
+    }
+    for (const entry of RECOMMENDATION_CATALOG) {
+      const expectedPrefix = prefixMap[entry.bucket]
+      expect(entry.id.startsWith(`${expectedPrefix}-`)).toBe(true)
+    }
+  })
+
+  it('has 17 security entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Security')).toHaveLength(17)
+  })
+
+  it('has 4 activity entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Activity')).toHaveLength(4)
+  })
+
+  it('has 3 responsiveness entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Responsiveness')).toHaveLength(3)
+  })
+
+  it('has 2 sustainability entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Sustainability')).toHaveLength(2)
+  })
+
+  it('has 14 documentation entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Documentation')).toHaveLength(14)
+  })
+})
+
+describe('getCatalogId', () => {
+  it('returns ID for known keys', () => {
+    expect(getCatalogId('Dangerous-Workflow')).toBe('SEC-1')
+    expect(getCatalogId('pr_flow')).toBe('ACT-1')
+    expect(getCatalogId('file:readme')).toBe('DOC-1')
+  })
+
+  it('returns ID for direct-check aliases', () => {
+    expect(getCatalogId('branch_protection')).toBe('SEC-3')
+    expect(getCatalogId('dependabot')).toBe('SEC-6')
+    expect(getCatalogId('security_policy')).toBe('SEC-14')
+    expect(getCatalogId('ci_cd')).toBe('SEC-16')
+  })
+
+  it('returns undefined for unknown keys', () => {
+    expect(getCatalogId('nonexistent')).toBeUndefined()
+  })
+})
+
+describe('getCatalogEntryByKey', () => {
+  it('returns full entry for known keys', () => {
+    const entry = getCatalogEntryByKey('Token-Permissions')
+    expect(entry).toEqual({
+      id: 'SEC-8',
+      bucket: 'Security',
+      key: 'Token-Permissions',
+      title: 'Restrict GitHub Actions token permissions',
+    })
+  })
+
+  it('returns entry for alias keys', () => {
+    const entry = getCatalogEntryByKey('branch_protection')
+    expect(entry?.id).toBe('SEC-3')
+    expect(entry?.key).toBe('Branch-Protection')
+  })
+
+  it('returns undefined for unknown keys', () => {
+    expect(getCatalogEntryByKey('nonexistent')).toBeUndefined()
+  })
+})

--- a/lib/recommendations/__tests__/reference-id.test.ts
+++ b/lib/recommendations/__tests__/reference-id.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { assignReferenceIds, getBucketPrefix, resolveReferenceId } from '../reference-id'
+
+describe('getBucketPrefix', () => {
+  it.each([
+    ['Security', 'SEC'],
+    ['Activity', 'ACT'],
+    ['Responsiveness', 'RSP'],
+    ['Sustainability', 'SUS'],
+    ['Documentation', 'DOC'],
+  ])('maps %s to %s', (bucket, expected) => {
+    expect(getBucketPrefix(bucket)).toBe(expected)
+  })
+
+  it('falls back to first 3 uppercase chars for unknown buckets', () => {
+    expect(getBucketPrefix('Custom')).toBe('CUS')
+  })
+})
+
+describe('resolveReferenceId', () => {
+  it('returns catalog ID for known security keys', () => {
+    expect(resolveReferenceId('Dangerous-Workflow', 'Security', 1)).toBe('SEC-1')
+    expect(resolveReferenceId('Token-Permissions', 'Security', 99)).toBe('SEC-8')
+  })
+
+  it('returns catalog ID for direct-check aliases', () => {
+    expect(resolveReferenceId('branch_protection', 'Security', 1)).toBe('SEC-3')
+    expect(resolveReferenceId('dependabot', 'Security', 1)).toBe('SEC-6')
+    expect(resolveReferenceId('security_policy', 'Security', 1)).toBe('SEC-14')
+    expect(resolveReferenceId('ci_cd', 'Security', 1)).toBe('SEC-16')
+  })
+
+  it('returns catalog ID for activity keys', () => {
+    expect(resolveReferenceId('pr_flow', 'Activity', 1)).toBe('ACT-1')
+    expect(resolveReferenceId('sustained_activity', 'Activity', 1)).toBe('ACT-4')
+  })
+
+  it('returns catalog ID for responsiveness keys', () => {
+    expect(resolveReferenceId('response_time', 'Responsiveness', 1)).toBe('RSP-1')
+    expect(resolveReferenceId('backlog_health', 'Responsiveness', 1)).toBe('RSP-3')
+  })
+
+  it('returns catalog ID for sustainability keys', () => {
+    expect(resolveReferenceId('contributor_diversity', 'Sustainability', 1)).toBe('SUS-1')
+    expect(resolveReferenceId('no_maintainers', 'Sustainability', 1)).toBe('SUS-2')
+  })
+
+  it('returns catalog ID for documentation keys', () => {
+    expect(resolveReferenceId('file:readme', 'Documentation', 1)).toBe('DOC-1')
+    expect(resolveReferenceId('section:usage', 'Documentation', 1)).toBe('DOC-9')
+    expect(resolveReferenceId('licensing:dco_cla', 'Documentation', 1)).toBe('DOC-14')
+  })
+
+  it('falls back to sequential ID for unknown keys', () => {
+    expect(resolveReferenceId('unknown_key', 'Activity', 5)).toBe('ACT-5')
+  })
+})
+
+describe('assignReferenceIds', () => {
+  it('assigns catalog IDs when keys match', () => {
+    const items = [
+      { bucket: 'Activity', key: 'pr_flow', message: 'first' },
+      { bucket: 'Activity', key: 'issue_flow', message: 'second' },
+      { bucket: 'Documentation', key: 'file:readme', message: 'doc1' },
+    ]
+    const result = assignReferenceIds(items)
+    expect(result.map((r) => r.referenceId)).toEqual(['ACT-1', 'ACT-2', 'DOC-1'])
+  })
+
+  it('preserves original item properties', () => {
+    const items = [{ bucket: 'Security', key: 'Dangerous-Workflow', extra: 42 }]
+    const result = assignReferenceIds(items)
+    expect(result[0]).toMatchObject({ bucket: 'Security', key: 'Dangerous-Workflow', extra: 42, referenceId: 'SEC-1' })
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(assignReferenceIds([])).toEqual([])
+  })
+
+  it('uses fallback sequential IDs for dynamic keys (starting at 101)', () => {
+    const items = [
+      { bucket: 'Documentation', key: 'inclusive_naming:branch:master' },
+      { bucket: 'Documentation', key: 'inclusive_naming:description:whitelist' },
+    ]
+    const result = assignReferenceIds(items)
+    expect(result[0]!.referenceId).toBe('DOC-101')
+    expect(result[1]!.referenceId).toBe('DOC-102')
+  })
+
+  it('mixes catalog and fallback IDs correctly', () => {
+    const items = [
+      { bucket: 'Documentation', key: 'file:readme' },
+      { bucket: 'Documentation', key: 'inclusive_naming:branch:master' },
+      { bucket: 'Documentation', key: 'file:contributing' },
+    ]
+    const result = assignReferenceIds(items)
+    expect(result.map((r) => r.referenceId)).toEqual(['DOC-1', 'DOC-101', 'DOC-3'])
+  })
+
+  it('same catalog key always resolves to same ID regardless of position', () => {
+    const items1 = [
+      { bucket: 'Activity', key: 'pr_flow' },
+      { bucket: 'Activity', key: 'sustained_activity' },
+    ]
+    const items2 = [
+      { bucket: 'Activity', key: 'sustained_activity' },
+      { bucket: 'Activity', key: 'pr_flow' },
+    ]
+    const result1 = assignReferenceIds(items1)
+    const result2 = assignReferenceIds(items2)
+    // ACT-4 is sustained_activity regardless of order
+    expect(result1[1]!.referenceId).toBe('ACT-4')
+    expect(result2[0]!.referenceId).toBe('ACT-4')
+    // ACT-1 is pr_flow regardless of order
+    expect(result1[0]!.referenceId).toBe('ACT-1')
+    expect(result2[1]!.referenceId).toBe('ACT-1')
+  })
+})

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -1,0 +1,137 @@
+/**
+ * Unified recommendation catalog — the single source of truth for all
+ * recommendation reference IDs. Every entry has a stable, human-readable
+ * ID (e.g. SEC-1, DOC-3) that is the same across all repos, so users
+ * can reference specific findings in conversations, reports, and issues.
+ *
+ * Bucket prefixes:
+ *   SEC — Security     ACT — Activity       RSP — Responsiveness
+ *   SUS — Sustainability   DOC — Documentation
+ */
+
+export interface CatalogEntry {
+  /** Stable reference ID shown to users (e.g. "SEC-1", "DOC-3") */
+  id: string
+  /** Bucket the recommendation belongs to */
+  bucket: string
+  /** Unique lookup key — matches the `item` or `key` field on generated recommendations */
+  key: string
+  /** Short human-readable title */
+  title: string
+}
+
+// ── Security ──────────────────────────────────────────────────────────
+
+const SEC: CatalogEntry[] = [
+  // Critical
+  { id: 'SEC-1', bucket: 'Security', key: 'Dangerous-Workflow', title: 'Fix dangerous GitHub Actions workflow patterns' },
+  { id: 'SEC-2', bucket: 'Security', key: 'Webhooks', title: 'Secure webhook configurations with token authentication' },
+  // High
+  { id: 'SEC-3', bucket: 'Security', key: 'Branch-Protection', title: 'Enforce branch protection on the default branch' },
+  { id: 'SEC-4', bucket: 'Security', key: 'Binary-Artifacts', title: 'Remove binary artifacts from the repository' },
+  { id: 'SEC-5', bucket: 'Security', key: 'Code-Review', title: 'Require code review before merging pull requests' },
+  { id: 'SEC-6', bucket: 'Security', key: 'Dependency-Update-Tool', title: 'Enable automated dependency updates' },
+  { id: 'SEC-7', bucket: 'Security', key: 'Signed-Releases', title: 'Sign release artifacts to attest provenance' },
+  { id: 'SEC-8', bucket: 'Security', key: 'Token-Permissions', title: 'Restrict GitHub Actions token permissions' },
+  { id: 'SEC-9', bucket: 'Security', key: 'Vulnerabilities', title: 'Fix known vulnerabilities in dependencies' },
+  { id: 'SEC-10', bucket: 'Security', key: 'Maintained', title: 'Maintain regular development activity' },
+  // Medium
+  { id: 'SEC-11', bucket: 'Security', key: 'Fuzzing', title: 'Adopt fuzz testing to find edge-case bugs' },
+  { id: 'SEC-12', bucket: 'Security', key: 'Pinned-Dependencies', title: 'Pin dependencies to specific versions by hash' },
+  { id: 'SEC-13', bucket: 'Security', key: 'SAST', title: 'Enable static application security testing (SAST)' },
+  { id: 'SEC-14', bucket: 'Security', key: 'Security-Policy', title: 'Add a security vulnerability disclosure policy' },
+  { id: 'SEC-15', bucket: 'Security', key: 'Packaging', title: 'Publish packages through official registries' },
+  // Low
+  { id: 'SEC-16', bucket: 'Security', key: 'CI-Tests', title: 'Run automated tests on pull requests' },
+  { id: 'SEC-17', bucket: 'Security', key: 'License', title: 'Add a recognized open-source license' },
+]
+
+/**
+ * Maps direct-check keys to their Scorecard equivalents so both resolve
+ * to the same catalog ID (e.g. "branch_protection" → SEC-3).
+ */
+const DIRECT_CHECK_ALIASES: Record<string, string> = {
+  branch_protection: 'Branch-Protection',
+  dependabot: 'Dependency-Update-Tool',
+  security_policy: 'Security-Policy',
+  ci_cd: 'CI-Tests',
+}
+
+// ── Activity ──────────────────────────────────────────────────────────
+
+const ACT: CatalogEntry[] = [
+  { id: 'ACT-1', bucket: 'Activity', key: 'pr_flow', title: 'Reduce PR backlog and speed up review throughput' },
+  { id: 'ACT-2', bucket: 'Activity', key: 'issue_flow', title: 'Triage and close stale issues' },
+  { id: 'ACT-3', bucket: 'Activity', key: 'completion_speed', title: 'Reduce time to merge PRs and close issues' },
+  { id: 'ACT-4', bucket: 'Activity', key: 'sustained_activity', title: 'Increase commit frequency for sustained momentum' },
+]
+
+// ── Responsiveness ────────────────────────────────────────────────────
+
+const RSP: CatalogEntry[] = [
+  { id: 'RSP-1', bucket: 'Responsiveness', key: 'response_time', title: 'Reduce issue and PR first-response times' },
+  { id: 'RSP-2', bucket: 'Responsiveness', key: 'resolution', title: 'Speed up issue resolution and PR merge times' },
+  { id: 'RSP-3', bucket: 'Responsiveness', key: 'backlog_health', title: 'Address stale issues and PRs' },
+]
+
+// ── Sustainability ────────────────────────────────────────────────────
+
+const SUS: CatalogEntry[] = [
+  { id: 'SUS-1', bucket: 'Sustainability', key: 'contributor_diversity', title: 'Onboard more contributors to reduce single-maintainer risk' },
+  { id: 'SUS-2', bucket: 'Sustainability', key: 'no_maintainers', title: 'Add a CODEOWNERS or MAINTAINERS.md file' },
+]
+
+// ── Documentation ─────────────────────────────────────────────────────
+
+const DOC: CatalogEntry[] = [
+  // File presence
+  { id: 'DOC-1', bucket: 'Documentation', key: 'file:readme', title: 'Add a README' },
+  { id: 'DOC-2', bucket: 'Documentation', key: 'file:license', title: 'Add a LICENSE file' },
+  { id: 'DOC-3', bucket: 'Documentation', key: 'file:contributing', title: 'Add CONTRIBUTING.md' },
+  { id: 'DOC-4', bucket: 'Documentation', key: 'file:code_of_conduct', title: 'Add CODE_OF_CONDUCT.md' },
+  { id: 'DOC-5', bucket: 'Documentation', key: 'file:security', title: 'Add SECURITY.md' },
+  { id: 'DOC-6', bucket: 'Documentation', key: 'file:changelog', title: 'Add CHANGELOG.md' },
+  // README sections
+  { id: 'DOC-7', bucket: 'Documentation', key: 'section:description', title: 'Add a project description to your README' },
+  { id: 'DOC-8', bucket: 'Documentation', key: 'section:installation', title: 'Add installation instructions to your README' },
+  { id: 'DOC-9', bucket: 'Documentation', key: 'section:usage', title: 'Add usage examples to your README' },
+  { id: 'DOC-10', bucket: 'Documentation', key: 'section:contributing', title: 'Add a contributing section to your README' },
+  { id: 'DOC-11', bucket: 'Documentation', key: 'section:license', title: 'Add a license section to your README' },
+  // Licensing
+  { id: 'DOC-12', bucket: 'Documentation', key: 'licensing:license', title: 'Add an open source license' },
+  { id: 'DOC-13', bucket: 'Documentation', key: 'licensing:osi_license', title: 'Use an OSI-approved license' },
+  { id: 'DOC-14', bucket: 'Documentation', key: 'licensing:dco_cla', title: 'Enforce a DCO or CLA for contributions' },
+]
+
+// ── Combined catalog ──────────────────────────────────────────────────
+
+export const RECOMMENDATION_CATALOG: CatalogEntry[] = [
+  ...SEC, ...ACT, ...RSP, ...SUS, ...DOC,
+]
+
+/** Fast lookup: key → CatalogEntry */
+const keyIndex = new Map<string, CatalogEntry>()
+for (const entry of RECOMMENDATION_CATALOG) {
+  keyIndex.set(entry.key, entry)
+}
+// Register direct-check aliases so e.g. "branch_protection" → SEC-3
+for (const [alias, canonical] of Object.entries(DIRECT_CHECK_ALIASES)) {
+  const entry = keyIndex.get(canonical)
+  if (entry) keyIndex.set(alias, entry)
+}
+
+/**
+ * Look up the stable reference ID for a recommendation key.
+ * Returns undefined for dynamic recommendations not in the catalog
+ * (e.g. inclusive naming findings).
+ */
+export function getCatalogId(key: string): string | undefined {
+  return keyIndex.get(key)?.id
+}
+
+/**
+ * Look up the full catalog entry for a recommendation key.
+ */
+export function getCatalogEntryByKey(key: string): CatalogEntry | undefined {
+  return keyIndex.get(key)
+}

--- a/lib/recommendations/reference-id.ts
+++ b/lib/recommendations/reference-id.ts
@@ -1,0 +1,60 @@
+/**
+ * Resolves stable reference IDs for recommendations using the unified catalog.
+ *
+ * Each recommendation carries a `key` field that maps to a catalog entry with
+ * a fixed ID (e.g. "pr_flow" → ACT-1, "Branch-Protection" → SEC-3). This means
+ * the same recommendation always has the same ID across all repos.
+ *
+ * For dynamic recommendations not in the catalog (e.g. inclusive naming findings),
+ * a sequential fallback ID is assigned using the bucket prefix.
+ */
+
+import { getCatalogId } from './catalog'
+
+const BUCKET_PREFIX: Record<string, string> = {
+  Security: 'SEC',
+  Activity: 'ACT',
+  Responsiveness: 'RSP',
+  Sustainability: 'SUS',
+  Documentation: 'DOC',
+}
+
+export function getBucketPrefix(bucket: string): string {
+  return BUCKET_PREFIX[bucket] ?? bucket.substring(0, 3).toUpperCase()
+}
+
+export interface WithReferenceId {
+  referenceId: string
+}
+
+/**
+ * Resolves the stable reference ID for a single recommendation.
+ * Falls back to a sequential ID if the key is not in the catalog.
+ */
+export function resolveReferenceId(key: string, bucket: string, fallbackIndex: number): string {
+  return getCatalogId(key) ?? `${getBucketPrefix(bucket)}-${fallbackIndex}`
+}
+
+/**
+ * Assigns reference IDs to a list of recommendations.
+ * Uses the catalog for stable IDs; falls back to sequential numbering
+ * for dynamic entries not in the catalog.
+ */
+export function assignReferenceIds<T extends { bucket: string; key: string }>(
+  items: readonly T[],
+): Array<T & WithReferenceId> {
+  const fallbackCounters = new Map<string, number>()
+  return items.map((item) => {
+    const catalogId = getCatalogId(item.key)
+    let referenceId: string
+    if (catalogId) {
+      referenceId = catalogId
+    } else {
+      const prefix = getBucketPrefix(item.bucket)
+      const count = (fallbackCounters.get(prefix) ?? 100) + 1
+      fallbackCounters.set(prefix, count)
+      referenceId = `${prefix}-${count}`
+    }
+    return { ...item, referenceId }
+  })
+}

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -9,6 +9,8 @@ import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-p
 
 export interface HealthScoreRecommendation {
   bucket: string
+  /** Stable catalog key for reference ID lookup (e.g. "pr_flow", "file:readme") */
+  key: string
   percentile: number
   message: string
   tab: 'activity' | 'responsiveness' | 'contributors' | 'documentation' | 'security'
@@ -80,6 +82,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   if (sustainabilityPercentile !== null) {
     recommendations.push({
       bucket: 'Sustainability',
+      key: 'contributor_diversity',
       percentile: sustainabilityPercentile,
       message: 'Onboard more contributors to reduce single-maintainer risk. The top 20% of contributors account for a disproportionate share of commits.',
       tab: 'contributors',
@@ -88,6 +91,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   if (result.maintainerCount === 'unavailable') {
     recommendations.push({
       bucket: 'Sustainability',
+      key: 'no_maintainers',
       percentile: sustainabilityPercentile ?? 0,
       message: 'No maintainers identified. Add a CODEOWNERS or MAINTAINERS.md file to make maintainer responsibility visible.',
       tab: 'contributors',
@@ -97,6 +101,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
     for (const rec of documentation.recommendations) {
       recommendations.push({
         bucket: 'Documentation',
+        key: `${rec.category}:${rec.item}`,
         percentile: documentationPercentile ?? 0,
         message: rec.text,
         tab: 'documentation',
@@ -107,6 +112,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
     for (const rec of security.recommendations) {
       recommendations.push({
         bucket: 'Security',
+        key: rec.item,
         percentile: securityPercentile ?? 0,
         message: rec.text,
         tab: 'security',
@@ -136,22 +142,22 @@ function getActivityRecommendations(score: ActivityScoreDefinition): HealthScore
 
   const prFlow = factors.find((f) => f.label === 'PR flow')
   if (prFlow?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', percentile: prFlow.percentile, message: 'Reduce PR backlog and speed up review throughput to improve merge rate.', tab: 'activity' })
+    recs.push({ bucket: 'Activity', key: 'pr_flow', percentile: prFlow.percentile, message: 'Reduce PR backlog and speed up review throughput to improve merge rate.', tab: 'activity' })
   }
 
   const issueFlow = factors.find((f) => f.label === 'Issue flow')
   if (issueFlow?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', percentile: issueFlow.percentile, message: 'Triage and close stale issues to improve issue flow.', tab: 'activity' })
+    recs.push({ bucket: 'Activity', key: 'issue_flow', percentile: issueFlow.percentile, message: 'Triage and close stale issues to improve issue flow.', tab: 'activity' })
   }
 
   const completionSpeed = factors.find((f) => f.label === 'Completion speed')
   if (completionSpeed?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', percentile: completionSpeed.percentile, message: 'Reduce time to merge PRs and close issues to improve completion speed.', tab: 'activity' })
+    recs.push({ bucket: 'Activity', key: 'completion_speed', percentile: completionSpeed.percentile, message: 'Reduce time to merge PRs and close issues to improve completion speed.', tab: 'activity' })
   }
 
   const sustained = factors.find((f) => f.label === 'Sustained activity')
   if (sustained?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', percentile: sustained.percentile, message: 'Increase commit frequency to show sustained development momentum.', tab: 'activity' })
+    recs.push({ bucket: 'Activity', key: 'sustained_activity', percentile: sustained.percentile, message: 'Increase commit frequency to show sustained development momentum.', tab: 'activity' })
   }
 
   return recs
@@ -163,17 +169,17 @@ function getResponsivenessRecommendations(score: ResponsivenessScoreDefinition):
 
   const responseTime = categories.find((c) => c.label === 'Issue & PR response time')
   if (responseTime?.percentile !== undefined) {
-    recs.push({ bucket: 'Responsiveness', percentile: responseTime.percentile, message: 'Reduce issue and PR first-response times — contributors are waiting longer than most repos in this bracket.', tab: 'responsiveness' })
+    recs.push({ bucket: 'Responsiveness', key: 'response_time', percentile: responseTime.percentile, message: 'Reduce issue and PR first-response times — contributors are waiting longer than most repos in this bracket.', tab: 'responsiveness' })
   }
 
   const resolution = categories.find((c) => c.label === 'Resolution metrics')
   if (resolution?.percentile !== undefined) {
-    recs.push({ bucket: 'Responsiveness', percentile: resolution.percentile, message: 'Speed up issue resolution and PR merge times to improve throughput.', tab: 'responsiveness' })
+    recs.push({ bucket: 'Responsiveness', key: 'resolution', percentile: resolution.percentile, message: 'Speed up issue resolution and PR merge times to improve throughput.', tab: 'responsiveness' })
   }
 
   const backlog = categories.find((c) => c.label === 'Volume & backlog health')
   if (backlog?.percentile !== undefined) {
-    recs.push({ bucket: 'Responsiveness', percentile: backlog.percentile, message: 'Address stale issues and PRs to improve backlog health.', tab: 'responsiveness' })
+    recs.push({ bucket: 'Responsiveness', key: 'backlog_health', percentile: backlog.percentile, message: 'Address stale issues and PRs to improve backlog health.', tab: 'responsiveness' })
   }
 
   return recs


### PR DESCRIPTION
## Summary
- Introduces a unified recommendation catalog (`lib/recommendations/catalog.ts`) with **40 fixed entries** across all five buckets, each with a stable reference ID (e.g. `SEC-8` = "Restrict GitHub Actions token permissions")
- IDs are **the same across all repos** — users can now say "we fixed SEC-8, here's how" and everyone knows what they mean
- Displays reference ID as a muted monospace badge on every recommendation card in the UI
- Includes reference IDs in both Markdown and JSON exports

| Range | Bucket | Count |
|-------|--------|-------|
| SEC-1 to SEC-17 | Security | 17 |
| ACT-1 to ACT-4 | Activity | 4 |
| RSP-1 to RSP-3 | Responsiveness | 3 |
| SUS-1 to SUS-2 | Sustainability | 2 |
| DOC-1 to DOC-14 | Documentation | 14 |

Direct-check aliases (e.g. `branch_protection` → `SEC-3`) resolve correctly. Dynamic inclusive-naming findings not in the catalog get fallback IDs starting at `DOC-101`.

Closes #159

## Test plan
- [x] Analyze a repo and verify reference ID badges appear on all recommendation cards (both security and non-security)
- [x] Verify the same recommendation always shows the same ID across different repos (e.g. SEC-8 is always "Restrict GitHub Actions token permissions")
- [x] Export Markdown report and confirm reference IDs appear in the Recommendations section
- [x] Export JSON report and confirm `referenceId` field is present on each recommendation
- [x] Run `npx vitest run` — all 486 tests pass (35 new tests in 2 new test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)