### PR TITLE
Add Security, Licensing & Compliance, and Inclusive Naming to exports

### DIFF
--- a/lib/export/json-export.test.ts
+++ b/lib/export/json-export.test.ts
@@ -139,6 +139,76 @@ describe('buildJsonExport', () => {
     expect(starsRow!.cells[1].repo).toBe('vercel/next.js')
   })
 
+  it('omits security, licensing, and inclusiveNaming when data is unavailable', async () => {
+    const result = buildJsonExport(MINIMAL_RESPONSE)
+    const text = await result.blob.text()
+    const parsed = JSON.parse(text) as { results: Array<{ security?: unknown; licensing?: unknown; inclusiveNaming?: unknown }> }
+    expect(parsed.results[0].security).toBeUndefined()
+    expect(parsed.results[0].licensing).toBeUndefined()
+  })
+
+  it('includes security data when securityResult is present', async () => {
+    const response: AnalyzeResponse = {
+      ...MINIMAL_RESPONSE,
+      results: [{
+        ...MINIMAL_RESPONSE.results[0],
+        securityResult: {
+          scorecard: {
+            overallScore: 6.5,
+            checks: [{ name: 'Code-Review', score: 7, reason: 'Found' }],
+            scorecardVersion: '5.0.0',
+          },
+          directChecks: [
+            { name: 'security_policy', detected: true, details: null },
+            { name: 'dependabot', detected: false, details: null },
+          ],
+          branchProtectionEnabled: true,
+        },
+      }],
+    }
+    const result = buildJsonExport(response)
+    const text = await result.blob.text()
+    const parsed = JSON.parse(text) as { results: Array<{ security: { score: number; mode: string; scorecard: { overallScore: number; checks: Array<{ name: string }> }; directChecks: Array<{ name: string; detected: boolean }> }; scores: { security: { value: number; mode: string } } }> }
+    expect(parsed.results[0].security).toBeDefined()
+    expect(parsed.results[0].security.mode).toBe('scorecard')
+    expect(parsed.results[0].security.scorecard.overallScore).toBe(6.5)
+    expect(parsed.results[0].security.scorecard.checks[0].name).toBe('Code-Review')
+    expect(parsed.results[0].security.directChecks).toHaveLength(2)
+    expect(parsed.results[0].scores.security).toBeDefined()
+    expect(parsed.results[0].scores.security.mode).toBe('scorecard')
+  })
+
+  it('includes licensing data when licensingResult is present', async () => {
+    const response: AnalyzeResponse = {
+      ...MINIMAL_RESPONSE,
+      results: [{
+        ...MINIMAL_RESPONSE.results[0],
+        licensingResult: {
+          license: { spdxId: 'Apache-2.0', name: 'Apache License 2.0', osiApproved: true, permissivenessTier: 'Permissive' },
+          additionalLicenses: [],
+          contributorAgreement: { signedOffByRatio: 0.5, dcoOrClaBot: true, enforced: true },
+        },
+      }],
+    }
+    const result = buildJsonExport(response)
+    const text = await result.blob.text()
+    const parsed = JSON.parse(text) as { results: Array<{ licensing: { license: { spdxId: string; osiApproved: boolean }; contributorAgreement: { enforced: boolean } } }> }
+    expect(parsed.results[0].licensing).toBeDefined()
+    expect(parsed.results[0].licensing.license.spdxId).toBe('Apache-2.0')
+    expect(parsed.results[0].licensing.license.osiApproved).toBe(true)
+    expect(parsed.results[0].licensing.contributorAgreement.enforced).toBe(true)
+  })
+
+  it('includes inclusiveNaming data when inclusiveNamingResult is present', async () => {
+    const result = buildJsonExport(MINIMAL_RESPONSE)
+    const text = await result.blob.text()
+    const parsed = JSON.parse(text) as { results: Array<{ inclusiveNaming: { branchScore: number; metadataScore: number; branchCheck: { passed: boolean } } }> }
+    expect(parsed.results[0].inclusiveNaming).toBeDefined()
+    expect(parsed.results[0].inclusiveNaming.branchCheck.passed).toBe(true)
+    expect(parsed.results[0].inclusiveNaming.branchScore).toBeDefined()
+    expect(parsed.results[0].inclusiveNaming.metadataScore).toBeDefined()
+  })
+
   it('includes all repos when multiple repos are present', async () => {
     const multiResponse: AnalyzeResponse = {
       ...MINIMAL_RESPONSE,

--- a/lib/export/json-export.ts
+++ b/lib/export/json-export.ts
@@ -8,6 +8,7 @@ import { getDocumentationScore } from '@/lib/documentation/score-config'
 import { assignReferenceIds, resolveReferenceId } from '@/lib/recommendations/reference-id'
 import { getResponsivenessScore } from '@/lib/responsiveness/score-config'
 import { getHealthScore } from '@/lib/scoring/health-score'
+import { getInclusiveNamingScore } from '@/lib/inclusive-naming/score-config'
 import { getSecurityScore } from '@/lib/security/score-config'
 
 export interface JsonExportResult {
@@ -20,6 +21,7 @@ interface RepoScores {
   sustainability: { value: number | string; tone: string; description: string }
   responsiveness: { value: number | string; tone: string; description: string }
   documentation: { value: number | string; tone: string; filesFound: number; readmeSections: number } | null
+  security: { value: number | string; tone: string; mode: string } | null
 }
 
 function computeScores(result: AnalysisResult): RepoScores {
@@ -36,11 +38,17 @@ function computeScores(result: AnalysisResult): RepoScores {
       readmeSections: result.documentationResult.readmeSections.filter((s) => s.detected).length,
     }
   }
+  let security: RepoScores['security'] = null
+  if (result.securityResult && result.securityResult !== 'unavailable') {
+    const secScore = getSecurityScore(result.securityResult, result.stars)
+    security = { value: secScore.value, tone: secScore.tone, mode: secScore.mode }
+  }
   return {
     activity: { value: activity.value, tone: activity.tone, description: activity.description },
     sustainability: { value: sustainability.value, tone: sustainability.tone, description: sustainability.description },
     responsiveness: { value: responsiveness.value, tone: responsiveness.tone, description: responsiveness.description },
     documentation,
+    security,
   }
 }
 
@@ -103,6 +111,84 @@ function computeRecommendations(result: AnalysisResult) {
   return [...nonSecurityWithIds, ...securityWithIds]
 }
 
+function computeSecurity(result: AnalysisResult) {
+  if (!result.securityResult || result.securityResult === 'unavailable') return undefined
+  const score = getSecurityScore(result.securityResult, result.stars)
+  return {
+    score: score.value,
+    tone: score.tone,
+    mode: score.mode,
+    compositeScore: score.compositeScore,
+    scorecardScore: score.scorecardScore,
+    directCheckScore: score.directCheckScore,
+    scorecard: result.securityResult.scorecard !== 'unavailable'
+      ? {
+          overallScore: result.securityResult.scorecard.overallScore,
+          version: result.securityResult.scorecard.scorecardVersion,
+          checks: result.securityResult.scorecard.checks.map((c) => ({
+            name: c.name,
+            score: c.score,
+            reason: c.reason,
+          })),
+        }
+      : null,
+    directChecks: result.securityResult.directChecks.map((c) => ({
+      name: c.name,
+      detected: c.detected,
+      details: c.details,
+    })),
+  }
+}
+
+function computeLicensing(result: AnalysisResult) {
+  if (!result.licensingResult || result.licensingResult === 'unavailable') return undefined
+  const lr = result.licensingResult
+  return {
+    license: {
+      spdxId: lr.license.spdxId,
+      name: lr.license.name,
+      osiApproved: lr.license.osiApproved,
+      permissivenessTier: lr.license.permissivenessTier,
+    },
+    additionalLicenses: lr.additionalLicenses.map((l) => ({
+      spdxId: l.spdxId,
+      name: l.name,
+      osiApproved: l.osiApproved,
+      permissivenessTier: l.permissivenessTier,
+    })),
+    contributorAgreement: {
+      enforced: lr.contributorAgreement.enforced,
+      signedOffByRatio: lr.contributorAgreement.signedOffByRatio,
+      dcoOrClaBot: lr.contributorAgreement.dcoOrClaBot,
+    },
+  }
+}
+
+function computeInclusiveNaming(result: AnalysisResult) {
+  if (!result.inclusiveNamingResult || result.inclusiveNamingResult === 'unavailable') return undefined
+  const inr = result.inclusiveNamingResult
+  const score = getInclusiveNamingScore(inr)
+  return {
+    compositeScore: score.compositeScore,
+    branchScore: score.branchScore,
+    metadataScore: score.metadataScore,
+    defaultBranchName: inr.defaultBranchName,
+    branchCheck: {
+      term: inr.branchCheck.term,
+      passed: inr.branchCheck.passed,
+      severity: inr.branchCheck.severity,
+      replacements: inr.branchCheck.replacements,
+    },
+    metadataChecks: inr.metadataChecks.map((c) => ({
+      checkType: c.checkType,
+      term: c.term,
+      passed: c.passed,
+      severity: c.severity,
+      replacements: c.replacements,
+    })),
+  }
+}
+
 function computeComparison(results: AnalysisResult[]) {
   if (results.length < 2) return undefined
   return buildComparisonSections(results).map((section) => ({
@@ -133,6 +219,9 @@ export function buildJsonExport(response: AnalyzeResponse): JsonExportResult {
       contributors: computeContributors(result),
       healthRatios: computeHealthRatios(result),
       recommendations: computeRecommendations(result),
+      security: computeSecurity(result),
+      licensing: computeLicensing(result),
+      inclusiveNaming: computeInclusiveNaming(result),
     })),
     comparison: computeComparison(response.results),
   }

--- a/lib/export/markdown-export.test.ts
+++ b/lib/export/markdown-export.test.ts
@@ -209,6 +209,108 @@ describe('buildMarkdownReport', () => {
     expect(md).toContain('## Failed Repositories')
     expect(md).toContain('bad/repo')
   })
+
+  it('omits Security section when securityResult is unavailable', () => {
+    const md = buildMarkdownReport(MINIMAL_RESPONSE)
+    expect(md).not.toContain('### Security')
+    expect(md).not.toContain('OpenSSF Scorecard')
+    expect(md).not.toContain('Direct Security Checks')
+  })
+
+  it('omits Licensing & Compliance section when licensingResult is unavailable', () => {
+    const md = buildMarkdownReport(MINIMAL_RESPONSE)
+    expect(md).not.toContain('### Licensing & Compliance')
+  })
+
+  it('omits Inclusive Naming section when inclusiveNamingResult is unavailable', () => {
+    const response: AnalyzeResponse = {
+      ...MINIMAL_RESPONSE,
+      results: [{ ...MINIMAL_RESPONSE.results[0], inclusiveNamingResult: 'unavailable' }],
+    }
+    const md = buildMarkdownReport(response)
+    expect(md).not.toContain('### Inclusive Naming')
+  })
+
+  it('renders Security section when securityResult has data', () => {
+    const response: AnalyzeResponse = {
+      ...MINIMAL_RESPONSE,
+      results: [{
+        ...MINIMAL_RESPONSE.results[0],
+        securityResult: {
+          scorecard: {
+            overallScore: 7.5,
+            checks: [
+              { name: 'Code-Review', score: 8, reason: 'Found' },
+              { name: 'Branch-Protection', score: -1, reason: 'Internal error' },
+            ],
+            scorecardVersion: '5.0.0',
+          },
+          directChecks: [
+            { name: 'security_policy', detected: true, details: null },
+            { name: 'dependabot', detected: false, details: null },
+            { name: 'ci_cd', detected: 'unavailable', details: null },
+            { name: 'branch_protection', detected: true, details: null },
+          ],
+          branchProtectionEnabled: true,
+        },
+      }],
+    }
+    const md = buildMarkdownReport(response)
+    expect(md).toContain('### Security')
+    expect(md).toContain('Scorecard + direct checks')
+    expect(md).toContain('OpenSSF Scorecard (v5.0.0)')
+    expect(md).toContain('7.5 / 10')
+    expect(md).toContain('Code-Review')
+    expect(md).toContain('8 / 10')
+    expect(md).toContain('Indeterminate')
+    expect(md).toContain('Security Policy')
+    expect(md).toContain('Detected')
+    expect(md).toContain('Not detected')
+    expect(md).toContain('Unavailable')
+  })
+
+  it('renders Licensing & Compliance section when licensingResult has data', () => {
+    const response: AnalyzeResponse = {
+      ...MINIMAL_RESPONSE,
+      results: [{
+        ...MINIMAL_RESPONSE.results[0],
+        licensingResult: {
+          license: { spdxId: 'MIT', name: 'MIT License', osiApproved: true, permissivenessTier: 'Permissive' },
+          additionalLicenses: [],
+          contributorAgreement: { signedOffByRatio: 0, dcoOrClaBot: false, enforced: false },
+        },
+      }],
+    }
+    const md = buildMarkdownReport(response)
+    expect(md).toContain('### Licensing & Compliance')
+    expect(md).toContain('MIT License (MIT)')
+    expect(md).toContain('Yes')
+    expect(md).toContain('Permissive')
+  })
+
+  it('renders Inclusive Naming section with findings', () => {
+    const response: AnalyzeResponse = {
+      ...MINIMAL_RESPONSE,
+      results: [{
+        ...MINIMAL_RESPONSE.results[0],
+        inclusiveNamingResult: {
+          defaultBranchName: 'master',
+          branchCheck: { checkType: 'branch', term: 'master', passed: false, tier: 1, severity: 'Replace immediately', replacements: ['main', 'trunk'], context: null },
+          metadataChecks: [
+            { checkType: 'description', term: 'whitelist', passed: false, tier: 2, severity: 'Recommended to replace', replacements: ['allowlist'], context: null },
+          ],
+        },
+      }],
+    }
+    const md = buildMarkdownReport(response)
+    expect(md).toContain('### Inclusive Naming')
+    expect(md).toContain('Fail')
+    expect(md).toContain('`master`')
+    expect(md).toContain('Replace immediately')
+    expect(md).toContain('main, trunk')
+    expect(md).toContain('whitelist')
+    expect(md).toContain('allowlist')
+  })
 })
 
 describe('buildMarkdownExport', () => {

--- a/lib/export/markdown-export.ts
+++ b/lib/export/markdown-export.ts
@@ -153,6 +153,7 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
     `| Activity | ${activity.value} |`,
     `| Responsiveness | ${responsiveness.value} |`,
     `| Documentation | ${result.documentationResult !== 'unavailable' ? getDocumentationScore(result.documentationResult, result.licensingResult, result.stars, result.inclusiveNamingResult).value : 'unavailable'} |`,
+    `| Security | ${result.securityResult && result.securityResult !== 'unavailable' ? getSecurityScore(result.securityResult, result.stars).value : 'unavailable'} |`,
     '',
   )
 
@@ -312,6 +313,121 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
       ])),
       '',
     )
