### PR TITLE
Fix OSS Health Score tooltip dimension order (#189)

### DIFF
--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -41,7 +41,7 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
       </div>
       <p className={`mt-1 line-clamp-2 text-xs italic text-slate-400 ${card.description === '—' ? '' : 'not-italic text-slate-500'}`}>{card.description === '—' ? 'No description found' : card.description}</p>
 
-      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Activity (25%), Responsiveness (25%), Contributors (23%), Security (15%), and Documentation (12%, includes licensing, compliance & inclusive naming) — scored relative to ${hs.bracketLabel} repositories.`}>
+      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%, includes licensing, compliance & inclusive naming), and Security (15%) — scored relative to ${hs.bracketLabel} repositories.`}>
         <div>
           <p className="text-xs font-medium uppercase tracking-wide">OSS Health Score</p>
           {hs.bracketLabel ? <p className="text-[10px] opacity-60">{hs.bracketLabel}</p> : null}


### PR DESCRIPTION
## Summary
- Reorder the OSS Health Score tooltip dimensions in `components/metric-cards/MetricCard.tsx` to match the tab order and landing-page dimension list from PR #185 / #186: Contributors, Activity, Responsiveness, Documentation, Security.

Closes #189.

## Test plan
- [x] Hover the OSS Health Score banner on a repo scorecard and confirm the tooltip reads: "Composite health score from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%, includes licensing, compliance & inclusive naming), and Security (15%) — scored relative to {bracket} repositories."
- [x] Confirm dimension order matches the result tabs and landing-page dimension cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)