### PR TITLE
Revert throwaway test PRs #244 and #245

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,3 @@ We welcome contributions! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup ins
 <p align="center">
   <a href="https://repopulse-arun-gupta.vercel.app"><strong>Try RepoPulse now →</strong></a>
 </p>
-// throwaway test for PR #243 scenario B/D

--- a/README.md
+++ b/README.md
@@ -105,4 +105,3 @@ We welcome contributions! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup ins
   <a href="https://repopulse-arun-gupta.vercel.app"><strong>Try RepoPulse now →</strong></a>
 </p>
 // throwaway test for PR #243 scenario B/D
-// throwaway test for PR #243 scenario A


### PR DESCRIPTION
Reverts the two throwaway PRs (#244, #245) that were created to validate scripts/claude-worktree.sh --cleanup-merged behavior for PR #243. They were accidentally left in main's history; this PR removes the throwaway README lines.

## Summary

- Reverts #245 (squash-merged throwaway).
- Reverts #244 (merge-commit throwaway).

## Test plan

- [X] `tail -3 README.md` on the cleanup branch shows only the original footer lines, no throwaway comments. *(Verified via `git show origin/cleanup-throwaway-pr-243-tests:README.md | tail -3`.)*
- [X] `git log --oneline` on the cleanup branch shows the two revert commits on top of the throwaway commits. *(Verified: `ffa9981 Revert "Merge pull request #244 ..."` and `fcd5c38 Revert "throwaway: test scenario A for PR #243 (#245)"` sit on top of the throwaway commits.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)