### PR TITLE
Pause SpecKit lifecycle after /speckit.specify for manual review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ When starting new feature work, follow this order exactly:
 2. Read `docs/PRODUCT.md` next to find the canonical product definition, acceptance criteria, and out-of-scope boundaries for that feature.
 3. Then run the SpecKit lifecycle in order:
    - `/speckit.specify`
+   - **Pause for spec review (mandatory).** After `/speckit.specify` completes, report the generated spec file path and stop. Do not proceed to `/speckit.plan` until the user replies with an explicit approval phrase: `"proceed"`, `"approved"`, or `"go to plan"`. If the user replies with revisions instead, apply them, re-report the spec path, and re-enter the paused state. Rationale: human-in-the-loop at the highest-leverage artifact — the spec encodes intent, scope, and acceptance, and must be validated before autonomous downstream work compounds on top of it.
    - `/speckit.plan`
    - `/speckit.tasks`
    - `/speckit.implement`

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,6 +139,16 @@ for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done
 
 The script creates `../forkprint-<issue>-<slug>/` on a new branch, picks the next free port in `3010–3100`, runs `npm install`, starts `next dev` in the background (log: `dev.log`, PID: `.dev.pid`), and launches `claude` with a prompt that runs the SpecKit lifecycle and opens a PR (never merges — see CLAUDE.md).
 
