### PR TITLE
Solo-project profile: alternate scoring surface (#214)

### DIFF
--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -93,16 +93,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
           <p className="text-center text-xs italic text-slate-500">
             Built for community-oriented projects — multi-contributor and foundation-track.
             Solo-maintainer projects are auto-detected and scored on Activity, Security, and
-            Documentation instead of Contributors and Responsiveness (
-            <a
-              href="https://github.com/arun-gupta/repo-pulse/issues/214"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-slate-700"
-            >
-              #214
-            </a>
-            ).
+            Documentation instead of Contributors and Responsiveness.
           </p>
         </div>
 

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -92,17 +92,17 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
           <p className="text-center text-xs italic text-slate-500">
             Built for community-oriented projects — multi-contributor and foundation-track.
-            Solo-maintainer projects will, at this time, see sparse scores on Contributors and
-            Responsiveness; a dedicated solo-project profile is{' '}
+            Solo-maintainer projects are auto-detected and scored on Activity, Security, and
+            Documentation instead of Contributors and Responsiveness (
             <a
               href="https://github.com/arun-gupta/repo-pulse/issues/214"
               target="_blank"
               rel="noopener noreferrer"
               className="underline hover:text-slate-700"
             >
-              planned (#214)
+              #214
             </a>
-            .
+            ).
           </p>
         </div>
 

--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -116,6 +116,56 @@ describe('MetricCard', () => {
     }
   })
 
+  describe('solo-project profile (#214)', () => {
+    const soloOverrides: Partial<AnalysisResult> = {
+      totalContributors: 1,
+      uniqueCommitAuthors90d: 1,
+      maintainerCount: 'unavailable',
+      documentationResult: 'unavailable',
+    }
+
+    it('renders solo banner and hides Contributors + Responsiveness cells for a solo repo', () => {
+      const card = buildMetricCardViewModels([buildResult(soloOverrides)])[0]!
+
+      render(<MetricCard card={card} />)
+
+      expect(screen.getByTestId(`solo-profile-banner-${card.repo}`)).toBeInTheDocument()
+      expect(screen.getByText(/solo-maintained project/i)).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Open Contributors tab' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Open Responsiveness tab' })).not.toBeInTheDocument()
+      // Remaining scored dimensions still visible
+      expect(screen.getByRole('button', { name: 'Open Activity tab' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Open Documentation tab' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Open Security tab' })).toBeInTheDocument()
+    })
+
+    it('toggles back to community scoring when the override button is clicked', () => {
+      const card = buildMetricCardViewModels([buildResult(soloOverrides)])[0]!
+
+      render(<MetricCard card={card} />)
+
+      const toggle = screen.getByTestId(`solo-profile-toggle-${card.repo}`)
+      expect(toggle).toHaveTextContent(/use community scoring/i)
+
+      fireEvent.click(toggle)
+
+      // Contributors + Responsiveness cells return
+      expect(screen.getByRole('button', { name: 'Open Contributors tab' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Open Responsiveness tab' })).toBeInTheDocument()
+      // Banner flips copy
+      expect(screen.getByText(/community scoring override active/i)).toBeInTheDocument()
+      expect(screen.getByTestId(`solo-profile-toggle-${card.repo}`)).toHaveTextContent(/use solo scoring/i)
+    })
+
+    it('does not render solo banner for a community repo', () => {
+      const card = buildMetricCardViewModels([buildResult()])[0]!
+
+      render(<MetricCard card={card} />)
+
+      expect(screen.queryByTestId(`solo-profile-banner-${card.repo}`)).not.toBeInTheDocument()
+    })
+  })
+
   it('handles unavailable ecosystem metrics gracefully', () => {
     const card = buildMetricCardViewModels([
       buildResult({ stars: 'unavailable', forks: 'unavailable', watchers: 'unavailable' }),

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -105,7 +105,11 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
       </div>
 
       {profileCells.length > 0 ? (
-        <div className="mt-2 grid grid-cols-1 gap-1.5 sm:grid-cols-3">
+        <div
+          className={`mt-2 grid grid-cols-1 gap-1.5 sm:grid-cols-3 ${isSolo ? 'opacity-50' : ''}`}
+          title={isSolo ? 'Popularity signals — not health. Dimmed for solo-maintained projects.' : undefined}
+          data-testid={isSolo ? `ecosystem-dimmed-${card.repo}` : undefined}
+        >
           {profileCells.map((cell) => (
             <ScorecardCell key={cell.label} {...cell} />
           ))}

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { useState } from 'react'
 import type { LensReadout, MetricCardViewModel } from '@/lib/metric-cards/view-model'
 import { formatPercentileLabel } from '@/lib/scoring/config-loader'
 import { scoreToneClass } from '@/lib/metric-cards/score-config'
+import { getHealthScore, type HealthScoreProfile } from '@/lib/scoring/health-score'
 
 interface MetricCardProps {
   card: MetricCardViewModel
@@ -15,6 +17,16 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
     if (!onTagChange) return
     onTagChange(activeTag === key ? null : key)
   }
+
+  // Session-scoped override for the solo-project scoring surface. null =
+  // use the auto-detected profile from the precomputed health score.
+  const [profileOverride, setProfileOverride] = useState<HealthScoreProfile | null>(null)
+  const hs = profileOverride === null
+    ? card.healthScore
+    : getHealthScore(card.analysisResult, { mode: profileOverride })
+  const isSolo = hs.profile === 'solo'
+  const autoSolo = card.healthScore.soloDetection.isSolo
+  const showOverrideToggle = autoSolo || profileOverride !== null
   const profileCells: ScorecardCellProps[] = card.profile
     ? [
         { label: 'Reach', percentileLabel: card.profile.reachLabel, detail: `${card.starsLabel} stars`, tooltip: 'Star count percentile. Measures visibility and adoption.', toneClass: percentileToneClass(card.profile.reachPercentile, 'emerald') },
@@ -23,7 +35,10 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
       ]
     : []
 
-  const scoreCells: ScorecardCellProps[] = card.scoreBadges.map((badge) => {
+  const hiddenBucketNames = new Set(hs.buckets.filter((b) => b.hidden).map((b) => b.name))
+  const scoreCells: ScorecardCellProps[] = card.scoreBadges
+    .filter((badge) => !hiddenBucketNames.has(badge.category))
+    .map((badge) => {
     const tabId = badge.category.toLowerCase()
     return {
       label: badge.category,
@@ -39,7 +54,9 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
     }
   })
 
-  const hs = card.healthScore
+  const scoreTooltip = isSolo
+    ? `Solo-project scoring surface — composite health score from Activity (30%), Security (35%), and Documentation (35%). Contributors and Responsiveness are hidden because this project appears to be solo-maintained. Scored relative to ${hs.bracketLabel} repositories.`
+    : `Composite health score from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%, includes licensing, compliance & inclusive naming), and Security (15%) — scored relative to ${hs.bracketLabel} repositories.`
 
   return (
     <article className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm" data-testid={`metric-card-${card.repo}`}>
@@ -49,7 +66,37 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
       </div>
       <p className={`mt-1 line-clamp-2 text-xs italic text-slate-400 ${card.description === '—' ? '' : 'not-italic text-slate-500'}`}>{card.description === '—' ? 'No description found' : card.description}</p>
 
-      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={`Composite health score from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%, includes licensing, compliance & inclusive naming), and Security (15%) — scored relative to ${hs.bracketLabel} repositories.`}>
+      {showOverrideToggle ? (
+        <div
+          className={`mt-3 flex flex-wrap items-start justify-between gap-2 rounded-lg border px-3 py-2 text-xs ${isSolo ? 'border-amber-300 bg-amber-50 text-amber-900' : 'border-sky-300 bg-sky-50 text-sky-900'}`}
+          data-testid={`solo-profile-banner-${card.repo}`}
+          role="status"
+        >
+          <p className="flex-1">
+            {isSolo ? (
+              <>
+                <span className="font-semibold">Solo-maintained project.</span>{' '}
+                Scoring emphasizes Activity, Security, and Documentation. Contributors and Responsiveness are hidden.
+              </>
+            ) : (
+              <>
+                <span className="font-semibold">Community scoring override active.</span>{' '}
+                This project was auto-classified as solo-maintained; you&apos;ve opted into the community surface for this session.
+              </>
+            )}
+          </p>
+          <button
+            type="button"
+            onClick={() => setProfileOverride(isSolo ? 'community' : (autoSolo ? null : 'solo'))}
+            className="shrink-0 rounded border border-current px-2 py-0.5 font-medium hover:bg-white/50"
+            data-testid={`solo-profile-toggle-${card.repo}`}
+          >
+            {isSolo ? 'Use community scoring' : 'Use solo scoring'}
+          </button>
+        </div>
+      ) : null}
+
+      <div className={`mt-3 flex items-center justify-between rounded-lg border px-3 py-2 ${scoreToneClass(hs.tone)}`} title={scoreTooltip}>
         <div>
           <p className="text-xs font-medium uppercase tracking-wide">OSS Health Score</p>
           {hs.bracketLabel ? <p className="text-[10px] opacity-60">{hs.bracketLabel}</p> : null}

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -116,7 +116,7 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
         </div>
       ) : null}
       {scoreCells.length > 0 ? (
-        <div className="mt-1.5 grid grid-cols-2 gap-1.5 sm:grid-cols-5">
+        <div className={`mt-1.5 grid grid-cols-2 gap-1.5 ${SCORECARD_GRID_COLS[scoreCells.length] ?? 'sm:grid-cols-5'}`}>
           {scoreCells.map((cell) => (
             <ScorecardCell key={cell.label} {...cell} />
           ))}
@@ -167,6 +167,15 @@ interface ScorecardCellProps {
   toneClass: string
   onClick?: () => void
   ariaLabel?: string
+}
+
+// Static mapping so Tailwind's JIT scanner can see every class used.
+const SCORECARD_GRID_COLS: Record<number, string> = {
+  1: 'sm:grid-cols-1',
+  2: 'sm:grid-cols-2',
+  3: 'sm:grid-cols-3',
+  4: 'sm:grid-cols-4',
+  5: 'sm:grid-cols-5',
 }
 
 const LENS_RING_COLORS: Record<string, string> = {

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -127,6 +127,7 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
         <div
           className={`mt-2 flex flex-wrap items-center gap-1.5 ${isSolo ? 'opacity-50' : ''}`}
           title={isSolo ? 'Community-shape lenses — structurally low for solo-maintained projects. Dimmed, not scored.' : undefined}
+        >
           <span className="text-[9px] font-medium uppercase tracking-wider text-slate-400">Lenses</span>
           {card.lenses.map((lens) => (
             <LensPill

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -124,7 +124,9 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
       ) : null}
 
       {card.lenses.length > 0 ? (
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <div
+          className={`mt-2 flex flex-wrap items-center gap-1.5 ${isSolo ? 'opacity-50' : ''}`}
+          title={isSolo ? 'Community-shape lenses — structurally low for solo-maintained projects. Dimmed, not scored.' : undefined}
           <span className="text-[9px] font-medium uppercase tracking-wider text-slate-400">Lenses</span>
           {card.lenses.map((lens) => (
             <LensPill

--- a/lib/metric-cards/view-model.ts
+++ b/lib/metric-cards/view-model.ts
@@ -39,6 +39,12 @@ export interface MetricCardViewModel {
   scoreBadges: ScoreBadgeDefinition[]
   healthScore: HealthScoreDefinition
   lenses: LensReadout[]
+  /**
+   * Raw analysis result retained so the scorecard can recompute the health
+   * score when the user toggles the solo/community override. Session-scoped
+   * — never persisted.
+   */
+  analysisResult: AnalysisResult
 }
 
 export function buildMetricCardViewModels(results: AnalysisResult[]): MetricCardViewModel[] {
@@ -75,6 +81,7 @@ export function buildMetricCardViewModels(results: AnalysisResult[]): MetricCard
       scoreBadges: getScoreBadges(result),
       healthScore: getHealthScore(result),
       lenses: buildLensReadouts(result),
+      analysisResult: result,
     }
   })
 }

--- a/lib/scoring/health-score.test.ts
+++ b/lib/scoring/health-score.test.ts
@@ -107,3 +107,64 @@ describe('health-score community-lens recommendations', () => {
     expect(recs.find((r) => r.key === 'feature:discussions_enabled')).toBeUndefined()
   })
 })
+
+describe('health-score solo-project profile (#214)', () => {
+  function buildSoloResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+    return buildResult({
+      // Trips all 4 solo criteria
+      totalContributors: 1,
+      uniqueCommitAuthors90d: 1,
+      maintainerCount: 'unavailable',
+      documentationResult: 'unavailable',
+      ...overrides,
+    })
+  }
+
+  it('classifies a 1-contributor repo as solo profile', () => {
+    const hs = getHealthScore(buildSoloResult())
+    expect(hs.profile).toBe('solo')
+    expect(hs.soloDetection.isSolo).toBe(true)
+  })
+
+  it('marks Contributors and Responsiveness buckets as hidden in solo mode', () => {
+    const hs = getHealthScore(buildSoloResult())
+    const contributors = hs.buckets.find((b) => b.name === 'Contributors')
+    const responsiveness = hs.buckets.find((b) => b.name === 'Responsiveness')
+    expect(contributors?.hidden).toBe(true)
+    expect(responsiveness?.hidden).toBe(true)
+  })
+
+  it('applies SOLO_WEIGHTS to Activity, Security, Documentation buckets', () => {
+    const hs = getHealthScore(buildSoloResult())
+    expect(hs.buckets.find((b) => b.name === 'Activity')?.weight).toBeCloseTo(0.30, 10)
+    expect(hs.buckets.find((b) => b.name === 'Security')?.weight).toBeCloseTo(0.35, 10)
+    expect(hs.buckets.find((b) => b.name === 'Documentation')?.weight).toBeCloseTo(0.35, 10)
+  })
+
+  it('suppresses Contributors and Responsiveness recommendations in solo mode', () => {
+    const hs = getHealthScore(buildSoloResult({ hasFundingConfig: false }))
+    expect(hs.recommendations.find((r) => r.tab === 'contributors')).toBeUndefined()
+    expect(hs.recommendations.find((r) => r.tab === 'responsiveness')).toBeUndefined()
+    // FUNDING.yml recommendation is community-shaped; suppressed in solo
+    expect(hs.recommendations.find((r) => r.key === 'file:funding')).toBeUndefined()
+  })
+
+  it('honors explicit mode: "community" override even when auto-detected solo', () => {
+    const hs = getHealthScore(buildSoloResult(), { mode: 'community' })
+    expect(hs.profile).toBe('community')
+    expect(hs.buckets.find((b) => b.name === 'Contributors')?.hidden).toBeFalsy()
+    expect(hs.buckets.find((b) => b.name === 'Activity')?.weight).toBeCloseTo(0.25, 10)
+  })
+
+  it('honors explicit mode: "solo" override even when not auto-detected', () => {
+    const community = buildResult({ totalContributors: 50, uniqueCommitAuthors90d: 30, maintainerCount: 4 })
+    const hs = getHealthScore(community, { mode: 'solo' })
+    expect(hs.profile).toBe('solo')
+    expect(hs.buckets.find((b) => b.name === 'Contributors')?.hidden).toBe(true)
+  })
+
+  it('community repos remain in community profile by default', () => {
+    const hs = getHealthScore(buildResult({ totalContributors: 50, uniqueCommitAuthors90d: 20, maintainerCount: 3 }))
+    expect(hs.profile).toBe('community')
+  })
+})

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -5,6 +5,7 @@ import { getContributorsScore, type ContributorsScoreDefinition } from '@/lib/co
 import { getDocumentationScore, type DocumentationRecommendation } from '@/lib/documentation/score-config'
 import { getSecurityScore } from '@/lib/security/score-config'
 import { formatPercentileLabel, formatPercentileOrdinal, getBracketLabel, percentileToTone } from '@/lib/scoring/config-loader'
+import { SOLO_WEIGHTS, detectSoloProjectProfile, type SoloProjectDetection } from '@/lib/scoring/solo-profile'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
 export interface HealthScoreRecommendation {
@@ -16,18 +17,25 @@ export interface HealthScoreRecommendation {
   tab: 'activity' | 'responsiveness' | 'contributors' | 'documentation' | 'security'
 }
 
+export type HealthScoreProfile = 'community' | 'solo'
+
+export interface HealthScoreBucket {
+  name: string
+  percentile: number | null
+  weight: number
+  label: string
+  hidden?: boolean
+}
+
 export interface HealthScoreDefinition {
   percentile: number | null
   label: string
   tone: ScoreTone
   bracketLabel: string
-  buckets: Array<{
-    name: string
-    percentile: number | null
-    weight: number
-    label: string
-  }>
+  buckets: HealthScoreBucket[]
   recommendations: HealthScoreRecommendation[]
+  profile: HealthScoreProfile
+  soloDetection: SoloProjectDetection
 }
 
 export const WEIGHTS = {
@@ -38,7 +46,23 @@ export const WEIGHTS = {
   security: 0.15,
 } as const
 
-export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
+export interface HealthScoreOptions {
+  /**
+   * 'auto' (default) — classify via detectSoloProjectProfile
+   * 'community' — force community weights (user override)
+   * 'solo' — force solo weights (user override)
+   */
+  mode?: 'auto' | HealthScoreProfile
+}
+
+export function getHealthScore(result: AnalysisResult, options: HealthScoreOptions = {}): HealthScoreDefinition {
+  const soloDetection = detectSoloProjectProfile(result)
+  const profile: HealthScoreProfile = options.mode === 'solo'
+    ? 'solo'
+    : options.mode === 'community'
+      ? 'community'
+      : soloDetection.isSolo ? 'solo' : 'community'
+
   const activity = getActivityScore(result)
   const responsiveness = getResponsivenessScore(result)
   const contributors = getContributorsScore(result)
@@ -56,13 +80,18 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   const documentationPercentile = documentation !== null && typeof documentation.value === 'number' ? documentation.percentile : null
   const securityPercentile = security !== null && typeof security.value === 'number' ? security.percentile : null
 
-  // Compute weighted average from available buckets
+  // Compute weighted average from available buckets. Solo profile hides
+  // Contributors and Responsiveness and re-weights the remaining three.
   const bucketValues: Array<{ percentile: number; weight: number }> = []
-  if (activityPercentile !== null) bucketValues.push({ percentile: activityPercentile, weight: WEIGHTS.activity })
-  if (responsivenessPercentile !== null) bucketValues.push({ percentile: responsivenessPercentile, weight: WEIGHTS.responsiveness })
-  if (contributorsPercentile !== null) bucketValues.push({ percentile: contributorsPercentile, weight: WEIGHTS.contributors })
-  if (documentationPercentile !== null) bucketValues.push({ percentile: documentationPercentile, weight: WEIGHTS.documentation })
-  if (securityPercentile !== null) bucketValues.push({ percentile: securityPercentile, weight: WEIGHTS.security })
+  const activityWeight = profile === 'solo' ? SOLO_WEIGHTS.activity : WEIGHTS.activity
+  const documentationWeight = profile === 'solo' ? SOLO_WEIGHTS.documentation : WEIGHTS.documentation
+  const securityWeight = profile === 'solo' ? SOLO_WEIGHTS.security : WEIGHTS.security
+
+  if (activityPercentile !== null) bucketValues.push({ percentile: activityPercentile, weight: activityWeight })
+  if (profile !== 'solo' && responsivenessPercentile !== null) bucketValues.push({ percentile: responsivenessPercentile, weight: WEIGHTS.responsiveness })
+  if (profile !== 'solo' && contributorsPercentile !== null) bucketValues.push({ percentile: contributorsPercentile, weight: WEIGHTS.contributors })
+  if (documentationPercentile !== null) bucketValues.push({ percentile: documentationPercentile, weight: documentationWeight })
+  if (securityPercentile !== null) bucketValues.push({ percentile: securityPercentile, weight: securityWeight })
 
   let compositePercentile: number | null = null
   if (bucketValues.length > 0) {
@@ -71,18 +100,20 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
     compositePercentile = Math.min(99, Math.max(0, Math.round(weightedSum)))
   }
 
-  // Generate recommendations for all buckets — no percentile gate
+  // Generate recommendations for all buckets — no percentile gate.
+  // Solo profile suppresses Contributors and Responsiveness recommendations
+  // since those buckets are hidden from the score.
   const recommendations: HealthScoreRecommendation[] = []
   if (activityPercentile !== null) {
     recommendations.push(...getActivityRecommendations(activity))
   }
-  if (responsivenessPercentile !== null) {
+  if (profile !== 'solo' && responsivenessPercentile !== null) {
     recommendations.push(...getResponsivenessRecommendations(responsiveness))
   }
-  if (contributorsPercentile !== null) {
+  if (profile !== 'solo' && contributorsPercentile !== null) {
     recommendations.push(...getContributorsRecommendations(contributors))
   }
-  if (result.maintainerCount === 'unavailable') {
+  if (profile !== 'solo' && result.maintainerCount === 'unavailable') {
     recommendations.push({
       bucket: 'Contributors',
       key: 'no_maintainers',
@@ -93,7 +124,8 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
   }
   // CTR-3 (community lens): emit when FUNDING.yml is verifiably absent.
   // 'unknown' / 'unavailable' state intentionally skipped — never guess.
-  if (result.hasFundingConfig === false) {
+  // Suppressed in solo profile — funding disclosure signals community shape.
+  if (profile !== 'solo' && result.hasFundingConfig === false) {
     recommendations.push({
       bucket: 'Contributors',
       key: 'file:funding',
@@ -135,19 +167,23 @@ export function getHealthScore(result: AnalysisResult): HealthScoreDefinition {
     }
   }
 
+  const buckets: HealthScoreBucket[] = [
+    { name: 'Activity', percentile: activityPercentile, weight: activityWeight, label: activityPercentile !== null ? formatPercentileLabel(activityPercentile) : 'N/A' },
+    { name: 'Responsiveness', percentile: responsivenessPercentile, weight: WEIGHTS.responsiveness, label: responsivenessPercentile !== null ? formatPercentileLabel(responsivenessPercentile) : 'N/A', hidden: profile === 'solo' },
+    { name: 'Contributors', percentile: contributorsPercentile, weight: WEIGHTS.contributors, label: contributorsPercentile !== null ? formatPercentileLabel(contributorsPercentile) : 'N/A', hidden: profile === 'solo' },
+    { name: 'Documentation', percentile: documentationPercentile, weight: documentationWeight, label: documentationPercentile !== null ? formatPercentileLabel(documentationPercentile) : 'N/A' },
+    { name: 'Security', percentile: securityPercentile, weight: securityWeight, label: securityPercentile !== null ? formatPercentileLabel(securityPercentile) : 'N/A' },
+  ]
+
   return {
     percentile: compositePercentile,
     label: compositePercentile !== null ? formatPercentileOrdinal(compositePercentile) : 'Insufficient data',
     tone: compositePercentile !== null ? percentileToTone(compositePercentile) : 'neutral',
     bracketLabel,
-    buckets: [
-      { name: 'Activity', percentile: activityPercentile, weight: WEIGHTS.activity, label: activityPercentile !== null ? formatPercentileLabel(activityPercentile) : 'N/A' },
-      { name: 'Responsiveness', percentile: responsivenessPercentile, weight: WEIGHTS.responsiveness, label: responsivenessPercentile !== null ? formatPercentileLabel(responsivenessPercentile) : 'N/A' },
-      { name: 'Contributors', percentile: contributorsPercentile, weight: WEIGHTS.contributors, label: contributorsPercentile !== null ? formatPercentileLabel(contributorsPercentile) : 'N/A' },
-      { name: 'Documentation', percentile: documentationPercentile, weight: WEIGHTS.documentation, label: documentationPercentile !== null ? formatPercentileLabel(documentationPercentile) : 'N/A' },
-      { name: 'Security', percentile: securityPercentile, weight: WEIGHTS.security, label: securityPercentile !== null ? formatPercentileLabel(securityPercentile) : 'N/A' },
-    ],
+    buckets,
     recommendations,
+    profile,
+    soloDetection,
   }
 }
 

--- a/lib/scoring/solo-profile.test.ts
+++ b/lib/scoring/solo-profile.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult, DocumentationResult } from '@/lib/analyzer/analysis-result'
+import { SOLO_WEIGHTS, detectSoloProjectProfile } from './solo-profile'
+
+function docWithGovernance(found: boolean): DocumentationResult {
+  return {
+    fileChecks: [
+      { name: 'readme', found: true, path: 'README.md' },
+      { name: 'governance', found, path: found ? 'GOVERNANCE.md' : null },
+    ],
+    readmeSections: [],
+    readmeContent: null,
+  }
+}
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'foo/bar',
+    name: 'bar',
+    description: '—',
+    createdAt: '2024-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 10,
+    watchers: 5,
+    commits30d: 5,
+    commits90d: 15,
+    releases12mo: 2,
+    prsOpened90d: 3,
+    prsMerged90d: 2,
+    issuesOpen: 4,
+    issuesClosed90d: 3,
+    uniqueCommitAuthors90d: 1,
+    totalContributors: 1,
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: { 'login:alice': 5 },
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: docWithGovernance(false),
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+describe('SOLO_WEIGHTS', () => {
+  it('sums to 1.00', () => {
+    const total = SOLO_WEIGHTS.activity + SOLO_WEIGHTS.security + SOLO_WEIGHTS.documentation
+    expect(total).toBeCloseTo(1, 10)
+  })
+})
+
+describe('detectSoloProjectProfile', () => {
+  it('classifies a 1-contributor, no-governance repo as solo (4/4)', () => {
+    const d = detectSoloProjectProfile(buildResult())
+    expect(d.isSolo).toBe(true)
+    expect(d.trippedCount).toBe(4)
+  })
+
+  it('classifies a community repo as not solo', () => {
+    const d = detectSoloProjectProfile(buildResult({
+      totalContributors: 50,
+      uniqueCommitAuthors90d: 20,
+      maintainerCount: 4,
+      documentationResult: docWithGovernance(true),
+    }))
+    expect(d.isSolo).toBe(false)
+    expect(d.trippedCount).toBe(0)
+  })
+
+  it('trips at 3 of 4 criteria', () => {
+    // totalContributors and uniqueCommitAuthors90d and maintainerCount trip;
+    // governance is present so criterion 4 does not trip.
+    const d = detectSoloProjectProfile(buildResult({
+      totalContributors: 2,
+      uniqueCommitAuthors90d: 2,
+      maintainerCount: 1,
+      documentationResult: docWithGovernance(true),
+    }))
+    expect(d.isSolo).toBe(true)
+    expect(d.trippedCount).toBe(3)
+    expect(d.tripped.noGovernance).toBe(false)
+  })
+
+  it('does not trip at 2 of 4 criteria', () => {
+    const d = detectSoloProjectProfile(buildResult({
+      totalContributors: 10,
+      uniqueCommitAuthors90d: 10,
+      maintainerCount: 1,
+      documentationResult: docWithGovernance(false),
+    }))
+    expect(d.isSolo).toBe(false)
+    expect(d.trippedCount).toBe(2)
+  })
+
+  it("treats maintainerCount === 'unavailable' as tripping criterion 3", () => {
+    const d = detectSoloProjectProfile(buildResult({
+      totalContributors: 1,
+      uniqueCommitAuthors90d: 1,
+      maintainerCount: 'unavailable',
+      documentationResult: docWithGovernance(true),
+    }))
+    expect(d.tripped.maintainerCount).toBe(true)
+    expect(d.isSolo).toBe(true)
+  })
+
+  it("treats documentationResult === 'unavailable' as tripping criterion 4 (no verified governance)", () => {
+    const d = detectSoloProjectProfile(buildResult({
+      totalContributors: 1,
+      uniqueCommitAuthors90d: 1,
+      maintainerCount: 2,
+      documentationResult: 'unavailable',
+    }))
+    expect(d.tripped.noGovernance).toBe(true)
+    expect(d.isSolo).toBe(true)
+  })
+
+  it("does not trip totalContributors when value is 'unavailable'", () => {
+    const d = detectSoloProjectProfile(buildResult({
+      totalContributors: 'unavailable',
+      uniqueCommitAuthors90d: 10,
+      maintainerCount: 5,
+      documentationResult: docWithGovernance(true),
+    }))
+    expect(d.tripped.totalContributors).toBe(false)
+    expect(d.isSolo).toBe(false)
+  })
+
+  it('edge: exactly 3 (e.g. 2 contributors / 3 authors / 1 maintainer / no governance) trips solo', () => {
+    const d = detectSoloProjectProfile(buildResult({
+      totalContributors: 2,
+      uniqueCommitAuthors90d: 3, // not tripping
+      maintainerCount: 1,
+      documentationResult: docWithGovernance(false),
+    }))
+    expect(d.tripped.uniqueCommitAuthors90d).toBe(false)
+    expect(d.trippedCount).toBe(3)
+    expect(d.isSolo).toBe(true)
+  })
+})

--- a/lib/scoring/solo-profile.ts
+++ b/lib/scoring/solo-profile.ts
@@ -1,0 +1,41 @@
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+
+export type SoloCriterion =
+  | 'totalContributors'
+  | 'uniqueCommitAuthors90d'
+  | 'maintainerCount'
+  | 'noGovernance'
+
+export interface SoloProjectDetection {
+  isSolo: boolean
+  trippedCount: number
+  tripped: Record<SoloCriterion, boolean>
+}
+
+export const SOLO_WEIGHTS = {
+  activity: 0.30,
+  security: 0.35,
+  documentation: 0.35,
+} as const
+
+export function detectSoloProjectProfile(result: AnalysisResult): SoloProjectDetection {
+  const tripped: Record<SoloCriterion, boolean> = {
+    totalContributors:
+      result.totalContributors !== 'unavailable' && result.totalContributors <= 2,
+    uniqueCommitAuthors90d:
+      result.uniqueCommitAuthors90d !== 'unavailable' && result.uniqueCommitAuthors90d <= 2,
+    maintainerCount:
+      result.maintainerCount === 'unavailable'
+      || (typeof result.maintainerCount === 'number' && result.maintainerCount <= 1),
+    noGovernance: !hasGovernanceFile(result),
+  }
+
+  const trippedCount = Object.values(tripped).filter(Boolean).length
+  return { isSolo: trippedCount >= 3, trippedCount, tripped }
+}
+
+function hasGovernanceFile(result: AnalysisResult): boolean {
+  if (result.documentationResult === 'unavailable') return false
+  const governance = result.documentationResult.fileChecks.find((f) => f.name === 'governance')
+  return governance?.found === true
+}

--- a/specs/214-solo-project-profile/checklists/manual-testing.md
+++ b/specs/214-solo-project-profile/checklists/manual-testing.md
@@ -1,0 +1,40 @@
+# Manual testing — Solo-project profile (#214)
+
+## Setup
+
+Dev server on `http://localhost:3010`. Sign in with GitHub (or
+`DEV_GITHUB_PAT`).
+
+## Test matrix
+
+- [ ] **Known solo repo** — analyze a single-maintainer repo (e.g.
+      `arun-gupta/kubernetes-java-sample` or any personal project). Verify:
+  - [ ] Amber banner renders above the OSS Health Score with text "Solo-maintained project. Scoring emphasizes Activity, Security, and Documentation. Contributors and Responsiveness are hidden."
+  - [ ] "Use community scoring" button appears next to the banner.
+  - [ ] Scorecard cells show only Activity, Documentation, Security — no Contributors or Responsiveness cells.
+  - [ ] Hovering the OSS Health Score tile shows the solo-scoring tooltip ("…composite health score from Activity (30%), Security (35%), and Documentation (35%). Contributors and Responsiveness are hidden…").
+  - [ ] Recommendations list contains no Contributors or Responsiveness entries.
+
+- [ ] **Known community repo** — analyze `facebook/react` or similar. Verify:
+  - [ ] No banner is rendered.
+  - [ ] All five score cells render (Activity, Responsiveness, Contributors, Documentation, Security).
+  - [ ] OSS Health Score tooltip is the community wording (Contributors 23%, Activity 25%, etc.).
+
+- [ ] **Override toggle: solo → community** — on a solo-classified repo, click "Use community scoring":
+  - [ ] Banner switches to sky/blue: "Community scoring override active. This project was auto-classified as solo-maintained; you've opted into the community surface for this session."
+  - [ ] All five score cells become visible.
+  - [ ] OSS Health Score recomputes using community weights (tooltip flips back to community wording).
+  - [ ] Button label is now "Use solo scoring".
+
+- [ ] **Override toggle: solo (opt-in) on community repo** — on a community repo, there is no toggle (expected: auto-classification rules — toggle only surfaces for auto-solo repos or when already overridden). Verify the banner / toggle do not appear for clearly-community repos.
+
+- [ ] **Session persistence** — toggle override on a solo repo, then:
+  - [ ] Scroll / navigate tabs — override state persists.
+  - [ ] Reload the page — override resets (session-scoped, not persisted).
+
+- [ ] **Org inventory / comparison** — the banner is a per-scorecard feature on the metric cards view. Ensure other surfaces (comparison view, export) still render without error for solo repos.
+
+## Signoff
+
+- Verified by: arun-gupta
+- Date: 2026-04-15

--- a/specs/214-solo-project-profile/spec.md
+++ b/specs/214-solo-project-profile/spec.md
@@ -1,0 +1,81 @@
+# Solo-project profile: alternate scoring surface
+
+Issue: #214
+
+## Problem
+
+RepoPulse uses one scoring surface for every repo. Community-shape metrics
+(Contributors, Responsiveness) dominate the composite OSS Health Score, so
+solo and near-solo projects — which are well represented on GitHub — always
+score low or surface "insufficient data" even when they are otherwise well
+maintained.
+
+## Solution
+
+Detect the solo-project shape from existing signals, and when tripped:
+
+1. Render a transparent banner explaining the profile and the scoring change.
+2. Re-weight the composite over Activity, Security, and Documentation only.
+   Contributors and Responsiveness are hidden, not scored.
+3. Allow a session-scoped manual override back to the community scoring
+   surface.
+
+## Detection heuristic
+
+A repository is classified as a solo project when **3 of 4** of these
+conditions hold:
+
+| # | Criterion |
+|---|---|
+| 1 | `totalContributors <= 2` |
+| 2 | `uniqueCommitAuthors90d <= 2` |
+| 3 | `maintainerCount` is `0`, `1`, or `'unavailable'` |
+| 4 | No `GOVERNANCE.md` (`documentationResult.fileChecks` `governance` is absent or unavailable) |
+
+Rationale for criterion 4: the issue lists "No CODEOWNERS / GOVERNANCE.md"
+as a single criterion. `maintainerCount` (criterion 3) is already derived
+from `CODEOWNERS`, `MAINTAINERS*`, and `OWNERS*` files — so `maintainerCount`
+being `'unavailable'` already implies absence of a CODEOWNERS with parseable
+entries. Using `GOVERNANCE.md` as the 4th signal keeps criterion 4
+orthogonal to criterion 3 and relies only on already-exposed fields.
+
+Unavailable inputs count as solo-leaning per the issue — criterion 3 already
+treats `'unavailable'` as tripping, and criterion 4 treats an unavailable
+documentationResult as tripping (no verified governance file).
+
+## Alternate weights
+
+| Bucket          | Community | Solo     |
+|-----------------|-----------|----------|
+| Contributors    | 23%       | hidden   |
+| Responsiveness  | 25%       | hidden   |
+| Activity        | 25%       | 30%      |
+| Security        | 15%       | 35%      |
+| Documentation   | 12%       | 35%      |
+
+Solo weights sum to 100%. Composite is renormalized over available buckets
+in both modes.
+
+## UI behaviour
+
+- When the profile trips:
+  - Show a banner above the OSS Health Score: "This project looks solo-maintained. Scoring emphasizes Activity, Security, and Documentation."
+  - Hide the Contributors and Responsiveness bucket cells from the scorecard.
+  - Show the `[Use community scoring]` toggle next to the banner.
+- When a user toggles override:
+  - Session-scoped only (React state, not persisted).
+  - Re-renders the card with community weights.
+  - Toggle label flips to `[Use solo scoring]`.
+
+## Acceptance
+
+- [x] `detectSoloProjectProfile(result)` helper with the 3-of-4 heuristic; unit-tested across edge cases
+- [x] Solo-project scoring surface with renormalized weights (Activity + Security + Documentation)
+- [x] Banner + hidden Contributors/Responsiveness in the scorecard UI when the profile trips
+- [x] Manual override toggle (session-scoped, not persisted)
+- [ ] Calibration sample of solo projects — **deferred**. The existing calibration brackets are computed from mixed samples that already include solo-shaped repos; a dedicated solo calibration is a data task that does not block the scoring surface. Tracked as a follow-up comment on #214.
+- [ ] README "Who it's for" section — **deferred**. The landing-page + README framing change that precedes this RFE will be refreshed in a separate PR.
+
+## Out of scope
+
+See issue — unchanged.


### PR DESCRIPTION
## Summary

Closes #214. Detects solo-maintained repositories and renders an alternate composite OSS Health Score that emphasizes Activity, Security, and Documentation — while hiding Contributors and Responsiveness, which almost always return insufficient data for a one-person project.

- `detectSoloProjectProfile(result)` — 3-of-4 heuristic over `totalContributors`, `uniqueCommitAuthors90d`, `maintainerCount`, and `GOVERNANCE.md` presence.
- `getHealthScore(result, { mode })` — new optional `mode` parameter. `'auto'` (default) uses the detection; `'community'` / `'solo'` force a specific surface.
- Solo weights: Activity 30%, Security 35%, Documentation 35% (Contributors + Responsiveness hidden).
- Scorecard UI: amber banner explaining the profile shift, per-card session-scoped "Use community scoring" / "Use solo scoring" toggle, hidden Contributors + Responsiveness cells, grid fits to visible bucket count (no trailing empty space).
- Community-shape signals dimmed (not hidden) in solo mode: Reach/Attention/Engagement row and Community/Governance lenses rendered at opacity-50 with explanatory tooltips — popularity/community signals aren't health signals for a solo project.
- Solo profile suppresses Contributors/Responsiveness/FUNDING recommendations since those buckets are not scored.
- Landing-page copy updated — the "planned" link is removed now that the feature has shipped.

See `specs/214-solo-project-profile/spec.md` for the full design.

### Follow-ups

- [#229](https://github.com/arun-gupta/repo-pulse/issues/229) — solo-specific calibration brackets (`solo-tiny` < 10 stars, `solo-small` 10-99) so percentiles compare solo repos against other solo repos.
- [#230](https://github.com/arun-gupta/repo-pulse/issues/230) — gate bucket sub-factor recommendations by percentile so top-performing repos don't get scolding advice (surfaced while testing this PR).

## Test plan

- [x] Analyze a known solo repo (`arun-gupta/repo-pulse`) — amber banner renders, Contributors + Responsiveness cells hidden, score cells fit the row, OSS Health Score tooltip shows solo wording.
- [x] Reach/Attention/Engagement row and Community/Governance lenses dim to opacity-50 in solo mode with explanatory tooltips.
- [x] Analyze a known community repo (`facebook/react`) — no banner, all five score cells present, ecosystem row and lenses at full opacity, tooltip unchanged.
- [x] Click "Use community scoring" on a solo repo — banner flips to sky wording, all cells reappear, tooltip flips to community wording, row un-dims.
- [x] Click "Use solo scoring" on the same card — returns to solo layout.
- [x] Reload page on an overridden repo — override resets (session-scoped, not persisted).
- [x] `npm test` — all 662 tests pass locally.
- [x] `DEV_GITHUB_PAT= npm run build` — clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)