### PR TITLE
Add cross-cutting tags to recommendation catalog

### DIFF
--- a/components/activity/ActivityView.tsx
+++ b/components/activity/ActivityView.tsx
@@ -4,17 +4,33 @@ import { useState } from 'react'
 import { ScoreBadge } from '@/components/metric-cards/ScoreBadge'
 import { HelpLabel } from '@/components/shared/HelpLabel'
 import { MetricValue } from '@/components/shared/MetricValue'
+import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import { getActivityScore, formatHours, formatPercentage } from '@/lib/activity/score-config'
 import { type ActivityWindowDays, type AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { buildActivitySections, getActivityWindowOptions } from '@/lib/activity/view-model'
+import { CONTRIB_EX_ACTIVITY_CARDS } from '@/lib/tags/tag-mappings'
 import { ActivityScoreHelp } from './ActivityScoreHelp'
 
 interface ActivityViewProps {
   results: AnalysisResult[]
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
-export function ActivityView({ results }: ActivityViewProps) {
+function getActivityCardTags(title: string): string[] {
+  if (CONTRIB_EX_ACTIVITY_CARDS.has(title)) return ['contrib-ex']
+  return []
+}
+
+export function ActivityView({ results, activeTag: externalTag, onTagChange }: ActivityViewProps) {
   const [windowDays, setWindowDays] = useState<ActivityWindowDays>(90)
+  const [localTag, setLocalTag] = useState<string | null>(null)
+  const activeTag = externalTag !== undefined ? externalTag : localTag
+  const handleTagClick = (tag: string) => {
+    const next = activeTag === tag ? null : tag
+    if (onTagChange) onTagChange(next)
+    else setLocalTag(next)
+  }
   const sections = buildActivitySections(results, windowDays)
   const windowOptions = getActivityWindowOptions()
   const staleIssueTooltip = `Share of currently open issues that were created more than ${windowDays === 365 ? '12 months' : `${windowDays} days`} ago. Lower is generally healthier.`
@@ -74,10 +90,22 @@ export function ActivityView({ results }: ActivityViewProps) {
                     <ScoreBadge category="Activity" value={score.value} tone={score.tone} />
                   </div>
                 </div>
+                {activeTag ? (
+                  <div className="mt-4">
+                    <ActiveFilterBar tag={activeTag} onClear={() => handleTagClick(activeTag)} />
+                  </div>
+                ) : null}
                 <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                  {section.cards.map((card) => (
+                  {section.cards
+                    .filter((card) => !activeTag || getActivityCardTags(card.title).includes(activeTag))
+                    .map((card) => {
+                      const tags = getActivityCardTags(card.title)
+                      return (
                     <div key={card.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{card.title}</p>
+                      <div className="flex items-center justify-between">
+                        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{card.title}</p>
+                        {tags.map((tag) => <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={handleTagClick} />)}
+                      </div>
                       {card.value ? <p className="mt-1 text-lg"><MetricValue value={card.value} /></p> : null}
                       {card.lines ? (
                         <dl className="mt-3 space-y-2">
@@ -111,7 +139,8 @@ export function ActivityView({ results }: ActivityViewProps) {
                       ) : null}
                       {card.detail ? <p className="mt-3 text-sm text-slate-600">{card.detail}</p> : null}
                     </div>
-                  ))}
+                      )
+                    })}
                 </div>
                 <ActivityScoreHelp score={score} />
               </>

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -7,6 +7,7 @@ import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import type { AnalysisResult, InclusiveNamingResult, LicensingResult } from '@/lib/analyzer/analysis-result'
 import { getDocumentationScore } from '@/lib/documentation/score-config'
 import { GOVERNANCE_DOC_FILES, LICENSING_IS_GOVERNANCE } from '@/lib/tags/governance'
+import { getDocFileTags, getReadmeSectionTags, LICENSING_IS_COMPLIANCE } from '@/lib/tags/tag-mappings'
 
 interface DocumentationViewProps {
   results: AnalysisResult[]
@@ -31,6 +32,13 @@ const SECTION_LABELS: Record<string, string> = {
   license: 'License',
 }
 
+function getDocFileAllTags(name: string): string[] {
+  const tags: string[] = []
+  if (GOVERNANCE_DOC_FILES.has(name)) tags.push('governance')
+  tags.push(...getDocFileTags(name))
+  return tags
+}
+
 function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingResult: LicensingResult | 'unavailable'; activeTag: string | null; onTagClick: (tag: string) => void }) {
   if (licensingResult === 'unavailable') {
     return (
@@ -50,6 +58,7 @@ function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingRe
       <div className="flex items-center justify-between">
         <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Licensing & Compliance</h3>
         {LICENSING_IS_GOVERNANCE ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={onTagClick} /> : null}
+        {LICENSING_IS_COMPLIANCE ? <TagPill tag="compliance" active={activeTag === 'compliance'} onClick={onTagClick} /> : null}
       </div>
       <ul className="mt-3 space-y-2">
         {/* License detection */}
@@ -252,14 +261,14 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
 
             <div className="mt-6 grid gap-6 md:grid-cols-2">
               {/* File presence */}
-              {!activeTag || fileChecks.some((c) => GOVERNANCE_DOC_FILES.has(c.name)) ? (
+              {!activeTag || fileChecks.some((c) => getDocFileAllTags(c.name).includes(activeTag)) ? (
                 <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
                   <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Documentation files</h3>
                   <ul className="mt-3 space-y-2">
                     {fileChecks
-                      .filter((check) => !activeTag || GOVERNANCE_DOC_FILES.has(check.name))
+                      .filter((check) => !activeTag || getDocFileAllTags(check.name).includes(activeTag))
                       .map((check) => {
-                        const isGov = GOVERNANCE_DOC_FILES.has(check.name)
+                        const tags = getDocFileAllTags(check.name)
                         return (
                           <li key={check.name} className="flex items-start gap-2">
                             <span className={`mt-0.5 text-sm ${check.found ? 'text-emerald-600' : 'text-red-400'}`}>
@@ -269,7 +278,7 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
                               <p className={`text-sm font-medium ${check.found ? 'text-slate-900' : 'text-slate-400'}`}>
                                 {FILE_LABELS[check.name] ?? check.name}
                                 {check.found && check.path ? <span className="ml-1 font-normal text-slate-400">({check.path})</span> : null}
-                                {isGov ? <> <TagPill tag="governance" active={activeTag === 'governance'} onClick={handleTagClick} /></> : null}
+                                {tags.map((tag) => <span key={tag}> <TagPill tag={tag} active={activeTag === tag} onClick={handleTagClick} /></span>)}
                               </p>
                               {!check.found ? (
                                 <p className="mt-0.5 text-xs text-amber-700">
@@ -284,36 +293,44 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
                 </div>
               ) : null}
 
-              {/* README sections — no governance items, hide when filtering */}
-              {!activeTag ? (
+              {/* README sections — show when no filter or when contrib-ex is active */}
+              {!activeTag || readmeSections.some((s) => getReadmeSectionTags(s.name).includes(activeTag)) ? (
                 <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
                   <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">README sections</h3>
                   <ul className="mt-3 space-y-2">
-                    {readmeSections.map((section) => (
-                      <li key={section.name} className="flex items-start gap-2">
-                        <span className={`mt-0.5 text-sm ${section.detected ? 'text-emerald-600' : 'text-red-400'}`}>
-                          {section.detected ? '✓' : '✗'}
-                        </span>
-                        <div className="min-w-0">
-                          <p className={`text-sm font-medium ${section.detected ? 'text-slate-900' : 'text-slate-400'}`}>
-                            {SECTION_LABELS[section.name] ?? section.name}
-                          </p>
-                          {!section.detected ? (
-                            <p className="mt-0.5 text-xs text-amber-700">
-                              {score.recommendations.find((r) => r.category === 'readme_section' && r.item === section.name)?.text}
-                            </p>
-                          ) : null}
-                        </div>
-                      </li>
-                    ))}
+                    {readmeSections
+                      .filter((section) => !activeTag || getReadmeSectionTags(section.name).includes(activeTag))
+                      .map((section) => {
+                        const tags = getReadmeSectionTags(section.name)
+                        return (
+                          <li key={section.name} className="flex items-start gap-2">
+                            <span className={`mt-0.5 text-sm ${section.detected ? 'text-emerald-600' : 'text-red-400'}`}>
+                              {section.detected ? '✓' : '✗'}
+                            </span>
+                            <div className="min-w-0 flex-1">
+                              <p className={`text-sm font-medium ${section.detected ? 'text-slate-900' : 'text-slate-400'}`}>
+                                {SECTION_LABELS[section.name] ?? section.name}
+                                {tags.map((tag) => <span key={tag}> <TagPill tag={tag} active={activeTag === tag} onClick={handleTagClick} /></span>)}
+                              </p>
+                              {!section.detected ? (
+                                <p className="mt-0.5 text-xs text-amber-700">
+                                  {score.recommendations.find((r) => r.category === 'readme_section' && r.item === section.name)?.text}
+                                </p>
+                              ) : null}
+                            </div>
+                          </li>
+                        )
+                      })}
                   </ul>
                 </div>
               ) : null}
 
-              {/* Licensing & Compliance — always governance */}
-              <LicensingPane licensingResult={result.licensingResult} activeTag={activeTag} onTagClick={handleTagClick} />
+              {/* Licensing & Compliance — governance + compliance */}
+              {!activeTag || activeTag === 'governance' || activeTag === 'compliance' ? (
+                <LicensingPane licensingResult={result.licensingResult} activeTag={activeTag} onTagClick={handleTagClick} />
+              ) : null}
 
-              {/* Inclusive Naming — hide when filtering governance */}
+              {/* Inclusive Naming — hide when any tag is filtering */}
               {!activeTag ? <InclusiveNamingPane inclusiveNamingResult={result.inclusiveNamingResult} /> : null}
             </div>
           </div>

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -401,7 +401,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       }
       activity={
         analysisResponse ? (
-          <ActivityView results={analysisResponse.results} />
+          <ActivityView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
           <p className="text-sm text-slate-500">
             Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
@@ -410,7 +410,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       }
       responsiveness={
         analysisResponse ? (
-          <ResponsivenessView results={analysisResponse.results} />
+          <ResponsivenessView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
           <p className="text-sm text-slate-500">
             Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.

--- a/components/responsiveness/ResponsivenessView.tsx
+++ b/components/responsiveness/ResponsivenessView.tsx
@@ -4,16 +4,32 @@ import { useState } from 'react'
 import { ScoreBadge } from '@/components/metric-cards/ScoreBadge'
 import { HelpLabel } from '@/components/shared/HelpLabel'
 import { MetricValue } from '@/components/shared/MetricValue'
+import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import { type ActivityWindowDays, type AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { buildResponsivenessSections, getResponsivenessWindowOptions } from '@/lib/responsiveness/view-model'
+import { CONTRIB_EX_RESPONSIVENESS_PANES } from '@/lib/tags/tag-mappings'
 import { ResponsivenessScoreHelp } from './ResponsivenessScoreHelp'
 
 interface ResponsivenessViewProps {
   results: AnalysisResult[]
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
-export function ResponsivenessView({ results }: ResponsivenessViewProps) {
+function getResponsivenessPaneTags(title: string): string[] {
+  if (CONTRIB_EX_RESPONSIVENESS_PANES.has(title)) return ['contrib-ex']
+  return []
+}
+
+export function ResponsivenessView({ results, activeTag: externalTag, onTagChange }: ResponsivenessViewProps) {
   const [windowDays, setWindowDays] = useState<ActivityWindowDays>(90)
+  const [localTag, setLocalTag] = useState<string | null>(null)
+  const activeTag = externalTag !== undefined ? externalTag : localTag
+  const handleTagClick = (tag: string) => {
+    const next = activeTag === tag ? null : tag
+    if (onTagChange) onTagChange(next)
+    else setLocalTag(next)
+  }
   const sections = buildResponsivenessSections(results, windowDays)
   const windowOptions = getResponsivenessWindowOptions()
 
@@ -63,10 +79,23 @@ export function ResponsivenessView({ results }: ResponsivenessViewProps) {
             </div>
           </div>
 
+          {activeTag ? (
+            <div className="mt-4">
+              <ActiveFilterBar tag={activeTag} onClear={() => handleTagClick(activeTag)} />
+            </div>
+          ) : null}
+
           <div className="grid gap-3 xl:grid-cols-2">
-            {section.panes.map((pane) => (
+            {section.panes
+              .filter((pane) => !activeTag || getResponsivenessPaneTags(pane.title).includes(activeTag))
+              .map((pane) => {
+                const tags = getResponsivenessPaneTags(pane.title)
+                return (
               <div key={pane.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{pane.title}</p>
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{pane.title}</p>
+                  {tags.map((tag) => <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={handleTagClick} />)}
+                </div>
                 <dl className="mt-3 space-y-2">
                   {pane.metrics.map((metric) => (
                     <div key={metric.label} className="flex items-baseline justify-between gap-4">
@@ -78,7 +107,8 @@ export function ResponsivenessView({ results }: ResponsivenessViewProps) {
                   ))}
                 </dl>
               </div>
-            ))}
+                )
+              })}
           </div>
 
           <ResponsivenessScoreHelp score={section.score} />

--- a/components/security/SecurityView.tsx
+++ b/components/security/SecurityView.tsx
@@ -7,6 +7,7 @@ import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { getSecurityScore } from '@/lib/security/score-config'
 import type { ScorecardCheck, DirectSecurityCheck, SecurityScoreDefinition } from '@/lib/security/analysis-result'
 import { GOVERNANCE_SCORECARD_CHECKS, GOVERNANCE_DIRECT_CHECKS } from '@/lib/tags/governance'
+import { getScorecardCheckTags, getDirectCheckTags } from '@/lib/tags/tag-mappings'
 
 interface SecurityViewProps {
   results: AnalysisResult[]
@@ -21,8 +22,22 @@ const DIRECT_CHECK_LABELS: Record<string, string> = {
   branch_protection: 'Branch Protection',
 }
 
+function getAllScorecardTags(name: string): string[] {
+  const tags: string[] = []
+  if (GOVERNANCE_SCORECARD_CHECKS.has(name)) tags.push('governance')
+  tags.push(...getScorecardCheckTags(name))
+  return tags
+}
+
+function getAllDirectCheckTags(name: string): string[] {
+  const tags: string[] = []
+  if (GOVERNANCE_DIRECT_CHECKS.has(name)) tags.push('governance')
+  tags.push(...getDirectCheckTags(name))
+  return tags
+}
+
 function ScorecardChecksTable({ checks, activeTag, onTagClick }: { checks: ScorecardCheck[]; activeTag: string | null; onTagClick: (tag: string) => void }) {
-  const filtered = activeTag ? checks.filter((c) => GOVERNANCE_SCORECARD_CHECKS.has(c.name)) : checks
+  const filtered = activeTag ? checks.filter((c) => getAllScorecardTags(c.name).includes(activeTag)) : checks
   if (filtered.length === 0) return null
 
   return (
@@ -30,12 +45,12 @@ function ScorecardChecksTable({ checks, activeTag, onTagClick }: { checks: Score
       <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">OpenSSF Scorecard Checks</h3>
       <div className="mt-3 space-y-2">
         {filtered.map((check) => {
-          const isGov = GOVERNANCE_SCORECARD_CHECKS.has(check.name)
+          const tags = getAllScorecardTags(check.name)
           return (
             <div key={check.name} className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <span className="text-sm text-slate-700">{check.name}</span>
-                {isGov ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={onTagClick} /> : null}
+                {tags.map((tag) => <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={onTagClick} />)}
               </div>
               <div className="flex items-center gap-2">
                 {check.score === -1 ? (
@@ -55,7 +70,7 @@ function ScorecardChecksTable({ checks, activeTag, onTagClick }: { checks: Score
 }
 
 function DirectChecksSection({ checks, activeTag, onTagClick }: { checks: DirectSecurityCheck[]; activeTag: string | null; onTagClick: (tag: string) => void }) {
-  const filtered = activeTag ? checks.filter((c) => GOVERNANCE_DIRECT_CHECKS.has(c.name)) : checks
+  const filtered = activeTag ? checks.filter((c) => getAllDirectCheckTags(c.name).includes(activeTag)) : checks
   if (filtered.length === 0) return null
 
   return (
@@ -63,7 +78,7 @@ function DirectChecksSection({ checks, activeTag, onTagClick }: { checks: Direct
       <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Direct Security Checks</h3>
       <ul className="mt-3 space-y-2">
         {filtered.map((check) => {
-          const isGov = GOVERNANCE_DIRECT_CHECKS.has(check.name)
+          const tags = getAllDirectCheckTags(check.name)
           return (
             <li key={check.name} className="flex items-start gap-2">
               {check.detected === 'unavailable' ? (
@@ -85,7 +100,7 @@ function DirectChecksSection({ checks, activeTag, onTagClick }: { checks: Direct
                   </p>
                 ) : null}
               </div>
-              {isGov ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={onTagClick} /> : null}
+              {tags.map((tag) => <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={onTagClick} />)}
             </li>
           )
         })}

--- a/components/tags/TagPill.tsx
+++ b/components/tags/TagPill.tsx
@@ -2,6 +2,18 @@
 
 const TAG_COLORS: Record<string, string> = {
   governance: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+  'supply-chain': 'bg-orange-50 text-orange-700 border-orange-200',
+  'quick-win': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  compliance: 'bg-rose-50 text-rose-700 border-rose-200',
+  'contrib-ex': 'bg-cyan-50 text-cyan-700 border-cyan-200',
+}
+
+const TAG_RING_COLORS: Record<string, string> = {
+  governance: 'ring-indigo-400',
+  'supply-chain': 'ring-orange-400',
+  'quick-win': 'ring-emerald-400',
+  compliance: 'ring-rose-400',
+  'contrib-ex': 'ring-cyan-400',
 }
 const DEFAULT_TAG_COLOR = 'bg-slate-50 text-slate-600 border-slate-200'
 
@@ -11,7 +23,7 @@ export function TagPill({ tag, active, onClick }: { tag: string; active: boolean
     <button
       type="button"
       onClick={(e) => { e.stopPropagation(); onClick(tag) }}
-      className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium transition-all ${color} ${active ? 'ring-2 ring-indigo-400 ring-offset-1' : 'hover:opacity-80'}`}
+      className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium transition-all ${color} ${active ? `ring-2 ${TAG_RING_COLORS[tag] ?? 'ring-indigo-400'} ring-offset-1` : 'hover:opacity-80'}`}
     >
       {tag}
     </button>
@@ -21,13 +33,13 @@ export function TagPill({ tag, active, onClick }: { tag: string; active: boolean
 export function ActiveFilterBar({ tag, onClear }: { tag: string; onClear: () => void }) {
   const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-indigo-200 bg-indigo-50 px-3 py-2">
-      <span className="text-xs text-indigo-600">Filtering by</span>
+    <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+      <span className="text-xs text-slate-600">Filtering by</span>
       <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${color}`}>{tag}</span>
       <button
         type="button"
         onClick={onClear}
-        className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-indigo-400 hover:bg-indigo-100 hover:text-indigo-600"
+        className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-400 hover:bg-slate-100 hover:text-slate-600"
         aria-label="Clear filter"
       >
         <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -82,6 +82,7 @@ describe('getCatalogEntryByKey', () => {
       bucket: 'Security',
       key: 'Token-Permissions',
       title: 'Restrict GitHub Actions token permissions',
+      tags: ['supply-chain'],
     })
   })
 
@@ -106,6 +107,58 @@ describe('getCatalogEntriesByTag', () => {
       'SEC-14', 'SEC-17', 'SEC-3', 'SEC-5',
       'SUS-2',
     ])
+  })
+
+  it('returns supply-chain-tagged entries', () => {
+    const entries = getCatalogEntriesByTag('supply-chain')
+    const ids = entries.map((e) => e.id).sort()
+    expect(ids).toEqual([
+      'SEC-12', 'SEC-15', 'SEC-4', 'SEC-6', 'SEC-7', 'SEC-8',
+    ])
+  })
+
+  it('returns quick-win-tagged entries', () => {
+    const entries = getCatalogEntriesByTag('quick-win')
+    const ids = entries.map((e) => e.id).sort()
+    expect(ids).toEqual([
+      'DOC-1', 'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
+      'SEC-14', 'SEC-16', 'SEC-6',
+    ])
+  })
+
+  it('returns compliance-tagged entries', () => {
+    const entries = getCatalogEntriesByTag('compliance')
+    const ids = entries.map((e) => e.id).sort()
+    expect(ids).toEqual([
+      'DOC-12', 'DOC-13', 'DOC-14', 'DOC-2',
+      'SEC-14', 'SEC-17',
+    ])
+  })
+
+  it('returns contrib-ex-tagged entries', () => {
+    const entries = getCatalogEntriesByTag('contrib-ex')
+    const ids = entries.map((e) => e.id).sort()
+    expect(ids).toEqual([
+      'ACT-2',
+      'DOC-1', 'DOC-10', 'DOC-11', 'DOC-3', 'DOC-4',
+      'DOC-7', 'DOC-8', 'DOC-9',
+      'RSP-1',
+    ])
+  })
+
+  it('entries with multiple tags return for each tag', () => {
+    // SEC-6 is both supply-chain and quick-win
+    const supplyChain = getCatalogEntriesByTag('supply-chain')
+    const quickWin = getCatalogEntriesByTag('quick-win')
+    expect(supplyChain.find((e) => e.id === 'SEC-6')).toBeDefined()
+    expect(quickWin.find((e) => e.id === 'SEC-6')).toBeDefined()
+
+    // DOC-2 is governance, quick-win, and compliance
+    const governance = getCatalogEntriesByTag('governance')
+    const compliance = getCatalogEntriesByTag('compliance')
+    expect(governance.find((e) => e.id === 'DOC-2')).toBeDefined()
+    expect(quickWin.find((e) => e.id === 'DOC-2')).toBeDefined()
+    expect(compliance.find((e) => e.id === 'DOC-2')).toBeDefined()
   })
 
   it('returns empty array for unknown tag', () => {

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -30,22 +30,22 @@ const SEC: CatalogEntry[] = [
   { id: 'SEC-2', bucket: 'Security', key: 'Webhooks', title: 'Secure webhook configurations with token authentication' },
   // High
   { id: 'SEC-3', bucket: 'Security', key: 'Branch-Protection', title: 'Enforce branch protection on the default branch', tags: ['governance'] },
-  { id: 'SEC-4', bucket: 'Security', key: 'Binary-Artifacts', title: 'Remove binary artifacts from the repository' },
+  { id: 'SEC-4', bucket: 'Security', key: 'Binary-Artifacts', title: 'Remove binary artifacts from the repository', tags: ['supply-chain'] },
   { id: 'SEC-5', bucket: 'Security', key: 'Code-Review', title: 'Require code review before merging pull requests', tags: ['governance'] },
-  { id: 'SEC-6', bucket: 'Security', key: 'Dependency-Update-Tool', title: 'Enable automated dependency updates' },
-  { id: 'SEC-7', bucket: 'Security', key: 'Signed-Releases', title: 'Sign release artifacts to attest provenance' },
-  { id: 'SEC-8', bucket: 'Security', key: 'Token-Permissions', title: 'Restrict GitHub Actions token permissions' },
+  { id: 'SEC-6', bucket: 'Security', key: 'Dependency-Update-Tool', title: 'Enable automated dependency updates', tags: ['supply-chain', 'quick-win'] },
+  { id: 'SEC-7', bucket: 'Security', key: 'Signed-Releases', title: 'Sign release artifacts to attest provenance', tags: ['supply-chain'] },
+  { id: 'SEC-8', bucket: 'Security', key: 'Token-Permissions', title: 'Restrict GitHub Actions token permissions', tags: ['supply-chain'] },
   { id: 'SEC-9', bucket: 'Security', key: 'Vulnerabilities', title: 'Fix known vulnerabilities in dependencies' },
   { id: 'SEC-10', bucket: 'Security', key: 'Maintained', title: 'Maintain regular development activity' },
   // Medium
   { id: 'SEC-11', bucket: 'Security', key: 'Fuzzing', title: 'Adopt fuzz testing to find edge-case bugs' },
-  { id: 'SEC-12', bucket: 'Security', key: 'Pinned-Dependencies', title: 'Pin dependencies to specific versions by hash' },
+  { id: 'SEC-12', bucket: 'Security', key: 'Pinned-Dependencies', title: 'Pin dependencies to specific versions by hash', tags: ['supply-chain'] },
   { id: 'SEC-13', bucket: 'Security', key: 'SAST', title: 'Enable static application security testing (SAST)' },
-  { id: 'SEC-14', bucket: 'Security', key: 'Security-Policy', title: 'Add a security vulnerability disclosure policy', tags: ['governance'] },
-  { id: 'SEC-15', bucket: 'Security', key: 'Packaging', title: 'Publish packages through official registries' },
+  { id: 'SEC-14', bucket: 'Security', key: 'Security-Policy', title: 'Add a security vulnerability disclosure policy', tags: ['governance', 'quick-win', 'compliance'] },
+  { id: 'SEC-15', bucket: 'Security', key: 'Packaging', title: 'Publish packages through official registries', tags: ['supply-chain'] },
   // Low
-  { id: 'SEC-16', bucket: 'Security', key: 'CI-Tests', title: 'Run automated tests on pull requests' },
-  { id: 'SEC-17', bucket: 'Security', key: 'License', title: 'Add a recognized open-source license', tags: ['governance'] },
+  { id: 'SEC-16', bucket: 'Security', key: 'CI-Tests', title: 'Run automated tests on pull requests', tags: ['quick-win'] },
+  { id: 'SEC-17', bucket: 'Security', key: 'License', title: 'Add a recognized open-source license', tags: ['governance', 'compliance'] },
 ]
 
 /**
@@ -63,7 +63,7 @@ const DIRECT_CHECK_ALIASES: Record<string, string> = {
 
 const ACT: CatalogEntry[] = [
   { id: 'ACT-1', bucket: 'Activity', key: 'pr_flow', title: 'Reduce PR backlog and speed up review throughput' },
-  { id: 'ACT-2', bucket: 'Activity', key: 'issue_flow', title: 'Triage and close stale issues' },
+  { id: 'ACT-2', bucket: 'Activity', key: 'issue_flow', title: 'Triage and close stale issues', tags: ['contrib-ex'] },
   { id: 'ACT-3', bucket: 'Activity', key: 'completion_speed', title: 'Reduce time to merge PRs and close issues' },
   { id: 'ACT-4', bucket: 'Activity', key: 'sustained_activity', title: 'Increase commit frequency for sustained momentum' },
 ]
@@ -71,7 +71,7 @@ const ACT: CatalogEntry[] = [
 // ── Responsiveness ────────────────────────────────────────────────────
 
 const RSP: CatalogEntry[] = [
-  { id: 'RSP-1', bucket: 'Responsiveness', key: 'response_time', title: 'Reduce issue and PR first-response times' },
+  { id: 'RSP-1', bucket: 'Responsiveness', key: 'response_time', title: 'Reduce issue and PR first-response times', tags: ['contrib-ex'] },
   { id: 'RSP-2', bucket: 'Responsiveness', key: 'resolution', title: 'Speed up issue resolution and PR merge times' },
   { id: 'RSP-3', bucket: 'Responsiveness', key: 'backlog_health', title: 'Address stale issues and PRs' },
 ]
@@ -87,22 +87,22 @@ const SUS: CatalogEntry[] = [
 
 const DOC: CatalogEntry[] = [
   // File presence
-  { id: 'DOC-1', bucket: 'Documentation', key: 'file:readme', title: 'Add a README' },
-  { id: 'DOC-2', bucket: 'Documentation', key: 'file:license', title: 'Add a LICENSE file', tags: ['governance'] },
-  { id: 'DOC-3', bucket: 'Documentation', key: 'file:contributing', title: 'Add CONTRIBUTING.md', tags: ['governance'] },
-  { id: 'DOC-4', bucket: 'Documentation', key: 'file:code_of_conduct', title: 'Add CODE_OF_CONDUCT.md', tags: ['governance'] },
-  { id: 'DOC-5', bucket: 'Documentation', key: 'file:security', title: 'Add SECURITY.md', tags: ['governance'] },
-  { id: 'DOC-6', bucket: 'Documentation', key: 'file:changelog', title: 'Add CHANGELOG.md', tags: ['governance'] },
+  { id: 'DOC-1', bucket: 'Documentation', key: 'file:readme', title: 'Add a README', tags: ['quick-win', 'contrib-ex'] },
+  { id: 'DOC-2', bucket: 'Documentation', key: 'file:license', title: 'Add a LICENSE file', tags: ['governance', 'quick-win', 'compliance'] },
+  { id: 'DOC-3', bucket: 'Documentation', key: 'file:contributing', title: 'Add CONTRIBUTING.md', tags: ['governance', 'quick-win', 'contrib-ex'] },
+  { id: 'DOC-4', bucket: 'Documentation', key: 'file:code_of_conduct', title: 'Add CODE_OF_CONDUCT.md', tags: ['governance', 'quick-win', 'contrib-ex'] },
+  { id: 'DOC-5', bucket: 'Documentation', key: 'file:security', title: 'Add SECURITY.md', tags: ['governance', 'quick-win'] },
+  { id: 'DOC-6', bucket: 'Documentation', key: 'file:changelog', title: 'Add CHANGELOG.md', tags: ['governance', 'quick-win'] },
   // README sections
-  { id: 'DOC-7', bucket: 'Documentation', key: 'section:description', title: 'Add a project description to your README' },
-  { id: 'DOC-8', bucket: 'Documentation', key: 'section:installation', title: 'Add installation instructions to your README' },
-  { id: 'DOC-9', bucket: 'Documentation', key: 'section:usage', title: 'Add usage examples to your README' },
-  { id: 'DOC-10', bucket: 'Documentation', key: 'section:contributing', title: 'Add a contributing section to your README' },
-  { id: 'DOC-11', bucket: 'Documentation', key: 'section:license', title: 'Add a license section to your README' },
+  { id: 'DOC-7', bucket: 'Documentation', key: 'section:description', title: 'Add a project description to your README', tags: ['contrib-ex'] },
+  { id: 'DOC-8', bucket: 'Documentation', key: 'section:installation', title: 'Add installation instructions to your README', tags: ['contrib-ex'] },
+  { id: 'DOC-9', bucket: 'Documentation', key: 'section:usage', title: 'Add usage examples to your README', tags: ['contrib-ex'] },
+  { id: 'DOC-10', bucket: 'Documentation', key: 'section:contributing', title: 'Add a contributing section to your README', tags: ['contrib-ex'] },
+  { id: 'DOC-11', bucket: 'Documentation', key: 'section:license', title: 'Add a license section to your README', tags: ['contrib-ex'] },
   // Licensing
-  { id: 'DOC-12', bucket: 'Documentation', key: 'licensing:license', title: 'Add an open source license', tags: ['governance'] },
-  { id: 'DOC-13', bucket: 'Documentation', key: 'licensing:osi_license', title: 'Use an OSI-approved license', tags: ['governance'] },
-  { id: 'DOC-14', bucket: 'Documentation', key: 'licensing:dco_cla', title: 'Enforce a DCO or CLA for contributions', tags: ['governance'] },
+  { id: 'DOC-12', bucket: 'Documentation', key: 'licensing:license', title: 'Add an open source license', tags: ['governance', 'compliance'] },
+  { id: 'DOC-13', bucket: 'Documentation', key: 'licensing:osi_license', title: 'Use an OSI-approved license', tags: ['governance', 'compliance'] },
+  { id: 'DOC-14', bucket: 'Documentation', key: 'licensing:dco_cla', title: 'Enforce a DCO or CLA for contributions', tags: ['governance', 'compliance'] },
 ]
 
 // ── Combined catalog ──────────────────────────────────────────────────

--- a/lib/security/recommendation-catalog.ts
+++ b/lib/security/recommendation-catalog.ts
@@ -82,6 +82,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Delete checked-in binaries (`.exe`, `.dll`, `.so`, `.jar`) and add them to `.gitignore`. Build artifacts from source in CI.',
     docsUrl: `${SCORECARD_DOCS_BASE}#binary-artifacts`,
     directCheckMapping: null,
+    tags: ['supply-chain'],
   },
   {
     key: 'Code-Review',
@@ -107,6 +108,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create `.github/dependabot.yml` with update schedules for your package ecosystems.',
     docsUrl: `${SCORECARD_DOCS_BASE}#dependency-update-tool`,
     directCheckMapping: 'dependabot',
+    tags: ['supply-chain', 'quick-win'],
   },
   {
     key: 'Signed-Releases',
@@ -119,6 +121,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Use `gpg --sign` or `cosign` to sign release artifacts, and attach `.sig` or `.pem` files to GitHub releases.',
     docsUrl: `${SCORECARD_DOCS_BASE}#signed-releases`,
     directCheckMapping: null,
+    tags: ['supply-chain'],
   },
   {
     key: 'Token-Permissions',
@@ -131,6 +134,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Add `permissions: read-all` at the top of workflow files and grant specific write permissions per job.',
     docsUrl: `${SCORECARD_DOCS_BASE}#token-permissions`,
     directCheckMapping: null,
+    tags: ['supply-chain'],
   },
   {
     key: 'Vulnerabilities',
@@ -181,6 +185,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Replace `uses: actions/checkout@v4` with `uses: actions/checkout@<full-sha>` in workflow files.',
     docsUrl: `${SCORECARD_DOCS_BASE}#pinned-dependencies`,
     directCheckMapping: null,
+    tags: ['supply-chain'],
   },
   {
     key: 'SAST',
@@ -205,7 +210,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create `SECURITY.md` with sections: Reporting a Vulnerability, Contact, Response Timeline. GitHub also supports private vulnerability reporting.',
     docsUrl: `${SCORECARD_DOCS_BASE}#security-policy`,
     directCheckMapping: 'security_policy',
-    tags: ['governance'],
+    tags: ['governance', 'quick-win', 'compliance'],
   },
   {
     key: 'Packaging',
@@ -218,6 +223,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: null,
     docsUrl: `${SCORECARD_DOCS_BASE}#packaging`,
     directCheckMapping: null,
+    tags: ['supply-chain'],
   },
 
   // --- Low risk Scorecard checks ---
@@ -232,6 +238,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Add a GitHub Actions workflow with `on: pull_request` that runs your test suite.',
     docsUrl: `${SCORECARD_DOCS_BASE}#ci-tests`,
     directCheckMapping: 'ci_cd',
+    tags: ['quick-win'],
   },
   {
     key: 'License',
@@ -244,7 +251,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create a `LICENSE` file at the repo root. Use `choosealicense.com` to pick an appropriate license.',
     docsUrl: `${SCORECARD_DOCS_BASE}#license`,
     directCheckMapping: null,
-    tags: ['governance'],
+    tags: ['governance', 'compliance'],
   },
 
   // --- Direct checks ---
@@ -259,7 +266,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create `SECURITY.md` at the repo root with sections for reporting process, contact info, and response expectations.',
     docsUrl: null,
     directCheckMapping: null,
-    tags: ['governance'],
+    tags: ['governance', 'quick-win', 'compliance'],
   },
   {
     key: 'dependabot',
@@ -272,6 +279,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create `.github/dependabot.yml` with update schedules for your package ecosystems.',
     docsUrl: null,
     directCheckMapping: null,
+    tags: ['supply-chain', 'quick-win'],
   },
   {
     key: 'ci_cd',
@@ -284,6 +292,7 @@ export const RECOMMENDATION_CATALOG: RecommendationCatalogEntry[] = [
     remediationHint: 'Create `.github/workflows/ci.yml` with a workflow that runs your test suite on push and pull_request events.',
     docsUrl: null,
     directCheckMapping: null,
+    tags: ['quick-win'],
   },
   {
     key: 'branch_protection',

--- a/lib/tags/tag-mappings.ts
+++ b/lib/tags/tag-mappings.ts
@@ -1,0 +1,144 @@
+/**
+ * Cross-cutting tag mappings for tab-level display items.
+ *
+ * These map the item keys used in each tab's data model to tags,
+ * so tag pills can appear on individual rows across all views.
+ *
+ * The governance tag has its own file (governance.ts) for backwards
+ * compatibility. All new tags are defined here.
+ */
+
+// ── supply-chain ─────────────────────────────────────────────────────
+
+/** Scorecard check names that are supply-chain signals */
+export const SUPPLY_CHAIN_SCORECARD_CHECKS = new Set([
+  'Binary-Artifacts',
+  'Dependency-Update-Tool',
+  'Signed-Releases',
+  'Token-Permissions',
+  'Pinned-Dependencies',
+  'Packaging',
+])
+
+/** Direct security check names that are supply-chain signals */
+export const SUPPLY_CHAIN_DIRECT_CHECKS = new Set([
+  'dependabot',
+])
+
+// ── quick-win ────────────────────────────────────────────────────────
+
+/** Documentation file-check names that are quick-win signals */
+export const QUICK_WIN_DOC_FILES = new Set([
+  'readme',
+  'license',
+  'contributing',
+  'code_of_conduct',
+  'security',
+  'changelog',
+])
+
+/** Scorecard check names that are quick-win signals */
+export const QUICK_WIN_SCORECARD_CHECKS = new Set([
+  'Security-Policy',
+  'CI-Tests',
+  'Dependency-Update-Tool',
+])
+
+/** Direct security check names that are quick-win signals */
+export const QUICK_WIN_DIRECT_CHECKS = new Set([
+  'security_policy',
+  'dependabot',
+  'ci_cd',
+])
+
+// ── compliance ───────────────────────────────────────────────────────
+
+/** Documentation file-check names that are compliance signals */
+export const COMPLIANCE_DOC_FILES = new Set([
+  'license',
+])
+
+/** Scorecard check names that are compliance signals */
+export const COMPLIANCE_SCORECARD_CHECKS = new Set([
+  'Security-Policy',
+  'License',
+])
+
+/** Direct security check names that are compliance signals */
+export const COMPLIANCE_DIRECT_CHECKS = new Set([
+  'security_policy',
+])
+
+/** Whether the licensing pane is compliance-tagged */
+export const LICENSING_IS_COMPLIANCE = true
+
+// ── contrib-ex ───────────────────────────────────────────────────────
+
+/** Documentation file-check names that are contributor-experience signals */
+export const CONTRIB_EX_DOC_FILES = new Set([
+  'readme',
+  'contributing',
+  'code_of_conduct',
+])
+
+/** README section names that are contributor-experience signals */
+export const CONTRIB_EX_README_SECTIONS = new Set([
+  'description',
+  'installation',
+  'usage',
+  'contributing',
+  'license',
+])
+
+/** Responsiveness pane titles that are contributor-experience signals */
+export const CONTRIB_EX_RESPONSIVENESS_PANES = new Set([
+  'Issue & PR response time',
+])
+
+/** Activity card titles that are contributor-experience signals */
+export const CONTRIB_EX_ACTIVITY_CARDS = new Set([
+  'Issues',
+])
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Returns all tags for a documentation file-check name.
+ */
+export function getDocFileTags(name: string): string[] {
+  const tags: string[] = []
+  if (QUICK_WIN_DOC_FILES.has(name)) tags.push('quick-win')
+  if (COMPLIANCE_DOC_FILES.has(name)) tags.push('compliance')
+  if (CONTRIB_EX_DOC_FILES.has(name)) tags.push('contrib-ex')
+  return tags
+}
+
+/**
+ * Returns all tags for a README section name.
+ */
+export function getReadmeSectionTags(name: string): string[] {
+  if (CONTRIB_EX_README_SECTIONS.has(name)) return ['contrib-ex']
+  return []
+}
+
+/**
+ * Returns all tags for a Scorecard check name.
+ */
+export function getScorecardCheckTags(name: string): string[] {
+  const tags: string[] = []
+  if (SUPPLY_CHAIN_SCORECARD_CHECKS.has(name)) tags.push('supply-chain')
+  if (QUICK_WIN_SCORECARD_CHECKS.has(name)) tags.push('quick-win')
+  if (COMPLIANCE_SCORECARD_CHECKS.has(name)) tags.push('compliance')
+  return tags
+}
+
+/**
+ * Returns all tags for a direct security check name.
+ */
+export function getDirectCheckTags(name: string): string[] {
+  const tags: string[] = []
+  if (SUPPLY_CHAIN_DIRECT_CHECKS.has(name)) tags.push('supply-chain')
+  if (QUICK_WIN_DIRECT_CHECKS.has(name)) tags.push('quick-win')
+  if (COMPLIANCE_DIRECT_CHECKS.has(name)) tags.push('compliance')
+  return tags
+}


### PR DESCRIPTION
## Summary
- Adds four new cross-cutting tags (`supply-chain`, `quick-win`, `compliance`, `contrib-ex`) to the unified and security recommendation catalogs
- Tag pills render on relevant items across Documentation, Security, Activity, and Responsiveness tabs with distinct colors (orange, emerald, rose, cyan)
- Clicking a tag pill filters the current tab to matching items; filter persists across tab switches via the existing shared `activeTag` mechanism
- Entries carrying multiple tags (e.g. SEC-6 shows both `supply-chain` and `quick-win`) render all pills correctly

## Test plan
- [x] Verify all four tags appear as clickable pills on the correct items in the **Recommendations** tab
- [x] Verify `supply-chain` pills appear on relevant Scorecard and direct checks in the **Security** tab
- [x] Verify `quick-win` and `compliance` pills appear on relevant doc file rows and security checks
- [x] Verify `contrib-ex` pills appear on README sections, doc file rows, Issues card (Activity), and response time pane (Responsiveness)
- [x] Verify clicking a tag pill filters the tab to matching items only
- [x] Verify filter persists when switching tabs and can be cleared via the filter bar
- [x] Verify entries with multiple tags show all tag pills correctly
- [x] Verify existing `governance` tag behavior is unchanged
- [x] Verify all 500 tests pass (`npx vitest run`) — 66 test files, 500 tests, 0 failures (4.33s)

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)