+**Mandatory pause after `/speckit.specify`.** Both interactive and `--headless` spawns halt after `/speckit.specify` and wait for your explicit approval before continuing to `/speckit.plan`. The kickoff prompt tells Claude to report the generated spec path and wait for one of the phrases `"proceed"`, `"approved"`, or `"go to plan"`. Spec revisions re-enter the paused state; only an approval phrase releases it. This exists because the spec is the highest-leverage artifact — revisions applied after plan/tasks are generated force Claude to re-derive everything downstream.
+
+**Releasing a paused headless session.** For `--headless` spawns:
+
+1. Tail the claude log to confirm the pause: `tail -f ../forkprint-<issue>-<slug>/claude.log`. You should see the spec path and a notice that Claude is waiting for approval.
+2. Open the spec file (`specs/NNN-feature-name/spec.md` inside the worktree) and review it.
+3. Release the session by resuming the `claude` CLI for that worktree (e.g. `cd ../forkprint-<issue>-<slug> && claude --resume`) and replying with `"proceed"` (or request revisions, then reply `"proceed"` once satisfied).
+
+The pause is per-worktree: in a batch spawn (`for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done`) you will need to review and release each worktree independently.
+
 **Cleanup:**
 
 ```bash

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -174,7 +174,13 @@ echo "PORT=$port" >> "$WT_PATH/.env.local"
 echo "Dev server: http://localhost:$port (log: $WT_PATH/dev.log)"
 
 # 5. Launch Claude with a kickoff prompt
-KICKOFF="Work on GitHub issue #${ISSUE}. Follow CLAUDE.md (read constitution, DEVELOPMENT.md, PRODUCT.md, then run the SpecKit lifecycle: /speckit.specify, /speckit.plan, /speckit.tasks, /speckit.implement). Dev server is already running on port ${port}. When done, push the branch and open a PR; do not merge."
+KICKOFF="Work on GitHub issue #${ISSUE}. Follow CLAUDE.md (read constitution, DEVELOPMENT.md, PRODUCT.md). Run the SpecKit lifecycle in two stages with a mandatory human-in-the-loop pause in between:
+
+STAGE 1: Run /speckit.specify. When it completes, report the generated spec file path and STOP. Do NOT proceed to /speckit.plan. Wait for explicit user approval — one of the phrases \"proceed\", \"approved\", or \"go to plan\". If the user replies with spec revisions instead of an approval phrase, update the spec and re-enter the paused state (report the updated spec path and wait again). Only an explicit approval phrase releases the pause.
+
+STAGE 2: After approval, run /speckit.plan, then /speckit.tasks, then /speckit.implement in sequence. When done, push the branch and open a PR; do not merge.
+
+Dev server is already running on port ${port}."
 
 cd "$WT_PATH"
 if (( HEADLESS )); then

--- a/specs/235-speckit-specify-pause/plan.md
+++ b/specs/235-speckit-specify-pause/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Workflow Pause After /speckit.specify
+
+**Branch**: `235-workflow-pause-after-speckit-specify-for` | **Date**: 2026-04-15 | **Spec**: `specs/235-speckit-specify-pause/spec.md`
+**Input**: Feature specification from `/specs/235-speckit-specify-pause/spec.md`
+
+## Summary
+
+Insert a mandatory human-in-the-loop pause after `/speckit.specify` and before `/speckit.plan` in the RepoPulse SpecKit workflow. The change is purely documentation/prompting — no runtime code, no product surface, no tests. Three files are updated: the kickoff prompt string in `scripts/claude-worktree.sh`, the Feature Selection Order section in `CLAUDE.md`, and the headless-release guidance in `docs/DEVELOPMENT.md`.
+
+## Technical Context
+
+**Language/Version**: N/A — documentation and shell-string change only.
+**Primary Dependencies**: None. Edits are confined to three plain-text files.
+**Storage**: N/A.
+**Testing**: Manual verification — spawn an interactive and a headless worktree; confirm Claude halts after `/speckit.specify`. No automated test layer (Vitest/Playwright) applies to prompt strings.
+**Target Platform**: Developer workstation running `scripts/claude-worktree.sh` on macOS/Linux.
+**Project Type**: Repository-level workflow change; not a Phase 1/2/3 product feature.
+**Performance Goals**: N/A.
+**Constraints**: The kickoff prompt must remain a single `KICKOFF` bash string. Approval phrases must be listed explicitly so Claude does not have to guess.
+**Scale/Scope**: Three files touched, zero new files, zero code paths added.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Reviewed `.specify/memory/constitution.md` v1.2. This change touches no product surface. Relevant gates:
+
+- **I. Technology Stack**: No new tech introduced. Pass.
+- **II. Accuracy Policy**: No metrics or data surfaces affected. Pass.
+- **III. Data Source Rules**: No API calls. Pass.
+- **IV. Analyzer Module Boundary**: No analyzer code touched. Pass.
+- **V. CHAOSS Alignment**: No scoring surface touched. Pass.
+- **IX. Feature Scope Rules** (YAGNI / Keep It Simple): Implementation is the smallest documentation change that satisfies the spec — three file edits, no helper flags, no secondary pause. Pass.
+- **XI. Testing**: No code added, so no TDD obligation. Manual verification documented in the PR Test Plan per §XIII.3. Pass.
+- **XII. Definition of Done**: PR Test Plan signoff required; README unchanged (no user-facing behaviour). Pass.
+- **XIII. Development Workflow**: Change happens on a feature branch, PR will carry a `## Test plan` section, `docs/DEVELOPMENT.md` is updated as part of the deliverable. Pass.
+- **"On Ambiguity → stop and ask"** (`CLAUDE.md`): This change operationalises that principle at the most load-bearing point in the SpecKit loop. Reinforces the constitution rather than challenging it.
+
+**Result**: All gates pass. No complexity deviations to track.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/235-speckit-specify-pause/
+├── spec.md                 # /speckit.specify output (done)
+├── plan.md                 # This file (/speckit.plan output)
+└── tasks.md                # /speckit.tasks output (next)
+```
+
+No `research.md`, `data-model.md`, `contracts/`, or `quickstart.md` — this feature has no unknowns, no entities, no external interfaces, and no runnable surface to demo.
+
+### Source (repository root)
+
+Three files touched; no new directories.
+
+```text
+scripts/claude-worktree.sh   # KICKOFF prompt string — add pause instruction + approval phrases
+CLAUDE.md                    # Feature Selection Order — document the pause as canonical
+docs/DEVELOPMENT.md          # scripts/claude-worktree.sh section — document --headless release path
+```
+
+**Structure Decision**: Repository-level workflow edit. No application code layout changes.
+
+## Phase 0 — Research
+
+No NEEDS CLARIFICATION markers in the spec. No unknown technologies or integrations. Phase 0 produces no artifact.
+
+Decisions captured inline:
+
+- **Approval phrases**: `"proceed"`, `"approved"`, `"go to plan"`. Chosen from the issue body; short, unambiguous, and already used informally in this project. Alternatives considered: a single fixed phrase (rejected — too rigid); a structured `/approve` slash command (rejected — out of scope per the spec's "no formal approval mechanism").
+- **Scope of pause**: spec-to-plan only. Plan-to-tasks pause is flagged optional in the issue; the spec marks it out of scope. Not adding it keeps the change minimal and avoids configuration surface.
+- **Headless release mechanism**: describe the existing `claude` CLI session-resume mechanism (attach and type the approval phrase, or send the follow-up message via whatever mechanism the `claude` CLI already supports). No new tooling is introduced; documentation points at existing behaviour.
+
+## Phase 1 — Design & Contracts
+
+No data entities. No contracts. No quickstart demo.
+
+Design boils down to three edit specifications:
+
+1. **`scripts/claude-worktree.sh` KICKOFF string (line ~177)**
+   - Current: single sentence instructing Claude to run the full lifecycle.
+   - New: same single-string shape, but splits the lifecycle into two stages separated by a mandatory pause. Must include (a) the halt instruction after `/speckit.specify`, (b) the explicit approval phrases that release the pause, (c) the instruction to surface the spec file path when pausing, (d) the rule that revision requests re-enter the paused state.
+
+2. **`CLAUDE.md` Feature Selection Order section**
+   - Current: 4-step SpecKit lifecycle listed in order with no intermediate checkpoint.
+   - New: insert an explicit step between `/speckit.specify` and `/speckit.plan` named "Pause for spec review". Include the rationale (human-in-the-loop at the highest-leverage artifact) and the approval phrases. This ensures the rule applies even when Claude is launched outside `claude-worktree.sh`.
+
+3. **`docs/DEVELOPMENT.md` "Spawning worktrees" subsection**
+   - Add a short paragraph under the headless spawn block explaining that headless runs halt after `/speckit.specify`, how to see the pause notice (`tail claude.log`), and how to release the session (resume via the `claude` CLI and reply with an approval phrase).
+
+Agent context file: not updated. No new technology introduced.
+
+## Re-evaluation After Phase 1
+
+Constitution gates rechecked — still pass. No violations introduced by the design.
+
+## Complexity Tracking
+
+None. No deviations.

--- a/specs/235-speckit-specify-pause/spec.md
+++ b/specs/235-speckit-specify-pause/spec.md
@@ -1,0 +1,76 @@
+# Feature Specification: Workflow Pause After /speckit.specify
+
+**Feature Branch**: `235-workflow-pause-after-speckit-specify-for`
+**Created**: 2026-04-15
+**Status**: Draft
+**Input**: GitHub issue #235 — Workflow: pause after `/speckit.specify` for manual validation before continuing the SpecKit lifecycle.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Mandatory pause after spec generation (Priority: P1)
+
+When Claude is launched via `scripts/claude-worktree.sh` (interactive or `--headless`) and runs the SpecKit lifecycle for an issue, it must halt after `/speckit.specify` completes. Claude reports the generated spec path and waits for explicit user approval before invoking `/speckit.plan`. The user reviews the spec, requests any revisions, and then types an approval phrase (e.g. "proceed", "approved", "go to plan") to release the workflow.
+
+**Why this priority**: The spec is the highest-leverage artifact and the moment where **human-in-the-loop review delivers the most value**. Specs encode intent, scope, and acceptance — judgment calls that require a human to validate before autonomous downstream work compounds on top of them. Revisions applied after plan and tasks already exist invalidate that downstream work, forcing Claude to re-derive plan and tasks against the corrected spec (as happened in the #212 session across ~7 spec revision rounds). A mandatory pause after `/speckit.specify` inserts the human checkpoint at exactly the point where it cuts the most wasted work, aligning the SpecKit loop with the constitution's "On Ambiguity → stop and ask" principle and preserving human authority over intent before Claude proceeds autonomously.
+
+**Independent Test**: Launch `scripts/claude-worktree.sh <issue>` against any issue. Confirm Claude runs `/speckit.specify`, prints the spec path, and stops — it must not invoke `/speckit.plan` until the user replies with an approval phrase.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh worktree spawned by `scripts/claude-worktree.sh`, **When** Claude completes `/speckit.specify`, **Then** Claude reports the spec file path, explicitly states it is waiting for user approval before continuing, and does not run `/speckit.plan`.
+2. **Given** Claude is paused after `/speckit.specify`, **When** the user replies with "proceed" (or "approved", or "go to plan"), **Then** Claude resumes the lifecycle starting with `/speckit.plan`.
+3. **Given** Claude is paused after `/speckit.specify`, **When** the user replies with spec revision requests instead of an approval phrase, **Then** Claude updates the spec and re-enters the paused state until an approval phrase is received.
+
+---
+
+### User Story 2 — Headless runs halt at the spec pause with a documented release path (Priority: P2)
+
+When `scripts/claude-worktree.sh --headless <issue>` is used, the spawned `claude -p` process halts at the same pause point. The repository documentation tells the user exactly how to release a paused headless session (for example, by attaching to the session, or by resuming it through the claude CLI with a follow-up message).
+
+**Why this priority**: Without explicit documentation, users batching multiple headless worktrees will not know the spec-review handoff exists, and will either wait indefinitely or discover the pause through surprise. Documenting this keeps the batch-worktree workflow tractable.
+
+**Independent Test**: Run `scripts/claude-worktree.sh --headless <issue>`. Inspect `claude.log` in the worktree: the log must show the pause notice after `/speckit.specify`, and the documentation must tell the user how to send a follow-up "proceed" message to release it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a headless worktree spawn, **When** `/speckit.specify` completes, **Then** `claude.log` records the pause notice with the spec path, and the process remains alive awaiting further input.
+2. **Given** the headless pause has been logged, **When** the user reads `docs/DEVELOPMENT.md`, **Then** they find a step-by-step description of how to release the paused session.
+
+---
+
+### Edge Cases
+
+- User replies with ambiguous feedback (not clearly an approval, not clearly a revision): Claude asks for explicit confirmation rather than guessing.
+- User asks to skip the pause for a specific run: not supported in this change; the pause is unconditional. Explicitly out of scope here — a flag-gated override can be a follow-up.
+- Spec generation completes but the spec file is empty or the command errored: Claude reports the failure and does not enter the pause state; the user handles the error path normally.
+- Secondary pause after `/speckit.plan`: optional per the issue. Treated as out of scope for this feature unless trivially additive.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `scripts/claude-worktree.sh` kickoff prompt MUST instruct Claude to halt after `/speckit.specify` and wait for explicit user approval before invoking `/speckit.plan`.
+- **FR-002**: The kickoff prompt MUST list the specific approval phrases that will release the pause (e.g. "proceed", "approved", "go to plan") so Claude recognises user intent unambiguously.
+- **FR-003**: `CLAUDE.md` Feature Selection Order MUST document the mandatory pause between `/speckit.specify` and `/speckit.plan` as part of the canonical workflow, so the rule applies even when Claude is launched outside `claude-worktree.sh`.
+- **FR-004**: Documentation (`docs/DEVELOPMENT.md`, in the `scripts/claude-worktree.sh` section) MUST describe how `--headless` worktree spawns behave at the pause point and how the user releases a paused headless session.
+- **FR-005**: The pause MUST be unconditional — it applies on every SpecKit lifecycle run launched via the kickoff prompt or documented in `CLAUDE.md`, regardless of feature size or headless mode.
+- **FR-006**: When paused, Claude MUST surface the spec file path so the user can open and review it directly without searching.
+- **FR-007**: After receiving an approval phrase, Claude MUST resume with `/speckit.plan` and continue the remaining lifecycle (`/speckit.tasks`, `/speckit.implement`) without a second mandatory pause (unless a secondary pause is explicitly added as part of this change).
+- **FR-008**: If the user provides spec revision requests during the pause, Claude MUST apply the revisions and re-enter the paused state rather than continuing to `/speckit.plan`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of worktrees spawned via `scripts/claude-worktree.sh` (interactive or headless) halt after `/speckit.specify` and wait for explicit user approval.
+- **SC-002**: The kickoff prompt and `CLAUDE.md` together contain the pause instruction — a reviewer reading either document alone can identify the pause rule without cross-referencing the other.
+- **SC-003**: `docs/DEVELOPMENT.md` documents the headless release path in a way that a user can follow without consulting the script source.
+- **SC-004**: For a feature whose spec requires revision, zero `/speckit.plan` or `/speckit.tasks` invocations occur before the revised spec is approved (measured by lifecycle command sequence in the session log).
+
+## Assumptions
+
+- The existing SpecKit command set (`/speckit.specify`, `/speckit.plan`, `/speckit.tasks`, `/speckit.implement`) remains unchanged. This feature is purely a workflow/prompting change.
+- Users launching Claude outside `scripts/claude-worktree.sh` will honour the `CLAUDE.md` documented workflow, so documenting the pause there is sufficient enforcement for the non-worktree path.
+- "Explicit user approval" is satisfied by a free-form text phrase the user types (e.g. "proceed", "approved"); a formal approval UI or multi-reviewer mechanism is out of scope.
+- A secondary pause between `/speckit.plan` and `/speckit.tasks` is not required for this release; the issue flags it as optional and only if trivially additive.
+- Existing in-flight worktrees (already past `/speckit.specify`) are unaffected by this change; the rule applies to sessions launched after the change merges.

--- a/specs/235-speckit-specify-pause/tasks.md
+++ b/specs/235-speckit-specify-pause/tasks.md
@@ -1,0 +1,60 @@
+# Tasks: Workflow Pause After /speckit.specify
+
+**Feature**: 235-workflow-pause-after-speckit-specify-for
+**Spec**: `specs/235-speckit-specify-pause/spec.md`
+**Plan**: `specs/235-speckit-specify-pause/plan.md`
+
+## Overview
+
+Documentation-and-prompt-string change. Three files are touched. No code, no tests, no migrations. Manual verification replaces automated testing per the plan.
+
+## Phase 1: Setup
+
+None. No project scaffolding required.
+
+## Phase 2: Foundational
+
+None. No shared prerequisites.
+
+## Phase 3: User Story 1 — Mandatory pause after spec generation (P1)
+
+**Goal**: Every SpecKit lifecycle run halts after `/speckit.specify` and requires explicit user approval before `/speckit.plan`.
+
+**Independent test**: Launch `scripts/claude-worktree.sh <issue>` against any open issue. Claude must generate the spec, surface the spec path, and stop. Typing "proceed" must release it.
+
+- [X] T001 [US1] Update the `KICKOFF` prompt string in `scripts/claude-worktree.sh` (the `KICKOFF="..."` assignment near line 177) so Claude is instructed to (a) run `/speckit.specify` first, (b) halt and report the spec file path, (c) wait for an explicit approval phrase from the set {"proceed", "approved", "go to plan"} before running `/speckit.plan`, (d) apply any revision requests and re-enter the paused state rather than continuing, (e) after approval, run `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` in sequence, then push and open a PR without merging.
+- [X] T002 [US1] Update the "Feature Selection Order" section in `CLAUDE.md` to insert an explicit "Pause for spec review" step between `/speckit.specify` and `/speckit.plan`. Include the approval phrases and a one-line rationale ("human-in-the-loop at the highest-leverage artifact — the spec encodes intent and must be validated before autonomous downstream work compounds on top of it").
+
+## Phase 4: User Story 2 — Headless release path documented (P2)
+
+**Goal**: A user running `--headless` worktrees can find, in `docs/DEVELOPMENT.md`, how the pause surfaces in `claude.log` and how to release the paused session.
+
+**Independent test**: A new user reads `docs/DEVELOPMENT.md`, spawns `scripts/claude-worktree.sh --headless <issue>`, and follows the documented steps end-to-end without opening the script source.
+
+- [X] T003 [US2] Extend the "Spawning worktrees with `scripts/claude-worktree.sh`" subsection of `docs/DEVELOPMENT.md` to document: (a) that headless runs halt after `/speckit.specify`, (b) how to observe the pause (`tail -f claude.log` in the worktree), (c) how to release the paused session by resuming the `claude` CLI session for that worktree and replying with an approval phrase, (d) that the pause applies per worktree, so batch spawns require a release per worktree.
+
+## Phase 5: Polish
+
+- [ ] T004 Manual verification — interactive: spawn a disposable test worktree via `scripts/claude-worktree.sh` against a test issue, confirm Claude halts after `/speckit.specify`, confirm "proceed" releases it, confirm revision requests re-enter the paused state. Clean up the test worktree afterwards.
+- [ ] T005 Manual verification — headless: spawn `scripts/claude-worktree.sh --headless <issue>`, confirm `claude.log` records the pause notice with the spec path, confirm the process remains alive, confirm the documented release steps work end-to-end. Clean up afterwards.
+- [ ] T006 Populate the PR `## Test plan` section with the manual verification steps from T004 and T005 so they are signed off before merge per constitution §XIII.3.
+
+## Dependencies
+
+- T001 and T002 can be authored in parallel but must both land together (either source instructs Claude; divergence is a bug).
+- T003 can be authored in parallel with T001/T002.
+- T004 depends on T001 being merged (or running against the edited worktree script).
+- T005 depends on T001 + T003.
+- T006 is the final step before PR merge.
+
+## Parallel Opportunities
+
+- T001, T002, T003 are edits to three distinct files with no logical ordering between them. All three can be drafted in a single pass.
+
+## MVP Scope
+
+US1 alone is the MVP — the pause itself. US2 (headless documentation) is a usability polish that is trivially additive and ships in the same PR because the deliverable list in the issue explicitly includes it.
+
+## Format Validation
+
+All tasks use the `- [ ] Tnnn [P?] [USn?] description with path` form. Setup/Foundational/Polish phases carry no `[USn]` label. File paths are named explicitly in every task.


