### PR TITLE
Dev-only DEV_GITHUB_PAT fallback for multi-worktree local testing (#207)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,9 @@ GITHUB_CLIENT_SECRET=
 #
 # Priority: numbered → comma-separated → single.
 # Each additional token roughly doubles rate limit throughput.
+
+# Dev-only: server-side PAT fallback to bypass OAuth when running multiple
+# worktrees on non-3000 ports (see issue #207). Ignored unless NODE_ENV=development.
+# The app throws at boot if this is set with NODE_ENV=production.
+# Required scope: public_repo (read access only).
+# DEV_GITHUB_PAT=ghp_...

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ next-env.d.ts
 
 # calibration script intermediate state
 scripts/calibrate-checkpoint.json
+
+# claude-worktree.sh runtime artifacts
+.dev.pid
+.claude.pid
+dev.log
+claude.log

--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { GET } from './route'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
 // Mock Next.js server cookies
 vi.mock('next/headers', () => ({
@@ -8,13 +7,33 @@ vi.mock('next/headers', () => ({
   }),
 }))
 
+// Mock server-only sentinel (would otherwise throw in a unit-test context)
+vi.mock('server-only', () => ({}))
+
+// Import AFTER mocks so the module-level `assertDevPatNotInProduction` runs
+// against our default env (development, no PAT).
+vi.stubEnv('NODE_ENV', 'development')
+vi.stubEnv('DEV_GITHUB_PAT', '')
+const { GET } = await import('./route')
+
+function mockRequest(url = 'http://localhost:3010/api/auth/login'): Request {
+  return new Request(url)
+}
+
 describe('GET /api/auth/login', () => {
   beforeEach(() => {
     vi.stubEnv('GITHUB_CLIENT_ID', 'test_client_id')
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_GITHUB_PAT', '')
   })
 
-  it('redirects to GitHub authorize URL', async () => {
-    const response = await GET()
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('redirects to GitHub authorize URL when no dev PAT is set', async () => {
+    const response = await GET(mockRequest())
     expect(response.status).toBe(302)
     const location = response.headers.get('location') ?? ''
     expect(location).toContain('https://github.com/login/oauth/authorize')
@@ -23,14 +42,65 @@ describe('GET /api/auth/login', () => {
   })
 
   it('includes a state parameter', async () => {
-    const response = await GET()
+    const response = await GET(mockRequest())
     const location = response.headers.get('location') ?? ''
     expect(location).toMatch(/state=[a-zA-Z0-9_-]+/)
   })
 
-  it('returns 500 when GITHUB_CLIENT_ID is not configured', async () => {
+  it('returns 500 when GITHUB_CLIENT_ID is not configured (and no dev PAT)', async () => {
     vi.stubEnv('GITHUB_CLIENT_ID', '')
-    const response = await GET()
+    const response = await GET(mockRequest())
     expect(response.status).toBe(500)
+  })
+
+  it('short-circuits OAuth when DEV_GITHUB_PAT is set in development', async () => {
+    vi.stubEnv('DEV_GITHUB_PAT', 'ghp_devtesttoken')
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ login: 'dev-user' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await GET(mockRequest())
+    expect(response.status).toBe(302)
+    const location = response.headers.get('location') ?? ''
+    expect(location).not.toContain('github.com/login/oauth/authorize')
+    expect(location).toContain('#token=ghp_devtesttoken')
+    expect(location).toContain('username=dev-user')
+
+    // Verifies the server fetched /user with the PAT
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/user',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer ghp_devtesttoken' }),
+      }),
+    )
+  })
+
+  it('returns 500 when DEV_GITHUB_PAT is set but GitHub rejects it', async () => {
+    vi.stubEnv('DEV_GITHUB_PAT', 'ghp_invalid')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Bad credentials', { status: 401 })),
+    )
+    const response = await GET(mockRequest())
+    expect(response.status).toBe(500)
+    const body = (await response.json()) as { error: string }
+    expect(body.error).toMatch(/rejected by GitHub/i)
+  })
+
+  it('ignores DEV_GITHUB_PAT in production (falls back to OAuth path)', async () => {
+    // Note: can't set NODE_ENV=production here without tripping the
+    // module-level assertDevPatNotInProduction that ran at import time.
+    // This test covers the getDevPat runtime guard only. The boot assertion
+    // has its own dedicated test file (server-pat.test.ts).
+    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('DEV_GITHUB_PAT', 'ghp_prodshouldignore')
+    const response = await GET(mockRequest())
+    expect(response.status).toBe(302)
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('github.com/login/oauth/authorize')
   })
 })

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,10 +1,30 @@
 import { cookies } from 'next/headers'
+import { getDevPat } from '@/lib/dev/server-pat'
 
 export const runtime = 'nodejs'
 
 const OAUTH_STATE_COOKIE = 'repo_pulse_oauth_state'
 
-export async function GET() {
+export async function GET(request: Request) {
+  // Dev-only short-circuit (#207): bypass GitHub OAuth when DEV_GITHUB_PAT is
+  // set in `next dev`. Resolves the multi-worktree port-mismatch problem
+  // without requiring OAuth App reconfiguration.
+  const devPat = getDevPat()
+  if (devPat) {
+    const username = await fetchGithubUsername(devPat)
+    if (username) {
+      const base = new URL('/', request.url)
+      return Response.redirect(
+        `${base.toString()}#token=${encodeURIComponent(devPat)}&username=${encodeURIComponent(username)}`,
+        302,
+      )
+    }
+    return Response.json(
+      { error: 'DEV_GITHUB_PAT is set but rejected by GitHub (invalid or lacking public_repo scope).' },
+      { status: 500 },
+    )
+  }
+
   const clientId = process.env.GITHUB_CLIENT_ID
 
   if (!clientId) {
@@ -29,4 +49,20 @@ export async function GET() {
   })
 
   return Response.redirect(`https://github.com/login/oauth/authorize?${params.toString()}`, 302)
+}
+
+async function fetchGithubUsername(token: string): Promise<string | null> {
+  try {
+    const res = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as { login?: string }
+    return body.login ?? null
+  } catch {
+    return null
+  }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -120,6 +120,44 @@ Safety layers:
 
 See issue #207 for the full rationale and constitution discussion.
 
+### Spawning worktrees with `scripts/claude-worktree.sh`
+
+`scripts/claude-worktree.sh` automates the parallel-worktree workflow: it provisions an isolated git worktree per issue, picks a free dev-server port, copies `.env.local` (so `DEV_GITHUB_PAT` flows through), starts `next dev`, and launches Claude with a kickoff prompt pointing at the issue.
+
+**Spawn:**
+
+```bash
+# interactive — slug auto-derived from the GitHub issue title
+scripts/claude-worktree.sh 207
+
+# headless — claude -p in background, log -> claude.log
+scripts/claude-worktree.sh --headless 207
+
+# batch
+for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done
+```
+
+The script creates `../forkprint-<issue>-<slug>/` on a new branch, picks the next free port in `3010–3100`, runs `npm install`, starts `next dev` in the background (log: `dev.log`, PID: `.dev.pid`), and launches `claude` with a prompt that runs the SpecKit lifecycle and opens a PR (never merges — see CLAUDE.md).
+
+**Cleanup:**
+
+```bash
+# Post-merge: from the main repo on `main`, pull main, kill processes,
+# remove the worktree, delete the branch (refuses if unmerged).
+scripts/claude-worktree.sh --cleanup-merged 207
+
+# Discard unmerged work (kills processes + force-removes worktree, keeps branch).
+scripts/claude-worktree.sh --remove 207
+```
+
+If something gets stuck:
+
+```bash
+git worktree list                 # what's still registered
+git worktree prune                # drop stale entries for deleted paths
+lsof -iTCP:3010-3100 -sTCP:LISTEN # any dev servers still bound?
+```
+
 ---
 
 ## Phase 2 feature order

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -93,6 +93,33 @@ npm run lint
 npm run build
 ```
 
+> **Note**: If you have `DEV_GITHUB_PAT` in `.env.local` (see multi-worktree section below), run `DEV_GITHUB_PAT= npm run build` — the build asserts this variable is not present in `NODE_ENV=production` contexts, and `next build` forces production.
+
+---
+
+## Multi-worktree local development (`DEV_GITHUB_PAT`)
+
+The GitHub OAuth App registers a single callback URL (`http://localhost:3000/api/auth/callback`). Running multiple worktrees concurrently means only the worktree on port 3000 can complete OAuth.
+
+To work around this in `next dev` (only — never production), set a GitHub PAT in `.env.local`:
+
+```bash
+# .env.local
+DEV_GITHUB_PAT=ghp_your_personal_access_token
+```
+
+Required scope: `public_repo` (read only).
+
+When set, clicking "Sign in with GitHub" short-circuits the OAuth round-trip and grants a session using the PAT directly. Unset the variable (or leave it blank) to restore the normal OAuth flow.
+
+Safety layers:
+
+- Gated by `NODE_ENV === 'development'` — ignored under `next build` / `next start` / deployed contexts.
+- Boot assertion: if `NODE_ENV=production` and `DEV_GITHUB_PAT` is set, the app throws at startup. Vercel deploys with this var set will fail to boot.
+- `.env.local` is gitignored; no secret enters the repo.
+
+See issue #207 for the full rationale and constitution discussion.
+
 ---
 
 ## Phase 2 feature order

--- a/lib/dev/server-pat.test.ts
+++ b/lib/dev/server-pat.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+describe('lib/dev/server-pat', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('getDevPat returns the PAT when NODE_ENV=development and DEV_GITHUB_PAT is set', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_GITHUB_PAT', 'ghp_devpat')
+    const { getDevPat } = await import('./server-pat')
+    expect(getDevPat()).toBe('ghp_devpat')
+  })
+
+  it('getDevPat returns null in development when DEV_GITHUB_PAT is missing', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_GITHUB_PAT', '')
+    const { getDevPat } = await import('./server-pat')
+    expect(getDevPat()).toBeNull()
+  })
+
+  it('getDevPat returns null in test env (treated as non-dev)', async () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('DEV_GITHUB_PAT', 'ghp_shouldignore')
+    const { getDevPat } = await import('./server-pat')
+    expect(getDevPat()).toBeNull()
+  })
+
+  it('assertDevPatNotInProduction throws when NODE_ENV=production and DEV_GITHUB_PAT is set', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('DEV_GITHUB_PAT', 'ghp_shouldnotexist')
+    // Module import triggers the assertion at top level.
+    await expect(import('./server-pat')).rejects.toThrow(/DEV_GITHUB_PAT is set with NODE_ENV=production/)
+  })
+
+  it('assertDevPatNotInProduction does not throw in production when DEV_GITHUB_PAT is absent', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('DEV_GITHUB_PAT', '')
+    await expect(import('./server-pat')).resolves.toBeDefined()
+  })
+})

