### PR TITLE
Gate bucket sub-factor recommendations by percentile (#230)

### DIFF
--- a/docs/scoring-and-calibration.md
+++ b/docs/scoring-and-calibration.md
@@ -206,6 +206,24 @@ The full list of sampled repos is in [`docs/calibrate-repos.md`](calibrate-repos
 
 ---
 
+## Recommendation gate
+
+Bucket sub-factor recommendations (Activity, Responsiveness, Contributors, Documentation, Security) are gated by percentile. A sub-factor recommendation is emitted only when the sub-factor's percentile is **strictly below** the gate. At or above the gate, the recommendation is suppressed — silent-when-good.
+
+The threshold lives in configuration at `lib/scoring/config-loader.ts`:
+
+```ts
+export const RECOMMENDATION_PERCENTILE_GATE = 50
+```
+
+Documentation and Security recommendations are gated by the bucket percentile (since each rec is tied to a missing file/section). Activity, Responsiveness, and Contributors recommendations are gated per sub-factor (PR flow, Issue flow, etc.), so a repo with a strong PR flow won't be told to "reduce PR backlog" even if another Activity sub-factor is weak.
+
+Presence-based community-lens signals (`FUNDING.yml`, Discussions disabled, missing `CODEOWNERS`) are not percentile-gated — they fire on verified absence of a specific artifact.
+
+Rationale: issue #230. Top performers should not be scolded about the dimension they are already strong on.
+
+---
+
 ## Staleness policy
 
 Calibration data is refreshed **quarterly**. If the `generated` date in `calibration-data.json` is more than **6 months old**, the RepoPulse UI surfaces a visible staleness warning:

--- a/lib/scoring/config-loader.ts
+++ b/lib/scoring/config-loader.ts
@@ -1,6 +1,13 @@
 import calibrationData from './calibration-data.json'
 import type { Unavailable } from '@/lib/analyzer/analysis-result'
 
+/**
+ * Percentile gate below which sub-factor recommendations are emitted. At or
+ * above this threshold a sub-factor is considered to be doing fine and the
+ * recommendation is suppressed — silent-when-good. See issue #230.
+ */
+export const RECOMMENDATION_PERCENTILE_GATE = 50
+
 export type BracketKey = 'emerging' | 'growing' | 'established' | 'popular'
 
 export interface PercentileSet {

--- a/lib/scoring/health-score.test.ts
+++ b/lib/scoring/health-score.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
-import { WEIGHTS, getHealthScore } from './health-score'
+import {
+  WEIGHTS,
+  getActivityRecommendations,
+  getContributorsRecommendations,
+  getHealthScore,
+  getResponsivenessRecommendations,
+} from './health-score'
+import type { ActivityScoreDefinition } from '@/lib/activity/score-config'
+import type { ResponsivenessScoreDefinition } from '@/lib/responsiveness/score-config'
+import type { ContributorsScoreDefinition } from '@/lib/contributors/score-config'
 
 function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
   return {
@@ -105,6 +114,148 @@ describe('health-score community-lens recommendations', () => {
     const result = buildResult({})
     const recs = getHealthScore(result).recommendations
     expect(recs.find((r) => r.key === 'feature:discussions_enabled')).toBeUndefined()
+  })
+})
+
+describe('health-score sub-factor recommendation gate (#230)', () => {
+  function makeActivity(factors: Record<string, number>): ActivityScoreDefinition {
+    return {
+      value: 50,
+      tone: 'warning',
+      description: '',
+      summary: '',
+      percentile: 50,
+      bracketLabel: '',
+      weightedFactors: Object.entries(factors).map(([label, percentile]) => ({
+        label,
+        weightLabel: '25%',
+        description: '',
+        percentile,
+      })),
+      missingInputs: [],
+    }
+  }
+
+  function makeResponsiveness(cats: Record<string, number>): ResponsivenessScoreDefinition {
+    return {
+      value: 50,
+      tone: 'warning',
+      description: '',
+      summary: '',
+      percentile: 50,
+      bracketLabel: '',
+      weightedCategories: Object.entries(cats).map(([label, percentile]) => ({
+        label,
+        weightLabel: '33%',
+        description: '',
+        percentile,
+      })),
+      missingInputs: [],
+    }
+  }
+
+  function makeContributors(factors: Record<string, number>): ContributorsScoreDefinition {
+    return {
+      value: 50,
+      tone: 'warning',
+      description: '',
+      summary: '',
+      percentile: 50,
+      bracketLabel: '',
+      weightedFactors: Object.entries(factors).map(([label, percentile]) => ({
+        label,
+        weightLabel: '20%',
+        description: '',
+        percentile,
+      })),
+      missingInputs: [],
+    }
+  }
+
+  it('suppresses Activity sub-factor recommendations at/above the 50th percentile', () => {
+    const keys = getActivityRecommendations(makeActivity({
+      'PR flow': 95,
+      'Issue flow': 30,
+      'Completion speed': 50,
+      'Sustained activity': 20,
+    })).map((r) => r.key)
+    expect(keys).not.toContain('pr_flow')
+    expect(keys).toContain('issue_flow')
+    expect(keys).not.toContain('completion_speed') // boundary: 50 suppressed
+    expect(keys).toContain('sustained_activity')
+  })
+
+  it('suppresses Responsiveness sub-factor recommendations at/above the 50th percentile', () => {
+    const keys = getResponsivenessRecommendations(makeResponsiveness({
+      'Issue & PR response time': 90,
+      'Resolution metrics': 49,
+      'Volume & backlog health': 50,
+    })).map((r) => r.key)
+    expect(keys).not.toContain('response_time')
+    expect(keys).toContain('resolution')
+    expect(keys).not.toContain('backlog_health')
+  })
+
+  it('suppresses Contributors sub-factor recommendations at/above the 50th percentile', () => {
+    const keys = getContributorsRecommendations(makeContributors({
+      'Contributor concentration': 85,
+      'Maintainer depth': 10,
+      'Repeat-contributor ratio': 55,
+      'New-contributor inflow': 49,
+      'Contribution breadth': 50,
+    })).map((r) => r.key)
+    expect(keys).not.toContain('contributor_diversity')
+    expect(keys).toContain('maintainer_depth')
+    expect(keys).not.toContain('repeat_contributor_ratio')
+    expect(keys).toContain('new_contributor_inflow')
+    expect(keys).not.toContain('contribution_breadth')
+  })
+
+  it('still emits every recommendation when every sub-factor is below the gate', () => {
+    const keys = getActivityRecommendations(makeActivity({
+      'PR flow': 5,
+      'Issue flow': 10,
+      'Completion speed': 15,
+      'Sustained activity': 20,
+    })).map((r) => r.key)
+    expect(keys).toEqual(expect.arrayContaining(['pr_flow', 'issue_flow', 'completion_speed', 'sustained_activity']))
+  })
+
+  it('suppresses Documentation and Security bucket recommendations when bucket percentile is at/above the gate', () => {
+    // Build a result that scores Documentation above the gate. The
+    // healthy-everywhere repo in the `popular` bracket has all files
+    // present and a long README, which produces a high doc percentile.
+    const docResult: AnalysisResult['documentationResult'] = {
+      fileChecks: [
+        { name: 'readme', found: true, path: 'README.md' },
+        { name: 'license', found: true, path: 'LICENSE' },
+        { name: 'contributing', found: true, path: 'CONTRIBUTING.md' },
+        { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+        { name: 'security', found: true, path: 'SECURITY.md' },
+        { name: 'governance', found: true, path: 'GOVERNANCE.md' },
+        { name: 'changelog', found: true, path: 'CHANGELOG.md' },
+        { name: 'issue_templates', found: true, path: '.github/ISSUE_TEMPLATE' },
+        { name: 'pull_request_template', found: true, path: '.github/PULL_REQUEST_TEMPLATE.md' },
+      ],
+      readmeSections: [
+        { name: 'description', detected: true },
+        { name: 'installation', detected: true },
+        { name: 'usage', detected: true },
+        { name: 'contributing', detected: true },
+        { name: 'license', detected: true },
+      ],
+      readmeContent: 'a'.repeat(5000),
+    }
+
+    const high = getHealthScore(buildResult({
+      stars: 50000,
+      totalContributors: 50,
+      uniqueCommitAuthors90d: 30,
+      maintainerCount: 5,
+      documentationResult: docResult,
+    }))
+    // At/above gate: no per-file documentation recs emitted.
+    expect(high.recommendations.find((r) => r.bucket === 'Documentation')).toBeUndefined()
   })
 })
 

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -4,7 +4,7 @@ import { getResponsivenessScore, type ResponsivenessScoreDefinition } from '@/li
 import { getContributorsScore, type ContributorsScoreDefinition } from '@/lib/contributors/score-config'
 import { getDocumentationScore, type DocumentationRecommendation } from '@/lib/documentation/score-config'
 import { getSecurityScore } from '@/lib/security/score-config'
-import { formatPercentileLabel, formatPercentileOrdinal, getBracketLabel, percentileToTone } from '@/lib/scoring/config-loader'
+import { RECOMMENDATION_PERCENTILE_GATE, formatPercentileLabel, formatPercentileOrdinal, getBracketLabel, percentileToTone } from '@/lib/scoring/config-loader'
 import { SOLO_WEIGHTS, detectSoloProjectProfile, type SoloProjectDetection } from '@/lib/scoring/solo-profile'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
@@ -100,9 +100,11 @@ export function getHealthScore(result: AnalysisResult, options: HealthScoreOptio
     compositePercentile = Math.min(99, Math.max(0, Math.round(weightedSum)))
   }
 
-  // Generate recommendations for all buckets — no percentile gate.
-  // Solo profile suppresses Contributors and Responsiveness recommendations
-  // since those buckets are hidden from the score.
+  // Sub-factor recommendations are gated by RECOMMENDATION_PERCENTILE_GATE
+  // (issue #230): only emit when the sub-factor is below the gate so
+  // top performers are not scolded. Solo profile additionally suppresses
+  // Contributors and Responsiveness recommendations since those buckets
+  // are hidden from the score.
   const recommendations: HealthScoreRecommendation[] = []
   if (activityPercentile !== null) {
     recommendations.push(...getActivityRecommendations(activity))
@@ -144,7 +146,7 @@ export function getHealthScore(result: AnalysisResult, options: HealthScoreOptio
       tab: 'activity',
     })
   }
-  if (documentation !== null) {
+  if (documentation !== null && (documentationPercentile ?? 0) < RECOMMENDATION_PERCENTILE_GATE) {
     for (const rec of documentation.recommendations) {
       recommendations.push({
         bucket: 'Documentation',
@@ -155,7 +157,7 @@ export function getHealthScore(result: AnalysisResult, options: HealthScoreOptio
       })
     }
   }
-  if (security !== null) {
+  if (security !== null && (securityPercentile ?? 0) < RECOMMENDATION_PERCENTILE_GATE) {
     for (const rec of security.recommendations) {
       recommendations.push({
         bucket: 'Security',
@@ -187,109 +189,113 @@ export function getHealthScore(result: AnalysisResult, options: HealthScoreOptio
   }
 }
 
-function getActivityRecommendations(score: ActivityScoreDefinition): HealthScoreRecommendation[] {
+function isBelowGate(percentile: number | undefined): percentile is number {
+  return percentile !== undefined && percentile < RECOMMENDATION_PERCENTILE_GATE
+}
+
+export function getActivityRecommendations(score: ActivityScoreDefinition): HealthScoreRecommendation[] {
   const recs: HealthScoreRecommendation[] = []
   const factors = score.weightedFactors
 
   const prFlow = factors.find((f) => f.label === 'PR flow')
-  if (prFlow?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', key: 'pr_flow', percentile: prFlow.percentile, message: 'Reduce PR backlog and speed up review throughput to improve merge rate.', tab: 'activity' })
+  if (isBelowGate(prFlow?.percentile)) {
+    recs.push({ bucket: 'Activity', key: 'pr_flow', percentile: prFlow!.percentile!, message: 'Reduce PR backlog and speed up review throughput to improve merge rate.', tab: 'activity' })
   }
 
   const issueFlow = factors.find((f) => f.label === 'Issue flow')
-  if (issueFlow?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', key: 'issue_flow', percentile: issueFlow.percentile, message: 'Triage and close stale issues to improve issue flow.', tab: 'activity' })
+  if (isBelowGate(issueFlow?.percentile)) {
+    recs.push({ bucket: 'Activity', key: 'issue_flow', percentile: issueFlow!.percentile!, message: 'Triage and close stale issues to improve issue flow.', tab: 'activity' })
   }
 
   const completionSpeed = factors.find((f) => f.label === 'Completion speed')
-  if (completionSpeed?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', key: 'completion_speed', percentile: completionSpeed.percentile, message: 'Reduce time to merge PRs and close issues to improve completion speed.', tab: 'activity' })
+  if (isBelowGate(completionSpeed?.percentile)) {
+    recs.push({ bucket: 'Activity', key: 'completion_speed', percentile: completionSpeed!.percentile!, message: 'Reduce time to merge PRs and close issues to improve completion speed.', tab: 'activity' })
   }
 
   const sustained = factors.find((f) => f.label === 'Sustained activity')
-  if (sustained?.percentile !== undefined) {
-    recs.push({ bucket: 'Activity', key: 'sustained_activity', percentile: sustained.percentile, message: 'Increase commit frequency to show sustained development momentum.', tab: 'activity' })
+  if (isBelowGate(sustained?.percentile)) {
+    recs.push({ bucket: 'Activity', key: 'sustained_activity', percentile: sustained!.percentile!, message: 'Increase commit frequency to show sustained development momentum.', tab: 'activity' })
   }
 
   return recs
 }
 
-function getResponsivenessRecommendations(score: ResponsivenessScoreDefinition): HealthScoreRecommendation[] {
+export function getResponsivenessRecommendations(score: ResponsivenessScoreDefinition): HealthScoreRecommendation[] {
   const recs: HealthScoreRecommendation[] = []
   const categories = score.weightedCategories
 
   const responseTime = categories.find((c) => c.label === 'Issue & PR response time')
-  if (responseTime?.percentile !== undefined) {
-    recs.push({ bucket: 'Responsiveness', key: 'response_time', percentile: responseTime.percentile, message: 'Reduce issue and PR first-response times — contributors are waiting longer than most repos in this bracket.', tab: 'responsiveness' })
+  if (isBelowGate(responseTime?.percentile)) {
+    recs.push({ bucket: 'Responsiveness', key: 'response_time', percentile: responseTime!.percentile!, message: 'Reduce issue and PR first-response times — contributors are waiting longer than most repos in this bracket.', tab: 'responsiveness' })
   }
 
   const resolution = categories.find((c) => c.label === 'Resolution metrics')
-  if (resolution?.percentile !== undefined) {
-    recs.push({ bucket: 'Responsiveness', key: 'resolution', percentile: resolution.percentile, message: 'Speed up issue resolution and PR merge times to improve throughput.', tab: 'responsiveness' })
+  if (isBelowGate(resolution?.percentile)) {
+    recs.push({ bucket: 'Responsiveness', key: 'resolution', percentile: resolution!.percentile!, message: 'Speed up issue resolution and PR merge times to improve throughput.', tab: 'responsiveness' })
   }
 
   const backlog = categories.find((c) => c.label === 'Volume & backlog health')
-  if (backlog?.percentile !== undefined) {
-    recs.push({ bucket: 'Responsiveness', key: 'backlog_health', percentile: backlog.percentile, message: 'Address stale issues and PRs to improve backlog health.', tab: 'responsiveness' })
+  if (isBelowGate(backlog?.percentile)) {
+    recs.push({ bucket: 'Responsiveness', key: 'backlog_health', percentile: backlog!.percentile!, message: 'Address stale issues and PRs to improve backlog health.', tab: 'responsiveness' })
   }
 
   return recs
 }
 
-function getContributorsRecommendations(score: ContributorsScoreDefinition): HealthScoreRecommendation[] {
+export function getContributorsRecommendations(score: ContributorsScoreDefinition): HealthScoreRecommendation[] {
   const recs: HealthScoreRecommendation[] = []
   const factors = score.weightedFactors
 
   const concentration = factors.find((f) => f.label === 'Contributor concentration')
-  if (concentration?.percentile !== undefined) {
+  if (isBelowGate(concentration?.percentile)) {
     recs.push({
       bucket: 'Contributors',
       key: 'contributor_diversity',
-      percentile: concentration.percentile,
+      percentile: concentration!.percentile!,
       message: 'Onboard more contributors to reduce single-maintainer risk. The top 20% of contributors account for a disproportionate share of commits.',
       tab: 'contributors',
     })
   }
 
   const maintainerDepth = factors.find((f) => f.label === 'Maintainer depth')
-  if (maintainerDepth?.percentile !== undefined) {
+  if (isBelowGate(maintainerDepth?.percentile)) {
     recs.push({
       bucket: 'Contributors',
       key: 'maintainer_depth',
-      percentile: maintainerDepth.percentile,
+      percentile: maintainerDepth!.percentile!,
       message: 'Grow maintainer depth by documenting additional owners in CODEOWNERS, MAINTAINERS.md, or GOVERNANCE.md so responsibility is not concentrated in a single person.',
       tab: 'contributors',
     })
   }
 
   const repeatRatio = factors.find((f) => f.label === 'Repeat-contributor ratio')
-  if (repeatRatio?.percentile !== undefined) {
+  if (isBelowGate(repeatRatio?.percentile)) {
     recs.push({
       bucket: 'Contributors',
       key: 'repeat_contributor_ratio',
-      percentile: repeatRatio.percentile,
+      percentile: repeatRatio!.percentile!,
       message: 'Invest in contributor retention — a higher share of repeat contributors signals durable engagement beyond one-time drive-bys.',
       tab: 'contributors',
     })
   }
 
   const newInflow = factors.find((f) => f.label === 'New-contributor inflow')
-  if (newInflow?.percentile !== undefined) {
+  if (isBelowGate(newInflow?.percentile)) {
     recs.push({
       bucket: 'Contributors',
       key: 'new_contributor_inflow',
-      percentile: newInflow.percentile,
+      percentile: newInflow!.percentile!,
       message: 'Surface good-first-issues and contributor onboarding so new contributors keep arriving alongside the returning base.',
       tab: 'contributors',
     })
   }
 
   const breadth = factors.find((f) => f.label === 'Contribution breadth')
-  if (breadth?.percentile !== undefined) {
+  if (isBelowGate(breadth?.percentile)) {
     recs.push({
       bucket: 'Contributors',
       key: 'contribution_breadth',
-      percentile: breadth.percentile,
+      percentile: breadth!.percentile!,
       message: 'Encourage contributions across commits, pull requests, and issues so engagement is not limited to a single surface.',
       tab: 'contributors',
     })

--- a/specs/230-gate-bucket-sub-factor-recommendations/checklists/manual-testing.md
+++ b/specs/230-gate-bucket-sub-factor-recommendations/checklists/manual-testing.md
@@ -1,0 +1,46 @@
+# Manual testing — Gate bucket sub-factor recommendations (#230)
+
+## Setup
+
+Dev server on `http://localhost:3010`. Sign in with GitHub (or
+`DEV_GITHUB_PAT`).
+
+## Test matrix
+
+- [ ] **Top-performing repo (Activity)** — analyze `facebook/react` or any
+      repo where Activity sub-factors (PR flow, Issue flow, Completion
+      speed, Sustained activity) score at or above the 50th percentile.
+  - [ ] The Recommendations tab does NOT surface `Reduce PR backlog…`,
+        `Triage and close stale issues…`, `Reduce time to merge PRs…`, or
+        `Increase commit frequency…` for sub-factors at/above the gate.
+  - [ ] Any sub-factor below the 50th percentile still surfaces its
+        recommendation.
+
+- [ ] **`arun-gupta/repo-pulse` regression check** — analyze the
+      own-project repo that exposed the bug.
+  - [ ] No false-positive Activity recommendations (ACT-2 "Triage and close
+        stale issues" and "Reduce PR backlog" both absent, since the repo
+        merges PRs and closes issues quickly).
+  - [ ] If Activity sub-factors are legitimately below gate, those recs
+        still appear.
+
+- [ ] **Low-performing repo** — analyze a repo with a stale backlog.
+  - [ ] Relevant sub-factor recommendations DO appear (gate only suppresses
+        at/above the threshold, not below).
+
+- [ ] **Presence-based community recs are unchanged** — on a repo without
+      `.github/FUNDING.yml` or with Discussions disabled:
+  - [ ] `file:funding` recommendation still fires (not gated).
+  - [ ] `feature:discussions_enabled` recommendation still fires (not gated).
+
+- [ ] **Documentation and Security bucket gating** — on a repo whose
+      Documentation bucket is ≥ 50th percentile but still missing one or
+      two minor files:
+  - [ ] Documentation recommendations are suppressed.
+  - [ ] On a repo whose Documentation bucket is < 50th percentile, the
+        per-missing-file recommendations still appear.
+
+## Signoff
+
+- Verified by: arun-gupta
+- Date: 2026-04-15

--- a/specs/230-gate-bucket-sub-factor-recommendations/spec.md
+++ b/specs/230-gate-bucket-sub-factor-recommendations/spec.md
@@ -1,0 +1,79 @@
+# Gate bucket sub-factor recommendations by percentile
+
+Issue: #230
+
+## Problem
+
+Bucket sub-factor recommendations emit regardless of the sub-factor's
+percentile. A repo scoring 95th percentile on PR flow still gets "Reduce PR
+backlog and speed up review throughput to improve merge rate" — the advice
+reads as a scolding when the repo is actually outperforming.
+
+Verified on `arun-gupta/repo-pulse` (from #214 testing): the repo closes
+issues quickly and merges PRs promptly, yet "Triage and close stale issues"
+(ACT-2) and "Reduce PR backlog" still surfaced as Activity recommendations.
+
+The root cause is explicit in `lib/scoring/health-score.ts`:
+
+```ts
+// Generate recommendations for all buckets — no percentile gate.
+```
+
+## Solution
+
+Introduce a single global recommendation gate, defined in configuration per
+constitution §VI:
+
+```ts
+export const RECOMMENDATION_PERCENTILE_GATE = 50
+```
+
+A sub-factor recommendation is emitted only when its percentile is
+**strictly below** the gate. At or above the gate, the recommendation is
+suppressed — silent-when-good.
+
+### Scope of the gate
+
+Applied to:
+
+- `getActivityRecommendations` — PR flow, Issue flow, Completion speed,
+  Sustained activity (gated per sub-factor percentile).
+- `getResponsivenessRecommendations` — Response time, Resolution,
+  Backlog health (gated per sub-factor percentile).
+- `getContributorsRecommendations` — Concentration, Maintainer depth,
+  Repeat-contributor ratio, New-contributor inflow, Contribution breadth
+  (gated per sub-factor percentile).
+- `getDocumentationScore` recommendations — gated by the **bucket**
+  percentile (`documentation.percentile`). Each recommendation is tied to a
+  missing file or README section; when the overall documentation bucket is
+  already at or above the gate, the few missing items do not warrant a
+  scold.
+- `getSecurityScore` recommendations — gated by the **bucket** percentile
+  (`security.percentile`), same reasoning.
+
+Not affected (these are presence-based community-lens signals, not
+percentile-driven scolds):
+
+- `file:funding` (CTR-3, missing `FUNDING.yml`)
+- `feature:discussions_enabled` (ACT-5, Discussions disabled)
+- `no_maintainers` (missing CODEOWNERS/MAINTAINERS)
+
+These fire on a verified boolean absence of the artifact, not on a
+percentile comparison. They stay as-is.
+
+## Acceptance
+
+- [x] Sub-factor recommendation emitters read a percentile threshold from
+      shared config (`RECOMMENDATION_PERCENTILE_GATE`).
+- [x] Recommendations at or above the threshold are suppressed.
+- [x] Documentation entry for the threshold (in `docs/scoring-and-calibration.md`).
+- [x] Unit tests: top-percentile sub-factors do NOT emit recs; below-gate
+      sub-factors still do.
+- [x] Manual verification on `arun-gupta/repo-pulse` — no false-positive
+      Activity recommendations.
+
+## Out of scope
+
+- Celebratory "great job" copy above a high percentile (stretch in the issue).
+- Per-bracket recalibration of the gate — one global threshold is enough.
+- Gating presence-based community-lens recs (FUNDING, Discussions, CODEOWNERS).


### PR DESCRIPTION
Closes #230.

## Summary

- Sub-factor recommendation emitters now read a gate from shared config (`RECOMMENDATION_PERCENTILE_GATE = 50` in `lib/scoring/config-loader.ts`) and only emit when the sub-factor's percentile is strictly below the gate — silent-when-good.
- Activity, Responsiveness, and Contributors gate per sub-factor (PR flow, Issue flow, etc.). Documentation and Security gate on the bucket percentile since each rec is tied to a missing file/section.
- Presence-based community-lens signals (`FUNDING.yml`, Discussions disabled, missing `CODEOWNERS`) remain ungated — they fire on verified absence, not percentile.
- Adds unit tests covering each bucket plus a boundary (`percentile === 50` is suppressed; `49` is emitted).
- Documents the threshold in `docs/scoring-and-calibration.md`.

## Follow-up issues surfaced during verification

- #232 — move manual testing checklist from per-spec file to PR Test Plan under the ephemeral-worktree workflow.
- #233 — documentation percentile over-inflation (3 of 9 files → 90th percentile on `arun-gupta/repo-pulse`).

## Test plan

- [x] Analyze `facebook/react` on `http://localhost:3010` — top-percentile Activity sub-factors do NOT produce their recs (only presence-based ACT-5 surfaces).
- [x] Analyze `arun-gupta/repo-pulse` — no false-positive Activity recommendations (regression from #214).
- [x] Analyze `tensorflow/tensorflow` — Contributors sub-factor recs (CTR-1, CTR-6) surface below-gate; Activity sub-factors correctly suppressed (only ACT-5 remains).
- [x] Analyze `jashkenas/underscore` — below-gate sub-factor recommendations DO appear (ACT-3 Completion speed + 11 per-file DOC-* items).
- [x] Confirm `file:funding` and `feature:discussions_enabled` recommendations still fire when those artifacts are absent (not gated).
- [x] Documentation bucket gating — above-gate repo (`arun-gupta/repo-pulse`, 90th pct): per-file docs recs suppressed. Below-gate repo (`jashkenas/underscore`): 11 DOC-* per-file recs surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)