### PR DESCRIPTION
## Summary

- Insert a mandatory human-in-the-loop pause after `/speckit.specify` and before `/speckit.plan`. Claude reports the generated spec path and waits for an explicit approval phrase (`"proceed"`, `"approved"`, or `"go to plan"`) before continuing.
- Rationale: the spec is the highest-leverage artifact. Revisions after plan/tasks already exist invalidate downstream work (the #212 session went through ~7 spec revision rounds). The pause moves the human checkpoint to the point where it prevents the most re-derivation.
- Three files changed: `scripts/claude-worktree.sh` (kickoff prompt), `CLAUDE.md` (Feature Selection Order), `docs/DEVELOPMENT.md` (`--headless` release guidance).

Closes #235.

## Test plan

- [x] **Interactive spawn**: run `scripts/claude-worktree.sh <test-issue>` against a disposable issue. Confirm Claude runs `/speckit.specify`, reports the spec path, and stops. Confirm `/speckit.plan` is NOT invoked until "proceed" is typed.
- [x] **Approval phrase release**: from the paused state, reply `"proceed"`. Confirm Claude resumes with `/speckit.plan`.
- [x] **Revision re-pause**: from the paused state, ask for a spec revision. Confirm Claude applies it and re-enters the paused state rather than continuing.
- [x] **Headless spawn** (validated post-merge, with #238 permission workaround): ran `scripts/claude-worktree.sh --headless 238`, resumed the session via `claude --resume <uuid>`, approved the script permission, confirmed Claude halted after `/speckit.specify` with the spec path and pause notice.
- [x] **Headless release** (validated post-merge): replied `proceed` in the resumed session; Claude moved to `/speckit.plan`.
- [x] **CLAUDE.md standalone**: open `CLAUDE.md` in isolation — the Feature Selection Order section alone makes the pause rule clear without cross-referencing `scripts/claude-worktree.sh`.
- [x] Clean up any disposable test worktrees (`scripts/claude-worktree.sh --remove <issue>`) — done for the #238 test worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)