### PR TITLE
Make Lens pills click-to-filter (#200)

### DIFF
--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import { buildMetricCardViewModels } from '@/lib/metric-cards/view-model'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { MetricCard } from './MetricCard'
@@ -56,6 +56,31 @@ describe('MetricCard', () => {
     expect(screen.getByText('No description found')).toBeInTheDocument()
   })
 
+  it('renders lens pills as non-clickable spans when no onTagChange is provided', () => {
+    const card = buildMetricCardViewModels([buildResult(sparseCommunityOverrides())])[0]!
+    render(<MetricCard card={card} />)
+    const communityLabel = screen.getByText(/^Community$/i)
+    expect(communityLabel.closest('button')).toBeNull()
+  })
+
+  it('renders lens pills as buttons and toggles activeTag when clicked', () => {
+    const card = buildMetricCardViewModels([buildResult(sparseCommunityOverrides())])[0]!
+    const onTagChange = vi.fn()
+
+    const { rerender } = render(<MetricCard card={card} activeTag={null} onTagChange={onTagChange} />)
+    const communityButton = screen.getByRole('button', { name: /community/i })
+    expect(communityButton).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(communityButton)
+    expect(onTagChange).toHaveBeenCalledWith('community')
+
+    rerender(<MetricCard card={card} activeTag="community" onTagChange={onTagChange} />)
+    const active = screen.getByRole('button', { name: /community/i })
+    expect(active).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(active)
+    expect(onTagChange).toHaveBeenLastCalledWith(null)
+  })
+
   it('handles unavailable ecosystem metrics gracefully', () => {
     const card = buildMetricCardViewModels([
       buildResult({ stars: 'unavailable', forks: 'unavailable', watchers: 'unavailable' }),
@@ -69,6 +94,13 @@ describe('MetricCard', () => {
     expect(screen.queryByText(/^Attention$/)).not.toBeInTheDocument()
   })
 })
+
+function sparseCommunityOverrides(): Partial<AnalysisResult> {
+  return {
+    hasFundingConfig: true,
+    hasDiscussionsEnabled: false,
+  }
+}
 
 function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
   return {

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -6,9 +6,15 @@ import { scoreToneClass } from '@/lib/metric-cards/score-config'
 
 interface MetricCardProps {
   card: MetricCardViewModel
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
-export function MetricCard({ card }: MetricCardProps) {
+export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
+  const handleLensClick = (key: string) => {
+    if (!onTagChange) return
+    onTagChange(activeTag === key ? null : key)
+  }
   const profileCells: ScorecardCellProps[] = card.profile
     ? [
         { label: 'Reach', percentileLabel: card.profile.reachLabel, detail: `${card.starsLabel} stars`, tooltip: 'Star count percentile. Measures visibility and adoption.', toneClass: percentileToneClass(card.profile.reachPercentile, 'emerald') },
@@ -62,7 +68,12 @@ export function MetricCard({ card }: MetricCardProps) {
         <div className="mt-2 flex flex-wrap items-center gap-1.5">
           <span className="text-[9px] font-medium uppercase tracking-wider text-slate-400">Lenses</span>
           {card.lenses.map((lens) => (
-            <LensPill key={lens.key} lens={lens} />
+            <LensPill
+              key={lens.key}
+              lens={lens}
+              active={activeTag === lens.key}
+              onClick={onTagChange ? () => handleLensClick(lens.key) : undefined}
+            />
           ))}
         </div>
       ) : null}
@@ -97,16 +108,37 @@ interface ScorecardCellProps {
   toneClass: string
 }
 
-function LensPill({ lens }: { lens: LensReadout }) {
-  return (
-    <span
-      className={`inline-flex items-baseline gap-1.5 rounded-full border px-2 py-0.5 text-[10px] ${scoreToneClass(lens.tone)}`}
-      title={lens.tooltip}
-    >
+const LENS_RING_COLORS: Record<string, string> = {
+  community: 'ring-amber-400',
+  governance: 'ring-indigo-400',
+}
+
+function LensPill({ lens, active, onClick }: { lens: LensReadout; active: boolean; onClick?: () => void }) {
+  const ringClass = active ? `ring-2 ${LENS_RING_COLORS[lens.key] ?? 'ring-slate-400'} ring-offset-1` : ''
+  const baseClass = `inline-flex items-baseline gap-1.5 rounded-full border px-2 py-0.5 text-[10px] ${scoreToneClass(lens.tone)} ${ringClass}`
+
+  const content = (
+    <>
       <span className="font-semibold uppercase tracking-wide">{lens.label}</span>
       <span className="font-medium">{lens.percentileLabel}</span>
       <span className="opacity-60">· {lens.detail}</span>
-    </span>
+    </>
+  )
+
+  if (!onClick) {
+    return <span className={baseClass} title={lens.tooltip}>{content}</span>
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${baseClass} transition-all hover:opacity-80`}
+      title={lens.tooltip}
+      aria-pressed={active}
+    >
+      {content}
+    </button>
   )
 }
 

--- a/components/metric-cards/MetricCardsOverview.tsx
+++ b/components/metric-cards/MetricCardsOverview.tsx
@@ -6,9 +6,11 @@ import { MetricCard } from './MetricCard'
 
 interface MetricCardsOverviewProps {
   results: AnalysisResult[]
+  activeTag?: string | null
+  onTagChange?: (tag: string | null) => void
 }
 
-export function MetricCardsOverview({ results }: MetricCardsOverviewProps) {
+export function MetricCardsOverview({ results, activeTag, onTagChange }: MetricCardsOverviewProps) {
   const cards = buildMetricCardViewModels(results)
 
   if (cards.length === 0) {
@@ -18,7 +20,7 @@ export function MetricCardsOverview({ results }: MetricCardsOverviewProps) {
   return (
     <section aria-label="Metric cards overview" className="space-y-4">
       {cards.map((card) => (
-        <MetricCard key={card.repo} card={card} />
+        <MetricCard key={card.repo} card={card} activeTag={activeTag ?? null} onTagChange={onTagChange} />
       ))}
     </section>
   )

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -311,7 +311,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       ) : null}
       {inputMode === 'repos' && analysisResponse ? (
         <section aria-label="Analysis results" className="space-y-4">
-          <MetricCardsOverview results={analysisResponse.results} />
+          <MetricCardsOverview results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
           {analysisResponse.failures.length > 0 ? (
             <section className="rounded border border-amber-200 bg-amber-50 p-4">
               <h2 className="font-semibold text-amber-900">Failed repositories</h2>


### PR DESCRIPTION
## Summary
- Community and Governance lens pills on the metric-card scorecard now click-to-filter, reusing the existing `activeTag`/`setActiveTag` state that already drives tab-level `TagPill` filtering
- `LensPill` renders as a `<button>` with `aria-pressed` when a handler is provided; falls back to a non-clickable `<span>` otherwise
- Active pill shows a tag-colored ring (amber for community, indigo for governance) matching the existing `TagPill` convention
- Clicking again clears the filter (same toggle semantics as the tab pills)

Closes #200. Follow-up #204 tracks per-tab match-count badges when a lens filter is active.

## Test plan
- [x] `npm test` — 608 tests pass (2 new MetricCard tests for the clickable behavior)
- [x] `npm run build` — production build succeeds
- [x] Manual (`pallets/flask`): click the **GOVERNANCE** lens pill on the overview card; confirm an amber/indigo ring appears on the pill
- [x] Manual (`pallets/flask`): with Governance active, navigate to Documentation / Contributors / Security tabs; confirm rows are filtered to governance-tagged items (same as clicking a governance `TagPill` inside a tab)
- [x] Manual (`pallets/flask`): click the active **GOVERNANCE** lens pill again; confirm the filter clears across all tabs
- [x] Manual (`pallets/flask`): repeat the same flow for the **COMMUNITY** lens pill
- [x] Manual: confirm existing in-tab `TagPill` behavior on Documentation / Contributors / Security / Activity / Responsiveness is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)