### PR TITLE
Group Markdown export recommendations by category

### DIFF
--- a/lib/export/markdown-export.ts
+++ b/lib/export/markdown-export.ts
@@ -348,13 +348,23 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
 
     if (nonSecurityRecs.length > 0) {
       const withIds = assignReferenceIds(nonSecurityRecs)
+      const grouped = new Map<string, typeof withIds>()
       for (const rec of withIds) {
-        lines.push(`- **${rec.referenceId}** — ${rec.message}`)
+        const group = grouped.get(rec.bucket) ?? []
+        group.push(rec)
+        grouped.set(rec.bucket, group)
       }
-      lines.push('')
+      for (const [bucket, recs] of grouped) {
+        lines.push(`#### ${bucket}`, '')
+        for (const rec of recs) {
+          lines.push(`- **${rec.referenceId}** — ${rec.message}`)
+        }
+        lines.push('')
+      }
     }
 
     if (securityRecs.length > 0) {
+      lines.push('#### Security', '')
       for (const [i, rec] of securityRecs.entries()) {
         const refId = resolveReferenceId(rec.item, 'Security', i + 1)
         const title = rec.title ?? rec.text


### PR DESCRIPTION
## Summary
- Groups non-security recommendations under `####` category headings (Activity, Responsiveness, Sustainability, Documentation) based on each recommendation's `bucket` field
- Renders security recommendations under a `#### Security` heading

Closes #165

## Test plan
- [x] Export a Markdown report for a repo with recommendations across multiple categories
- [x] Verify recommendations appear grouped under category sub-headings, not as a flat list
- [x] Verify security recommendations appear under a `#### Security` heading
- [x] Verify a repo with no recommendations still exports cleanly — covered by existing tests: `RESULT_BASE` with `securityResult: 'unavailable'` produces a report without a Recommendations section; all 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)