### PR TITLE
Move manual testing checklist to PR Test Plan (#232)

### DIFF
--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -54,10 +54,6 @@ You **MUST** consider the user input before proceeding (if not empty).
      - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
      - Completed items: Lines matching `- [X]` or `- [x]`
      - Incomplete items: Lines matching `- [ ]`
-   - Treat `manual-testing.md` specially:
-     - It MUST exist before implementation begins
-     - Its incompleteness does **not** block `/speckit.implement`
-     - It is completed and signed off later, before opening the PR
    - Create a status table:
 
      ```text
@@ -69,25 +65,21 @@ You **MUST** consider the user input before proceeding (if not empty).
      ```
 
    - Calculate overall status:
-     - **PASS**: All non-manual checklists have 0 incomplete items, and `manual-testing.md` exists
-     - **FAIL**: One or more non-manual checklists have incomplete items, or `manual-testing.md` is missing
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
 
-   - **If any non-manual checklist is incomplete**:
+   - **If any checklist is incomplete**:
      - Display the table with incomplete item counts
      - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
      - Wait for user response before continuing
      - If user says "no" or "wait" or "stop", halt execution
      - If user says "yes" or "proceed" or "continue", proceed to step 3
 
-   - **If `manual-testing.md` is missing**:
-     - **STOP** and ask: "The feature is missing `checklists/manual-testing.md`. Do you want me to create it before implementation continues? (yes/no)"
-     - Wait for user response before continuing
-     - If user says "no" or "wait" or "stop", halt execution
-     - If user says "yes" or "proceed" or "continue", create the file and then proceed to step 3
-
-   - **If all non-manual checklists are complete and `manual-testing.md` exists**:
-     - Display the table showing checklist status, and note that `manual-testing.md` is expected to remain incomplete until after implementation
+   - **If all checklists are complete**:
+     - Display the table showing checklist status
      - Automatically proceed to step 3
+
+   Note: Manual testing signoff happens in the PR body's `## Test plan` section, not in an in-repo checklist file.
 
 3. Load and analyze the implementation context:
    - **REQUIRED**: Read tasks.md for the complete task list and execution plan

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,7 +1,9 @@
 # RepoPulse Constitution
 
-**Version**: 1.1 — Amended 2026-04-06
-**Amendment**: Section III rules 4 and 6 updated to reflect OAuth-only authentication (P1-F14). PAT input and server-side `GITHUB_TOKEN` removed. Rationale: GitHub OAuth distributes rate limit consumption across individual user quotas, enabling the app to scale to any number of concurrent users without a shared API quota bottleneck. Storing the OAuth token in-memory only (never in localStorage or cookies) eliminates the XSS token-theft risk present in the previous PAT-based localStorage flow, improving security while preserving the stateless Phase 1 architecture. Signed off by: arun-gupta.
+**Version**: 1.2 — Amended 2026-04-15
+**Amendment**: Sections XII and XIII updated to drop the per-feature `specs/NNN-feature-name/checklists/manual-testing.md` file. The PR body's `## Test plan` section is now the single source of truth for manual testing signoff. Rationale: under the one-Claude-per-issue ephemeral-worktree workflow, the in-repo checklist file duplicated the PR Test Plan, drifted from it, and added ceremony without adding coverage. GitHub preserves PR bodies indefinitely and they are queryable via `gh pr view --json body`, so the test record remains durable. Signed off by: arun-gupta.
+
+**Previous amendment (v1.1, 2026-04-06)**: Section III rules 4 and 6 updated to reflect OAuth-only authentication (P1-F14). PAT input and server-side `GITHUB_TOKEN` removed. Rationale: GitHub OAuth distributes rate limit consumption across individual user quotas, enabling the app to scale to any number of concurrent users without a shared API quota bottleneck. Storing the OAuth token in-memory only (never in localStorage or cookies) eliminates the XSS token-theft risk present in the previous PAT-based localStorage flow, improving security while preserving the stateless Phase 1 architecture. Signed off by: arun-gupta.
 
 **Single authoritative source of all project rules.**
 Every spec, plan, task, and line of code must comply. No exceptions.
@@ -175,8 +177,7 @@ A feature is complete only when all of the following are true:
 - [ ] No TODOs, dead code, `console.log`, or untyped values remain
 - [ ] All spec documents for the feature are current
 - [ ] `docs/DEVELOPMENT.md` reflects the feature's completed status in the implementation order
-- [ ] `specs/NNN-feature-name/checklists/manual-testing.md` exists for the feature
-- [ ] Manual testing checklist completed and signed off
+- [ ] PR Test Plan completed and signed off before merge
 - [ ] README updated for any user-facing or setup changes
 - [ ] Constitution compliance verified — no rule violated
 
@@ -186,13 +187,12 @@ A feature is complete only when all of the following are true:
 
 1. All work happens on feature branches. No direct commits to `main`.
 2. All tests must pass and linting must be clean before a PR is merged.
-3. Every feature must maintain `specs/NNN-feature-name/checklists/manual-testing.md`.
-4. A manual testing checklist must be completed and signed off before submitting a PR.
-5. README must be updated to reflect any user-facing or setup changes before submitting a PR.
-6. `docs/DEVELOPMENT.md` must be updated when a feature is completed so the implementation order reflects current status.
-7. A PR must be opened and merged before starting the next feature.
-8. Credentials go in `.env.local` only — never committed. `.env.example` is committed with placeholder values.
-9. README is updated when a completed feature changes the user-facing behavior or setup steps.
+3. Every PR must include a `## Test plan` section in its body — this is the single source of truth for manual testing signoff. All checkboxes must be checked before merge.
+4. README must be updated to reflect any user-facing or setup changes before submitting a PR.
+5. `docs/DEVELOPMENT.md` must be updated when a feature is completed so the implementation order reflects current status.
+6. A PR must be opened and merged before starting the next feature.
+7. Credentials go in `.env.local` only — never committed. `.env.example` is committed with placeholder values.
+8. README is updated when a completed feature changes the user-facing behavior or setup steps.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -38,7 +38,7 @@ Review the task list before implementation begins.
 
 > `/speckit.implement` `[P1-F01]`
 
-Each feature must include a manual testing checklist at `specs/NNN-feature-name/checklists/manual-testing.md`. Create it during the feature workflow if it does not already exist, and complete/sign it off before opening the PR.
+Implement the feature per the generated tasks.
 
 ### Step 5 — PR
 
@@ -49,7 +49,7 @@ Before opening a PR, verify the Definition of Done (constitution Section XII):
 - [ ] No TODOs, dead code, `console.log`, or untyped values remain
 - [ ] All spec documents for the feature are current
 - [ ] `docs/DEVELOPMENT.md` reflects the feature's completed status in the implementation order table (`✅ Done`)
-- [ ] Manual testing checklist completed and signed off
+- [ ] PR body includes a `## Test plan` section; all checkboxes are checked before merge
 - [ ] README updated for any user-facing or setup changes
 - [ ] Constitution compliance verified — no rule violated
 
@@ -249,7 +249,7 @@ There is no central signal registry. When adding a new signal to an existing len
 
 - `.specify/` is managed by SpecKit. Do not manually edit files inside it outside of the workflows above.
 - Feature specs live in `specs/NNN-feature-name/`.
-- Every feature must have `specs/NNN-feature-name/checklists/manual-testing.md`.
+- Manual testing signoff lives in the PR body's `## Test plan` section — not in an in-repo checklist file.
 - Constitution: `.specify/memory/constitution.md`
 - Product definition: `docs/PRODUCT.md`
 - Deployment guide: `docs/DEPLOYMENT.md`

--- a/docs/oss-health-42-signals/README.md
+++ b/docs/oss-health-42-signals/README.md
@@ -355,7 +355,7 @@ Percentile anchors (p25, p50, p75, p90) will be refreshed quarterly. This means 
 
 **AI-assisted development.** The project was built with **Claude Code** and **OpenAI Codex** as AI coding assistants, with **VS Code** for code review. Every scoring algorithm, UI component, calibration pipeline, and test was written through human–AI collaboration — proving that AI-assisted development can produce production-grade open source tooling.
 
-**Specification-Driven Development (SpecKit).** Non-trivial features follow a [SpecKit](https://github.com/github/spec-kit) loop: `/speckit.specify` → `/speckit.plan` → `/speckit.tasks` → `/speckit.implement`. The spec captures *what* and *why*; SpecKit generates TypeScript contracts (interfaces, view props, data-flow shapes) as the *how*. Each feature lands in `specs/NNN-feature-name/` with a manual-testing checklist that has to be signed off before the PR opens.
+**Specification-Driven Development (SpecKit).** Non-trivial features follow a [SpecKit](https://github.com/github/spec-kit) loop: `/speckit.specify` → `/speckit.plan` → `/speckit.tasks` → `/speckit.implement`. The spec captures *what* and *why*; SpecKit generates TypeScript contracts (interfaces, view props, data-flow shapes) as the *how*. Each feature lands in `specs/NNN-feature-name/`, and manual-testing signoff happens in the PR body's `## Test plan` section before merge.
 
 **Governance layer.** Two in-repo documents keep intent and execution aligned:
 


### PR DESCRIPTION
Closes #232.

## Summary

- Amend constitution to **v1.2**: drop the per-feature `specs/NNN-feature-name/checklists/manual-testing.md` requirement from §XII (Definition of Done) and §XIII (Development Workflow). The PR body's `## Test plan` section is now the single source of truth for manual testing signoff.
- Update `docs/DEVELOPMENT.md` Step 4 and Step 5 to match, and refresh the Notes section.
- Drop the `manual-testing.md` special-case logic in `.claude/commands/speckit.implement.md` so the command no longer stops to create the file.
- Refresh the blurb in `docs/oss-health-42-signals/README.md`.

No migration: existing `specs/*/checklists/manual-testing.md` files are left in place as historical record (mass-deletion is explicitly out of scope per the issue).

## Test plan

- [x] `.specify/memory/constitution.md` shows version 1.2, dated 2026-04-15, with rationale and signoff.
- [x] Constitution §XII no longer references `specs/NNN-feature-name/checklists/manual-testing.md` and replaces the two dropped bullets with "PR Test Plan completed and signed off before merge."
- [x] Constitution §XIII no longer requires an in-repo manual testing checklist file; rule 3 now points to the PR body's `## Test plan`.
- [x] `docs/DEVELOPMENT.md` Step 4 no longer requires the checklist file; Step 5 DoD lists a PR Test Plan bullet in place of the checklist bullets.
- [x] `.claude/commands/speckit.implement.md` no longer branches on `manual-testing.md` presence; checklist status logic treats all checklists uniformly.
- [x] No other tooling, skill templates, or scripts reference the dropped checklist path in a way that would break CI or `/speckit.implement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)