### PR TITLE
Add --help flag to scripts/claude-worktree.sh (#240)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -124,6 +124,8 @@ See issue #207 for the full rationale and constitution discussion.
 
 `scripts/claude-worktree.sh` automates the parallel-worktree workflow: it provisions an isolated git worktree per issue, picks a free dev-server port, copies `.env.local` (so `DEV_GITHUB_PAT` flows through), starts `next dev`, and launches Claude with a kickoff prompt pointing at the issue.
 
+Run `scripts/claude-worktree.sh --help` for the canonical usage reference.
+
 **Spawn:**
 
 ```bash

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -1,28 +1,42 @@
 #!/usr/bin/env bash
 # Provision an isolated Claude worktree for an issue and launch Claude in it.
-#
-# Usage:
-#   scripts/claude-worktree.sh [--headless] <issue-number> [slug]
-#   scripts/claude-worktree.sh 210                      # slug auto-derived from issue title via gh
-#   scripts/claude-worktree.sh 210 feature-x            # slug explicit
-#   scripts/claude-worktree.sh --headless 210
-#
-# What it does:
-#   1. Creates ../forkprint-<issue>-<slug> as a git worktree on a new branch
-#   2. Picks the next free port >= 3010 and writes it to .env.local as PORT
-#   3. Runs npm install in the worktree
-#   4. Starts `npm run dev` on that port in the background (log -> dev.log)
-#   5. Launches `claude` with a kickoff prompt pointing at the issue
-#      (interactive by default; --headless runs `claude -p` in background -> claude.log)
-#
-# Batch example (headless):
-#   for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i" auto; done
-#
-# Cleanup:
-#   scripts/claude-worktree.sh --remove <issue-number>          # discard worktree (works on unmerged work)
-#   scripts/claude-worktree.sh --cleanup-merged <issue-number>  # post-merge: pull main + remove worktree + delete branch
+# Run `scripts/claude-worktree.sh --help` for usage.
 
 set -euo pipefail
+
+print_usage() {
+  cat <<'EOF'
+Provision an isolated Claude worktree for an issue and launch Claude in it.
+
+Usage:
+  scripts/claude-worktree.sh [--headless] <issue-number> [slug]
+  scripts/claude-worktree.sh --remove <issue-number>
+  scripts/claude-worktree.sh --cleanup-merged <issue-number>
+
+Options:
+  --headless          Run claude -p in background (log -> claude.log)
+  --remove            Discard worktree (works on unmerged work)
+  --cleanup-merged    Post-merge: pull main, remove worktree, delete branch
+  -h, --help          Show this help and exit
+
+Behavior:
+  1. Creates ../forkprint-<issue>-<slug> as a git worktree on a new branch
+     (slug auto-derived from the issue title via gh when omitted).
+  2. Picks the next free port >= 3010 and writes it to .env.local as PORT.
+  3. Runs npm install in the worktree.
+  4. Starts `npm run dev` on that port in the background (log -> dev.log).
+  5. Launches `claude` with a kickoff prompt pointing at the issue
+     (interactive by default; --headless runs `claude -p` -> claude.log).
+
+Batch example (headless):
+  for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  print_usage
+  exit 0
+fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 PARENT_DIR="$(dirname "$REPO_ROOT")"


### PR DESCRIPTION
## Summary
- Add `--help` / `-h` that prints the usage block and exits 0, handled before `--remove` / `--cleanup-merged` / `--headless`
- Collapse the duplicated header comment — usage text now lives in a single `print_usage` heredoc (single source of truth)
- Point `docs/DEVELOPMENT.md` at `scripts/claude-worktree.sh --help` as the canonical usage reference

Closes #240.

## Test plan
- [x] `scripts/claude-worktree.sh --help` prints usage and exits 0
- [x] `scripts/claude-worktree.sh -h` prints the same usage and exits 0
- [x] `scripts/claude-worktree.sh --remove <issue>` still works (help branch doesn't shadow it)
- [x] `scripts/claude-worktree.sh --cleanup-merged <issue>` still works
- [x] `scripts/claude-worktree.sh --headless <issue>` still works
- [x] `docs/DEVELOPMENT.md` references `--help` as the canonical usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)