### PR TITLE
Add governance tag to recommendation catalogs

### DIFF
--- a/components/contributors/ContributorsView.tsx
+++ b/components/contributors/ContributorsView.tsx
@@ -8,9 +8,11 @@ import { SustainabilityPane } from './SustainabilityPane'
 
 interface ContributorsViewProps {
   results: AnalysisResult[]
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
-export function ContributorsView({ results }: ContributorsViewProps) {
+export function ContributorsView({ results, activeTag, onTagChange }: ContributorsViewProps) {
   const [includeBots, setIncludeBots] = useState(false)
   const [windowDays, setWindowDays] = useState<ContributorWindowDays>(90)
   const sections = buildContributorsViewModels(results, { includeBots, windowDays })
@@ -58,7 +60,7 @@ export function ContributorsView({ results }: ContributorsViewProps) {
             includeBots={includeBots}
             onToggleIncludeBots={() => setIncludeBots((current) => !current)}
           />
-          <SustainabilityPane section={section} />
+          <SustainabilityPane section={section} activeTag={activeTag} onTagChange={onTagChange} />
         </article>
       ))}
     </section>

--- a/components/contributors/SustainabilityPane.tsx
+++ b/components/contributors/SustainabilityPane.tsx
@@ -4,8 +4,10 @@ import { useState } from 'react'
 import { ScoreBadge } from '@/components/metric-cards/ScoreBadge'
 import { HelpLabel } from '@/components/shared/HelpLabel'
 import { MetricValue } from '@/components/shared/MetricValue'
+import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import { formatPercentage } from '@/lib/contributors/score-config'
 import type { ContributorsSectionViewModel } from '@/lib/contributors/view-model'
+import { GOVERNANCE_SUSTAINABILITY_METRICS } from '@/lib/tags/governance'
 import { ContributionBarChart } from './ContributionBarChart'
 
 interface SustainabilityPaneProps {
@@ -17,6 +19,8 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
   const [showExperimentalHeatmap, setShowExperimentalHeatmap] = useState(false)
   const [showExperimentalNames, setShowExperimentalNames] = useState(true)
   const [showExperimentalNumbers, setShowExperimentalNumbers] = useState(false)
+  const [activeTag, setActiveTag] = useState<string | null>(null)
+  const handleTagClick = (tag: string) => setActiveTag((prev) => (prev === tag ? null : tag))
 
   return (
     <section aria-label="Sustainability pane" className="rounded-2xl border border-slate-200 bg-white p-4">
@@ -58,18 +62,31 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
         ) : null}
       </div>
 
+      {activeTag ? (
+        <div className="mt-4">
+          <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+        </div>
+      ) : null}
+
       <dl className="mt-4 grid gap-3 md:grid-cols-2">
-        {section.sustainabilityMetrics.map((metric) => (
-          <div key={metric.label} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
-              <HelpLabel label={metric.label} helpText={metric.hoverText} />
-            </dt>
-            <dd className="mt-1 text-base"><MetricValue value={metric.value} /></dd>
-            {metric.supportingText ? <p className="mt-1 text-xs text-slate-500">{metric.supportingText}</p> : null}
-          </div>
-        ))}
+        {section.sustainabilityMetrics
+          .filter((metric) => !activeTag || GOVERNANCE_SUSTAINABILITY_METRICS.has(metric.label))
+          .map((metric) => {
+            const isGov = GOVERNANCE_SUSTAINABILITY_METRICS.has(metric.label)
+            return (
+              <div key={metric.label} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                <dt className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-slate-500">
+                  <HelpLabel label={metric.label} helpText={metric.hoverText} />
+                  {isGov ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={handleTagClick} /> : null}
+                </dt>
+                <dd className="mt-1 text-base"><MetricValue value={metric.value} /></dd>
+                {metric.supportingText ? <p className="mt-1 text-xs text-slate-500">{metric.supportingText}</p> : null}
+              </div>
+            )
+          })}
       </dl>
 
+      {!activeTag ? (
       <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
         <div className="flex flex-col gap-1">
           <p className="text-xs font-medium uppercase tracking-wide text-slate-900">Organization Affiliation</p>
@@ -143,6 +160,7 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
           />
         ) : null}
       </div>
+      ) : null}
 
     </section>
   )

