### PR TITLE
Show repo description in the scorecard

### DIFF
--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -39,6 +39,22 @@ describe('MetricCard', () => {
     expect(screen.getByText('Insufficient verified public data')).toBeInTheDocument()
   })
 
+  it('renders repo description below header', () => {
+    const card = buildMetricCardViewModels([buildResult()])[0]!
+
+    render(<MetricCard card={card} />)
+
+    expect(screen.getByText('The library for web and native user interfaces.')).toBeInTheDocument()
+  })
+
+  it('shows fallback for unavailable description', () => {
+    const card = buildMetricCardViewModels([buildResult({ description: 'unavailable' })])[0]!
+
+    render(<MetricCard card={card} />)
+
+    expect(screen.getByText('No description found')).toBeInTheDocument()
+  })
+
   it('handles unavailable ecosystem metrics gracefully', () => {
     const card = buildMetricCardViewModels([
       buildResult({ stars: 'unavailable', forks: 'unavailable', watchers: 'unavailable' }),

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -36,6 +36,7 @@ export function MetricCard({ card }: MetricCardProps) {
         <h3 className="font-semibold text-slate-900">{card.repo}</h3>
         <p className="text-xs text-slate-400">Created: {card.createdAtLabel}</p>
       </div>
+      <p className={`mt-1 line-clamp-2 text-xs italic text-slate-400 ${card.description === '—' ? '' : 'not-italic text-slate-500'}`}>{card.description === '—' ? 'No description found' : card.description}</p>
 
       <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Activity (25%), Responsiveness (25%), Contributors (23%), Security (15%), and Documentation (12%, includes licensing, compliance & inclusive naming) — scored relative to ${hs.bracketLabel} repositories.`}>
         <div>


### PR DESCRIPTION
## Summary
- Display repo description below the header (repo name + created date) in the scorecard card
- Long descriptions are truncated with CSS `line-clamp-2`
- Repos without a description show "No description found" in italic muted text

Closes #94

## Test plan
- [x] Verify description appears below repo name for repos that have one
- [x] Verify "No description found" shown in italic for repos without a description
- [x] Verify long descriptions are truncated to 2 lines — verified with `git/git` on mobile viewport
- [x] Verify compact layout is not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)