### PR TITLE
Rework Contributors score as a weighted composite (#184)

### DIFF
--- a/components/contributors/ContributorsScorePane.tsx
+++ b/components/contributors/ContributorsScorePane.tsx
@@ -6,6 +6,7 @@ import { HelpLabel } from '@/components/shared/HelpLabel'
 import { MetricValue } from '@/components/shared/MetricValue'
 import { TagPill, ActiveFilterBar } from '@/components/tags/TagPill'
 import { formatPercentage } from '@/lib/contributors/score-config'
+import { formatPercentileLabel } from '@/lib/scoring/config-loader'
 import type { ContributorsSectionViewModel } from '@/lib/contributors/view-model'
 import { GOVERNANCE_CONTRIBUTORS_METRICS } from '@/lib/tags/governance'
 import { COMMUNITY_CONTRIBUTORS_METRICS } from '@/lib/tags/community'
@@ -47,7 +48,7 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
           <div>
             <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is this scored?</p>
             <p className="mt-1 text-sm text-slate-700">
-              RepoPulse scores contributor diversity from recent commit concentration, ranked as a percentile against repos in the same star bracket. Lower top-20% share means the active contributor base is more distributed.
+              {section.contributorsScore.summary ?? 'Contributors combines contributor concentration, maintainer depth, repeat and new-contributor signals, and contribution breadth, scored relative to the repo\'s star bracket.'}
             </p>
           </div>
           <button
@@ -59,13 +60,40 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
             {showDetails ? 'Hide details' : 'Show details'}
           </button>
         </div>
+        {section.contributorsScore.weightedFactors && section.contributorsScore.weightedFactors.length > 0 ? (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {section.contributorsScore.weightedFactors.map((factor) => (
+              <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700">
+                <span className="font-semibold text-slate-900">{factor.label}</span> <span>{factor.weightLabel}</span>
+                {factor.percentile !== undefined ? (
+                  <span className="ml-1 text-slate-500">({formatPercentileLabel(factor.percentile)})</span>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
         {showDetails ? (
-          <div className="mt-3 rounded-lg border border-slate-200 bg-white p-3">
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Concentration</p>
-            <p className="mt-1 text-sm text-slate-700">
-              Top-20% contributor share: {formatPercentage(section.contributorsScore.concentration)}
-              {section.contributorsScore.bracketLabel ? ` — scored relative to ${section.contributorsScore.bracketLabel} repositories` : ''}
-            </p>
+          <div className="mt-3 grid gap-2">
+            {section.contributorsScore.weightedFactors && section.contributorsScore.weightedFactors.length > 0 ? (
+              section.contributorsScore.weightedFactors.map((factor) => (
+                <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{factor.label} ({factor.weightLabel})</p>
+                    {factor.percentile !== undefined ? (
+                      <p className="text-sm font-semibold text-slate-900">{formatPercentileLabel(factor.percentile)}</p>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600">{factor.description}</p>
+                </div>
+              ))
+            ) : null}
+            <div className="rounded-lg border border-slate-200 bg-white p-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Top-20% contributor share</p>
+              <p className="mt-1 text-sm text-slate-700">
+                {formatPercentage(section.contributorsScore.concentration)}
+                {section.contributorsScore.bracketLabel ? ` — scored relative to ${section.contributorsScore.bracketLabel} repositories` : ''}
+              </p>
+            </div>
           </div>
         ) : null}
       </div>

--- a/lib/comparison/sections.ts
+++ b/lib/comparison/sections.ts
@@ -40,6 +40,11 @@ export type ComparisonAttributeId =
   | 'documentation-readme-sections'
   | 'fork-rate-health'
   | 'repeat-contributor-ratio-health'
+  | 'contributors-factor-concentration'
+  | 'contributors-factor-maintainer-depth'
+  | 'contributors-factor-repeat-ratio'
+  | 'contributors-factor-new-inflow'
+  | 'contributors-factor-breadth'
 
 export type ComparisonDirection = 'higher-is-better' | 'lower-is-better' | 'neutral'
 export type ComparisonValueType = 'number' | 'percentage' | 'duration' | 'label'
@@ -83,6 +88,37 @@ function formatDurationHours(value: number | Unavailable) {
 
 function getContributorWindowMetrics(result: AnalysisResult) {
   return result.contributorMetricsByWindow?.[90]
+}
+
+function contributorsFactorRows(): ComparisonAttributeDefinition[] {
+  const factors: Array<{
+    id: ComparisonAttributeId
+    label: string
+    factorLabel: string
+    helpText: string
+  }> = [
+    { id: 'contributors-factor-concentration', label: 'Concentration factor', factorLabel: 'Contributor concentration', helpText: 'Contributor-concentration sub-factor percentile (40% weight).' },
+    { id: 'contributors-factor-maintainer-depth', label: 'Maintainer depth factor', factorLabel: 'Maintainer depth', helpText: 'Maintainer-depth sub-factor percentile (15% weight).' },
+    { id: 'contributors-factor-repeat-ratio', label: 'Repeat-contributor factor', factorLabel: 'Repeat-contributor ratio', helpText: 'Repeat-contributor sub-factor percentile (20% weight).' },
+    { id: 'contributors-factor-new-inflow', label: 'New-contributor inflow factor', factorLabel: 'New-contributor inflow', helpText: 'New-contributor-inflow sub-factor percentile (10% weight).' },
+    { id: 'contributors-factor-breadth', label: 'Contribution breadth factor', factorLabel: 'Contribution breadth', helpText: 'Contribution-breadth sub-factor percentile (15% weight).' },
+  ]
+  return factors.map(({ id, label, factorLabel, helpText }) => ({
+    id,
+    sectionId: 'contributors' as const,
+    label,
+    helpText,
+    direction: 'higher-is-better' as const,
+    valueType: 'number' as const,
+    getValue: (result: AnalysisResult) => {
+      const factor = getContributorsScore(result).weightedFactors.find((f) => f.label === factorLabel)
+      return factor?.percentile ?? 'unavailable'
+    },
+    formatValue: (value: number | Unavailable) => {
+      if (value === 'unavailable') return '—'
+      return formatPercentileLabel(value as number)
+    },
+  }))
 }
 
 function getActivityWindowMetrics(result: AnalysisResult) {
@@ -203,6 +239,7 @@ export const COMPARISON_SECTIONS: ComparisonSectionDefinition[] = [
           return formatPercentileLabel(value as number)
         },
       },
+      ...contributorsFactorRows(),
       {
         id: 'repeat-contributor-ratio',
         sectionId: 'contributors',

--- a/lib/contributors/score-config.ts
+++ b/lib/contributors/score-config.ts
@@ -1,4 +1,4 @@
-import type { AnalysisResult, Unavailable } from '@/lib/analyzer/analysis-result'
+import type { AnalysisResult, ContributorWindowDays, Unavailable } from '@/lib/analyzer/analysis-result'
 import type { ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
 import { formatPercentileLabel, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
 
@@ -6,22 +6,113 @@ export interface ContributorsScoreDefinition {
   value: ScoreValue
   tone: ScoreTone
   description: string
+  summary: string
   percentile: number
   bracketLabel: string
   concentration: number | Unavailable
   topContributorCount: number | Unavailable
   contributorCount: number | Unavailable
+  weightedFactors: Array<{
+    label: string
+    weightLabel: string
+    description: string
+    percentile?: number
+  }>
+  missingInputs: string[]
 }
+
+type FactorKey =
+  | 'concentration'
+  | 'maintainerDepth'
+  | 'repeatRatio'
+  | 'newInflow'
+  | 'contributionBreadth'
+
+interface ContributorsFactorDefinition {
+  key: FactorKey
+  label: string
+  weight: number
+  description: string
+}
+
+const CONTRIBUTORS_FACTORS: ContributorsFactorDefinition[] = [
+  {
+    key: 'concentration',
+    label: 'Contributor concentration',
+    weight: 40,
+    description: 'Top-20% contributor commit share, scored relative to the repo\'s star bracket. Lower concentration is healthier.',
+  },
+  {
+    key: 'maintainerDepth',
+    label: 'Maintainer depth',
+    weight: 15,
+    description: 'Count of maintainers or owners parsed from public CODEOWNERS, MAINTAINERS, OWNERS, or GOVERNANCE files.',
+  },
+  {
+    key: 'repeatRatio',
+    label: 'Repeat-contributor ratio',
+    weight: 20,
+    description: 'Share of recent active contributors with more than one commit in the window.',
+  },
+  {
+    key: 'newInflow',
+    label: 'New-contributor inflow',
+    weight: 10,
+    description: 'Share of recent active contributors who are new to the repo. Presence is healthy; dominance is project-lifecycle sensitive.',
+  },
+  {
+    key: 'contributionBreadth',
+    label: 'Contribution breadth',
+    weight: 15,
+    description: 'Presence of recent commits, pull requests, and issues — a repo with all three surfaces is more broadly engaged.',
+  },
+]
 
 const INSUFFICIENT_SCORE: ContributorsScoreDefinition = {
   value: 'Insufficient verified public data',
   tone: 'neutral',
   description: 'RepoPulse cannot verify enough contributor-distribution data to score contributors yet.',
+  summary: 'Verified contributor-distribution inputs are incomplete.',
   percentile: 0,
   bracketLabel: '',
   concentration: 'unavailable',
   topContributorCount: 'unavailable',
   contributorCount: 'unavailable',
+  weightedFactors: CONTRIBUTORS_FACTORS.map((factor) => ({
+    label: factor.label,
+    weightLabel: `${factor.weight}%`,
+    description: factor.description,
+  })),
+  missingInputs: [],
+}
+
+export interface ContributorsScoreExtras {
+  maintainerCount?: number | Unavailable
+  newContributors?: number | Unavailable
+  repeatContributors?: number | Unavailable
+  activeContributors?: number | Unavailable
+  commitsPresent?: boolean
+  prsPresent?: boolean
+  issuesPresent?: boolean
+  hasFundingConfig?: AnalysisResult['hasFundingConfig']
+}
+
+function deriveExtras(result: AnalysisResult, windowDays: ContributorWindowDays = 90): ContributorsScoreExtras {
+  const windowMetrics = result.contributorMetricsByWindow?.[windowDays]
+  return {
+    maintainerCount: result.maintainerCount,
+    newContributors: windowMetrics?.newContributors ?? 'unavailable',
+    repeatContributors: windowMetrics?.repeatContributors ?? 'unavailable',
+    activeContributors: windowMetrics?.uniqueCommitAuthors ?? result.uniqueCommitAuthors90d,
+    commitsPresent: isPositive(result.commits90d),
+    prsPresent: isPositive(result.prsOpened90d) || isPositive(result.prsMerged90d),
+    issuesPresent: isPositive(result.issuesOpen) || isPositive(result.issuesClosed90d),
+    hasFundingConfig: result.hasFundingConfig,
+  }
+}
+
+function isPositive(value: number | Unavailable | undefined): boolean {
+  return typeof value === 'number' && value > 0
 }
 
 /**
@@ -34,33 +125,21 @@ function fundingBonus(hasFundingConfig: AnalysisResult['hasFundingConfig']): num
 }
 
 export function getContributorsScore(result: AnalysisResult): ContributorsScoreDefinition {
-  const cal = getCalibrationForStars(result.stars)
-  const bracketLabel = getBracketLabel(result.stars)
-  const concentration = getContributionConcentrationDetails(result.commitCountsByAuthor)
-
-  if (concentration === 'unavailable') {
-    return INSUFFICIENT_SCORE
-  }
-
-  // Inverted: lower concentration = higher percentile (better contributor diversity)
-  const basePercentile = interpolatePercentile(concentration.share, cal.topContributorShare, true)
-  const percentile = Math.min(99, basePercentile + fundingBonus(result.hasFundingConfig))
-
-  return {
-    value: percentile,
-    tone: percentileToTone(percentile),
-    description: `Contributor concentration ranks at the ${formatPercentileLabel(percentile)} percentile among ${bracketLabel} repositories.`,
-    percentile,
-    bracketLabel,
-    concentration: concentration.share,
-    topContributorCount: concentration.topContributorCount,
-    contributorCount: concentration.contributorCount,
-  }
+  return computeContributorsScore(result.commitCountsByAuthor, result.stars, deriveExtras(result))
 }
 
 export function getContributorsScoreFromCommitCounts(
   commitCountsByAuthor: Record<string, number> | Unavailable,
   stars: number | Unavailable = 'unavailable',
+  extras: ContributorsScoreExtras = {},
+): ContributorsScoreDefinition {
+  return computeContributorsScore(commitCountsByAuthor, stars, extras)
+}
+
+function computeContributorsScore(
+  commitCountsByAuthor: Record<string, number> | Unavailable,
+  stars: number | Unavailable,
+  extras: ContributorsScoreExtras,
 ): ContributorsScoreDefinition {
   const cal = getCalibrationForStars(stars)
   const bracketLabel = getBracketLabel(stars)
@@ -70,18 +149,135 @@ export function getContributorsScoreFromCommitCounts(
     return INSUFFICIENT_SCORE
   }
 
-  const percentile = interpolatePercentile(concentration.share, cal.topContributorShare, true)
+  // Inverted: lower concentration = higher percentile (better contributor diversity)
+  const concentrationPercentile = interpolatePercentile(concentration.share, cal.topContributorShare, true)
+
+  // Prefer provided activeContributors; fall back to the commit-author set size.
+  const activeContributors =
+    typeof extras.activeContributors === 'number'
+      ? extras.activeContributors
+      : concentration.contributorCount
+
+  const subPercentiles: Partial<Record<FactorKey, number>> = {
+    concentration: concentrationPercentile,
+  }
+
+  const maintainerPercentile = evaluateMaintainerDepth(extras.maintainerCount)
+  if (maintainerPercentile !== undefined) subPercentiles.maintainerDepth = maintainerPercentile
+
+  const repeatPercentile = evaluateRepeatRatio(extras.repeatContributors, activeContributors)
+  if (repeatPercentile !== undefined) subPercentiles.repeatRatio = repeatPercentile
+
+  const newInflowPercentile = evaluateNewInflow(extras.newContributors, activeContributors)
+  if (newInflowPercentile !== undefined) subPercentiles.newInflow = newInflowPercentile
+
+  const breadthPercentile = evaluateContributionBreadth(extras)
+  if (breadthPercentile !== undefined) subPercentiles.contributionBreadth = breadthPercentile
+
+  // Weighted composite — renormalize across available factors so 'unavailable'
+  // is excluded (not counted as zero), per issue #184 acceptance criteria.
+  let totalWeight = 0
+  let weightedSum = 0
+  for (const factor of CONTRIBUTORS_FACTORS) {
+    const p = subPercentiles[factor.key]
+    if (p === undefined) continue
+    totalWeight += factor.weight
+    weightedSum += p * factor.weight
+  }
+  const compositePercentile = totalWeight > 0 ? Math.round(weightedSum / totalWeight) : concentrationPercentile
+
+  const percentile = Math.min(99, Math.max(0, compositePercentile + fundingBonus(extras.hasFundingConfig)))
+
+  const missingInputs = getMissingInputs(extras)
 
   return {
     value: percentile,
     tone: percentileToTone(percentile),
-    description: `Contributor concentration ranks at the ${formatPercentileLabel(percentile)} percentile among ${bracketLabel} repositories.`,
+    description: `Contributors rank at the ${formatPercentileLabel(percentile)} percentile among ${bracketLabel} repositories.`,
+    summary: `Contributors combines contributor concentration, maintainer depth, repeat and new-contributor signals, and contribution breadth, scored relative to ${bracketLabel} repositories.`,
     percentile,
     bracketLabel,
     concentration: concentration.share,
     topContributorCount: concentration.topContributorCount,
     contributorCount: concentration.contributorCount,
+    weightedFactors: CONTRIBUTORS_FACTORS.map((factor) => ({
+      label: factor.label,
+      weightLabel: `${factor.weight}%`,
+      description: factor.description,
+      percentile: subPercentiles[factor.key],
+    })),
+    missingInputs,
   }
+}
+
+function getMissingInputs(extras: ContributorsScoreExtras): string[] {
+  const missing: string[] = []
+  if (extras.maintainerCount === 'unavailable' || extras.maintainerCount === undefined) {
+    missing.push('Maintainer count')
+  }
+  if (extras.repeatContributors === 'unavailable' || extras.repeatContributors === undefined) {
+    missing.push('Repeat contributors')
+  }
+  if (extras.newContributors === 'unavailable' || extras.newContributors === undefined) {
+    missing.push('New contributors')
+  }
+  return missing
+}
+
+/**
+ * Maintainer depth heuristic (pending #152 calibration).
+ * Approximates a percentile from raw count: 0 → 0, 1 → 25, 2 → 45,
+ * 3–4 → 60, 5–9 → 78, 10+ → 92. Monotonic-increasing and bounded at 99.
+ */
+function evaluateMaintainerDepth(maintainerCount: number | Unavailable | undefined): number | undefined {
+  if (maintainerCount === 'unavailable' || maintainerCount === undefined) return undefined
+  if (maintainerCount <= 0) return 0
+  if (maintainerCount === 1) return 25
+  if (maintainerCount === 2) return 45
+  if (maintainerCount <= 4) return 60
+  if (maintainerCount <= 9) return 78
+  return 92
+}
+
+function evaluateRepeatRatio(
+  repeatContributors: number | Unavailable | undefined,
+  activeContributors: number | Unavailable | undefined,
+): number | undefined {
+  if (repeatContributors === 'unavailable' || repeatContributors === undefined) return undefined
+  if (activeContributors === 'unavailable' || activeContributors === undefined) return undefined
+  if (activeContributors <= 0) return 0
+  const ratio = Math.min(1, repeatContributors / activeContributors)
+  // Linear approximation pending calibration data. 0 → 0, 0.5 → 50, 1 → 99.
+  return Math.round(ratio * 99)
+}
+
+/**
+ * New-contributor inflow is project-lifecycle sensitive: both "no new contributors"
+ * and "100% new contributors" are weaker signals than a healthy mix. Peak at ~40%
+ * new (fresh inflow + returning base), drop off on either side.
+ */
+function evaluateNewInflow(
+  newContributors: number | Unavailable | undefined,
+  activeContributors: number | Unavailable | undefined,
+): number | undefined {
+  if (newContributors === 'unavailable' || newContributors === undefined) return undefined
+  if (activeContributors === 'unavailable' || activeContributors === undefined) return undefined
+  if (activeContributors <= 0) return 0
+  const ratio = Math.min(1, newContributors / activeContributors)
+  // Triangular curve: peak 80 at ratio 0.4, 40 at 0, 40 at 1.
+  if (ratio <= 0.4) return Math.round(40 + (ratio / 0.4) * 40)
+  return Math.round(80 - ((ratio - 0.4) / 0.6) * 40)
+}
+
+function evaluateContributionBreadth(extras: ContributorsScoreExtras): number | undefined {
+  // Presence bonus — only emit when at least one signal is verifiably observed.
+  const signals = [extras.commitsPresent, extras.prsPresent, extras.issuesPresent]
+  if (signals.every((s) => s === undefined)) return undefined
+  const presentCount = signals.filter(Boolean).length
+  if (presentCount === 0) return 0
+  if (presentCount === 1) return 33
+  if (presentCount === 2) return 66
+  return 99
 }
 
 export function computeContributionConcentration(
@@ -136,4 +332,3 @@ export function formatPercentage(value: number | Unavailable) {
 
   return `${(value * 100).toFixed(1)}%`
 }
-

--- a/lib/contributors/score-config.ts
+++ b/lib/contributors/score-config.ts
@@ -193,7 +193,7 @@ function computeContributorsScore(
   return {
     value: percentile,
     tone: percentileToTone(percentile),
-    description: `Contributors rank at the ${formatPercentileLabel(percentile)} percentile among ${bracketLabel} repositories.`,
+    description: `Contributors rank at the ${formatPercentileLabel(percentile)} among ${bracketLabel} repositories.`,
     summary: `Contributors combines contributor concentration, maintainer depth, repeat and new-contributor signals, and contribution breadth, scored relative to ${bracketLabel} repositories.`,
     percentile,
     bracketLabel,

--- a/lib/contributors/view-model.ts
+++ b/lib/contributors/view-model.ts
@@ -49,11 +49,20 @@ export function buildContributorsViewModels(
   return results.map((result) => {
     const windowMetrics = getContributorWindowMetrics(result, windowDays)
     const filteredCommitCountsByAuthor = filterCommitCountsByAuthorBots(windowMetrics.commitCountsByAuthor, includeBots)
-    const contributorsScore = getContributorsScoreFromCommitCounts(filteredCommitCountsByAuthor, result.stars)
     const concentration = computeContributionConcentration(filteredCommitCountsByAuthor)
     const repeatContributors = computeRepeatContributors(filteredCommitCountsByAuthor)
     const activeContributors = getActiveContributorCount(filteredCommitCountsByAuthor)
     const contributionTypes = computeContributionTypes(result)
+    const contributorsScore = getContributorsScoreFromCommitCounts(filteredCommitCountsByAuthor, result.stars, {
+      maintainerCount: result.maintainerCount,
+      repeatContributors,
+      newContributors: windowMetrics.newContributors,
+      activeContributors,
+      commitsPresent: contributionTypes.includes('Commits'),
+      prsPresent: contributionTypes.includes('Pull requests'),
+      issuesPresent: contributionTypes.includes('Issues'),
+      hasFundingConfig: result.hasFundingConfig,
+    })
     const experimentalCommitCounts = windowMetrics.commitCountsByExperimentalOrg
     const elephantFactor = computeElephantFactor(experimentalCommitCounts)
     const singleVendorDependencyRatio = computeSingleVendorDependencyRatio(experimentalCommitCounts)

--- a/lib/export/json-export.ts
+++ b/lib/export/json-export.ts
@@ -80,6 +80,11 @@ function computeContributors(result: AnalysisResult) {
   if (!section) return undefined
   return {
     contributorsScore: section.contributorsScore.value,
+    contributorsScoreFactors: section.contributorsScore.weightedFactors.map((f) => ({
+      label: f.label,
+      weightLabel: f.weightLabel,
+      percentile: f.percentile ?? null,
+    })),
     contributorsMetrics: section.contributorsMetrics.map((m) => ({ label: m.label, value: m.value })),
     coreMetrics: section.coreMetrics.map((m) => ({ label: m.label, value: m.value })),
     experimentalMetrics: section.experimentalMetrics.map((m) => ({ label: m.label, value: m.value })),

--- a/lib/export/markdown-export.ts
+++ b/lib/export/markdown-export.ts
@@ -175,6 +175,12 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
       ...(typesOfContributions ? [['Types of contributions', typesOfContributions] as [string, string]] : []),
     ]),
     '',
+    '**Score factors**',
+    '',
+    '| Factor | Weight | Percentile |',
+    '| --- | --- | --- |',
+    ...contributorsScore.weightedFactors.map((f) => `| ${f.label} | ${f.weightLabel} | ${f.percentile !== undefined ? `${f.percentile}` : '—'} |`),
+    '',
   )
 
   if (contributors?.experimentalMetrics.length) {

--- a/lib/metric-cards/score-config.ts
+++ b/lib/metric-cards/score-config.ts
@@ -84,9 +84,10 @@ export function getScoreBadges(result?: AnalysisResult): ScoreBadgeDefinition[] 
           value: contributorsScore.value,
           tone: contributorsScore.tone,
           description: contributorsScore.description,
-          detail: typeof contributorsScore.contributorCount === 'number'
-            ? `${contributorsScore.contributorCount.toLocaleString()} contributors`
-            : undefined,
+          detail: getTopFactorDetail(contributorsScore.weightedFactors)
+            ?? (typeof contributorsScore.contributorCount === 'number'
+              ? `${contributorsScore.contributorCount.toLocaleString()} contributors`
+              : undefined),
         }
       : badge.category === 'Responsiveness'
       ? {

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -46,8 +46,8 @@ describe('RECOMMENDATION_CATALOG', () => {
     expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Responsiveness')).toHaveLength(3)
   })
 
-  it('has 3 contributors entries', () => {
-    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Contributors')).toHaveLength(3)
+  it('has 7 contributors entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Contributors')).toHaveLength(7)
   })
 
   it('has 16 documentation entries', () => {
@@ -106,7 +106,7 @@ describe('getCatalogEntriesByTag', () => {
     const governance = getCatalogEntriesByTag('governance')
     const ids = governance.map((e) => e.id).sort()
     expect(ids).toEqual([
-      'CTR-2', 'CTR-3',
+      'CTR-2', 'CTR-3', 'CTR-4',
       'DOC-12', 'DOC-13', 'DOC-14',
       'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
       'SEC-14', 'SEC-17', 'SEC-3', 'SEC-5',
@@ -144,6 +144,7 @@ describe('getCatalogEntriesByTag', () => {
     const ids = entries.map((e) => e.id).sort()
     expect(ids).toEqual([
       'ACT-2', 'ACT-5',
+      'CTR-5', 'CTR-6', 'CTR-7',
       'DOC-1', 'DOC-10', 'DOC-11', 'DOC-15', 'DOC-16', 'DOC-3', 'DOC-4',
       'DOC-7', 'DOC-8', 'DOC-9',
       'RSP-1',

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -83,6 +83,10 @@ const CTR: CatalogEntry[] = [
   { id: 'CTR-1', bucket: 'Contributors', key: 'contributor_diversity', title: 'Onboard more contributors to reduce single-maintainer risk' },
   { id: 'CTR-2', bucket: 'Contributors', key: 'no_maintainers', title: 'Add a CODEOWNERS or MAINTAINERS.md file', tags: ['governance'] },
   { id: 'CTR-3', bucket: 'Contributors', key: 'file:funding', title: 'Add a FUNDING.yml to disclose funding channels', tags: ['community', 'governance'] },
+  { id: 'CTR-4', bucket: 'Contributors', key: 'maintainer_depth', title: 'Grow maintainer depth by documenting additional owners', tags: ['governance'] },
+  { id: 'CTR-5', bucket: 'Contributors', key: 'repeat_contributor_ratio', title: 'Invest in contributor retention to grow repeat-contributor share', tags: ['contrib-ex'] },
+  { id: 'CTR-6', bucket: 'Contributors', key: 'new_contributor_inflow', title: 'Surface good-first-issues and onboarding to attract new contributors', tags: ['contrib-ex'] },
+  { id: 'CTR-7', bucket: 'Contributors', key: 'contribution_breadth', title: 'Encourage contributions across commits, pull requests, and issues', tags: ['contrib-ex'] },
 ]
 
 // ── Documentation ─────────────────────────────────────────────────────

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -1,7 +1,7 @@
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { getActivityScore, type ActivityScoreDefinition } from '@/lib/activity/score-config'
 import { getResponsivenessScore, type ResponsivenessScoreDefinition } from '@/lib/responsiveness/score-config'
-import { getContributorsScore } from '@/lib/contributors/score-config'
+import { getContributorsScore, type ContributorsScoreDefinition } from '@/lib/contributors/score-config'
 import { getDocumentationScore, type DocumentationRecommendation } from '@/lib/documentation/score-config'
 import { getSecurityScore } from '@/lib/security/score-config'
 import { formatPercentileLabel, formatPercentileOrdinal, getBracketLabel, percentileToTone } from '@/lib/scoring/config-loader'
@@ -80,13 +80,7 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
     recommendations.push(...getResponsivenessRecommendations(responsiveness))
   }
   if (contributorsPercentile !== null) {
-    recommendations.push({
-      bucket: 'Contributors',
-      key: 'contributor_diversity',
-      percentile: contributorsPercentile,
-      message: 'Onboard more contributors to reduce single-maintainer risk. The top 20% of contributors account for a disproportionate share of commits.',
-      tab: 'contributors',
-    })
+    recommendations.push(...getContributorsRecommendations(contributors))
   }
   if (result.maintainerCount === 'unavailable') {
     recommendations.push({
@@ -201,6 +195,68 @@ function getResponsivenessRecommendations(score: ResponsivenessScoreDefinition):
   const backlog = categories.find((c) => c.label === 'Volume & backlog health')
   if (backlog?.percentile !== undefined) {
     recs.push({ bucket: 'Responsiveness', key: 'backlog_health', percentile: backlog.percentile, message: 'Address stale issues and PRs to improve backlog health.', tab: 'responsiveness' })
+  }
+
+  return recs
+}
+
+function getContributorsRecommendations(score: ContributorsScoreDefinition): HealthScoreRecommendation[] {
+  const recs: HealthScoreRecommendation[] = []
+  const factors = score.weightedFactors
+
+  const concentration = factors.find((f) => f.label === 'Contributor concentration')
+  if (concentration?.percentile !== undefined) {
+    recs.push({
+      bucket: 'Contributors',
+      key: 'contributor_diversity',
+      percentile: concentration.percentile,
+      message: 'Onboard more contributors to reduce single-maintainer risk. The top 20% of contributors account for a disproportionate share of commits.',
+      tab: 'contributors',
+    })
+  }
+
+  const maintainerDepth = factors.find((f) => f.label === 'Maintainer depth')
+  if (maintainerDepth?.percentile !== undefined) {
+    recs.push({
+      bucket: 'Contributors',
+      key: 'maintainer_depth',
+      percentile: maintainerDepth.percentile,
+      message: 'Grow maintainer depth by documenting additional owners in CODEOWNERS, MAINTAINERS.md, or GOVERNANCE.md so responsibility is not concentrated in a single person.',
+      tab: 'contributors',
+    })
+  }
+
+  const repeatRatio = factors.find((f) => f.label === 'Repeat-contributor ratio')
+  if (repeatRatio?.percentile !== undefined) {
+    recs.push({
+      bucket: 'Contributors',
+      key: 'repeat_contributor_ratio',
+      percentile: repeatRatio.percentile,
+      message: 'Invest in contributor retention — a higher share of repeat contributors signals durable engagement beyond one-time drive-bys.',
+      tab: 'contributors',
+    })
+  }
+
+  const newInflow = factors.find((f) => f.label === 'New-contributor inflow')
+  if (newInflow?.percentile !== undefined) {
+    recs.push({
+      bucket: 'Contributors',
+      key: 'new_contributor_inflow',
+      percentile: newInflow.percentile,
+      message: 'Surface good-first-issues and contributor onboarding so new contributors keep arriving alongside the returning base.',
+      tab: 'contributors',
+    })
+  }
+
+  const breadth = factors.find((f) => f.label === 'Contribution breadth')
+  if (breadth?.percentile !== undefined) {
+    recs.push({
+      bucket: 'Contributors',
+      key: 'contribution_breadth',
+      percentile: breadth.percentile,
+      message: 'Encourage contributions across commits, pull requests, and issues so engagement is not limited to a single surface.',
+      tab: 'contributors',
+    })
   }
 
   return recs

--- a/specs/184-contributors-composite-score/checklists/manual-testing.md
+++ b/specs/184-contributors-composite-score/checklists/manual-testing.md
@@ -1,0 +1,11 @@
+# Manual testing — #184 Contributors composite score
+
+- [x] `npm test` passes (all 630 tests).
+- [x] `DEV_GITHUB_PAT= npm run build` succeeds.
+- [ ] Analyze a repo with many maintainers and verify the "Maintainer depth" pill appears with a non-zero percentile in the Contributors score pane.
+- [ ] Analyze a repo with `maintainerCount` unavailable and verify "Maintainer depth" factor is excluded from the composite (no percentile in pill, weights renormalize).
+- [ ] Expand the "Show details" section under Contributors score and confirm all 5 factors render with label, weight, per-factor percentile, and description.
+- [ ] Confirm two repos with the same top-20% share but different maintainer counts now get different Contributors percentiles.
+- [ ] Confirm recommendations view shows per-factor entries (CTR-1 contributor_diversity, CTR-4 maintainer_depth, CTR-5 repeat_contributor_ratio, CTR-6 new_contributor_inflow, CTR-7 contribution_breadth) when inputs are verified.
+
+Signed off by: arun-gupta

--- a/specs/184-contributors-composite-score/spec.md
+++ b/specs/184-contributors-composite-score/spec.md
@@ -1,0 +1,36 @@
+# 184 — Contributors score composite
+
+Source issue: [#184](https://github.com/arun-gupta/repo-pulse/issues/184)
+
+## Problem
+
+`getContributorsScore()` is computed from a single signal — top-20% commit concentration — so two repos with identical concentration but wildly different maintainer counts or repeat-contributor ratios get the same Contributors percentile. That does not match the Contributors tab, which already surfaces those additional signals.
+
+## Solution
+
+Rework `getContributorsScore()` into a weighted composite mirroring Activity and Responsiveness (`weightedFactors`). Sub-factors and initial weights (pending #152 recalibration):
+
+| Sub-factor | Weight | Signal | Direction |
+|---|---|---|---|
+| Contributor concentration | 40% | Top-20% commit share | lower-is-better (existing calibration) |
+| Maintainer depth | 15% | Maintainer count (CODEOWNERS/MAINTAINERS/OWNERS/GOVERNANCE) | higher-is-better (heuristic) |
+| Repeat-contributor ratio | 20% | Repeat / active contributors in window | higher-is-better (heuristic) |
+| New-contributor inflow | 10% | New / active contributors in window | project-lifecycle curve (peak ~0.4) |
+| Contribution breadth | 15% | Commits + PRs + issues presence | presence signal (33/66/99) |
+
+Weights renormalize across available factors so `unavailable` inputs are excluded — never counted as zero.
+
+## Acceptance criteria (from issue)
+
+- [x] `ContributorsScoreDefinition` exposes a `weightedFactors` array analogous to Activity/Responsiveness.
+- [x] Each sub-factor produces a percentile against the calibrated peer set; the bucket percentile is a weighted composite.
+- [x] When a sub-factor's input is `unavailable`, it is excluded from the weighted average (weights renormalize).
+- [x] `ContributorsScorePane` shows a "How is this scored?" / details section with per-sub-factor percentiles.
+- [x] Recommendations are emitted per sub-factor (`CTR-4..7` added).
+- [ ] Calibration refresh tracked in #152 covers the new sub-factors.
+
+## Out of scope
+
+- Changing Contributors bucket's 23% composite weight.
+- Experimental org-attribution signals (Elephant Factor, Single-vendor dependency ratio).
+- Cross-bucket moves — Community scoring belongs to #70.


### PR DESCRIPTION
Closes #184.

## Summary
- Rework `getContributorsScore()` into a weighted composite of five sub-factors (Contributor concentration 40%, Repeat-contributor ratio 20%, Maintainer depth 15%, New-contributor inflow 10%, Contribution breadth 15%) — mirrors the `weightedFactors` pattern used by Activity and Responsiveness.
- Unavailable sub-factors are excluded (weights renormalize across the available set) — no factor is counted as zero.
- `ContributorsScorePane` now surfaces per-sub-factor percentiles in the "How is this scored?" details section alongside the existing top-20% share.
- Recommendations are emitted per sub-factor; catalog gains `CTR-4..CTR-7` (`maintainer_depth`, `repeat_contributor_ratio`, `new_contributor_inflow`, `contribution_breadth`).
- Markdown + JSON exports include the sub-factor breakdown; Comparison table adds five per-factor rows.
- Contributors overview tile shows the strongest sub-factor (e.g. "Maintainer depth strongest"), matching Activity/Responsiveness.

Heuristic approximations are used for sub-factors that don't yet have calibration data (maintainer depth, repeat ratio, new inflow, breadth) — same pattern as Activity's `evaluateSustainedActivity`/`evaluateReleaseCadence`. Real calibration is tracked in #152.

## Test plan
- [x] `npm test` — all 630 tests pass
- [x] `DEV_GITHUB_PAT= npm run build` succeeds
- [x] Analyze a repo with many maintainers and verify "Maintainer depth" pill shows a non-zero percentile in the Contributors score pane
- [x] Analyze a repo with `maintainerCount` unavailable and verify "Maintainer depth" is excluded (no percentile in pill) — verified with `sindresorhus/is`; composite still renders at 38th percentile
- [x] Expand the "Show details" section under Contributors score and confirm all 5 factors render with label, weight, per-factor percentile, and description
- [x] Confirm two repos with the same top-20% share but different maintainer counts now get different Contributors percentiles — verified `facebook/react` (45th) vs `sindresorhus/is` (38th) with very close concentration factors (4th / 9th)
- [x] Confirm Recommendations view shows per-factor entries (CTR-1/4/5/6/7) when inputs are verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)