### PR TITLE
Rename Sustainability bucket to Contributors and polish scorecard

### DIFF
--- a/components/app-shell/ResultsTabs.tsx
+++ b/components/app-shell/ResultsTabs.tsx
@@ -73,6 +73,7 @@ export function ResultsTabs({ tabs, activeTab, onChange, matchCounts }: ResultsT
             type="button"
             aria-haspopup="true"
             aria-expanded={menuOpen}
+            title={activeOverflowTab ? activeOverflowTab.description : undefined}
             className={
               activeOverflowTab
                 ? 'inline-flex items-center gap-1 rounded-full bg-slate-900 px-2.5 py-1.5 text-sm font-medium text-white'
@@ -97,6 +98,7 @@ export function ResultsTabs({ tabs, activeTab, onChange, matchCounts }: ResultsT
                     type="button"
                     data-tab-id={tab.id}
                     aria-selected={tab.id === activeTab}
+                    title={tab.description}
                     className={
                       tab.id === activeTab
                         ? 'block w-full px-4 py-2 text-left text-sm font-medium text-slate-900 bg-slate-100'
@@ -138,6 +140,7 @@ function TabButton({ tab, active, onClick, badgeCount }: { tab: ResultTabDefinit
       type="button"
       data-tab-id={tab.id}
       aria-selected={active}
+      title={tab.description}
       className={
         active
           ? 'whitespace-nowrap rounded-full bg-slate-900 px-2.5 py-1.5 text-sm font-medium text-white'

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -61,6 +61,10 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
           <div className="flex flex-wrap justify-center gap-1.5 sm:grid sm:grid-cols-2 sm:gap-2">
             <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
+              <p className="font-semibold uppercase tracking-wide text-slate-500">👥 Contributors</p>
+              <p className="mt-0.5 hidden text-slate-600 sm:block">Contributor concentration, repeat and new contributor mix</p>
+            </div>
+            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
               <p className="font-semibold uppercase tracking-wide text-slate-500">⚡ Activity</p>
               <p className="mt-0.5 hidden text-slate-600 sm:block">PR throughput, issue flow, commit cadence, release frequency</p>
             </div>
@@ -69,16 +73,12 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
               <p className="mt-0.5 hidden text-slate-600 sm:block">Response times, resolution speed, backlog health</p>
             </div>
             <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
-              <p className="font-semibold uppercase tracking-wide text-slate-500">👥 Contributors</p>
-              <p className="mt-0.5 hidden text-slate-600 sm:block">Contributor concentration, repeat and new contributor mix</p>
-            </div>
-            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
-              <p className="font-semibold uppercase tracking-wide text-slate-500">🔒 Security</p>
-              <p className="mt-0.5 hidden text-slate-600 sm:block">OpenSSF Scorecard, dependency automation, branch protection</p>
-            </div>
-            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:col-span-2 sm:rounded-lg sm:px-3 sm:py-2">
               <p className="font-semibold uppercase tracking-wide text-slate-500">📄 Documentation</p>
               <p className="mt-0.5 hidden text-slate-600 sm:block">Key project files, README quality, licensing compliance, inclusive naming</p>
+            </div>
+            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:col-span-2 sm:rounded-lg sm:px-3 sm:py-2">
+              <p className="font-semibold uppercase tracking-wide text-slate-500">🔒 Security</p>
+              <p className="mt-0.5 hidden text-slate-600 sm:block">OpenSSF Scorecard, dependency automation, branch protection</p>
             </div>
           </div>
 

--- a/components/contributors/ContributorsScorePane.test.tsx
+++ b/components/contributors/ContributorsScorePane.test.tsx
@@ -1,16 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
-import { SustainabilityPane } from './SustainabilityPane'
+import { ContributorsScorePane } from './ContributorsScorePane'
 
-describe('SustainabilityPane', () => {
-  it('renders score details and the non-duplicative sustainability metrics', async () => {
+describe('ContributorsScorePane', () => {
+  it('renders score details and the non-duplicative contributor metrics', async () => {
     render(
-      <SustainabilityPane
+      <ContributorsScorePane
         section={{
           repo: 'facebook/react',
           coreMetrics: [],
-          sustainabilityScore: {
+          contributorsScore: {
             value: 45,
             tone: 'warning',
             description: 'Contributor concentration ranks at the 45th percentile among Growing (100–999 stars) repositories.',
@@ -20,7 +20,7 @@ describe('SustainabilityPane', () => {
             topContributorCount: 1,
             contributorCount: 5,
           },
-          sustainabilityMetrics: [
+          contributorsMetrics: [
             { label: 'Top 20% contributor share', value: '62.5%', supportingText: '1 of 5 active contributors' },
             {
               label: 'Maintainer count',
@@ -106,7 +106,7 @@ describe('SustainabilityPane', () => {
       ),
     ).toBeInTheDocument()
     expect(screen.queryByText(/^Missing data$/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/later sustainability signals/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/later contributor signals/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/grouped areas/i)).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: /show details/i }))
@@ -137,11 +137,11 @@ describe('SustainabilityPane', () => {
 
   it('does not render a missing-data panel', () => {
     render(
-      <SustainabilityPane
+      <ContributorsScorePane
         section={{
           repo: 'facebook/react',
           coreMetrics: [],
-          sustainabilityScore: {
+          contributorsScore: {
             value: 82,
             tone: 'success',
             description: 'Contributor concentration ranks at the 82nd percentile among Growing (100–999 stars) repositories.',
@@ -151,7 +151,7 @@ describe('SustainabilityPane', () => {
             topContributorCount: 1,
             contributorCount: 5,
           },
-          sustainabilityMetrics: [{ label: 'Top 20% contributor share', value: '40.0%', supportingText: '1 of 5 active contributors' }],
+          contributorsMetrics: [{ label: 'Top 20% contributor share', value: '40.0%', supportingText: '1 of 5 active contributors' }],
           experimentalMetrics: [],
           experimentalHeatmap: [],
           experimentalWarning:

--- a/components/contributors/ContributorsScorePane.tsx
+++ b/components/contributors/ContributorsScorePane.tsx
@@ -7,16 +7,16 @@ import { MetricValue } from '@/components/shared/MetricValue'
 import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import { formatPercentage } from '@/lib/contributors/score-config'
 import type { ContributorsSectionViewModel } from '@/lib/contributors/view-model'
-import { GOVERNANCE_SUSTAINABILITY_METRICS } from '@/lib/tags/governance'
+import { GOVERNANCE_CONTRIBUTORS_METRICS } from '@/lib/tags/governance'
 import { ContributionBarChart } from './ContributionBarChart'
 
-interface SustainabilityPaneProps {
+interface ContributorsScorePaneProps {
   section: ContributorsSectionViewModel
   activeTag?: string | null
   onTagChange?: (tag: string | null) => void
 }
 
-export function SustainabilityPane({ section, activeTag: externalTag, onTagChange }: SustainabilityPaneProps) {
+export function ContributorsScorePane({ section, activeTag: externalTag, onTagChange }: ContributorsScorePaneProps) {
   const [showDetails, setShowDetails] = useState(false)
   const [showExperimentalHeatmap, setShowExperimentalHeatmap] = useState(false)
   const [showExperimentalNames, setShowExperimentalNames] = useState(true)
@@ -30,14 +30,14 @@ export function SustainabilityPane({ section, activeTag: externalTag, onTagChang
   }
 
   return (
-    <section aria-label="Sustainability pane" className="rounded-2xl border border-slate-200 bg-white p-4">
+    <section aria-label="Contributors score pane" className="rounded-2xl border border-slate-200 bg-white p-4">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">Sustainability</h3>
-          <p className="mt-1 text-sm text-slate-600">{section.sustainabilityScore.description}</p>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">Contributors score</h3>
+          <p className="mt-1 text-sm text-slate-600">{section.contributorsScore.description}</p>
         </div>
         <div className="w-full md:max-w-xs">
-          <ScoreBadge category="Sustainability" value={section.sustainabilityScore.value} tone={section.sustainabilityScore.tone} />
+          <ScoreBadge category="Contributors" value={section.contributorsScore.value} tone={section.contributorsScore.tone} />
         </div>
       </div>
 
@@ -46,7 +46,7 @@ export function SustainabilityPane({ section, activeTag: externalTag, onTagChang
           <div>
             <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is this scored?</p>
             <p className="mt-1 text-sm text-slate-700">
-              RepoPulse scores sustainability from recent commit concentration, ranked as a percentile against repos in the same star bracket. Lower top-20% share means the active contributor base is more distributed.
+              RepoPulse scores contributor diversity from recent commit concentration, ranked as a percentile against repos in the same star bracket. Lower top-20% share means the active contributor base is more distributed.
             </p>
           </div>
           <button
@@ -62,8 +62,8 @@ export function SustainabilityPane({ section, activeTag: externalTag, onTagChang
           <div className="mt-3 rounded-lg border border-slate-200 bg-white p-3">
             <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Concentration</p>
             <p className="mt-1 text-sm text-slate-700">
-              Top-20% contributor share: {formatPercentage(section.sustainabilityScore.concentration)}
-              {section.sustainabilityScore.bracketLabel ? ` — scored relative to ${section.sustainabilityScore.bracketLabel} repositories` : ''}
+              Top-20% contributor share: {formatPercentage(section.contributorsScore.concentration)}
+              {section.contributorsScore.bracketLabel ? ` — scored relative to ${section.contributorsScore.bracketLabel} repositories` : ''}
             </p>
           </div>
         ) : null}
@@ -76,10 +76,10 @@ export function SustainabilityPane({ section, activeTag: externalTag, onTagChang
       ) : null}
 
       <dl className="mt-4 grid gap-3 md:grid-cols-2">
-        {section.sustainabilityMetrics
-          .filter((metric) => !activeTag || GOVERNANCE_SUSTAINABILITY_METRICS.has(metric.label))
+        {section.contributorsMetrics
+          .filter((metric) => !activeTag || GOVERNANCE_CONTRIBUTORS_METRICS.has(metric.label))
           .map((metric) => {
-            const isGov = GOVERNANCE_SUSTAINABILITY_METRICS.has(metric.label)
+            const isGov = GOVERNANCE_CONTRIBUTORS_METRICS.has(metric.label)
             return (
               <div key={metric.label} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
                 <dt className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-slate-500">

--- a/components/contributors/ContributorsView.test.tsx
+++ b/components/contributors/ContributorsView.test.tsx
@@ -5,7 +5,7 @@ import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { ContributorsView } from './ContributorsView'
 
 describe('ContributorsView', () => {
-  it('renders core and sustainability panes for each repository section', () => {
+  it('renders core and contributors-score panes for each repository section', () => {
     render(<ContributorsView results={[buildResult()]} />)
 
     const region = screen.getByRole('region', { name: /contributors view/i })
@@ -13,12 +13,12 @@ describe('ContributorsView', () => {
     expect(within(region).getByRole('button', { name: '90d' })).toHaveAttribute('aria-pressed', 'true')
     const corePane = within(region).getByRole('region', { name: /core contributors pane/i })
     expect(within(region).getByText('facebook/react')).toBeInTheDocument()
-    expect(within(region).getByRole('heading', { name: /core/i })).toBeInTheDocument()
-    expect(within(region).getByRole('heading', { name: /sustainability/i })).toBeInTheDocument()
+    expect(within(region).getByRole('heading', { name: /^core/i })).toBeInTheDocument()
+    expect(within(region).getByRole('heading', { name: /contributors score/i })).toBeInTheDocument()
     expect(within(corePane).getByText('Repeat contributor ratio')).toBeInTheDocument()
     expect(within(corePane).getByText('New contributor ratio')).toBeInTheDocument()
     expect(within(corePane).getByText(/^Contribution chart$/i)).toBeInTheDocument()
-    expect(within(region).queryByText(/later sustainability signals/i)).not.toBeInTheDocument()
+    expect(within(region).queryByText(/later contributor signals/i)).not.toBeInTheDocument()
   })
 
   it('lets the user include detected bot accounts in recent-commit metrics', async () => {

--- a/components/contributors/ContributorsView.tsx
+++ b/components/contributors/ContributorsView.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { CONTRIBUTOR_WINDOW_DAYS, type AnalysisResult, type ContributorWindowDays } from '@/lib/analyzer/analysis-result'
 import { buildContributorsViewModels } from '@/lib/contributors/view-model'
 import { CoreContributorsPane } from './CoreContributorsPane'
-import { SustainabilityPane } from './SustainabilityPane'
+import { ContributorsScorePane } from './ContributorsScorePane'
 
 interface ContributorsViewProps {
   results: AnalysisResult[]
@@ -48,10 +48,7 @@ export function ContributorsView({ results, activeTag, onTagChange }: Contributo
         <article key={section.repo} className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
           <div>
             <h2 className="text-lg font-semibold text-slate-900">{section.repo}</h2>
-            <p className="mt-1 text-sm text-slate-600">{`Contributor health and sustainability signals derived from verified public repository activity over the last ${section.windowDays} days.`}</p>
-            <p className="mt-2 text-sm text-slate-700">
-              The `Contributors` tab is the workspace for contributor analysis; the corresponding overview score category is `Sustainability`.
-            </p>
+            <p className="mt-1 text-sm text-slate-600">{`Contributor health and diversity signals derived from verified public repository activity over the last ${section.windowDays} days.`}</p>
           </div>
           <CoreContributorsPane
             metrics={section.coreMetrics}
@@ -60,7 +57,7 @@ export function ContributorsView({ results, activeTag, onTagChange }: Contributo
             includeBots={includeBots}
             onToggleIncludeBots={() => setIncludeBots((current) => !current)}
           />
-          <SustainabilityPane section={section} activeTag={activeTag} onTagChange={onTagChange} />
+          <ContributorsScorePane section={section} activeTag={activeTag} onTagChange={onTagChange} />
         </article>
       ))}
     </section>

--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -19,7 +19,7 @@ describe('MetricCard', () => {
     expect(screen.getByText(/^Engagement$/)).toBeInTheDocument()
     expect(screen.getByText(/^Activity$/)).toBeInTheDocument()
     expect(screen.getByText(/^Responsiveness$/)).toBeInTheDocument()
-    expect(screen.getByText(/^Sustainability$/)).toBeInTheDocument()
+    expect(screen.getByText(/^Contributors$/)).toBeInTheDocument()
 
     // Supporting details inline
     expect(screen.getByText(/244,295 stars/)).toBeInTheDocument()
@@ -35,7 +35,7 @@ describe('MetricCard', () => {
 
     render(<MetricCard card={card} />)
 
-    // Sustainability has no commit data → insufficient
+    // Contributors has no commit data → insufficient
     expect(screen.getByText('Insufficient verified public data')).toBeInTheDocument()
   })
 

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -9,24 +9,21 @@ interface MetricCardProps {
 }
 
 export function MetricCard({ card }: MetricCardProps) {
-  const cells: ScorecardCellProps[] = []
+  const profileCells: ScorecardCellProps[] = card.profile
+    ? [
+        { label: 'Reach', percentileLabel: card.profile.reachLabel, detail: `${card.starsLabel} stars`, tooltip: 'Star count percentile. Measures visibility and adoption.', toneClass: percentileToneClass(card.profile.reachPercentile, 'emerald') },
+        { label: 'Attention', percentileLabel: card.profile.attentionLabel, detail: `${card.profile.watcherRateLabel} watcher rate`, tooltip: 'Watcher-to-star ratio. More watchers = more people following updates.', toneClass: percentileToneClass(card.profile.attentionPercentile, 'violet') },
+        { label: 'Engagement', percentileLabel: card.profile.engagementLabel, detail: `${card.profile.forkRateLabel} fork rate`, tooltip: 'Fork-to-star ratio. More forks = more people building on the project.', toneClass: percentileToneClass(card.profile.engagementPercentile, 'sky') },
+      ]
+    : []
 
-  if (card.profile) {
-    cells.push(
-      { label: 'Reach', percentileLabel: card.profile.reachLabel, detail: `${card.starsLabel} stars`, tooltip: 'Star count percentile. Measures visibility and adoption.', toneClass: percentileToneClass(card.profile.reachPercentile, 'emerald') },
-      { label: 'Attention', percentileLabel: card.profile.attentionLabel, detail: `${card.profile.watcherRateLabel} watcher rate`, tooltip: 'Watcher-to-star ratio. More watchers = more people following updates.', toneClass: percentileToneClass(card.profile.attentionPercentile, 'violet') },
-      { label: 'Engagement', percentileLabel: card.profile.engagementLabel, detail: `${card.profile.forkRateLabel} fork rate`, tooltip: 'Fork-to-star ratio. More forks = more people building on the project.', toneClass: percentileToneClass(card.profile.engagementPercentile, 'sky') },
-    )
-  }
-
-  for (const badge of card.scoreBadges) {
-    cells.push({
-      label: badge.category,
-      percentileLabel: typeof badge.value === 'number' ? formatPercentileLabel(badge.value) : String(badge.value),
-      tooltip: badge.description,
-      toneClass: scoreToneClass(badge.tone),
-    })
-  }
+  const scoreCells: ScorecardCellProps[] = card.scoreBadges.map((badge) => ({
+    label: badge.category,
+    percentileLabel: typeof badge.value === 'number' ? formatPercentileLabel(badge.value) : String(badge.value),
+    detail: badge.detail,
+    tooltip: badge.description,
+    toneClass: scoreToneClass(badge.tone),
+  }))
 
   const hs = card.healthScore
 
@@ -46,11 +43,20 @@ export function MetricCard({ card }: MetricCardProps) {
         <p className="text-lg font-bold">{hs.label}</p>
       </div>
 
-      <div className="mt-2 grid grid-cols-1 gap-1.5 sm:grid-cols-3">
-        {cells.map((cell) => (
-          <ScorecardCell key={cell.label} {...cell} />
-        ))}
-      </div>
+      {profileCells.length > 0 ? (
+        <div className="mt-2 grid grid-cols-1 gap-1.5 sm:grid-cols-3">
+          {profileCells.map((cell) => (
+            <ScorecardCell key={cell.label} {...cell} />
+          ))}
+        </div>
+      ) : null}
+      {scoreCells.length > 0 ? (
+        <div className="mt-1.5 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+          {scoreCells.map((cell) => (
+            <ScorecardCell key={cell.label} {...cell} />
+          ))}
+        </div>
+      ) : null}
 
       {hs.recommendations.length > 0 ? (
         <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-center">
@@ -84,12 +90,12 @@ interface ScorecardCellProps {
 
 function ScorecardCell({ label, percentileLabel, detail, tooltip, toneClass }: ScorecardCellProps) {
   return (
-    <div className={`rounded border px-2 py-1.5 ${toneClass}`} title={tooltip}>
+    <div className={`flex min-h-[44px] flex-col justify-between rounded border px-2 py-1.5 ${toneClass}`} title={tooltip}>
       <div className="flex items-baseline justify-between gap-1">
         <span className="text-[10px] font-medium uppercase tracking-wide">{label}</span>
         <span className="text-xs font-semibold">{percentileLabel}</span>
       </div>
-      {detail ? <p className="mt-0.5 text-[10px] opacity-60">{detail}</p> : null}
+      <p className="mt-0.5 text-[10px] opacity-60">{detail ?? '\u00A0'}</p>
     </div>
   )
 }

--- a/components/recommendations/RecommendationsView.test.tsx
+++ b/components/recommendations/RecommendationsView.test.tsx
@@ -179,7 +179,7 @@ describe('RecommendationsView security recommendations', () => {
 })
 
 describe('RecommendationsView collapse/expand', () => {
-  // Build a result that produces both Sustainability and Security recommendations
+  // Build a result that produces both Contributors and Security recommendations
   function buildCollapsibleResult(): AnalysisResult {
     return buildResult({
       // Security result to generate Security recommendations
@@ -207,8 +207,8 @@ describe('RecommendationsView collapse/expand', () => {
   it('renders all buckets expanded by default', () => {
     render(<RecommendationsView results={[buildCollapsibleResult()]} />)
 
-    // Sustainability bucket header should be visible (via button)
-    expect(screen.getByRole('button', { name: /Sustainability/i })).toBeInTheDocument()
+    // Contributors bucket header should be visible (via button)
+    expect(screen.getByRole('button', { name: /Contributors/i })).toBeInTheDocument()
     // Security bucket header should be visible
     expect(screen.getByRole('button', { name: /Security/i })).toBeInTheDocument()
 
@@ -221,11 +221,11 @@ describe('RecommendationsView collapse/expand', () => {
     const user = userEvent.setup()
     render(<RecommendationsView results={[buildCollapsibleResult()]} />)
 
-    // Find and click the Sustainability bucket toggle
-    const sustainabilityToggle = screen.getByRole('button', { name: /Sustainability/i })
-    await user.click(sustainabilityToggle)
+    // Find and click the Contributors bucket toggle
+    const contributorsToggle = screen.getByRole('button', { name: /Contributors/i })
+    await user.click(contributorsToggle)
 
-    // Sustainability recommendations should be hidden
+    // Contributors recommendations should be hidden
     expect(screen.queryByText(/No maintainers identified/)).not.toBeInTheDocument()
 
     // Security should still be visible
@@ -236,13 +236,13 @@ describe('RecommendationsView collapse/expand', () => {
     const user = userEvent.setup()
     render(<RecommendationsView results={[buildCollapsibleResult()]} />)
 
-    const sustainabilityToggle = screen.getByRole('button', { name: /Sustainability/i })
+    const contributorsToggle = screen.getByRole('button', { name: /Contributors/i })
     // Collapse
-    await user.click(sustainabilityToggle)
+    await user.click(contributorsToggle)
     expect(screen.queryByText(/No maintainers identified/)).not.toBeInTheDocument()
 
     // Expand again
-    await user.click(sustainabilityToggle)
+    await user.click(contributorsToggle)
     expect(screen.getByText(/No maintainers identified/)).toBeInTheDocument()
   })
 
@@ -302,7 +302,7 @@ describe('RecommendationsView collapse/expand', () => {
     render(<RecommendationsView results={[buildCollapsibleResult()]} />)
 
     // Chevron SVG should be present on bucket toggle buttons
-    const sustainabilityToggle = screen.getByRole('button', { name: /Sustainability/i })
-    expect(sustainabilityToggle.querySelector('svg')).toBeInTheDocument()
+    const contributorsToggle = screen.getByRole('button', { name: /Contributors/i })
+    expect(contributorsToggle.querySelector('svg')).toBeInTheDocument()
   })
 })

--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -20,7 +20,7 @@ interface RecommendationsViewProps {
 const BUCKET_COLORS: Record<string, string> = {
   Activity: 'bg-blue-100 text-blue-800',
   Responsiveness: 'bg-purple-100 text-purple-800',
-  Sustainability: 'bg-emerald-100 text-emerald-800',
+  Contributors: 'bg-emerald-100 text-emerald-800',
   Documentation: 'bg-amber-100 text-amber-800',
   Security: 'bg-red-100 text-red-800',
 }

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -20,6 +20,7 @@ import { useAuth } from '@/components/auth/AuthContext'
 import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
+import { resultTabs } from '@/lib/results-shell/tabs'
 import { decodeRepos } from '@/lib/export/shareable-url'
 import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
 import { RepoInputForm } from './RepoInputForm'
@@ -240,56 +241,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
 
   const showOrgWorkspace = inputMode === 'org' && !analysisResponse
   const successfulRepoCount = analysisResponse?.results.length ?? 0
-  const repoTabs: ResultTabDefinition[] = [
-    {
-      id: 'overview',
-      label: 'Overview',
-      status: 'implemented',
-      description: 'Current analysis summary, ecosystem profile, and shared status',
-    },
-    {
-      id: 'contributors',
-      label: 'Contributors',
-      status: 'implemented',
-      description: 'Core contributor metrics and sustainability signals.',
-    },
-    {
-      id: 'activity',
-      label: 'Activity',
-      status: 'implemented',
-      description: 'Activity metrics, scoring, and detailed repo flow signals.',
-    },
-    {
-      id: 'responsiveness',
-      label: 'Responsiveness',
-      status: 'implemented',
-      description: 'Response-time, backlog-health, and engagement signals from public issue and PR activity.',
-    },
-    {
-      id: 'documentation',
-      label: 'Documentation',
-      status: 'implemented',
-      description: 'Documentation file presence, README quality, and improvement recommendations.',
-    },
-    {
-      id: 'security',
-      label: 'Security',
-      status: 'implemented',
-      description: 'Security posture including OpenSSF Scorecard checks, dependency automation, and branch protection.',
-    },
-    {
-      id: 'recommendations',
-      label: 'Recommendations',
-      status: 'implemented',
-      description: 'Actionable recommendations across all scoring dimensions.',
-    },
-    {
-      id: 'comparison' as const,
-      label: 'Comparison',
-      status: 'implemented' as const,
-      description: 'Side-by-side comparison across analyzed repositories.',
-    },
-  ]
+  const repoTabs: ResultTabDefinition[] = resultTabs
 
   const overviewContent = (
     <div className="space-y-4">

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -104,8 +104,8 @@ Phase 2 adds new scoring buckets to the health score. Requirements specs live in
 | 1 | P2-F01a | Documentation scoring (basic) | #66 | ✅ Done |
 | 2 | P2-F02 | Licensing & Compliance | #115 | ✅ Done |
 | 3 | P2-F03 | Inclusive naming | #107 | ✅ Done |
-| 4 | P2-F07 | Security scoring | #68 | |
-| 5 | P2-F04 | Governance & Transparency | #116 | |
+| 4 | P2-F07 | Security scoring | #68 | ✅ Done |
+| 5 | P2-F04 | Governance & Transparency | #116 | ✅ Done |
 | 6 | P2-F05 | Community scoring | #70 | |
 | 7 | P2-F06 | Foundation-aware recommendations | #119 | |
 | 8 | P2-F08 | Accessibility & Onboarding | #117 | |

--- a/e2e/metric-cards.spec.ts
+++ b/e2e/metric-cards.spec.ts
@@ -34,7 +34,7 @@ test.describe('P1-F07 Metric Cards', () => {
     await expect(overview).toContainText('Ecosystem profile')
     await expect(overview).toContainText('Engagement')
     await expect(overview).toContainText('Activity')
-    await expect(overview).toContainText('Sustainability')
+    await expect(overview).toContainText('Contributors')
     await expect(overview).toContainText('Responsiveness')
   })
 

--- a/lib/comparison/sections.ts
+++ b/lib/comparison/sections.ts
@@ -1,6 +1,6 @@
 import type { AnalysisResult, Unavailable } from '@/lib/analyzer/analysis-result'
 import { getMergeRateGuidance } from '@/lib/activity/merge-rate-guidance'
-import { computeContributionConcentration, getSustainabilityScore, formatPercentage as formatContributorPercentage } from '@/lib/contributors/score-config'
+import { computeContributionConcentration, getContributorsScore, formatPercentage as formatContributorPercentage } from '@/lib/contributors/score-config'
 import { getResponsivenessScore } from '@/lib/responsiveness/score-config'
 import { getDocumentationScore } from '@/lib/documentation/score-config'
 import { computeHealthRatio } from '@/lib/health-ratios/ratio-definitions'
@@ -16,7 +16,7 @@ export type ComparisonAttributeId =
   | 'total-contributors'
   | 'maintainer-count'
   | 'top-contributor-share'
-  | 'sustainability-score'
+  | 'contributors-score'
   | 'repeat-contributor-ratio'
   | 'new-contributor-ratio'
   | 'commits-90d'
@@ -148,7 +148,7 @@ export const COMPARISON_SECTIONS: ComparisonSectionDefinition[] = [
   {
     id: 'contributors',
     label: 'Contributors',
-    description: 'Compare contributor breadth and sustainability signals.',
+    description: 'Compare contributor breadth and diversity signals.',
     attributes: [
       {
         id: 'total-contributors',
@@ -181,14 +181,14 @@ export const COMPARISON_SECTIONS: ComparisonSectionDefinition[] = [
         formatValue: formatContributorPercentage,
       },
       {
-        id: 'sustainability-score',
+        id: 'contributors-score',
         sectionId: 'contributors',
-        label: 'Sustainability score',
-        helpText: 'Derived sustainability score from contributor concentration, as a percentile within the star bracket.',
+        label: 'Contributors score',
+        helpText: 'Contributor-diversity score, derived from commit concentration and expressed as a percentile within the star bracket.',
         direction: 'higher-is-better',
         valueType: 'number',
         getValue: (result) => {
-          const score = getSustainabilityScore(result)
+          const score = getContributorsScore(result)
           if (typeof score.value !== 'number') return 'unavailable'
           return score.value
         },

--- a/lib/contributors/score-config.test.ts
+++ b/lib/contributors/score-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computeContributionConcentration, getSustainabilityScore } from './score-config'
+import { computeContributionConcentration, getContributorsScore } from './score-config'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 
 describe('contributors/score-config', () => {
@@ -15,8 +15,8 @@ describe('contributors/score-config', () => {
     ).toBeCloseTo(5 / 12)
   })
 
-  it('returns a high sustainability score for broadly distributed contributor activity', () => {
-    const score = getSustainabilityScore(
+  it('returns a high contributors score for broadly distributed contributor activity', () => {
+    const score = getContributorsScore(
       buildResult({
         commitCountsByAuthor: {
           'login:alice': 2,
@@ -33,7 +33,7 @@ describe('contributors/score-config', () => {
   })
 
   it('returns insufficient data when contributor distribution cannot be verified', () => {
-    const score = getSustainabilityScore(buildResult({ commitCountsByAuthor: 'unavailable' }))
+    const score = getContributorsScore(buildResult({ commitCountsByAuthor: 'unavailable' }))
 
     expect(score.value).toBe('Insufficient verified public data')
     expect(score.tone).toBe('neutral')

--- a/lib/contributors/score-config.ts
+++ b/lib/contributors/score-config.ts
@@ -2,7 +2,7 @@ import type { AnalysisResult, Unavailable } from '@/lib/analyzer/analysis-result
 import type { ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
 import { formatPercentileLabel, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
 
-export interface SustainabilityScoreDefinition {
+export interface ContributorsScoreDefinition {
   value: ScoreValue
   tone: ScoreTone
   description: string
@@ -13,10 +13,10 @@ export interface SustainabilityScoreDefinition {
   contributorCount: number | Unavailable
 }
 
-const INSUFFICIENT_SCORE: SustainabilityScoreDefinition = {
+const INSUFFICIENT_SCORE: ContributorsScoreDefinition = {
   value: 'Insufficient verified public data',
   tone: 'neutral',
-  description: 'RepoPulse cannot verify enough contributor-distribution data to score sustainability yet.',
+  description: 'RepoPulse cannot verify enough contributor-distribution data to score contributors yet.',
   percentile: 0,
   bracketLabel: '',
   concentration: 'unavailable',
@@ -24,7 +24,7 @@ const INSUFFICIENT_SCORE: SustainabilityScoreDefinition = {
   contributorCount: 'unavailable',
 }
 
-export function getSustainabilityScore(result: AnalysisResult): SustainabilityScoreDefinition {
+export function getContributorsScore(result: AnalysisResult): ContributorsScoreDefinition {
   const cal = getCalibrationForStars(result.stars)
   const bracketLabel = getBracketLabel(result.stars)
   const concentration = getContributionConcentrationDetails(result.commitCountsByAuthor)
@@ -33,7 +33,7 @@ export function getSustainabilityScore(result: AnalysisResult): SustainabilitySc
     return INSUFFICIENT_SCORE
   }
 
-  // Inverted: lower concentration = higher percentile (better sustainability)
+  // Inverted: lower concentration = higher percentile (better contributor diversity)
   const percentile = interpolatePercentile(concentration.share, cal.topContributorShare, true)
 
   return {
@@ -48,10 +48,10 @@ export function getSustainabilityScore(result: AnalysisResult): SustainabilitySc
   }
 }
 
-export function getSustainabilityScoreFromCommitCounts(
+export function getContributorsScoreFromCommitCounts(
   commitCountsByAuthor: Record<string, number> | Unavailable,
   stars: number | Unavailable = 'unavailable',
-): SustainabilityScoreDefinition {
+): ContributorsScoreDefinition {
   const cal = getCalibrationForStars(stars)
   const bracketLabel = getBracketLabel(stars)
   const concentration = getContributionConcentrationDetails(commitCountsByAuthor)

--- a/lib/contributors/view-model.test.ts
+++ b/lib/contributors/view-model.test.ts
@@ -3,7 +3,7 @@ import { buildContributorsViewModels } from './view-model'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 
 describe('contributors/view-model', () => {
-  it('builds core and sustainability rows for each repository', () => {
+  it('builds core and contributors-score rows for each repository', () => {
     const section = buildContributorsViewModels([
       buildResult({
         totalContributors: 12,
@@ -99,15 +99,15 @@ describe('contributors/view-model', () => {
     expect(section.coreMetrics.find((metric) => metric.label === 'Contribution concentration')).toBeUndefined()
     expect(section.heatmap[0]?.contributor).toBe('alice')
     expect(section.heatmap.map((cell) => cell.intensity)).toEqual(['max', 'higher', 'high', 'low', 'low'])
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Top 20% contributor share')?.value).toMatch(/36\.4%/)
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Top 20% contributor share')?.supportingText).toBe(
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Top 20% contributor share')?.value).toMatch(/36\.4%/)
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Top 20% contributor share')?.supportingText).toBe(
       '1 of 5 active contributors',
     )
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Scored contributor group')).toBeUndefined()
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Inactive contributors')).toBeUndefined()
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Maintainer count')?.value).toBe('3')
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Occasional contributors')).toBeUndefined()
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Types of contributions')?.value).toBe('Commits, Pull requests, Issues')
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Scored contributor group')).toBeUndefined()
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Inactive contributors')).toBeUndefined()
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Maintainer count')?.value).toBe('3')
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Occasional contributors')).toBeUndefined()
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Types of contributions')?.value).toBe('Commits, Pull requests, Issues')
     expect(section.experimentalMetrics.find((metric) => metric.label === 'Elephant Factor')?.value).toBe('1')
     expect(section.experimentalMetrics.find((metric) => metric.label === 'Single-vendor dependency ratio')?.value).toBe('63.6%')
     expect(section.experimentalHeatmap.map((cell) => cell.contributor)).toEqual(['meta', 'openai', 'vercel'])
@@ -119,7 +119,7 @@ describe('contributors/view-model', () => {
 
     expect(section.coreMetrics.find((metric) => metric.label === 'Contribution concentration')).toBeUndefined()
     expect(section.heatmap).toEqual([])
-    expect(section.sustainabilityScore.value).toBe('Insufficient verified public data')
+    expect(section.contributorsScore.value).toBe('Insufficient verified public data')
     expect(section.missingData).toContain('Contribution concentration')
     expect(section.missingData).toContain('Maintainer count')
     expect(section.missingData).toContain('Repeat contributor ratio')
@@ -239,7 +239,7 @@ describe('contributors/view-model', () => {
 
     expect(section.windowDays).toBe(30)
     expect(section.coreMetrics.find((metric) => metric.label === 'Contributor composition')?.supportingText).toBe('1 repeat, 1 one-time, 10 inactive')
-    expect(section.sustainabilityMetrics.find((metric) => metric.label === 'Top 20% contributor share')?.supportingText).toBe(
+    expect(section.contributorsMetrics.find((metric) => metric.label === 'Top 20% contributor share')?.supportingText).toBe(
       '1 of 2 active contributors',
     )
   })

--- a/lib/contributors/view-model.ts
+++ b/lib/contributors/view-model.ts
@@ -1,6 +1,6 @@
 import type { AnalysisResult, ContributorWindowDays, ContributorWindowMetrics, Unavailable } from '@/lib/analyzer/analysis-result'
 import { buildContributorRatioMetricRows } from '@/lib/health-ratios/view-model'
-import { computeContributionConcentration, formatPercentage, getSustainabilityScoreFromCommitCounts } from './score-config'
+import { computeContributionConcentration, formatPercentage, getContributorsScoreFromCommitCounts } from './score-config'
 import { formatPercentileLabel, getCalibrationForStars, interpolatePercentile } from '@/lib/scoring/config-loader'
 
 export interface ContributorMetricRow {
@@ -32,8 +32,8 @@ export interface ContributorsSectionViewModel {
   coreMetrics: ContributorMetricRow[]
   heatmap: ContributorHeatmapCell[]
   experimentalHeatmap: ContributorHeatmapCell[]
-  sustainabilityScore: ReturnType<typeof getSustainabilityScoreFromCommitCounts>
-  sustainabilityMetrics: ContributorMetricRow[]
+  contributorsScore: ReturnType<typeof getContributorsScoreFromCommitCounts>
+  contributorsMetrics: ContributorMetricRow[]
   experimentalMetrics: ContributorMetricRow[]
   experimentalWarning: string
   missingData: string[]
@@ -49,7 +49,7 @@ export function buildContributorsViewModels(
   return results.map((result) => {
     const windowMetrics = getContributorWindowMetrics(result, windowDays)
     const filteredCommitCountsByAuthor = filterCommitCountsByAuthorBots(windowMetrics.commitCountsByAuthor, includeBots)
-    const sustainabilityScore = getSustainabilityScoreFromCommitCounts(filteredCommitCountsByAuthor, result.stars)
+    const contributorsScore = getContributorsScoreFromCommitCounts(filteredCommitCountsByAuthor, result.stars)
     const concentration = computeContributionConcentration(filteredCommitCountsByAuthor)
     const repeatContributors = computeRepeatContributors(filteredCommitCountsByAuthor)
     const activeContributors = getActiveContributorCount(filteredCommitCountsByAuthor)
@@ -82,14 +82,14 @@ export function buildContributorsViewModels(
       ],
       heatmap: buildHeatmap(filteredCommitCountsByAuthor),
       experimentalHeatmap: buildHeatmap(experimentalCommitCounts, 'organization'),
-      sustainabilityScore,
-      sustainabilityMetrics: [
+      contributorsScore,
+      contributorsMetrics: [
         {
           label: 'Top 20% contributor share',
-          value: formatConcentrationWithPercentile(sustainabilityScore.concentration, result.stars),
+          value: formatConcentrationWithPercentile(contributorsScore.concentration, result.stars),
           supportingText: getTopContributorGroupText(
-            sustainabilityScore.topContributorCount,
-            sustainabilityScore.contributorCount,
+            contributorsScore.topContributorCount,
+            contributorsScore.contributorCount,
           ),
         },
         {

--- a/lib/export/json-export.test.ts
+++ b/lib/export/json-export.test.ts
@@ -69,11 +69,11 @@ describe('buildJsonExport', () => {
   it('includes computed contributor metrics for each repo', async () => {
     const result = buildJsonExport(MINIMAL_RESPONSE)
     const text = await result.blob.text()
-    const parsed = JSON.parse(text) as { results: Array<{ contributors: { sustainabilityScore: string; sustainabilityMetrics: Array<{ label: string; value: string }>; experimentalMetrics: Array<{ label: string; value: string }> } }> }
+    const parsed = JSON.parse(text) as { results: Array<{ contributors: { contributorsScore: string; contributorsMetrics: Array<{ label: string; value: string }>; experimentalMetrics: Array<{ label: string; value: string }> } }> }
     const contributors = parsed.results[0].contributors
     expect(contributors).toBeDefined()
-    expect(contributors.sustainabilityScore).toBeDefined()
-    expect(contributors.sustainabilityMetrics.some((m) => m.label === 'Top 20% contributor share')).toBe(true)
+    expect(contributors.contributorsScore).toBeDefined()
+    expect(contributors.contributorsMetrics.some((m) => m.label === 'Top 20% contributor share')).toBe(true)
     expect(contributors.experimentalMetrics.some((m) => m.label === 'Elephant Factor')).toBe(true)
     expect(contributors.experimentalMetrics.some((m) => m.label === 'Single-vendor dependency ratio')).toBe(true)
   })
@@ -81,13 +81,13 @@ describe('buildJsonExport', () => {
   it('includes computed scores for each repo', async () => {
     const result = buildJsonExport(MINIMAL_RESPONSE)
     const text = await result.blob.text()
-    const parsed = JSON.parse(text) as { results: Array<{ scores: { activity: { value: string }; sustainability: { value: string }; responsiveness: { value: string } } }> }
+    const parsed = JSON.parse(text) as { results: Array<{ scores: { activity: { value: string }; contributors: { value: string }; responsiveness: { value: string } } }> }
     const scores = parsed.results[0].scores
     expect(scores).toBeDefined()
     expect(scores.activity).toHaveProperty('value')
     expect(scores.activity).toHaveProperty('tone')
     expect(scores.activity).toHaveProperty('description')
-    expect(scores.sustainability).toHaveProperty('value')
+    expect(scores.contributors).toHaveProperty('value')
     expect(scores.responsiveness).toHaveProperty('value')
   })
 

--- a/lib/export/json-export.ts
+++ b/lib/export/json-export.ts
@@ -1,7 +1,7 @@
 import type { AnalysisResult, AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import { getActivityScore } from '@/lib/activity/score-config'
 import { buildComparisonSections } from '@/lib/comparison/view-model'
-import { getSustainabilityScore } from '@/lib/contributors/score-config'
+import { getContributorsScore } from '@/lib/contributors/score-config'
 import { buildContributorsViewModels } from '@/lib/contributors/view-model'
 import { buildHealthRatioRows } from '@/lib/health-ratios/view-model'
 import { getDocumentationScore } from '@/lib/documentation/score-config'
@@ -18,7 +18,7 @@ export interface JsonExportResult {
 
 interface RepoScores {
   activity: { value: number | string; tone: string; description: string }
-  sustainability: { value: number | string; tone: string; description: string }
+  contributors: { value: number | string; tone: string; description: string }
   responsiveness: { value: number | string; tone: string; description: string }
   documentation: { value: number | string; tone: string; filesFound: number; readmeSections: number } | null
   security: { value: number | string; tone: string; mode: string } | null
@@ -26,7 +26,7 @@ interface RepoScores {
 
 function computeScores(result: AnalysisResult): RepoScores {
   const activity = getActivityScore(result)
-  const sustainability = getSustainabilityScore(result)
+  const contributors = getContributorsScore(result)
   const responsiveness = getResponsivenessScore(result)
   let documentation: RepoScores['documentation'] = null
   if (result.documentationResult !== 'unavailable') {
@@ -45,7 +45,7 @@ function computeScores(result: AnalysisResult): RepoScores {
   }
   return {
     activity: { value: activity.value, tone: activity.tone, description: activity.description },
-    sustainability: { value: sustainability.value, tone: sustainability.tone, description: sustainability.description },
+    contributors: { value: contributors.value, tone: contributors.tone, description: contributors.description },
     responsiveness: { value: responsiveness.value, tone: responsiveness.tone, description: responsiveness.description },
     documentation,
     security,
@@ -78,8 +78,8 @@ function computeContributors(result: AnalysisResult) {
   const section = buildContributorsViewModels([result])[0]
   if (!section) return undefined
   return {
-    sustainabilityScore: section.sustainabilityScore.value,
-    sustainabilityMetrics: section.sustainabilityMetrics.map((m) => ({ label: m.label, value: m.value })),
+    contributorsScore: section.contributorsScore.value,
+    contributorsMetrics: section.contributorsMetrics.map((m) => ({ label: m.label, value: m.value })),
     coreMetrics: section.coreMetrics.map((m) => ({ label: m.label, value: m.value })),
     experimentalMetrics: section.experimentalMetrics.map((m) => ({ label: m.label, value: m.value })),
   }

--- a/lib/export/markdown-export.test.ts
+++ b/lib/export/markdown-export.test.ts
@@ -86,7 +86,7 @@ describe('buildMarkdownReport', () => {
     expect(md).toContain('Releases (12 months)')
   })
 
-  it('includes detailed sustainability metrics', () => {
+  it('includes detailed contributor metrics', () => {
     const md = buildMarkdownReport(MINIMAL_RESPONSE)
     expect(md).toContain('Total contributors')
     expect(md).toContain('Unique commit authors')

--- a/lib/export/markdown-export.ts
+++ b/lib/export/markdown-export.ts
@@ -2,7 +2,7 @@ import type { AnalysisResult, AnalyzeResponse, ResponsivenessMetrics } from '@/l
 import { getActivityScore } from '@/lib/activity/score-config'
 import { buildComparisonSections } from '@/lib/comparison/view-model'
 import { limitComparedResults } from '@/lib/comparison/view-model'
-import { getSustainabilityScore } from '@/lib/contributors/score-config'
+import { getContributorsScore } from '@/lib/contributors/score-config'
 import { getDocumentationScore } from '@/lib/documentation/score-config'
 import { buildContributorsViewModels } from '@/lib/contributors/view-model'
 import { buildSpectrumProfile } from '@/lib/ecosystem-map/classification'
@@ -88,7 +88,7 @@ const HEALTH_RATIO_CATEGORY_LABELS: Record<string, string> = {
 
 function renderRepo(result: AnalysisResult, appUrl?: string): string {
   const activity = getActivityScore(result)
-  const sustainability = getSustainabilityScore(result)
+  const contributorsScore = getContributorsScore(result)
   const responsiveness = getResponsivenessScore(result)
   const contributors = buildContributorsViewModels([result])[0]
   const healthRatioRows = buildHealthRatioRows([result])
@@ -149,7 +149,7 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
     '',
     '| Score | Value |',
     '| --- | --- |',
-    `| Sustainability | ${sustainability.value} |`,
+    `| Contributors | ${contributorsScore.value} |`,
     `| Activity | ${activity.value} |`,
     `| Responsiveness | ${responsiveness.value} |`,
     `| Documentation | ${result.documentationResult !== 'unavailable' ? getDocumentationScore(result.documentationResult, result.licensingResult, result.stars, result.inclusiveNamingResult).value : 'unavailable'} |`,
@@ -157,12 +157,12 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
     '',
   )
 
-  // Contributors section (contains Sustainability score)
-  const typesOfContributions = contributors?.sustainabilityMetrics.find((m) => m.label === 'Types of contributions')?.value
+  // Contributors section
+  const typesOfContributions = contributors?.contributorsMetrics.find((m) => m.label === 'Types of contributions')?.value
   lines.push(
     '### Contributors',
     '',
-    `**Sustainability score**: ${sustainability.value}`,
+    `**Contributors score**: ${contributorsScore.value}`,
     '',
     mdTable([
       ['Total contributors', fmt(result.totalContributors)],
@@ -170,7 +170,7 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
       ['Repeat contributors (90 days)', fmt(result.contributorMetricsByWindow?.[90]?.repeatContributors ?? 'unavailable')],
       ['New contributors (90 days)', fmt(result.contributorMetricsByWindow?.[90]?.newContributors ?? 'unavailable')],
       ['Maintainer count', fmt(result.maintainerCount)],
-      ['Top 20% contributor share', fmtPct(sustainability.concentration)],
+      ['Top 20% contributor share', fmtPct(contributorsScore.concentration)],
       ...(typesOfContributions ? [['Types of contributions', typesOfContributions] as [string, string]] : []),
     ]),
     '',

--- a/lib/metric-cards/score-config.test.ts
+++ b/lib/metric-cards/score-config.test.ts
@@ -8,7 +8,7 @@ describe('score-config', () => {
 
     expect(badges).toHaveLength(4)
     expect(badges.map((badge) => badge.category)).toEqual([
-      'Sustainability',
+      'Contributors',
       'Activity',
       'Responsiveness',
       'Security',
@@ -23,11 +23,11 @@ describe('score-config', () => {
     expect(scoreToneClass('neutral')).toContain('slate')
   })
 
-  it('replaces the activity, sustainability, and responsiveness placeholders when real scores are available', () => {
+  it('replaces the activity, contributors, and responsiveness placeholders when real scores are available', () => {
     const badges = getScoreBadges(buildResult())
 
     expect(typeof badges.find((badge) => badge.category === 'Activity')?.value).toBe('number')
-    expect(typeof badges.find((badge) => badge.category === 'Sustainability')?.value).toBe('number')
+    expect(typeof badges.find((badge) => badge.category === 'Contributors')?.value).toBe('number')
     expect(typeof badges.find((badge) => badge.category === 'Responsiveness')?.value).toBe('number')
   })
 })

--- a/lib/metric-cards/score-config.ts
+++ b/lib/metric-cards/score-config.ts
@@ -1,25 +1,26 @@
 import type { ScoreBadgeProps, ScoreCategory, ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { getActivityScore } from '@/lib/activity/score-config'
-import { getSustainabilityScore } from '@/lib/contributors/score-config'
+import { getContributorsScore } from '@/lib/contributors/score-config'
 import { getResponsivenessScore } from '@/lib/responsiveness/score-config'
 import { getSecurityScore } from '@/lib/security/score-config'
 
 export interface ScoreBadgeDefinition extends ScoreBadgeProps {
   description: string
+  detail?: string
 }
 
 const PENDING_VALUE: ScoreValue = 'Not scored yet'
 const PENDING_TONE: ScoreTone = 'neutral'
 
-export const SCORE_CATEGORIES: ScoreCategory[] = ['Sustainability', 'Activity', 'Responsiveness', 'Security']
+export const SCORE_CATEGORIES: ScoreCategory[] = ['Contributors', 'Activity', 'Responsiveness', 'Security']
 
 export const DEFAULT_SCORE_BADGES: ScoreBadgeDefinition[] = [
   {
-    category: 'Sustainability',
+    category: 'Contributors',
     value: PENDING_VALUE,
     tone: PENDING_TONE,
-    description: 'Score will populate when sustainability scoring lands in P1-F09.',
+    description: 'Contributor-diversity score. Based on concentration of commits across contributors.',
   },
   {
     category: 'Activity',
@@ -53,7 +54,7 @@ export function getScoreBadges(result?: AnalysisResult): ScoreBadgeDefinition[] 
   }
 
   const activityScore = getActivityScore(result)
-  const sustainabilityScore = getSustainabilityScore(result)
+  const contributorsScore = getContributorsScore(result)
   const responsivenessScore = getResponsivenessScore(result)
   const securityScore = result.securityResult !== 'unavailable'
     ? getSecurityScore(result.securityResult, result.stars)
@@ -65,13 +66,17 @@ export function getScoreBadges(result?: AnalysisResult): ScoreBadgeDefinition[] 
           value: activityScore.value,
           tone: activityScore.tone,
           description: activityScore.description,
+          detail: getTopFactorDetail(activityScore.weightedFactors),
         }
-      : badge.category === 'Sustainability'
+      : badge.category === 'Contributors'
       ? {
           ...badge,
-          value: sustainabilityScore.value,
-          tone: sustainabilityScore.tone,
-          description: sustainabilityScore.description,
+          value: contributorsScore.value,
+          tone: contributorsScore.tone,
+          description: contributorsScore.description,
+          detail: typeof contributorsScore.contributorCount === 'number'
+            ? `${contributorsScore.contributorCount.toLocaleString()} contributors`
+            : undefined,
         }
       : badge.category === 'Responsiveness'
       ? {
@@ -79,6 +84,7 @@ export function getScoreBadges(result?: AnalysisResult): ScoreBadgeDefinition[] 
           value: responsivenessScore.value,
           tone: responsivenessScore.tone,
           description: responsivenessScore.description,
+          detail: getTopFactorDetail(responsivenessScore.weightedCategories),
         }
       : badge.category === 'Security' && securityScore
       ? {
@@ -88,9 +94,19 @@ export function getScoreBadges(result?: AnalysisResult): ScoreBadgeDefinition[] 
           description: securityScore.mode === 'scorecard'
             ? 'OpenSSF Scorecard + direct checks'
             : 'Direct security checks only',
+          detail: securityScore.mode === 'scorecard' && typeof securityScore.scorecardScore === 'number'
+            ? `${(securityScore.scorecardScore * 10).toFixed(1)}/10 Scorecard`
+            : 'Direct checks only',
         }
       : badge,
   )
+}
+
+function getTopFactorDetail(factors: Array<{ label: string; percentile?: number }>): string | undefined {
+  const scored = factors.filter((f): f is { label: string; percentile: number } => typeof f.percentile === 'number')
+  if (scored.length === 0) return undefined
+  const top = scored.reduce((best, f) => (f.percentile > best.percentile ? f : best))
+  return `${top.label} strongest`
 }
 
 export function scoreToneClass(tone: ScoreTone) {

--- a/lib/metric-cards/view-model.test.ts
+++ b/lib/metric-cards/view-model.test.ts
@@ -23,7 +23,7 @@ describe('buildMetricCardViewModels', () => {
     expect(typeof card.profile?.reachPercentile).toBe('number')
     expect(card.profile?.reachLabel).toMatch(/\d+\w{2} percentile/)
     expect(card.scoreBadges).toHaveLength(4)
-    expect(card.scoreBadges.find((badge) => badge.category === 'Sustainability')?.value).toBe('Insufficient verified public data')
+    expect(card.scoreBadges.find((badge) => badge.category === 'Contributors')?.value).toBe('Insufficient verified public data')
     expect(card.details.find((detail) => detail.label === 'Releases (12mo)')?.value).toBe('—')
   })
 

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -14,7 +14,7 @@ describe('RECOMMENDATION_CATALOG', () => {
 
   it('contains entries for all five buckets', () => {
     const buckets = new Set(RECOMMENDATION_CATALOG.map((e) => e.bucket))
-    expect(buckets).toEqual(new Set(['Security', 'Activity', 'Responsiveness', 'Sustainability', 'Documentation']))
+    expect(buckets).toEqual(new Set(['Security', 'Activity', 'Responsiveness', 'Contributors', 'Documentation']))
   })
 
   it('IDs follow the PREFIX-N pattern', () => {
@@ -26,7 +26,7 @@ describe('RECOMMENDATION_CATALOG', () => {
   it('IDs use the correct prefix for their bucket', () => {
     const prefixMap: Record<string, string> = {
       Security: 'SEC', Activity: 'ACT', Responsiveness: 'RSP',
-      Sustainability: 'SUS', Documentation: 'DOC',
+      Contributors: 'CTR', Documentation: 'DOC',
     }
     for (const entry of RECOMMENDATION_CATALOG) {
       const expectedPrefix = prefixMap[entry.bucket]
@@ -46,8 +46,8 @@ describe('RECOMMENDATION_CATALOG', () => {
     expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Responsiveness')).toHaveLength(3)
   })
 
-  it('has 2 sustainability entries', () => {
-    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Sustainability')).toHaveLength(2)
+  it('has 2 contributors entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Contributors')).toHaveLength(2)
   })
 
   it('has 14 documentation entries', () => {
@@ -102,10 +102,10 @@ describe('getCatalogEntriesByTag', () => {
     const governance = getCatalogEntriesByTag('governance')
     const ids = governance.map((e) => e.id).sort()
     expect(ids).toEqual([
+      'CTR-2',
       'DOC-12', 'DOC-13', 'DOC-14',
       'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
       'SEC-14', 'SEC-17', 'SEC-3', 'SEC-5',
-      'SUS-2',
     ])
   })
 

--- a/lib/recommendations/__tests__/reference-id.test.ts
+++ b/lib/recommendations/__tests__/reference-id.test.ts
@@ -6,7 +6,7 @@ describe('getBucketPrefix', () => {
     ['Security', 'SEC'],
     ['Activity', 'ACT'],
     ['Responsiveness', 'RSP'],
-    ['Sustainability', 'SUS'],
+    ['Contributors', 'CTR'],
     ['Documentation', 'DOC'],
   ])('maps %s to %s', (bucket, expected) => {
     expect(getBucketPrefix(bucket)).toBe(expected)
@@ -40,9 +40,9 @@ describe('resolveReferenceId', () => {
     expect(resolveReferenceId('backlog_health', 'Responsiveness', 1)).toBe('RSP-3')
   })
 
-  it('returns catalog ID for sustainability keys', () => {
-    expect(resolveReferenceId('contributor_diversity', 'Sustainability', 1)).toBe('SUS-1')
-    expect(resolveReferenceId('no_maintainers', 'Sustainability', 1)).toBe('SUS-2')
+  it('returns catalog ID for contributors keys', () => {
+    expect(resolveReferenceId('contributor_diversity', 'Contributors', 1)).toBe('CTR-1')
+    expect(resolveReferenceId('no_maintainers', 'Contributors', 1)).toBe('CTR-2')
   })
 
   it('returns catalog ID for documentation keys', () => {

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -6,7 +6,7 @@
  *
  * Bucket prefixes:
  *   SEC — Security     ACT — Activity       RSP — Responsiveness
- *   SUS — Sustainability   DOC — Documentation
+ *   CTR — Contributors   DOC — Documentation
  */
 
 export interface CatalogEntry {
@@ -76,11 +76,11 @@ const RSP: CatalogEntry[] = [
   { id: 'RSP-3', bucket: 'Responsiveness', key: 'backlog_health', title: 'Address stale issues and PRs' },
 ]
 
-// ── Sustainability ────────────────────────────────────────────────────
+// ── Contributors ──────────────────────────────────────────────────────
 
-const SUS: CatalogEntry[] = [
-  { id: 'SUS-1', bucket: 'Sustainability', key: 'contributor_diversity', title: 'Onboard more contributors to reduce single-maintainer risk' },
-  { id: 'SUS-2', bucket: 'Sustainability', key: 'no_maintainers', title: 'Add a CODEOWNERS or MAINTAINERS.md file', tags: ['governance'] },
+const CTR: CatalogEntry[] = [
+  { id: 'CTR-1', bucket: 'Contributors', key: 'contributor_diversity', title: 'Onboard more contributors to reduce single-maintainer risk' },
+  { id: 'CTR-2', bucket: 'Contributors', key: 'no_maintainers', title: 'Add a CODEOWNERS or MAINTAINERS.md file', tags: ['governance'] },
 ]
 
 // ── Documentation ─────────────────────────────────────────────────────
@@ -108,7 +108,7 @@ const DOC: CatalogEntry[] = [
 // ── Combined catalog ──────────────────────────────────────────────────
 
 export const RECOMMENDATION_CATALOG: CatalogEntry[] = [
-  ...SEC, ...ACT, ...RSP, ...SUS, ...DOC,
+  ...SEC, ...ACT, ...RSP, ...CTR, ...DOC,
 ]
 
 /** Fast lookup: key → CatalogEntry */

--- a/lib/recommendations/reference-id.ts
+++ b/lib/recommendations/reference-id.ts
@@ -15,7 +15,7 @@ const BUCKET_PREFIX: Record<string, string> = {
   Security: 'SEC',
   Activity: 'ACT',
   Responsiveness: 'RSP',
-  Sustainability: 'SUS',
+  Contributors: 'CTR',
   Documentation: 'DOC',
 }
 

--- a/lib/results-shell/tabs.ts
+++ b/lib/results-shell/tabs.ts
@@ -10,32 +10,32 @@ export const resultTabs: ResultTabDefinition[] = [
   {
     id: 'contributors',
     label: 'Contributors',
-    status: 'placeholder',
-    description: 'Core contributor metrics and sustainability signals are coming soon.',
+    status: 'implemented',
+    description: 'Contributor concentration, repeat and new contributor mix.',
   },
   {
     id: 'activity',
     label: 'Activity',
     status: 'implemented',
-    description: 'Activity metrics, scoring, and detailed repo flow signals.',
+    description: 'PR throughput, issue flow, commit cadence, release frequency.',
   },
   {
     id: 'responsiveness',
     label: 'Responsiveness',
     status: 'implemented',
-    description: 'Response-time, backlog-health, and engagement signals from public issue and PR activity.',
+    description: 'Response times, resolution speed, backlog health.',
   },
   {
     id: 'documentation',
     label: 'Documentation',
     status: 'implemented',
-    description: 'Documentation file presence, README quality, and improvement recommendations.',
+    description: 'Key project files, README quality, licensing compliance, inclusive naming.',
   },
   {
     id: 'security',
     label: 'Security',
     status: 'implemented',
-    description: 'Security posture including OpenSSF Scorecard checks, dependency automation, and branch protection.',
+    description: 'OpenSSF Scorecard, dependency automation, branch protection.',
   },
   {
     id: 'recommendations',

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -1,7 +1,7 @@
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { getActivityScore, type ActivityScoreDefinition } from '@/lib/activity/score-config'
 import { getResponsivenessScore, type ResponsivenessScoreDefinition } from '@/lib/responsiveness/score-config'
-import { getSustainabilityScore, type SustainabilityScoreDefinition } from '@/lib/contributors/score-config'
+import { getContributorsScore } from '@/lib/contributors/score-config'
 import { getDocumentationScore, type DocumentationRecommendation } from '@/lib/documentation/score-config'
 import { getSecurityScore } from '@/lib/security/score-config'
 import { formatPercentileLabel, formatPercentileOrdinal, getBracketLabel, percentileToTone } from '@/lib/scoring/config-loader'
@@ -33,7 +33,7 @@ export interface HealthScoreDefinition {
 const WEIGHTS = {
   activity: 0.25,
   responsiveness: 0.25,
-  sustainability: 0.23,
+  contributors: 0.23,
   documentation: 0.12,
   security: 0.15,
 } as const
@@ -41,18 +41,18 @@ const WEIGHTS = {
 export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   const activity = getActivityScore(result)
   const responsiveness = getResponsivenessScore(result)
-  const sustainability = getSustainabilityScore(result)
+  const contributors = getContributorsScore(result)
   const documentation = result.documentationResult !== 'unavailable'
     ? getDocumentationScore(result.documentationResult, result.licensingResult, result.stars, result.inclusiveNamingResult)
     : null
   const security = result.securityResult !== 'unavailable'
     ? getSecurityScore(result.securityResult, result.stars)
     : null
-  const bracketLabel = activity.bracketLabel || responsiveness.bracketLabel || sustainability.bracketLabel || ''
+  const bracketLabel = activity.bracketLabel || responsiveness.bracketLabel || contributors.bracketLabel || ''
 
   const activityPercentile = typeof activity.value === 'number' ? activity.percentile : null
   const responsivenessPercentile = typeof responsiveness.value === 'number' ? responsiveness.percentile : null
-  const sustainabilityPercentile = typeof sustainability.value === 'number' ? sustainability.percentile : null
+  const contributorsPercentile = typeof contributors.value === 'number' ? contributors.percentile : null
   const documentationPercentile = documentation !== null && typeof documentation.value === 'number' ? documentation.percentile : null
   const securityPercentile = security !== null && typeof security.value === 'number' ? security.percentile : null
 
@@ -60,7 +60,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   const bucketValues: Array<{ percentile: number; weight: number }> = []
   if (activityPercentile !== null) bucketValues.push({ percentile: activityPercentile, weight: WEIGHTS.activity })
   if (responsivenessPercentile !== null) bucketValues.push({ percentile: responsivenessPercentile, weight: WEIGHTS.responsiveness })
-  if (sustainabilityPercentile !== null) bucketValues.push({ percentile: sustainabilityPercentile, weight: WEIGHTS.sustainability })
+  if (contributorsPercentile !== null) bucketValues.push({ percentile: contributorsPercentile, weight: WEIGHTS.contributors })
   if (documentationPercentile !== null) bucketValues.push({ percentile: documentationPercentile, weight: WEIGHTS.documentation })
   if (securityPercentile !== null) bucketValues.push({ percentile: securityPercentile, weight: WEIGHTS.security })
 
@@ -79,20 +79,20 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   if (responsivenessPercentile !== null) {
     recommendations.push(...getResponsivenessRecommendations(responsiveness))
   }
-  if (sustainabilityPercentile !== null) {
+  if (contributorsPercentile !== null) {
     recommendations.push({
-      bucket: 'Sustainability',
+      bucket: 'Contributors',
       key: 'contributor_diversity',
-      percentile: sustainabilityPercentile,
+      percentile: contributorsPercentile,
       message: 'Onboard more contributors to reduce single-maintainer risk. The top 20% of contributors account for a disproportionate share of commits.',
       tab: 'contributors',
     })
   }
   if (result.maintainerCount === 'unavailable') {
     recommendations.push({
-      bucket: 'Sustainability',
+      bucket: 'Contributors',
       key: 'no_maintainers',
-      percentile: sustainabilityPercentile ?? 0,
+      percentile: contributorsPercentile ?? 0,
       message: 'No maintainers identified. Add a CODEOWNERS or MAINTAINERS.md file to make maintainer responsibility visible.',
       tab: 'contributors',
     })
@@ -128,7 +128,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
     buckets: [
       { name: 'Activity', percentile: activityPercentile, weight: WEIGHTS.activity, label: activityPercentile !== null ? formatPercentileLabel(activityPercentile) : 'N/A' },
       { name: 'Responsiveness', percentile: responsivenessPercentile, weight: WEIGHTS.responsiveness, label: responsivenessPercentile !== null ? formatPercentileLabel(responsivenessPercentile) : 'N/A' },
-      { name: 'Sustainability', percentile: sustainabilityPercentile, weight: WEIGHTS.sustainability, label: sustainabilityPercentile !== null ? formatPercentileLabel(sustainabilityPercentile) : 'N/A' },
+      { name: 'Contributors', percentile: contributorsPercentile, weight: WEIGHTS.contributors, label: contributorsPercentile !== null ? formatPercentileLabel(contributorsPercentile) : 'N/A' },
       { name: 'Documentation', percentile: documentationPercentile, weight: WEIGHTS.documentation, label: documentationPercentile !== null ? formatPercentileLabel(documentationPercentile) : 'N/A' },
       { name: 'Security', percentile: securityPercentile, weight: WEIGHTS.security, label: securityPercentile !== null ? formatPercentileLabel(securityPercentile) : 'N/A' },
     ],

--- a/lib/search/search-engine.test.ts
+++ b/lib/search/search-engine.test.ts
@@ -4,7 +4,7 @@ import type { SearchIndex } from './types'
 
 const index: SearchIndex = {
   overview: ['facebook/react', 'Stars: 230000', 'Activity score: High'],
-  contributors: ['facebook/react', 'alice: 30 commits', 'Sustainability score: Medium'],
+  contributors: ['facebook/react', 'alice: 30 commits', 'Contributors score: Medium'],
   activity: ['facebook/react', 'PR merge rate: 87%', 'Commits (30d): 20', 'Stale issue ratio: 12%'],
   responsiveness: ['facebook/react', 'Issue first response (median): 4.2h', 'Responsiveness score: High'],
   documentation: ['facebook/react', 'README: found', 'LICENSE: MIT', 'CONTRIBUTING: found', 'SECURITY.md: not found'],

--- a/lib/tags/governance.ts
+++ b/lib/tags/governance.ts
@@ -29,19 +29,19 @@ export const GOVERNANCE_DIRECT_CHECKS = new Set([
   'security_policy',
 ])
 
-/** Sustainability metric labels that are governance signals */
-export const GOVERNANCE_SUSTAINABILITY_METRICS = new Set([
+/** Contributors-tab metric labels that are governance signals */
+export const GOVERNANCE_CONTRIBUTORS_METRICS = new Set([
   'Maintainer count',
 ])
 
 /** Returns true if the licensing pane is governance-tagged (always true) */
 export const LICENSING_IS_GOVERNANCE = true
 
-export function isGovernanceItem(key: string, domain: 'doc_file' | 'scorecard' | 'direct_check' | 'sustainability_metric'): boolean {
+export function isGovernanceItem(key: string, domain: 'doc_file' | 'scorecard' | 'direct_check' | 'contributors_metric'): boolean {
   switch (domain) {
     case 'doc_file': return GOVERNANCE_DOC_FILES.has(key)
     case 'scorecard': return GOVERNANCE_SCORECARD_CHECKS.has(key)
     case 'direct_check': return GOVERNANCE_DIRECT_CHECKS.has(key)
-    case 'sustainability_metric': return GOVERNANCE_SUSTAINABILITY_METRICS.has(key)
+    case 'contributors_metric': return GOVERNANCE_CONTRIBUTORS_METRICS.has(key)
   }
 }

--- a/specs/008-metric-cards/contracts/metric-card-props.ts
+++ b/specs/008-metric-cards/contracts/metric-card-props.ts
@@ -2,7 +2,7 @@ import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 
 export type ScoreValue = number | 'Not scored yet' | 'Insufficient verified public data'
 export type ScoreTone = 'success' | 'warning' | 'danger' | 'neutral'
-export type ScoreCategory = 'Activity' | 'Sustainability' | 'Responsiveness' | 'Documentation' | 'Security'
+export type ScoreCategory = 'Activity' | 'Contributors' | 'Responsiveness' | 'Documentation' | 'Security'
 
 export interface ScoreBadgeProps {
   category: ScoreCategory


### PR DESCRIPTION
## Summary

- Rename the `Sustainability` health bucket to `Contributors` across scoring, UI, exports, recommendations, and tags — it was always computed from contributor-diversity signals and already lived under the Contributors tab, so the old name was a translation layer users had to decode. Composite weight (23%) unchanged.
- Polish the scorecard: give each health-dimension tile a concise subtitle, split the 7-tile grid into a 3-col profile row + 4-col score row so the four health tiles share an even spread, and normalize tile height.
- Add native tooltips to every results tab (including the "More" overflow button when a hidden tab is active). Sync every tab description to match the landing-page phrasing; consolidate a duplicate tab list; reorder the landing page's dimension list to match the webapp tab order.
- Mark Phase 2 features P2-F07 (Security, #68) and P2-F04 (Governance, #116) as ✅ Done in `docs/DEVELOPMENT.md` — both shipped but the table was stale.

## Scope

**In**: scorecard naming/layout, tab order/tooltips, landing page ordering, phase-2 doc-table refresh.

**Out**: the Community scoring feature work (spec + design) — parked on `180-community-scoring` for a separate PR.

## Key changes

- Function: `getSustainabilityScore` → `getContributorsScore`
- Type: `SustainabilityScoreDefinition` → `ContributorsScoreDefinition`
- Pane: `SustainabilityPane` → `ContributorsScorePane` (file renamed via `git mv`)
- Recommendation reference-ID prefix: `SUS-*` → `CTR-*`
- Governance tag helper: `GOVERNANCE_SUSTAINABILITY_METRICS` → `GOVERNANCE_CONTRIBUTORS_METRICS`
- Composite `WEIGHTS` key: `sustainability` → `contributors`
- JSON export key: `scores.sustainability` → `scores.contributors`; `contributors.sustainabilityScore`/`sustainabilityMetrics` → `contributorsScore`/`contributorsMetrics`
- `RepoInputClient.tsx` now imports `resultTabs` from `lib/results-shell/tabs.ts` instead of redefining the list inline
- `ScoreBadgeDefinition.detail?` added and populated; `MetricCard` grid restructured; `ScorecardCell` height normalized with a non-breaking-space fallback
- Landing-page `AuthGate` dimension list reordered to Contributors → Activity → Responsiveness → Documentation → Security (Security now gets `sm:col-span-2`)

## Test plan

- [x] `npm test` passes (552 tests)
- [x] `npm run build` passes
- [x] Webapp: open any analyzed repo, confirm the scorecard shows "Contributors" (not "Sustainability") on the tile and the Contributors Score pane heading
- [x] Webapp: confirm the four health tiles (Contributors, Activity, Responsiveness, Security) render as one even row with consistent heights, and each has a subtitle
- [x] Webapp: hover each tab — tooltip appears, including when Recommendations or Comparison is the active tab under "More"
- [x] Webapp: confirm Documentation tab tooltip reads "Key project files, README quality, licensing compliance, inclusive naming." (no stale "improvement recommendations" copy)
- [x] Sign-in page: confirm dimension order matches webapp tab order (Contributors → Activity → Responsiveness → Documentation → Security) and Security spans full width on desktop
- [x] Recommendations tab: expand/collapse the Contributors bucket header works; bucket reference IDs show as `CTR-1`, `CTR-2`
- [x] Export (JSON): confirm the top-level `scores.contributors` key exists and `contributors.contributorsScore` / `contributorsMetrics` are populated
- [x] Export (Markdown): confirm the Contributors section header shows "Contributors score: …"
- [x] `docs/DEVELOPMENT.md`: P2-F07 and P2-F04 show ✅ Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)