--- a/components/contributors/SustainabilityPane.tsx
+++ b/components/contributors/SustainabilityPane.tsx
@@ -12,15 +12,22 @@ import { ContributionBarChart } from './ContributionBarChart'
 
 interface SustainabilityPaneProps {
   section: ContributorsSectionViewModel
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
-export function SustainabilityPane({ section }: SustainabilityPaneProps) {
+export function SustainabilityPane({ section, activeTag: externalTag, onTagChange }: SustainabilityPaneProps) {
   const [showDetails, setShowDetails] = useState(false)
   const [showExperimentalHeatmap, setShowExperimentalHeatmap] = useState(false)
   const [showExperimentalNames, setShowExperimentalNames] = useState(true)
   const [showExperimentalNumbers, setShowExperimentalNumbers] = useState(false)
-  const [activeTag, setActiveTag] = useState<string | null>(null)
-  const handleTagClick = (tag: string) => setActiveTag((prev) => (prev === tag ? null : tag))
+  const [localTag, setLocalTag] = useState<string | null>(null)
+  const activeTag = externalTag !== undefined ? externalTag : localTag
+  const handleTagClick = (tag: string) => {
+    const next = activeTag === tag ? null : tag
+    if (onTagChange) onTagChange(next)
+    else setLocalTag(next)
+  }
 
   return (
     <section aria-label="Sustainability pane" className="rounded-2xl border border-slate-200 bg-white p-4">
@@ -64,7 +71,7 @@ export function SustainabilityPane({ section }: SustainabilityPaneProps) {
 
       {activeTag ? (
         <div className="mt-4">
-          <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+          <ActiveFilterBar tag={activeTag} onClear={() => handleTagClick(activeTag)} />
         </div>
       ) : null}
 

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -10,6 +10,8 @@ import { GOVERNANCE_DOC_FILES, LICENSING_IS_GOVERNANCE } from '@/lib/tags/govern
 
 interface DocumentationViewProps {
   results: AnalysisResult[]
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
 const FILE_LABELS: Record<string, string> = {
@@ -200,9 +202,14 @@ function InclusiveNamingPane({ inclusiveNamingResult }: { inclusiveNamingResult:
   )
 }
 
-export function DocumentationView({ results }: DocumentationViewProps) {
-  const [activeTag, setActiveTag] = useState<string | null>(null)
-  const handleTagClick = (tag: string) => setActiveTag((prev) => (prev === tag ? null : tag))
+export function DocumentationView({ results, activeTag: externalTag, onTagChange }: DocumentationViewProps) {
+  const [localTag, setLocalTag] = useState<string | null>(null)
+  const activeTag = externalTag !== undefined ? externalTag : localTag
+  const handleTagClick = (tag: string) => {
+    const next = activeTag === tag ? null : tag
+    if (onTagChange) onTagChange(next)
+    else setLocalTag(next)
+  }
 
   return (
     <section aria-label="Documentation view" className="space-y-6">
@@ -239,7 +246,7 @@ export function DocumentationView({ results }: DocumentationViewProps) {
 
             {activeTag ? (
               <div className="mt-4">
-                <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+                <ActiveFilterBar tag={activeTag} onClear={() => handleTagClick(activeTag)} />
               </div>
             ) : null}
 

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -1,9 +1,12 @@
 'use client'
 
+import { useState } from 'react'
 import { ScoreBadge } from '@/components/metric-cards/ScoreBadge'
 import { DocumentationScoreHelp } from '@/components/documentation/DocumentationScoreHelp'
+import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import type { AnalysisResult, InclusiveNamingResult, LicensingResult } from '@/lib/analyzer/analysis-result'
 import { getDocumentationScore } from '@/lib/documentation/score-config'
+import { GOVERNANCE_DOC_FILES, LICENSING_IS_GOVERNANCE } from '@/lib/tags/governance'
 
 interface DocumentationViewProps {
   results: AnalysisResult[]
@@ -26,7 +29,7 @@ const SECTION_LABELS: Record<string, string> = {
   license: 'License',
 }
 
-function LicensingPane({ licensingResult }: { licensingResult: LicensingResult | 'unavailable' }) {
+function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingResult: LicensingResult | 'unavailable'; activeTag: string | null; onTagClick: (tag: string) => void }) {
   if (licensingResult === 'unavailable') {
     return (
       <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
@@ -42,7 +45,10 @@ function LicensingPane({ licensingResult }: { licensingResult: LicensingResult |
 
   return (
     <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Licensing & Compliance</h3>
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Licensing & Compliance</h3>
+        {LICENSING_IS_GOVERNANCE ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={onTagClick} /> : null}
+      </div>
       <ul className="mt-3 space-y-2">
         {/* License detection */}
         <li className="flex items-start gap-2">
@@ -195,6 +201,9 @@ function InclusiveNamingPane({ inclusiveNamingResult }: { inclusiveNamingResult:
 }
 
 export function DocumentationView({ results }: DocumentationViewProps) {
+  const [activeTag, setActiveTag] = useState<string | null>(null)
+  const handleTagClick = (tag: string) => setActiveTag((prev) => (prev === tag ? null : tag))
+
   return (
     <section aria-label="Documentation view" className="space-y-6">
       {results.map((result) => {
@@ -228,61 +237,77 @@ export function DocumentationView({ results }: DocumentationViewProps) {
 
             <DocumentationScoreHelp score={score} />
 
+            {activeTag ? (
+              <div className="mt-4">
+                <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+              </div>
+            ) : null}
+
             <div className="mt-6 grid gap-6 md:grid-cols-2">
               {/* File presence */}
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-                <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Documentation files</h3>
-                <ul className="mt-3 space-y-2">
-                  {fileChecks.map((check) => (
-                    <li key={check.name} className="flex items-start gap-2">
-                      <span className={`mt-0.5 text-sm ${check.found ? 'text-emerald-600' : 'text-red-400'}`}>
-                        {check.found ? '✓' : '✗'}
-                      </span>
-                      <div className="min-w-0">
-                        <p className={`text-sm font-medium ${check.found ? 'text-slate-900' : 'text-slate-400'}`}>
-                          {FILE_LABELS[check.name] ?? check.name}
-                          {check.found && check.path ? <span className="ml-1 font-normal text-slate-400">({check.path})</span> : null}
-                        </p>
-                        {!check.found ? (
-                          <p className="mt-0.5 text-xs text-amber-700">
-                            {score.recommendations.find((r) => r.category === 'file' && r.item === check.name)?.text}
+              {!activeTag || fileChecks.some((c) => GOVERNANCE_DOC_FILES.has(c.name)) ? (
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Documentation files</h3>
+                  <ul className="mt-3 space-y-2">
+                    {fileChecks
+                      .filter((check) => !activeTag || GOVERNANCE_DOC_FILES.has(check.name))
+                      .map((check) => {
+                        const isGov = GOVERNANCE_DOC_FILES.has(check.name)
+                        return (
+                          <li key={check.name} className="flex items-start gap-2">
+                            <span className={`mt-0.5 text-sm ${check.found ? 'text-emerald-600' : 'text-red-400'}`}>
+                              {check.found ? '✓' : '✗'}
+                            </span>
+                            <div className="min-w-0 flex-1">
+                              <p className={`text-sm font-medium ${check.found ? 'text-slate-900' : 'text-slate-400'}`}>
+                                {FILE_LABELS[check.name] ?? check.name}
+                                {check.found && check.path ? <span className="ml-1 font-normal text-slate-400">({check.path})</span> : null}
+                              </p>
+                              {!check.found ? (
+                                <p className="mt-0.5 text-xs text-amber-700">
+                                  {score.recommendations.find((r) => r.category === 'file' && r.item === check.name)?.text}
+                                </p>
+                              ) : null}
+                            </div>
+                            {isGov ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={handleTagClick} /> : null}
+                          </li>
+                        )
+                      })}
+                  </ul>
+                </div>
+              ) : null}
+
+              {/* README sections — no governance items, hide when filtering */}
+              {!activeTag ? (
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">README sections</h3>
+                  <ul className="mt-3 space-y-2">
+                    {readmeSections.map((section) => (
+                      <li key={section.name} className="flex items-start gap-2">
+                        <span className={`mt-0.5 text-sm ${section.detected ? 'text-emerald-600' : 'text-red-400'}`}>
+                          {section.detected ? '✓' : '✗'}
+                        </span>
+                        <div className="min-w-0">
+                          <p className={`text-sm font-medium ${section.detected ? 'text-slate-900' : 'text-slate-400'}`}>
+                            {SECTION_LABELS[section.name] ?? section.name}
                           </p>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+                          {!section.detected ? (
+                            <p className="mt-0.5 text-xs text-amber-700">
+                              {score.recommendations.find((r) => r.category === 'readme_section' && r.item === section.name)?.text}
+                            </p>
+                          ) : null}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
 
-              {/* README sections */}
-              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-                <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">README sections</h3>
-                <ul className="mt-3 space-y-2">
-                  {readmeSections.map((section) => (
-                    <li key={section.name} className="flex items-start gap-2">
-                      <span className={`mt-0.5 text-sm ${section.detected ? 'text-emerald-600' : 'text-red-400'}`}>
-                        {section.detected ? '✓' : '✗'}
-                      </span>
-                      <div className="min-w-0">
-                        <p className={`text-sm font-medium ${section.detected ? 'text-slate-900' : 'text-slate-400'}`}>
-                          {SECTION_LABELS[section.name] ?? section.name}
-                        </p>
-                        {!section.detected ? (
-                          <p className="mt-0.5 text-xs text-amber-700">
-                            {score.recommendations.find((r) => r.category === 'readme_section' && r.item === section.name)?.text}
-                          </p>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+              {/* Licensing & Compliance — always governance */}
+              <LicensingPane licensingResult={result.licensingResult} activeTag={activeTag} onTagClick={handleTagClick} />
 
-              {/* Licensing & Compliance */}
-              <LicensingPane licensingResult={result.licensingResult} />
-
-              {/* Inclusive Naming */}
-              <InclusiveNamingPane inclusiveNamingResult={result.inclusiveNamingResult} />
+              {/* Inclusive Naming — hide when filtering governance */}
+              {!activeTag ? <InclusiveNamingPane inclusiveNamingResult={result.inclusiveNamingResult} /> : null}
             </div>
           </div>
         )

--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -7,6 +7,8 @@ import { getSecurityScore } from '@/lib/security/score-config'
 import type { SecurityRecommendation } from '@/lib/security/analysis-result'
 import { CATEGORY_DEFINITIONS } from '@/lib/security/recommendation-catalog'
 import { assignReferenceIds, resolveReferenceId } from '@/lib/recommendations/reference-id'
+import { getCatalogEntryByKey } from '@/lib/recommendations/catalog'
+import { getCatalogEntry as getSecurityCatalogEntry } from '@/lib/security/recommendation-catalog'
 
 interface RecommendationsViewProps {
   results: AnalysisResult[]
@@ -32,6 +34,54 @@ const SOURCE_LABELS: Record<string, string> = {
   direct_check: 'Direct check',
 }
 
+const TAG_COLORS: Record<string, string> = {
+  governance: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+}
+const DEFAULT_TAG_COLOR = 'bg-slate-50 text-slate-600 border-slate-200'
+
+function getTagsForKey(key: string, isSecurityRec: boolean): string[] {
+  const unified = getCatalogEntryByKey(key)?.tags ?? []
+  if (isSecurityRec) {
+    const sec = getSecurityCatalogEntry(key)?.tags ?? []
+    if (sec.length > 0 && unified.length === 0) return sec
+    if (sec.length > 0) return [...new Set([...unified, ...sec])]
+  }
+  return unified
+}
+
+function TagPill({ tag, active, onClick }: { tag: string; active: boolean; onClick: (tag: string) => void }) {
+  const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); onClick(tag) }}
+      className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium transition-all ${color} ${active ? 'ring-2 ring-indigo-400 ring-offset-1' : 'hover:opacity-80'}`}
+    >
+      {tag}
+    </button>
+  )
+}
+
+function ActiveFilterBar({ tag, onClear }: { tag: string; onClear: () => void }) {
+  const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
+      <span className="text-xs text-indigo-600">Filtering by</span>
+      <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${color}`}>{tag}</span>
+      <button
+        type="button"
+        onClick={onClear}
+        className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-indigo-400 hover:bg-indigo-100 hover:text-indigo-600"
+        aria-label="Clear filter"
+      >
+        <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M2 2l8 8M10 2l-8 8" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
     <svg
@@ -44,7 +94,8 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
   )
 }
 
-function SecurityRecommendationCard({ rec, referenceId }: { rec: SecurityRecommendation; referenceId?: string }) {
+function SecurityRecommendationCard({ rec, referenceId, activeTag, onTagClick }: { rec: SecurityRecommendation; referenceId?: string; activeTag: string | null; onTagClick: (tag: string) => void }) {
+  const tags = getTagsForKey(rec.item, true)
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-4">
       <div className="flex items-start justify-between gap-2">
@@ -55,6 +106,9 @@ function SecurityRecommendationCard({ rec, referenceId }: { rec: SecurityRecomme
           {rec.title ?? rec.text}
         </h4>
         <div className="flex shrink-0 gap-1.5">
+          {tags.map((tag) => (
+            <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={onTagClick} />
+          ))}
           {rec.riskLevel ? (
             <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${RISK_COLORS[rec.riskLevel] ?? ''}`}>
               {rec.riskLevel}
@@ -96,22 +150,34 @@ function SecurityRecommendationsGroup({
   onToggle,
   categoryCollapsed,
   onCategoryToggle,
+  activeTag,
+  onTagClick,
 }: {
   recommendations: SecurityRecommendation[]
   expanded: boolean
   onToggle: () => void
   categoryCollapsed: Record<string, boolean>
   onCategoryToggle: (key: string) => void
+  activeTag: string | null
+  onTagClick: (tag: string) => void
 }) {
   // Resolve catalog IDs — each rec's `item` field is the catalog key
   const withIds = recommendations.map((rec, i) => ({
     rec,
     referenceId: resolveReferenceId(rec.item, 'Security', i + 1),
+    tags: getTagsForKey(rec.item, true),
   }))
 
+  // Filter by active tag
+  const filtered = activeTag
+    ? withIds.filter((entry) => entry.tags.includes(activeTag))
+    : withIds
+
+  if (filtered.length === 0) return null
+
   // Group by category
-  const groups = new Map<string, typeof withIds>()
-  for (const entry of withIds) {
+  const groups = new Map<string, typeof filtered>()
+  for (const entry of filtered) {
     const key = entry.rec.groupCategory ?? 'best_practices'
     const group = groups.get(key) ?? []
     group.push(entry)
@@ -135,7 +201,7 @@ function SecurityRecommendationsGroup({
         <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${BUCKET_COLORS.Security}`}>
           Security
         </span>
-        <span className="text-xs text-slate-400">{recommendations.length} recommendation{recommendations.length !== 1 ? 's' : ''}</span>
+        <span className="text-xs text-slate-400">{filtered.length} recommendation{filtered.length !== 1 ? 's' : ''}</span>
       </button>
       {expanded ? (
         <div className="mt-3 space-y-4">
@@ -156,7 +222,7 @@ function SecurityRecommendationsGroup({
                 {!collapsed ? (
                   <div className="space-y-2">
                     {entries.map(({ rec, referenceId }) => (
-                      <SecurityRecommendationCard key={`${rec.item}-${referenceId}`} rec={rec} referenceId={referenceId} />
+                      <SecurityRecommendationCard key={`${rec.item}-${referenceId}`} rec={rec} referenceId={referenceId} activeTag={activeTag} onTagClick={onTagClick} />
                     ))}
                   </div>
                 ) : null}
@@ -172,6 +238,11 @@ function SecurityRecommendationsGroup({
 export function RecommendationsView({ results }: RecommendationsViewProps) {
   const [collapsedBuckets, setCollapsedBuckets] = useState<Record<string, boolean>>({})
   const [categoryCollapsed, setCategoryCollapsed] = useState<Record<string, boolean>>({})
+  const [activeTag, setActiveTag] = useState<string | null>(null)
+
+  const handleTagClick = (tag: string) => {
+    setActiveTag((prev) => (prev === tag ? null : tag))
+  }
 
   return (
     <section aria-label="Recommendations view" className="space-y-6">
@@ -196,18 +267,30 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
           )
         }
 
-        // Assign reference IDs to non-security recs
-        const nonSecurityWithIds = assignReferenceIds(nonSecurityRecs)
+        // Assign reference IDs and resolve tags for non-security recs
+        const nonSecurityWithIds = assignReferenceIds(nonSecurityRecs).map((rec) => ({
+          ...rec,
+          tags: getTagsForKey(rec.key, false),
+        }))
+
+        // Filter by active tag
+        const filteredNonSecurity = activeTag
+          ? nonSecurityWithIds.filter((rec) => rec.tags.includes(activeTag))
+          : nonSecurityWithIds
+        const filteredSecurityRecs = activeTag
+          ? securityRecs.filter((rec) => getTagsForKey(rec.item, true).includes(activeTag))
+          : securityRecs
 
         // Group non-security recs by bucket
-        const bucketGroups = new Map<string, typeof nonSecurityWithIds>()
-        for (const rec of nonSecurityWithIds) {
+        const bucketGroups = new Map<string, typeof filteredNonSecurity>()
+        for (const rec of filteredNonSecurity) {
           const group = bucketGroups.get(rec.bucket) ?? []
           group.push(rec)
           bucketGroups.set(rec.bucket, group)
         }
 
-        const bucketCount = bucketGroups.size + (securityRecs.length > 0 ? 1 : 0)
+        const filteredTotal = filteredNonSecurity.length + filteredSecurityRecs.length
+        const bucketCount = bucketGroups.size + (filteredSecurityRecs.length > 0 ? 1 : 0)
 
         // Collect all bucket keys for expand/collapse all
         const allBucketKeys = [...Array.from(bucketGroups.keys()), ...(securityRecs.length > 0 ? ['Security'] : [])]
@@ -240,7 +323,9 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
               <div>
                 <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
                 <p className="mt-1 text-sm text-slate-500">
-                  {totalCount} recommendation{totalCount !== 1 ? 's' : ''} across {bucketCount} dimension{bucketCount !== 1 ? 's' : ''}
+                  {activeTag
+                    ? `${filteredTotal} of ${totalCount} recommendation${totalCount !== 1 ? 's' : ''} matching "${activeTag}"`
+                    : `${totalCount} recommendation${totalCount !== 1 ? 's' : ''} across ${bucketCount} dimension${bucketCount !== 1 ? 's' : ''}`}
                 </p>
               </div>
               <button
@@ -251,6 +336,16 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
                 {allExpanded ? 'Collapse all' : 'Expand all'}
               </button>
             </div>
+
+            {activeTag ? (
+              <div className="mt-3">
+                <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+              </div>
+            ) : null}
+
+            {filteredTotal === 0 && activeTag ? (
+              <p className="mt-4 text-center text-sm text-slate-400">No recommendations match the "{activeTag}" tag.</p>
+            ) : null}
 
             <div className="mt-4 space-y-4">
               {Array.from(bucketGroups.entries()).map(([bucket, recs]) => {
@@ -274,7 +369,10 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
                         {recs.map((rec, i) => (
                           <li key={i} className="flex items-start gap-2">
                             <span className="shrink-0 rounded bg-slate-200 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-500">{rec.referenceId}</span>
-                            <p className="text-sm text-slate-700">{rec.message}</p>
+                            <p className="flex-1 text-sm text-slate-700">{rec.message}</p>
+                            {rec.tags.map((tag) => (
+                              <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={handleTagClick} />
+                            ))}
                           </li>
                         ))}
                       </ul>
@@ -283,13 +381,15 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
                 )
               })}
 
-              {securityRecs.length > 0 ? (
+              {filteredSecurityRecs.length > 0 ? (
                 <SecurityRecommendationsGroup
-                  recommendations={securityRecs}
+                  recommendations={filteredSecurityRecs}
                   expanded={!collapsedBuckets['Security']}
                   onToggle={() => setCollapsedBuckets((prev) => ({ ...prev, Security: !prev.Security }))}
                   categoryCollapsed={categoryCollapsed}
                   onCategoryToggle={(key) => setCategoryCollapsed((prev) => ({ ...prev, [key]: !prev[key] }))}
+                  activeTag={activeTag}
+                  onTagClick={handleTagClick}
                 />
               ) : null}
             </div>

--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -13,6 +13,8 @@ import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 
 interface RecommendationsViewProps {
   results: AnalysisResult[]
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
 const BUCKET_COLORS: Record<string, string> = {
@@ -198,13 +200,16 @@ function SecurityRecommendationsGroup({
   )
 }
 
-export function RecommendationsView({ results }: RecommendationsViewProps) {
+export function RecommendationsView({ results, activeTag: externalTag, onTagChange }: RecommendationsViewProps) {
   const [collapsedBuckets, setCollapsedBuckets] = useState<Record<string, boolean>>({})
   const [categoryCollapsed, setCategoryCollapsed] = useState<Record<string, boolean>>({})
-  const [activeTag, setActiveTag] = useState<string | null>(null)
+  const [localTag, setLocalTag] = useState<string | null>(null)
+  const activeTag = externalTag !== undefined ? externalTag : localTag
 
   const handleTagClick = (tag: string) => {
-    setActiveTag((prev) => (prev === tag ? null : tag))
+    const next = activeTag === tag ? null : tag
+    if (onTagChange) onTagChange(next)
+    else setLocalTag(next)
   }
 
   return (
@@ -302,7 +307,7 @@ export function RecommendationsView({ results }: RecommendationsViewProps) {
 
             {activeTag ? (
               <div className="mt-3">
-                <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+                <ActiveFilterBar tag={activeTag} onClear={() => handleTagClick(activeTag)} />
               </div>
             ) : null}
 

--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -9,6 +9,7 @@ import { CATEGORY_DEFINITIONS } from '@/lib/security/recommendation-catalog'
 import { assignReferenceIds, resolveReferenceId } from '@/lib/recommendations/reference-id'
 import { getCatalogEntryByKey } from '@/lib/recommendations/catalog'
 import { getCatalogEntry as getSecurityCatalogEntry } from '@/lib/security/recommendation-catalog'
+import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 
 interface RecommendationsViewProps {
   results: AnalysisResult[]
@@ -34,11 +35,6 @@ const SOURCE_LABELS: Record<string, string> = {
   direct_check: 'Direct check',
 }
 
-const TAG_COLORS: Record<string, string> = {
-  governance: 'bg-indigo-50 text-indigo-700 border-indigo-200',
-}
-const DEFAULT_TAG_COLOR = 'bg-slate-50 text-slate-600 border-slate-200'
-
 function getTagsForKey(key: string, isSecurityRec: boolean): string[] {
   const unified = getCatalogEntryByKey(key)?.tags ?? []
   if (isSecurityRec) {
@@ -47,39 +43,6 @@ function getTagsForKey(key: string, isSecurityRec: boolean): string[] {
     if (sec.length > 0) return [...new Set([...unified, ...sec])]
   }
   return unified
-}
-
-function TagPill({ tag, active, onClick }: { tag: string; active: boolean; onClick: (tag: string) => void }) {
-  const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
-  return (
-    <button
-      type="button"
-      onClick={(e) => { e.stopPropagation(); onClick(tag) }}
-      className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium transition-all ${color} ${active ? 'ring-2 ring-indigo-400 ring-offset-1' : 'hover:opacity-80'}`}
-    >
-      {tag}
-    </button>
-  )
-}
-
-function ActiveFilterBar({ tag, onClear }: { tag: string; onClear: () => void }) {
-  const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
-  return (
-    <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
-      <span className="text-xs text-indigo-600">Filtering by</span>
-      <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${color}`}>{tag}</span>
-      <button
-        type="button"
-        onClick={onClear}
-        className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-indigo-400 hover:bg-indigo-100 hover:text-indigo-600"
-        aria-label="Clear filter"
-      >
-        <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M2 2l8 8M10 2l-8 8" />
-        </svg>
-      </button>
-    </div>
-  )
 }
 
 function ChevronIcon({ expanded }: { expanded: boolean }) {

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -40,6 +40,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [inputMode, setInputMode] = useState<'repos' | 'org'>('repos')
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const [quoteIndex, setQuoteIndex] = useState<number | null>(null)
+  const [activeTag, setActiveTag] = useState<string | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -391,7 +392,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       overview={overviewContent}
       contributors={
         analysisResponse ? (
-          <ContributorsView results={analysisResponse.results} />
+          <ContributorsView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
           <p className="text-sm text-slate-500">
             Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
@@ -418,7 +419,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       }
       documentation={
         analysisResponse ? (
-          <DocumentationView results={analysisResponse.results} />
+          <DocumentationView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
           <p className="text-sm text-slate-500">
             Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
@@ -427,7 +428,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       }
       security={
         analysisResponse ? (
-          <SecurityView results={analysisResponse.results} />
+          <SecurityView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
           <p className="text-sm text-slate-500">
             Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
@@ -436,7 +437,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       }
       recommendations={
         analysisResponse ? (
-          <RecommendationsView results={analysisResponse.results} />
+          <RecommendationsView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
           <p className="text-sm text-slate-500">
             Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.

--- a/components/security/SecurityView.tsx
+++ b/components/security/SecurityView.tsx
@@ -1,9 +1,12 @@
 'use client'
 
+import { useState } from 'react'
 import { ScoreBadge } from '@/components/metric-cards/ScoreBadge'
+import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { getSecurityScore } from '@/lib/security/score-config'
 import type { ScorecardCheck, DirectSecurityCheck, SecurityScoreDefinition } from '@/lib/security/analysis-result'
+import { GOVERNANCE_SCORECARD_CHECKS, GOVERNANCE_DIRECT_CHECKS } from '@/lib/tags/governance'
 
 interface SecurityViewProps {
   results: AnalysisResult[]
@@ -16,58 +19,74 @@ const DIRECT_CHECK_LABELS: Record<string, string> = {
   branch_protection: 'Branch Protection',
 }
 
-function ScorecardChecksTable({ checks }: { checks: ScorecardCheck[] }) {
+function ScorecardChecksTable({ checks, activeTag, onTagClick }: { checks: ScorecardCheck[]; activeTag: string | null; onTagClick: (tag: string) => void }) {
+  const filtered = activeTag ? checks.filter((c) => GOVERNANCE_SCORECARD_CHECKS.has(c.name)) : checks
+  if (filtered.length === 0) return null
+
   return (
     <section aria-label="OpenSSF Scorecard Checks" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
       <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">OpenSSF Scorecard Checks</h3>
       <div className="mt-3 space-y-2">
-        {checks.map((check) => (
-          <div key={check.name} className="flex items-center justify-between">
-            <span className="text-sm text-slate-700">{check.name}</span>
-            <div className="flex items-center gap-2">
-              {check.score === -1 ? (
-                <span className="text-xs text-slate-400">indeterminate</span>
-              ) : (
-                <span className={`text-sm font-medium ${check.score >= 7 ? 'text-emerald-600' : check.score >= 4 ? 'text-amber-600' : 'text-red-500'}`}>
-                  {check.score}/10
-                </span>
-              )}
+        {filtered.map((check) => {
+          const isGov = GOVERNANCE_SCORECARD_CHECKS.has(check.name)
+          return (
+            <div key={check.name} className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-slate-700">{check.name}</span>
+                {isGov ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={onTagClick} /> : null}
+              </div>
+              <div className="flex items-center gap-2">
+                {check.score === -1 ? (
+                  <span className="text-xs text-slate-400">indeterminate</span>
+                ) : (
+                  <span className={`text-sm font-medium ${check.score >= 7 ? 'text-emerald-600' : check.score >= 4 ? 'text-amber-600' : 'text-red-500'}`}>
+                    {check.score}/10
+                  </span>
+                )}
+              </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </section>
   )
 }
 
-function DirectChecksSection({ checks }: { checks: DirectSecurityCheck[] }) {
+function DirectChecksSection({ checks, activeTag, onTagClick }: { checks: DirectSecurityCheck[]; activeTag: string | null; onTagClick: (tag: string) => void }) {
+  const filtered = activeTag ? checks.filter((c) => GOVERNANCE_DIRECT_CHECKS.has(c.name)) : checks
+  if (filtered.length === 0) return null
+
   return (
     <section aria-label="Direct Security Checks" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
       <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Direct Security Checks</h3>
       <ul className="mt-3 space-y-2">
-        {checks.map((check) => (
-          <li key={check.name} className="flex items-start gap-2">
-            {check.detected === 'unavailable' ? (
-              <span className="mt-0.5 text-sm text-slate-400">—</span>
-            ) : check.detected ? (
-              <span className="mt-0.5 text-sm text-emerald-600">✓</span>
-            ) : (
-              <span className="mt-0.5 text-sm text-red-400">✗</span>
-            )}
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-slate-700">{DIRECT_CHECK_LABELS[check.name] ?? check.name}</p>
-              {check.details ? (
-                <p className="text-xs text-slate-500">{check.details}</p>
-              ) : check.detected === 'unavailable' ? (
-                <p className="text-xs text-slate-400">
-                  {check.name === 'branch_protection'
-                    ? 'Requires admin access to the repository'
-                    : 'Unavailable'}
-                </p>
-              ) : null}
-            </div>
-          </li>
-        ))}
+        {filtered.map((check) => {
+          const isGov = GOVERNANCE_DIRECT_CHECKS.has(check.name)
+          return (
+            <li key={check.name} className="flex items-start gap-2">
+              {check.detected === 'unavailable' ? (
+                <span className="mt-0.5 text-sm text-slate-400">—</span>
+              ) : check.detected ? (
+                <span className="mt-0.5 text-sm text-emerald-600">✓</span>
+              ) : (
+                <span className="mt-0.5 text-sm text-red-400">✗</span>
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-slate-700">{DIRECT_CHECK_LABELS[check.name] ?? check.name}</p>
+                {check.details ? (
+                  <p className="text-xs text-slate-500">{check.details}</p>
+                ) : check.detected === 'unavailable' ? (
+                  <p className="text-xs text-slate-400">
+                    {check.name === 'branch_protection'
+                      ? 'Requires admin access to the repository'
+                      : 'Unavailable'}
+                  </p>
+                ) : null}
+              </div>
+              {isGov ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={onTagClick} /> : null}
+            </li>
+          )
+        })}
       </ul>
     </section>
   )
@@ -107,6 +126,9 @@ function SecuritySummary({
 }
 
 export function SecurityView({ results }: SecurityViewProps) {
+  const [activeTag, setActiveTag] = useState<string | null>(null)
+  const handleTagClick = (tag: string) => setActiveTag((prev) => (prev === tag ? null : tag))
+
   if (results.length === 0) return null
 
   return (
@@ -135,19 +157,27 @@ export function SecurityView({ results }: SecurityViewProps) {
               <SecuritySummary score={score} scorecardOverallScore={scorecardOverallScore} />
             </div>
 
+            {activeTag ? (
+              <div className="mt-4">
+                <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+              </div>
+            ) : null}
+
             <div className="mt-6 grid gap-4 md:grid-cols-2">
               {hasScorecard ? (
                 <ScorecardChecksTable
                   checks={(result.securityResult.scorecard as Exclude<typeof result.securityResult.scorecard, 'unavailable'>).checks}
+                  activeTag={activeTag}
+                  onTagClick={handleTagClick}
                 />
-              ) : (
+              ) : !activeTag ? (
                 <section aria-label="OpenSSF Scorecard" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
                   <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">OpenSSF Scorecard</h3>
                   <p className="mt-3 text-sm text-slate-400">Scorecard data not available for this repository.</p>
                 </section>
-              )}
+              ) : null}
 
-              <DirectChecksSection checks={result.securityResult.directChecks} />
+              <DirectChecksSection checks={result.securityResult.directChecks} activeTag={activeTag} onTagClick={handleTagClick} />
             </div>
 
           </div>

--- a/components/security/SecurityView.tsx
+++ b/components/security/SecurityView.tsx
@@ -10,6 +10,8 @@ import { GOVERNANCE_SCORECARD_CHECKS, GOVERNANCE_DIRECT_CHECKS } from '@/lib/tag
 
 interface SecurityViewProps {
   results: AnalysisResult[]
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
 const DIRECT_CHECK_LABELS: Record<string, string> = {
@@ -125,9 +127,14 @@ function SecuritySummary({
   )
 }
 
-export function SecurityView({ results }: SecurityViewProps) {
-  const [activeTag, setActiveTag] = useState<string | null>(null)
-  const handleTagClick = (tag: string) => setActiveTag((prev) => (prev === tag ? null : tag))
+export function SecurityView({ results, activeTag: externalTag, onTagChange }: SecurityViewProps) {
+  const [localTag, setLocalTag] = useState<string | null>(null)
+  const activeTag = externalTag !== undefined ? externalTag : localTag
+  const handleTagClick = (tag: string) => {
+    const next = activeTag === tag ? null : tag
+    if (onTagChange) onTagChange(next)
+    else setLocalTag(next)
+  }
 
   if (results.length === 0) return null
 
@@ -159,7 +166,7 @@ export function SecurityView({ results }: SecurityViewProps) {
 
             {activeTag ? (
               <div className="mt-4">
-                <ActiveFilterBar tag={activeTag} onClear={() => setActiveTag(null)} />
+                <ActiveFilterBar tag={activeTag} onClear={() => handleTagClick(activeTag)} />
               </div>
             ) : null}
 

--- a/components/tags/TagPill.tsx
+++ b/components/tags/TagPill.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+const TAG_COLORS: Record<string, string> = {
+  governance: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+}
+const DEFAULT_TAG_COLOR = 'bg-slate-50 text-slate-600 border-slate-200'
+
+export function TagPill({ tag, active, onClick }: { tag: string; active: boolean; onClick: (tag: string) => void }) {
+  const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); onClick(tag) }}
+      className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium transition-all ${color} ${active ? 'ring-2 ring-indigo-400 ring-offset-1' : 'hover:opacity-80'}`}
+    >
+      {tag}
+    </button>
+  )
+}
+
+export function ActiveFilterBar({ tag, onClear }: { tag: string; onClear: () => void }) {
+  const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
+      <span className="text-xs text-indigo-600">Filtering by</span>
+      <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${color}`}>{tag}</span>
+      <button
+        type="button"
+        onClick={onClear}
+        className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-indigo-400 hover:bg-indigo-100 hover:text-indigo-600"
+        aria-label="Clear filter"
+      >
+        <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M2 2l8 8M10 2l-8 8" />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { RECOMMENDATION_CATALOG, getCatalogId, getCatalogEntryByKey } from '../catalog'
+import { RECOMMENDATION_CATALOG, getCatalogId, getCatalogEntryByKey, getCatalogEntriesByTag } from '../catalog'
 
 describe('RECOMMENDATION_CATALOG', () => {
   it('has no duplicate IDs', () => {
@@ -93,5 +93,17 @@ describe('getCatalogEntryByKey', () => {
 
   it('returns undefined for unknown keys', () => {
     expect(getCatalogEntryByKey('nonexistent')).toBeUndefined()
+  })
+})
+
+describe('getCatalogEntriesByTag', () => {
+  it('returns governance-tagged entries', () => {
+    const governance = getCatalogEntriesByTag('governance')
+    const ids = governance.map((e) => e.id).sort()
+    expect(ids).toEqual(['DOC-6', 'SEC-3', 'SEC-5', 'SUS-2'])
+  })
+
+  it('returns empty array for unknown tag', () => {
+    expect(getCatalogEntriesByTag('nonexistent')).toEqual([])
   })
 })

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -100,7 +100,12 @@ describe('getCatalogEntriesByTag', () => {
   it('returns governance-tagged entries', () => {
     const governance = getCatalogEntriesByTag('governance')
     const ids = governance.map((e) => e.id).sort()
-    expect(ids).toEqual(['DOC-6', 'SEC-3', 'SEC-5', 'SUS-2'])
+    expect(ids).toEqual([
+      'DOC-12', 'DOC-13', 'DOC-14',
+      'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
+      'SEC-14', 'SEC-17', 'SEC-3', 'SEC-5',
+      'SUS-2',
+    ])
   })
 
   it('returns empty array for unknown tag', () => {

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -18,6 +18,8 @@ export interface CatalogEntry {
   key: string
   /** Short human-readable title */
   title: string
+  /** Cross-cutting tags for filtering (e.g. "governance") */
+  tags?: string[]
 }
 
 // ── Security ──────────────────────────────────────────────────────────
@@ -27,9 +29,9 @@ const SEC: CatalogEntry[] = [
   { id: 'SEC-1', bucket: 'Security', key: 'Dangerous-Workflow', title: 'Fix dangerous GitHub Actions workflow patterns' },
   { id: 'SEC-2', bucket: 'Security', key: 'Webhooks', title: 'Secure webhook configurations with token authentication' },
   // High
-  { id: 'SEC-3', bucket: 'Security', key: 'Branch-Protection', title: 'Enforce branch protection on the default branch' },
+  { id: 'SEC-3', bucket: 'Security', key: 'Branch-Protection', title: 'Enforce branch protection on the default branch', tags: ['governance'] },
   { id: 'SEC-4', bucket: 'Security', key: 'Binary-Artifacts', title: 'Remove binary artifacts from the repository' },
-  { id: 'SEC-5', bucket: 'Security', key: 'Code-Review', title: 'Require code review before merging pull requests' },
+  { id: 'SEC-5', bucket: 'Security', key: 'Code-Review', title: 'Require code review before merging pull requests', tags: ['governance'] },
   { id: 'SEC-6', bucket: 'Security', key: 'Dependency-Update-Tool', title: 'Enable automated dependency updates' },
   { id: 'SEC-7', bucket: 'Security', key: 'Signed-Releases', title: 'Sign release artifacts to attest provenance' },
   { id: 'SEC-8', bucket: 'Security', key: 'Token-Permissions', title: 'Restrict GitHub Actions token permissions' },
@@ -78,7 +80,7 @@ const RSP: CatalogEntry[] = [
 
 const SUS: CatalogEntry[] = [
   { id: 'SUS-1', bucket: 'Sustainability', key: 'contributor_diversity', title: 'Onboard more contributors to reduce single-maintainer risk' },
-  { id: 'SUS-2', bucket: 'Sustainability', key: 'no_maintainers', title: 'Add a CODEOWNERS or MAINTAINERS.md file' },
+  { id: 'SUS-2', bucket: 'Sustainability', key: 'no_maintainers', title: 'Add a CODEOWNERS or MAINTAINERS.md file', tags: ['governance'] },
 ]
 
 // ── Documentation ─────────────────────────────────────────────────────
@@ -90,7 +92,7 @@ const DOC: CatalogEntry[] = [
   { id: 'DOC-3', bucket: 'Documentation', key: 'file:contributing', title: 'Add CONTRIBUTING.md' },
   { id: 'DOC-4', bucket: 'Documentation', key: 'file:code_of_conduct', title: 'Add CODE_OF_CONDUCT.md' },
   { id: 'DOC-5', bucket: 'Documentation', key: 'file:security', title: 'Add SECURITY.md' },
-  { id: 'DOC-6', bucket: 'Documentation', key: 'file:changelog', title: 'Add CHANGELOG.md' },
+  { id: 'DOC-6', bucket: 'Documentation', key: 'file:changelog', title: 'Add CHANGELOG.md', tags: ['governance'] },
   // README sections
   { id: 'DOC-7', bucket: 'Documentation', key: 'section:description', title: 'Add a project description to your README' },
   { id: 'DOC-8', bucket: 'Documentation', key: 'section:installation', title: 'Add installation instructions to your README' },
@@ -134,4 +136,11 @@ export function getCatalogId(key: string): string | undefined {
  */
 export function getCatalogEntryByKey(key: string): CatalogEntry | undefined {
   return keyIndex.get(key)
+}
+
+/**
+ * Return all catalog entries that carry a given tag (e.g. "governance").
+ */
+export function getCatalogEntriesByTag(tag: string): CatalogEntry[] {
+  return RECOMMENDATION_CATALOG.filter((e) => e.tags?.includes(tag))
 }

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -41,11 +41,11 @@ const SEC: CatalogEntry[] = [
   { id: 'SEC-11', bucket: 'Security', key: 'Fuzzing', title: 'Adopt fuzz testing to find edge-case bugs' },
   { id: 'SEC-12', bucket: 'Security', key: 'Pinned-Dependencies', title: 'Pin dependencies to specific versions by hash' },
   { id: 'SEC-13', bucket: 'Security', key: 'SAST', title: 'Enable static application security testing (SAST)' },
-  { id: 'SEC-14', bucket: 'Security', key: 'Security-Policy', title: 'Add a security vulnerability disclosure policy' },
+  { id: 'SEC-14', bucket: 'Security', key: 'Security-Policy', title: 'Add a security vulnerability disclosure policy', tags: ['governance'] },
   { id: 'SEC-15', bucket: 'Security', key: 'Packaging', title: 'Publish packages through official registries' },
   // Low
   { id: 'SEC-16', bucket: 'Security', key: 'CI-Tests', title: 'Run automated tests on pull requests' },
-  { id: 'SEC-17', bucket: 'Security', key: 'License', title: 'Add a recognized open-source license' },
+  { id: 'SEC-17', bucket: 'Security', key: 'License', title: 'Add a recognized open-source license', tags: ['governance'] },
 ]
 
 /**
@@ -88,10 +88,10 @@ const SUS: CatalogEntry[] = [
 const DOC: CatalogEntry[] = [
   // File presence
   { id: 'DOC-1', bucket: 'Documentation', key: 'file:readme', title: 'Add a README' },
-  { id: 'DOC-2', bucket: 'Documentation', key: 'file:license', title: 'Add a LICENSE file' },
-  { id: 'DOC-3', bucket: 'Documentation', key: 'file:contributing', title: 'Add CONTRIBUTING.md' },
-  { id: 'DOC-4', bucket: 'Documentation', key: 'file:code_of_conduct', title: 'Add CODE_OF_CONDUCT.md' },
-  { id: 'DOC-5', bucket: 'Documentation', key: 'file:security', title: 'Add SECURITY.md' },
+  { id: 'DOC-2', bucket: 'Documentation', key: 'file:license', title: 'Add a LICENSE file', tags: ['governance'] },
+  { id: 'DOC-3', bucket: 'Documentation', key: 'file:contributing', title: 'Add CONTRIBUTING.md', tags: ['governance'] },
+  { id: 'DOC-4', bucket: 'Documentation', key: 'file:code_of_conduct', title: 'Add CODE_OF_CONDUCT.md', tags: ['governance'] },
+  { id: 'DOC-5', bucket: 'Documentation', key: 'file:security', title: 'Add SECURITY.md', tags: ['governance'] },
   { id: 'DOC-6', bucket: 'Documentation', key: 'file:changelog', title: 'Add CHANGELOG.md', tags: ['governance'] },
   // README sections
   { id: 'DOC-7', bucket: 'Documentation', key: 'section:description', title: 'Add a project description to your README' },
@@ -100,9 +100,9 @@ const DOC: CatalogEntry[] = [
   { id: 'DOC-10', bucket: 'Documentation', key: 'section:contributing', title: 'Add a contributing section to your README' },
   { id: 'DOC-11', bucket: 'Documentation', key: 'section:license', title: 'Add a license section to your README' },
   // Licensing
-  { id: 'DOC-12', bucket: 'Documentation', key: 'licensing:license', title: 'Add an open source license' },
-  { id: 'DOC-13', bucket: 'Documentation', key: 'licensing:osi_license', title: 'Use an OSI-approved license' },
-  { id: 'DOC-14', bucket: 'Documentation', key: 'licensing:dco_cla', title: 'Enforce a DCO or CLA for contributions' },
+  { id: 'DOC-12', bucket: 'Documentation', key: 'licensing:license', title: 'Add an open source license', tags: ['governance'] },
+  { id: 'DOC-13', bucket: 'Documentation', key: 'licensing:osi_license', title: 'Use an OSI-approved license', tags: ['governance'] },
+  { id: 'DOC-14', bucket: 'Documentation', key: 'licensing:dco_cla', title: 'Enforce a DCO or CLA for contributions', tags: ['governance'] },
 ]
 
 // ── Combined catalog ──────────────────────────────────────────────────

--- a/lib/security/recommendation-catalog.ts
+++ b/lib/security/recommendation-catalog.ts
@@ -205,6 +205,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create `SECURITY.md` with sections: Reporting a Vulnerability, Contact, Response Timeline. GitHub also supports private vulnerability reporting.',
     docsUrl: `${SCORECARD_DOCS_BASE}#security-policy`,
     directCheckMapping: 'security_policy',
+    tags: ['governance'],
   },
   {
     key: 'Packaging',
@@ -243,6 +244,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create a `LICENSE` file at the repo root. Use `choosealicense.com` to pick an appropriate license.',
     docsUrl: `${SCORECARD_DOCS_BASE}#license`,
     directCheckMapping: null,
+    tags: ['governance'],
   },
 
   // --- Direct checks ---
@@ -257,6 +259,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create `SECURITY.md` at the repo root with sections for reporting process, contact info, and response expectations.',
     docsUrl: null,
     directCheckMapping: null,
+    tags: ['governance'],
   },
   {
     key: 'dependabot',

--- a/lib/security/recommendation-catalog.ts
+++ b/lib/security/recommendation-catalog.ts
@@ -11,6 +11,8 @@ export interface RecommendationCatalogEntry {
   remediationHint: string | null
   docsUrl: string | null
   directCheckMapping: string | null
+  /** Cross-cutting tags for filtering (e.g. "governance") */
+  tags?: string[]
 }
 
 export interface RecommendationCategoryDefinition {
@@ -67,6 +69,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Go to Settings > Branches > Add rule for your default branch. Require at least 1 reviewer and enable "Require status checks to pass."',
     docsUrl: `${SCORECARD_DOCS_BASE}#branch-protection`,
     directCheckMapping: 'branch_protection',
+    tags: ['governance'],
   },
   {
     key: 'Binary-Artifacts',
@@ -91,6 +94,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Enable "Require pull request reviews before merging" in branch protection rules and set minimum reviewers to 1+.',
     docsUrl: `${SCORECARD_DOCS_BASE}#code-review`,
     directCheckMapping: null,
+    tags: ['governance'],
   },
   {
     key: 'Dependency-Update-Tool',
@@ -289,6 +293,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Go to Settings > Branches > Add rule for your default branch. Require at least 1 reviewer.',
     docsUrl: null,
     directCheckMapping: null,
+    tags: ['governance'],
   },
 ]
 

--- a/lib/tags/governance.ts
+++ b/lib/tags/governance.ts
@@ -1,0 +1,47 @@
+/**
+ * Governance tag mappings for tab-level display items.
+ *
+ * These map the item keys used in each tab's data model to the
+ * governance tag, so tag pills can appear on individual rows
+ * across Documentation, Security, and Contributors views.
+ */
+
+/** Documentation file-check names that are governance signals */
+export const GOVERNANCE_DOC_FILES = new Set([
+  'license',
+  'contributing',
+  'code_of_conduct',
+  'security',
+  'changelog',
+])
+
+/** Scorecard check names that are governance signals */
+export const GOVERNANCE_SCORECARD_CHECKS = new Set([
+  'Branch-Protection',
+  'Code-Review',
+  'Security-Policy',
+  'License',
+])
+
+/** Direct security check names that are governance signals */
+export const GOVERNANCE_DIRECT_CHECKS = new Set([
+  'branch_protection',
+  'security_policy',
+])
+
+/** Sustainability metric labels that are governance signals */
+export const GOVERNANCE_SUSTAINABILITY_METRICS = new Set([
+  'Maintainer count',
+])
+
+/** Returns true if the licensing pane is governance-tagged (always true) */
+export const LICENSING_IS_GOVERNANCE = true
+
+export function isGovernanceItem(key: string, domain: 'doc_file' | 'scorecard' | 'direct_check' | 'sustainability_metric'): boolean {
+  switch (domain) {
+    case 'doc_file': return GOVERNANCE_DOC_FILES.has(key)
+    case 'scorecard': return GOVERNANCE_SCORECARD_CHECKS.has(key)
+    case 'direct_check': return GOVERNANCE_DIRECT_CHECKS.has(key)
+    case 'sustainability_metric': return GOVERNANCE_SUSTAINABILITY_METRICS.has(key)
+  }
+}


### PR DESCRIPTION
## Summary
- Add optional `tags` field to `CatalogEntry` and `RecommendationCatalogEntry` interfaces
- Tag 13 recommendations as `governance` across Security, Documentation, and Sustainability buckets
- Add `getCatalogEntriesByTag()` helper for querying entries by tag
- Render tags as clickable filter pills across all relevant tabs — clicking filters each view to matching entries, with a clear button to reset
- Governance tag state is shared across tabs — selecting in one tab persists when switching to another

### Governance-tagged entries (13)

**Security**
- SEC-3 — Enforce branch protection on the default branch
- SEC-5 — Require code review before merging pull requests
- SEC-14 — Add a security vulnerability disclosure policy
- SEC-17 — Add a recognized open-source license

**Sustainability**
- SUS-2 — Add a CODEOWNERS or MAINTAINERS.md file

**Documentation**
- DOC-2 — Add a LICENSE file
- DOC-3 — Add CONTRIBUTING.md
- DOC-4 — Add CODE_OF_CONDUCT.md
- DOC-5 — Add SECURITY.md
- DOC-6 — Add CHANGELOG.md
- DOC-12 — Add an open source license
- DOC-13 — Use an OSI-approved license
- DOC-14 — Enforce a DCO or CLA for contributions

### Tabs with governance tag pills

| Tab | Tagged items |
|---|---|
| Documentation | LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG file rows + entire Licensing pane |
| Security | Branch-Protection, Code-Review, Security-Policy, License (Scorecard) + branch_protection, security_policy (direct checks) |
| Contributors | Maintainer count metric |
| Recommendations | All 13 governance-tagged entries |

Closes #116

## Test plan
- [x] All existing catalog/reference-id/recommendation tests pass
- [x] `getCatalogEntriesByTag('governance')` returns all 13 entries
- [x] `getCatalogEntriesByTag('nonexistent')` returns empty array
- [x] Governance pill appears on tagged items across Documentation, Security, Contributors, and Recommendations tabs
- [x] Clicking pill filters view to governance-only items
- [x] Filter bar shows active tag with clear (X) button
- [x] Clicking pill again or X clears filter and restores full view
- [x] Non-tagged items hidden when filter active
- [x] Summary text updates to show filtered count
- [x] Tag selection persists when switching between tabs
- [x] No regressions in recommendation rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)