### PR TITLE
Reorder OSS Health Score tooltip dimensions to match tab order (#189)

### DIFF
--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -41,7 +41,7 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
       </div>
       <p className={`mt-1 line-clamp-2 text-xs italic text-slate-400 ${card.description === '—' ? '' : 'not-italic text-slate-500'}`}>{card.description === '—' ? 'No description found' : card.description}</p>
 
-      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Activity (25%), Responsiveness (25%), Contributors (23%), Security (15%), and Documentation (12%, includes licensing, compliance & inclusive naming) — scored relative to ${hs.bracketLabel} repositories.`}>
+      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%, includes licensing, compliance & inclusive naming), and Security (15%) — scored relative to ${hs.bracketLabel} repositories.`}>
         <div>
           <p className="text-xs font-medium uppercase tracking-wide">OSS Health Score</p>
           {hs.bracketLabel ? <p className="text-[10px] opacity-60">{hs.bracketLabel}</p> : null}


### PR DESCRIPTION
## Summary
- Reorders the OSS Health Score composite tooltip to Contributors → Activity → Responsiveness → Documentation → Security
- Matches the result tab order and landing-page dimension cards established in PR #185 and PR #186
- Fixes #189

## Test plan
- [x] Hover the OSS Health Score banner on a result card; tooltip reads: "Composite health score from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%, includes licensing, compliance & inclusive naming), and Security (15%) — scored relative to {bracket} repositories."
- [x] Order matches the result tabs (Contributors, Activity, Responsiveness, Documentation, Security)
- [x] \`npm test\` passes — 608/608 tests across 76 files
- [x] \`npm run lint\` — no new issues introduced by this change (5 pre-existing errors + 13 warnings in unrelated files: RepoInputClient, ecosystem-map, health-ratios, scoring helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)