+  }
+
+  // Security section
+  if (result.securityResult && result.securityResult !== 'unavailable') {
+    const secScore = getSecurityScore(result.securityResult, result.stars)
+    const DIRECT_CHECK_LABELS: Record<string, string> = {
+      security_policy: 'Security Policy',
+      dependabot: 'Dependabot / Dependency Updates',
+      ci_cd: 'CI/CD Pipeline',
+      branch_protection: 'Branch Protection',
+    }
+
+    lines.push(
+      '### Security',
+      '',
+      `**Score**: ${secScore.value}`,
+      `**Mode**: ${secScore.mode === 'scorecard' ? 'Scorecard + direct checks' : 'Direct checks only'}`,
+      '',
+    )
+
+    if (result.securityResult.scorecard !== 'unavailable') {
+      const sc = result.securityResult.scorecard
+      lines.push(
+        `#### OpenSSF Scorecard (v${sc.scorecardVersion})`,
+        '',
+        `**Overall score**: ${sc.overallScore} / 10`,
+        '',
+        '| Check | Score |',
+        '| --- | --- |',
+        ...sc.checks.map((c) =>
+          `| ${c.name} | ${c.score === -1 ? 'Indeterminate' : `${c.score} / 10`} |`
+        ),
+        '',
+      )
+    }
+
+    if (result.securityResult.directChecks.length > 0) {
+      lines.push(
+        '#### Direct Security Checks',
+        '',
+        '| Check | Status |',
+        '| --- | --- |',
+        ...result.securityResult.directChecks.map((c) => {
+          const label = DIRECT_CHECK_LABELS[c.name] ?? c.name
+          const status = c.detected === 'unavailable' ? 'Unavailable' : c.detected ? 'Detected' : 'Not detected'
+          return `| ${label} | ${status} |`
+        }),
+        '',
+      )
+    }
+  }
+
+  // Licensing & Compliance section
+  if (result.licensingResult && result.licensingResult !== 'unavailable') {
+    const lr = result.licensingResult
+    const license = lr.license
+
+    lines.push(
+      '### Licensing & Compliance',
+      '',
+    )
+
+    const licensingRows: [string, string][] = [
+      ['License', license.spdxId ? `${license.name} (${license.spdxId})` : 'Not detected'],
+    ]
+    if (lr.additionalLicenses.length > 0) {
+      licensingRows.push(['Additional licenses', lr.additionalLicenses.map((l) => l.name).join(', ')])
+    }
+    licensingRows.push(
+      ['OSI approved', license.osiApproved === true ? 'Yes' : license.osiApproved === false ? 'No' : '—'],
+      ['Permissiveness tier', license.permissivenessTier ?? '—'],
+      ['DCO/CLA enforced', lr.contributorAgreement.enforced === true ? 'Yes' : lr.contributorAgreement.enforced === false ? 'No' : '—'],
+    )
+
+    lines.push(mdTable(licensingRows), '')
+  }
+
+  // Inclusive Naming section
+  if (result.inclusiveNamingResult && result.inclusiveNamingResult !== 'unavailable') {
+    const inr = result.inclusiveNamingResult
+
+    lines.push(
+      '### Inclusive Naming',
+      '',
+    )
+
+    // Default branch
+    const branchStatus = inr.branchCheck.passed ? 'Pass' : 'Fail'
+    const branchDetail = inr.defaultBranchName ? ` (\`${inr.defaultBranchName}\`)` : ''
+    lines.push(`**Default branch**: ${branchStatus}${branchDetail}`, '')
+
+    if (!inr.branchCheck.passed && inr.branchCheck.severity) {
+      lines.push(`- Severity: ${inr.branchCheck.severity}`)
+      if (inr.branchCheck.replacements.length > 0) {
+        lines.push(`- Suggested replacements: ${inr.branchCheck.replacements.join(', ')}`)
+      }
+      lines.push('')
+    }
+
+    // Metadata checks
+    const failingChecks = inr.metadataChecks.filter((c) => !c.passed)
+    if (failingChecks.length > 0) {
+      lines.push(
+        '#### Findings',
+        '',
+        '| Term | Location | Severity | Suggested Replacement |',
+        '| --- | --- | --- | --- |',
+        ...failingChecks.map((c) =>
+          `| ${c.term} | ${c.checkType} | ${c.severity ?? '—'} | ${c.replacements.length > 0 ? c.replacements.join(', ') : '—'} |`
+        ),
+        '',
+      )
+    } else {
+      lines.push('No non-inclusive terms found.', '')
+    }
   }
 
   // Health Ratios section with tables per category


### PR DESCRIPTION
## Summary
- Adds **Security** section to Markdown/JSON exports with composite score, OpenSSF Scorecard checks, and direct security check results
- Adds **Licensing & Compliance** section with license type, SPDX ID, OSI status, permissiveness tier, and DCO/CLA enforcement
- Adds **Inclusive Naming** section with default branch check, metadata findings with severity levels and replacement suggestions
- Adds Security score to the overview scores table in both export formats

Closes #170

## Test plan
- [x] Export Markdown for a repo with full security data (scorecard + direct checks) — verify Security section appears with checks table
- [x] Export Markdown for a repo with direct-only security mode — verify mode label shows "Direct checks only"
- [x] Export Markdown for a repo with licensing data — verify Licensing & Compliance section shows license, OSI, tier, DCO/CLA
- [x] Export Markdown for a repo with inclusive naming findings — verify Inclusive Naming section shows branch check and findings table
- [x] Export JSON and verify `security`, `licensing`, and `inclusiveNaming` keys are present on each result
- [x] Export JSON and verify `scores.security` is populated
- [x] Open a shareable URL and re-export — verify all new sections render
- [x] Export for a repo where security/licensing/inclusive naming are unavailable — verify no crash, sections omitted gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)