--- a/lib/dev/server-pat.ts
+++ b/lib/dev/server-pat.ts
@@ -1,0 +1,52 @@
+/**
+ * Dev-only server-side GitHub PAT fallback (#207).
+ *
+ * When running `next dev` with `DEV_GITHUB_PAT` set in `.env.local`, the app
+ * bypasses the GitHub OAuth round-trip and treats the developer as signed in
+ * using the PAT directly. This exists to unblock multi-worktree local testing
+ * where only one worktree can bind to port 3000 (the registered OAuth App
+ * callback port).
+ *
+ * Safety:
+ *  - Gated by `NODE_ENV === 'development'`. Next.js only sets this under
+ *    `next dev`; `next build && next start` and Vercel deployments force
+ *    `production`, so the PAT is ignored in every non-dev context.
+ *  - If `DEV_GITHUB_PAT` is somehow present with `NODE_ENV === 'production'`
+ *    (misconfiguration), `assertDevPatNotInProduction` throws at import time
+ *    so the app refuses to boot rather than silently leaking credentials.
+ *  - This module is server-only (`'server-only'`). Importing it from a
+ *    client bundle will fail the Next.js build.
+ *
+ * Constitution §III.4 prohibits user-facing PAT input. This is a dev-only
+ * server-side mechanism invisible to end users, documented as a scoped
+ * exception in issue #207.
+ */
+import 'server-only'
+
+assertDevPatNotInProduction()
+
+/**
+ * Returns the dev PAT when running in `next dev` with `DEV_GITHUB_PAT` set,
+ * else null. Callers should treat null as "use the regular OAuth path".
+ */
+export function getDevPat(): string | null {
+  if (process.env.NODE_ENV !== 'development') return null
+  const pat = process.env.DEV_GITHUB_PAT
+  if (!pat || pat.length === 0) return null
+  return pat
+}
+
+/**
+ * Throws if `DEV_GITHUB_PAT` is set while `NODE_ENV === 'production'`.
+ * Called at module-import time so a misconfigured deploy fails loudly
+ * at server start, not when the first auth request comes in.
+ */
+export function assertDevPatNotInProduction(): void {
+  if (process.env.NODE_ENV === 'production' && process.env.DEV_GITHUB_PAT) {
+    throw new Error(
+      'DEV_GITHUB_PAT is set with NODE_ENV=production. ' +
+        'This variable is for local development only and must never ship to production. ' +
+        'Remove it from the deployed environment and rebuild.',
+    )
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),
+      // Next.js "server-only" sentinel is a runtime no-op but trips
+      // vitest's module resolver. Alias to an empty shim so server-side
+      // modules import cleanly in tests.
+      'server-only': path.resolve(__dirname, './vitest.shims/server-only.ts'),
     },
   },
   test: {

--- a/vitest.shims/server-only.ts
+++ b/vitest.shims/server-only.ts
@@ -1,0 +1,4 @@
+// Empty shim for Next.js `server-only` import used under vitest.
+// In production, importing `server-only` from a client bundle is a build
+// error. Tests run in isolation from the Next.js bundler, so we stub it.
+export {}


### PR DESCRIPTION
## Summary
- Implements the Option B decision recorded on #207: when running `next dev` with `DEV_GITHUB_PAT` set in `.env.local`, bypass GitHub OAuth and grant a session using the PAT directly
- Unblocks multi-worktree local testing — only one worktree can bind to port 3000 (the registered OAuth callback), and every other worktree previously got stuck on OAuth
- Invisible to contributors who don't opt in; no effect in `next build` / `next start` / deployed contexts

Closes #207.

### Safety layers
- Gated by `NODE_ENV === 'development'` (Next.js sets this only under `next dev`)
- Requires explicit opt-in via `DEV_GITHUB_PAT` in `.env.local` (which is gitignored)
- `assertDevPatNotInProduction()` runs at module-import time — a misconfigured production deploy with the var set fails loudly at boot rather than silently leaking credentials
- Module is marked `server-only`; importing from a client bundle is a build error

### Not changed
- OAuth flow unchanged for every contributor who doesn't set the PAT
- Constitution §III.4 (no user-facing PAT) unchanged — this is dev-only, server-side, never touches the client

## Test plan
- [x] `npx vitest run lib/dev app/api/auth` — 16 tests pass (5 PAT helper + 6 login route including 3 new)
- [x] `npm test` — 616 tests pass (no regressions from the 608 baseline)
- [x] `DEV_GITHUB_PAT= npm run build` — production build succeeds when the PAT is not set
- [x] `DEV_GITHUB_PAT=ghp_whatever npm run build` — production build **fails** with the assertion error (verifies the guardrail)
- [x] Verified live: `curl -I http://localhost:3000/api/auth/login` with `DEV_GITHUB_PAT` set returns `302` → `http://localhost:3000/#token=<PAT>&username=arun-gupta` (no GitHub round-trip, live `/user` fetch resolved the username)
- [x] Unset-PAT path covered by the "redirects to GitHub authorize URL when no dev PAT is set" unit test — same code path a browser would hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)