### PR TITLE
Frame RepoPulse as a community-project tool; link #214 for solo-project follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ RepoPulse analyzes any public GitHub repository and produces a composite **OSS H
 
 RepoPulse is built for **community-oriented projects** — multi-contributor repositories with users, maintainers, and a growth story. The primary audience is:
 
-- OSPOs and program managers evaluating OSS health across a portfolio
 - Maintainers of projects with 3+ active contributors looking to close specific gaps
+- OSPOs and program managers evaluating OSS health across a portfolio
 - Foundation-track projects (CNCF, Apache, Linux Foundation, etc.) preparing for stage reviews
 
 **Not the right fit at this time** for solo-maintainer projects or 1–2 person dependencies. Those projects will see low Contributors and Responsiveness scores with the current scoring surface — not a judgment, just a poor match between today's signals and the project's shape. A dedicated solo-project profile with re-weighted scoring (Activity / Security / Documentation emphasized) is planned in [#214](https://github.com/arun-gupta/repo-pulse/issues/214).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ RepoPulse analyzes any public GitHub repository and produces a composite **OSS H
 
 > **Try it now** — paste any GitHub repo URL into [repopulse-arun-gupta.vercel.app](https://repopulse-arun-gupta.vercel.app) and get a health report in seconds.
 
+## Who it's for
+
+RepoPulse is built for **community-oriented projects** — multi-contributor repositories with users, maintainers, and a growth story. The primary audience is:
+
+- Foundation-track projects (CNCF, Apache, Linux Foundation, etc.) preparing for stage reviews
+- OSPOs and program managers evaluating OSS health across a portfolio
+- Maintainers of projects with 3+ active contributors looking to close specific gaps
+
+**Not the right fit for** solo-maintainer projects or 1–2 person dependencies. Those projects will see low Contributors and Responsiveness scores by design — not a judgment, just a poor match between the tool's signals and the project's shape. A dedicated solo-project profile with re-weighted scoring (Activity / Security / Documentation emphasized) is planned in [#214](https://github.com/arun-gupta/repo-pulse/issues/214).
+
 ## Key Features
 
 | | Feature | Description |

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ RepoPulse analyzes any public GitHub repository and produces a composite **OSS H
 
 RepoPulse is built for **community-oriented projects** — multi-contributor repositories with users, maintainers, and a growth story. The primary audience is:
 
-- Foundation-track projects (CNCF, Apache, Linux Foundation, etc.) preparing for stage reviews
 - OSPOs and program managers evaluating OSS health across a portfolio
 - Maintainers of projects with 3+ active contributors looking to close specific gaps
+- Foundation-track projects (CNCF, Apache, Linux Foundation, etc.) preparing for stage reviews
 
 **Not the right fit at this time** for solo-maintainer projects or 1–2 person dependencies. Those projects will see low Contributors and Responsiveness scores with the current scoring surface — not a judgment, just a poor match between today's signals and the project's shape. A dedicated solo-project profile with re-weighted scoring (Activity / Security / Documentation emphasized) is planned in [#214](https://github.com/arun-gupta/repo-pulse/issues/214).
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ RepoPulse is built for **community-oriented projects** — multi-contributor rep
 - OSPOs and program managers evaluating OSS health across a portfolio
 - Maintainers of projects with 3+ active contributors looking to close specific gaps
 
-**Not the right fit for** solo-maintainer projects or 1–2 person dependencies. Those projects will see low Contributors and Responsiveness scores by design — not a judgment, just a poor match between the tool's signals and the project's shape. A dedicated solo-project profile with re-weighted scoring (Activity / Security / Documentation emphasized) is planned in [#214](https://github.com/arun-gupta/repo-pulse/issues/214).
+**Not the right fit at this time** for solo-maintainer projects or 1–2 person dependencies. Those projects will see low Contributors and Responsiveness scores with the current scoring surface — not a judgment, just a poor match between today's signals and the project's shape. A dedicated solo-project profile with re-weighted scoring (Activity / Security / Documentation emphasized) is planned in [#214](https://github.com/arun-gupta/repo-pulse/issues/214).
 
 ## Key Features
 

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -89,6 +89,21 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             <span className="text-slate-300">|</span>
             <span>Export as JSON or Markdown</span>
           </div>
+
+          <p className="text-center text-xs italic text-slate-500">
+            Built for community-oriented projects — multi-contributor and foundation-track.
+            Solo-maintainer projects will see sparse scores on Contributors and Responsiveness; a
+            dedicated solo-project profile is{' '}
+            <a
+              href="https://github.com/arun-gupta/repo-pulse/issues/214"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-slate-700"
+            >
+              planned (#214)
+            </a>
+            .
+          </p>
         </div>
 
         <SignInButton />

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -92,8 +92,8 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
           <p className="text-center text-xs italic text-slate-500">
             Built for community-oriented projects — multi-contributor and foundation-track.
-            Solo-maintainer projects will see sparse scores on Contributors and Responsiveness; a
-            dedicated solo-project profile is{' '}
+            Solo-maintainer projects will, at this time, see sparse scores on Contributors and
+            Responsiveness; a dedicated solo-project profile is{' '}
             <a
               href="https://github.com/arun-gupta/repo-pulse/issues/214"
               target="_blank"


### PR DESCRIPTION
## Summary
- Responds to maintainer feedback that RepoPulse scores solo / 1-2 contributor projects unfairly (Contributors and Responsiveness always low)
- Step 1 of 2: be upfront about the audience. New "Who it's for" section in README, italic framing note on the landing page, both linking to #214 (planned solo-project profile)
- Step 2 (re-weighted scoring surface for solo projects) is scoped in #214

## Test plan
- [x] `npx vitest run components/auth` — 11 tests pass (AuthGate tests unaffected)
- [x] `npm run build` — production build succeeds
- [x] Manual: sign out, confirm the new framing note appears under the dimension list on the landing page with a working link to #214
- [x] Manual: README "Who it's for" section renders correctly on GitHub with the #214 link clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)