### PR TITLE
Add Governance lens to scorecard (#191)

### DIFF
--- a/lib/governance/completeness.test.ts
+++ b/lib/governance/completeness.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { computeGovernanceCompleteness } from './completeness'
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'foo/bar',
+    name: 'bar',
+    description: '—',
+    createdAt: '2024-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 10,
+    watchers: 5,
+    commits30d: 5,
+    commits90d: 15,
+    releases12mo: 2,
+    prsOpened90d: 3,
+    prsMerged90d: 2,
+    issuesOpen: 4,
+    issuesClosed90d: 3,
+    uniqueCommitAuthors90d: 4,
+    totalContributors: 10,
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: { 'login:alice': 5 },
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+describe('computeGovernanceCompleteness', () => {
+  it('all-unknown bare fixture → ratio=null, percentile=null, neutral tone', () => {
+    const g = computeGovernanceCompleteness(buildResult())
+    expect(g.unknown.length).toBe(8)
+    expect(g.present.length + g.missing.length).toBe(0)
+    expect(g.ratio).toBeNull()
+    expect(g.percentile).toBeNull()
+    expect(g.tone).toBe('neutral')
+  })
+
+  it('mixed: counts signals across all three categories (invariant total=8)', () => {
+    const g = computeGovernanceCompleteness(buildResult({
+      maintainerCount: 3,
+      documentationResult: {
+        fileChecks: [
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
+        ],
+        readmeSections: [],
+        readmeContent: null,
+      },
+      securityResult: {
+        scorecard: {
+          overallScore: 7,
+          checks: [{ name: 'Code-Review', score: 8, reason: 'reviews' }],
+          scorecardVersion: 'v4',
+        },
+        directChecks: [
+          { name: 'branch_protection', detected: true, details: null },
+        ],
+        branchProtectionEnabled: true,
+      },
+    }))
+
+    // present: license, code_of_conduct, branch_protection, code_review, maintainers → 5
+    // missing: contributing, security, changelog → 3
+    // unknown: 0
+    expect(g.present.length + g.missing.length + g.unknown.length).toBe(8)
+    expect(g.present).toEqual(expect.arrayContaining(['license', 'code_of_conduct', 'branch_protection', 'code_review', 'maintainers']))
+    expect(g.missing).toEqual(expect.arrayContaining(['contributing', 'security', 'changelog']))
+    expect(g.ratio).toBeCloseTo(5 / 8, 5)
+    expect(g.percentile).toBeGreaterThan(0)
+  })
+
+  it('all-present → ratio=1, percentile=99', () => {
+    const g = computeGovernanceCompleteness(buildResult({
+      maintainerCount: 2,
+      documentationResult: {
+        fileChecks: [
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: true, path: 'CONTRIBUTING.md' },
+          { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+          { name: 'security', found: true, path: 'SECURITY.md' },
+          { name: 'changelog', found: true, path: 'CHANGELOG.md' },
+        ],
+        readmeSections: [],
+        readmeContent: null,
+      },
+      securityResult: {
+        scorecard: {
+          overallScore: 9,
+          checks: [{ name: 'Code-Review', score: 9, reason: 'ok' }],
+          scorecardVersion: 'v4',
+        },
+        directChecks: [{ name: 'branch_protection', detected: true, details: null }],
+        branchProtectionEnabled: true,
+      },
+    }))
+    expect(g.present.length).toBe(8)
+    expect(g.missing.length).toBe(0)
+    expect(g.ratio).toBe(1)
+    expect(g.percentile).toBe(99)
+    expect(g.tone).not.toBe('neutral')
+  })
+
+  it('all-missing → ratio=0, percentile=0', () => {
+    const g = computeGovernanceCompleteness(buildResult({
+      maintainerCount: 0,
+      documentationResult: {
+        fileChecks: [
+          { name: 'license', found: false, path: null },
+          { name: 'contributing', found: false, path: null },
+          { name: 'code_of_conduct', found: false, path: null },
+          { name: 'security', found: false, path: null },
+          { name: 'changelog', found: false, path: null },
+        ],
+        readmeSections: [],
+        readmeContent: null,
+      },
+      securityResult: {
+        scorecard: {
+          overallScore: 1,
+          checks: [{ name: 'Code-Review', score: 0, reason: 'none' }],
+          scorecardVersion: 'v4',
+        },
+        directChecks: [{ name: 'branch_protection', detected: false, details: null }],
+        branchProtectionEnabled: false,
+      },
+    }))
+    expect(g.missing.length).toBe(8)
+    expect(g.ratio).toBe(0)
+    expect(g.percentile).toBe(0)
+  })
+
+  it('invariant: present + missing + unknown always = 8', () => {
+    const cases: Partial<AnalysisResult>[] = [
+      { maintainerCount: 5 },
+      { maintainerCount: 0 },
+      {
+        documentationResult: {
+          fileChecks: [{ name: 'license', found: true, path: 'LICENSE' }],
+          readmeSections: [],
+          readmeContent: null,
+        },
+      },
+      {
+        securityResult: {
+          scorecard: 'unavailable',
+          directChecks: [{ name: 'branch_protection', detected: true, details: null }],
+          branchProtectionEnabled: true,
+        },
+      },
+    ]
+    for (const overrides of cases) {
+      const g = computeGovernanceCompleteness(buildResult(overrides))
+      expect(g.present.length + g.missing.length + g.unknown.length).toBe(8)
+    }
+  })
+
+  it('excludes unknowns from both numerator and denominator', () => {
+    // Only one known signal (maintainers present). Everything else unknown.
+    const g = computeGovernanceCompleteness(buildResult({ maintainerCount: 4 }))
+    expect(g.present).toContain('maintainers')
+    expect(g.ratio).toBe(1)
+    expect(g.percentile).toBe(99)
+  })
+
+  it('Code-Review score between 0 and threshold counts as missing; score=-1 as unknown', () => {
+    const belowThreshold = computeGovernanceCompleteness(buildResult({
+      securityResult: {
+        scorecard: {
+          overallScore: 5,
+          checks: [{ name: 'Code-Review', score: 5, reason: 'partial' }],
+          scorecardVersion: 'v4',
+        },
+        directChecks: [],
+        branchProtectionEnabled: 'unavailable',
+      },
+    }))
+    expect(belowThreshold.missing).toContain('code_review')
+
+    const indeterminate = computeGovernanceCompleteness(buildResult({
+      securityResult: {
+        scorecard: {
+          overallScore: 5,
+          checks: [{ name: 'Code-Review', score: -1, reason: 'unknown' }],
+          scorecardVersion: 'v4',
+        },
+        directChecks: [],
+        branchProtectionEnabled: 'unavailable',
+      },
+    }))
+    expect(indeterminate.unknown).toContain('code_review')
+  })
+})

--- a/lib/governance/completeness.ts
+++ b/lib/governance/completeness.ts
@@ -1,0 +1,106 @@
+import type { AnalysisResult, Unavailable } from '@/lib/analyzer/analysis-result'
+import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
+import { percentileToTone } from '@/lib/scoring/config-loader'
+
+/**
+ * Governance completeness readout (#191).
+ *
+ * Cross-cutting summary — counts how many of the eight governance signals
+ * are present. Equal weighting. Unknowns excluded from numerator and
+ * denominator (same convention as the Community lens). Does not feed the
+ * composite OSS Health Score.
+ */
+
+export type GovernanceSignalKey =
+  | 'license'
+  | 'contributing'
+  | 'code_of_conduct'
+  | 'security'
+  | 'changelog'
+  | 'branch_protection'
+  | 'code_review'
+  | 'maintainers'
+
+export interface GovernanceCompleteness {
+  present: GovernanceSignalKey[]
+  missing: GovernanceSignalKey[]
+  unknown: GovernanceSignalKey[]
+  ratio: number | null
+  percentile: number | null
+  tone: ScoreTone
+}
+
+type Presence = boolean | 'unknown'
+
+// Scorecard check pass threshold — matches the SecurityView UI convention
+// (score >= 7 = green). score === -1 means "indeterminate" → unknown.
+const SCORECARD_PASS_THRESHOLD = 7
+
+function extractSignalPresence(result: AnalysisResult): Record<GovernanceSignalKey, Presence> {
+  const fromDocFile = (name: string): Presence => {
+    if (result.documentationResult === 'unavailable') return 'unknown'
+    const check = result.documentationResult.fileChecks.find((c) => c.name === name)
+    return check ? check.found : 'unknown'
+  }
+
+  const branchProtection: Presence = (() => {
+    if (result.securityResult === 'unavailable') return 'unknown'
+    const bp = result.securityResult.directChecks.find((c) => c.name === 'branch_protection')
+    if (!bp || bp.detected === 'unavailable') return 'unknown'
+    return bp.detected
+  })()
+
+  const codeReview: Presence = (() => {
+    if (result.securityResult === 'unavailable') return 'unknown'
+    if (result.securityResult.scorecard === 'unavailable') return 'unknown'
+    const check = result.securityResult.scorecard.checks.find((c) => c.name === 'Code-Review')
+    if (!check || check.score === -1) return 'unknown'
+    return check.score >= SCORECARD_PASS_THRESHOLD
+  })()
+
+  return {
+    license: fromDocFile('license'),
+    contributing: fromDocFile('contributing'),
+    code_of_conduct: fromDocFile('code_of_conduct'),
+    security: fromDocFile('security'),
+    changelog: fromDocFile('changelog'),
+    branch_protection: branchProtection,
+    code_review: codeReview,
+    maintainers: maintainerCountPresence(result.maintainerCount),
+  }
+}
+
+function maintainerCountPresence(count: number | Unavailable): Presence {
+  if (count === 'unavailable') return 'unknown'
+  return count > 0
+}
+
+export function computeGovernanceCompleteness(result: AnalysisResult): GovernanceCompleteness {
+  const presence = extractSignalPresence(result)
+  const present: GovernanceSignalKey[] = []
+  const missing: GovernanceSignalKey[] = []
+  const unknown: GovernanceSignalKey[] = []
+
+  for (const [key, value] of Object.entries(presence) as Array<[GovernanceSignalKey, Presence]>) {
+    if (value === true) present.push(key)
+    else if (value === false) missing.push(key)
+    else unknown.push(key)
+  }
+
+  const denominator = present.length + missing.length
+  if (denominator === 0) {
+    return { present, missing, unknown, ratio: null, percentile: null, tone: 'neutral' }
+  }
+
+  const ratio = present.length / denominator
+  const percentile = Math.max(0, Math.min(99, Math.round(ratio * 99)))
+
+  return {
+    present,
+    missing,
+    unknown,
+    ratio,
+    percentile,
+    tone: percentileToTone(percentile),
+  }
+}

--- a/lib/metric-cards/view-model.ts
+++ b/lib/metric-cards/view-model.ts
@@ -3,6 +3,7 @@ import { buildEcosystemRows } from '@/lib/ecosystem-map/chart-data'
 import { getScoreBadges, type ScoreBadgeDefinition } from './score-config'
 import { getHealthScore, type HealthScoreDefinition } from '@/lib/scoring/health-score'
 import { computeCommunityCompleteness } from '@/lib/community/completeness'
+import { computeGovernanceCompleteness } from '@/lib/governance/completeness'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
 /**
@@ -94,6 +95,18 @@ function buildLensReadouts(result: AnalysisResult): LensReadout[] {
       detail: `${community.present.length} of ${community.present.length + community.missing.length} signals`,
       tooltip: 'Community is a cross-cutting lens — count of community signals present. Does not feed the composite OSS Health Score.',
       tone: community.tone,
+    })
+  }
+
+  const governance = computeGovernanceCompleteness(result)
+  if (governance.ratio !== null) {
+    lenses.push({
+      key: 'governance',
+      label: 'Governance',
+      percentileLabel: governance.percentile !== null ? `${governance.percentile}th percentile` : '—',
+      detail: `${governance.present.length} of ${governance.present.length + governance.missing.length} signals`,
+      tooltip: 'Governance is a cross-cutting lens — count of governance signals present (license, contributing, CoC, security, changelog, branch protection, code review, maintainers). Does not feed the composite OSS Health Score.',
+      tone: governance.tone,
     })
   }
 


### PR DESCRIPTION
## Summary
- Adds `lib/governance/completeness.ts` with `computeGovernanceCompleteness`, mirroring the Community lens shape
- Registers the Governance lens in `buildLensReadouts` so it renders as a second pill on the Lenses row
- Eight signals, equal weighting, unknowns excluded from numerator and denominator

Closes #191.

### Scope note
Per discussion, the pill ships as a non-clickable readout to match the Community lens precedent (#70). Making both lens pills click-to-filter (the original acceptance criterion in #191) is deferred to follow-up issue #200.

## Test plan
- [x] `npm test` — all 606 tests pass including the 7 new governance tests
- [x] `npm run build` — production build succeeds
- [x] (`pallets/flask`) Manual: analyze a well-governed repo and confirm a second pill labeled `GOVERNANCE` appears beside `COMMUNITY` on each metric card with a sensible percentile and `N of M signals` detail
- [x] (`sindresorhus/is`) Manual: analyze a sparse repo and confirm Governance pill either shows low/missing signals or is omitted (when all signals are unknown)
- [x] (`pallets/flask`) Manual: confirm existing governance tag pills on Documentation / Contributors / Security views are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)