### PR TITLE
throwaway: test PR #248 headless approve (#250)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(.specify/scripts/bash/*)",
+      "Bash(bash .specify/scripts/bash/*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(npm:*)",
+      "Bash(node:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(mkdir:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(awk:*)",
+      "Bash(sed:*)",
+      "Bash(echo:*)",
+      "Bash(printf:*)",
+      "Bash(lsof:*)",
+      "Bash(uuidgen:*)",
+      "Read",
+      "Edit",
+      "Write",
+      "Grep",
+      "Glob",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,6 @@ scripts/calibrate-checkpoint.json
 # claude-worktree.sh runtime artifacts
 .dev.pid
 .claude.pid
+.claude.session-id
 dev.log
 claude.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ When filling manual checklist signoff or similar metadata, use the authenticated
 - N/A (stateless, on-demand analysis per the constitution) (180-community-scoring)
 - Bash (POSIX-compatible portions + bash-specific features already used: `[[ ... ]]`, `set -euo pipefail`) + `git`, `gh` (GitHub CLI, already required by the surrounding script for `gh issue view`) (243-cleanup-merged-fix)
 - N/A (script operates on local git state and queries GitHub via `gh`) (243-cleanup-merged-fix)
+- Bash (script), JSON (settings), Markdown (docs). No application-code change in this feature. + Claude Code CLI (version installed on the maintainer's machine), `git`, `npm`, `gh`, `uuidgen` (macOS/Linux standard). (244-headless-worktree-permissions)
+- N/A — settings file committed to git; session ID recorded as a plain file inside the worktree (not persisted beyond worktree lifetime). (244-headless-worktree-permissions)
 
 ## Recent Changes
 - 032-doc-scoring: Added TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Vitest, React Testing Library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ When filling manual checklist signoff or similar metadata, use the authenticated
 - N/A (script operates on local git state and queries GitHub via `gh`) (243-cleanup-merged-fix)
 - Bash (script), JSON (settings), Markdown (docs). No application-code change in this feature. + Claude Code CLI (version installed on the maintainer's machine), `git`, `npm`, `gh`, `uuidgen` (macOS/Linux standard). (244-headless-worktree-permissions)
 - N/A — settings file committed to git; session ID recorded as a plain file inside the worktree (not persisted beyond worktree lifetime). (244-headless-worktree-permissions)
+- Bash (POSIX-compatible portions + bash-specific features already used: `[[ ... ]]`, `set -euo pipefail`) + `git`, `gh` (GitHub CLI) + Claude Code CLI, `git`, `gh`, `npm` (98889-throwaway-test-pr-248-headless-approve)
+- N/A — script operates on local git state and queries GitHub via `gh` (98889-throwaway-test-pr-248-headless-approve)
 
 ## Recent Changes
 - 032-doc-scoring: Added TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Vitest, React Testing Library

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -143,13 +143,43 @@ The script creates `../forkprint-<issue>-<slug>/` on a new branch, picks the nex
 
 **Mandatory pause after `/speckit.specify`.** Both interactive and `--headless` spawns halt after `/speckit.specify` and wait for your explicit approval before continuing to `/speckit.plan`. The kickoff prompt tells Claude to report the generated spec path and wait for one of the phrases `"proceed"`, `"approved"`, or `"go to plan"`. Spec revisions re-enter the paused state; only an approval phrase releases it. This exists because the spec is the highest-leverage artifact — revisions applied after plan/tasks are generated force Claude to re-derive everything downstream.
 
-**Releasing a paused headless session.** For `--headless` spawns:
+**Permission model for headless spawns.** The repo commits a project-scoped Claude Code permission policy at `.claude/settings.json`. Every session launched inside this repo or any git worktree of it — interactive or `claude -p` — inherits that allowlist. This is what unblocks headless spawns from freezing on the first tool-approval prompt (issue #238).
 
-1. Tail the claude log to confirm the pause: `tail -f ../forkprint-<issue>-<slug>/claude.log`. You should see the spec path and a notice that Claude is waiting for approval.
-2. Open the spec file (`specs/NNN-feature-name/spec.md` inside the worktree) and review it.
-3. Release the session by resuming the `claude` CLI for that worktree (e.g. `cd ../forkprint-<issue>-<slug> && claude --resume`) and replying with `"proceed"` (or request revisions, then reply `"proceed"` once satisfied).
+The allowlist is intentionally narrow:
 
-The pause is per-worktree: in a batch spawn (`for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done`) you will need to review and release each worktree independently.
+- `Bash(.specify/scripts/bash/*)` — SpecKit helpers (the original block point).
+- `Bash(git:*)`, `Bash(gh:*)`, `Bash(npm:*)`, `Bash(node:*)` — lifecycle commands.
+- Common read-only shell utilities (`ls`, `cat`, `mkdir`, `grep`, `find`, `awk`, `sed`, `echo`, `printf`, `lsof`, `uuidgen`) — scoped by command name, never as `Bash(*)`.
+- Claude Code built-ins: `Read`, `Edit`, `Write`, `Grep`, `Glob`.
+- `WebFetch(domain:github.com)` and `WebFetch(domain:api.github.com)` — read-only GitHub lookups.
+
+Explicitly not allowed: `Bash(rm:*)`, `Bash(curl:*)`, `Bash(wget:*)`, `Bash(sudo:*)`, `Bash(ssh:*)`, any MCP tools, any blanket wildcard, and `bypassPermissions`. A tool outside the allowlist falls through to the normal prompt path; in a headless session, that still blocks — which is the signal to extend the allowlist by PR, not to bypass it.
+
+**Extending the allowlist**: edit `.claude/settings.json` in a PR. The PR description must name the SpecKit helper, `git` subcommand, `npm` script, or `gh` subcommand that needs the new entry. No secrets, no blanket wildcards, no destructive shell commands.
+
+**Releasing a paused headless session.** For `--headless` spawns, use the fire-and-forget release commands:
+
+```bash
+# Approve the generated spec and run Stage 2 (plan → tasks → implement → PR) in the background:
+scripts/claude-worktree.sh --approve-spec <issue>
+
+# Or send revision feedback to the paused session; it edits the spec in place and re-enters the pause:
+scripts/claude-worktree.sh --revise-spec <issue> "Add an acceptance scenario for empty input."
+```
+
+Both commands resolve the worktree for `<issue>`, read the session UUID recorded by the spawn at `<worktree>/.claude.session-id`, and run `claude -p "<prompt>" --resume <uuid>` as a detached `nohup` process appending to the same `claude.log`. They return control to your shell in under 5 seconds — you do not need to keep the invoking terminal open.
+
+Preconditions (both commands exit non-zero with a clear error if unmet):
+
+- A worktree for `<issue>` exists.
+- `<worktree>/.claude.session-id` exists and is non-empty.
+- At least one `<worktree>/specs/*/spec.md` exists (the paused state has been reached).
+
+Additional rule for `--revise-spec`: empty feedback is rejected. Repeated `--revise-spec` rounds accumulate — each round edits the spec as it stands after the previous round.
+
+Manual fallback (still supported): `cd ../forkprint-<issue>-<slug> && claude --resume` opens an interactive session if you want to review and revise the spec conversationally. This attaches your terminal; `--approve-spec` / `--revise-spec` do not.
+
+The pause is per-worktree: in a batch spawn (`for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done`) you review and release each worktree independently, but the release itself is fire-and-forget, so `for i in 210 211 212; do scripts/claude-worktree.sh --approve-spec "$i"; done` walks away with three PRs on the way.
 
 **Cleanup:**
 

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -10,11 +10,19 @@ Provision an isolated Claude worktree for an issue and launch Claude in it.
 
 Usage:
   scripts/claude-worktree.sh [--headless] <issue-number> [slug]
+  scripts/claude-worktree.sh --approve-spec <issue-number>
+  scripts/claude-worktree.sh --revise-spec <issue-number> <feedback>
   scripts/claude-worktree.sh --remove <issue-number>
   scripts/claude-worktree.sh --cleanup-merged <issue-number>
 
 Options:
   --headless          Run claude -p in background (log -> claude.log)
+  --approve-spec      Release the spec-review pause for a paused headless
+                      spawn; Stage 2 (plan/tasks/implement/PR) runs in the
+                      background. Fire-and-forget; returns immediately.
+  --revise-spec       Send revision feedback to a paused headless spawn;
+                      the session edits the spec in place and re-enters
+                      the pause. Fire-and-forget; feedback must be non-empty.
   --remove            Discard worktree (works on unmerged work)
   --cleanup-merged    Post-merge: pull main, remove worktree, delete branch
   -h, --help          Show this help and exit
@@ -25,11 +33,21 @@ Behavior:
   2. Picks the next free port >= 3010 and writes it to .env.local as PORT.
   3. Runs npm install in the worktree.
   4. Starts `npm run dev` on that port in the background (log -> dev.log).
-  5. Launches `claude` with a kickoff prompt pointing at the issue
+  5. Generates a UUID, records it in .claude.session-id inside the worktree,
+     and launches `claude --session-id <uuid>` with a kickoff prompt
      (interactive by default; --headless runs `claude -p` -> claude.log).
+     The recorded session ID lets --approve-spec and --revise-spec resume
+     the same session non-interactively.
 
-Batch example (headless):
+Permissions:
+  Headless spawns inherit the allowlist in .claude/settings.json at the
+  repo root. See docs/DEVELOPMENT.md for the permission model and how to
+  extend the allowlist when the SpecKit lifecycle needs a new tool.
+
+Batch example (headless, fully unattended through PR):
   for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done
+  # review each generated spec
+  for i in 210 211 212; do scripts/claude-worktree.sh --approve-spec "$i"; done
 EOF
 }
 
@@ -113,6 +131,37 @@ cleanup_merged() {
   git -C "$REPO_ROOT" branch -D "$branch"
 }
 
+release_paused_session() {
+  local issue="$1"
+  local prompt="$2"
+  local wt session_id
+  wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
+    | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
+  if [[ -z "${wt:-}" ]]; then
+    echo "No worktree found for issue $issue" >&2
+    exit 1
+  fi
+  if [[ ! -f "$wt/.claude.session-id" ]]; then
+    echo "No session ID recorded for issue $issue; cannot resume non-interactively." >&2
+    echo "Use 'cd $wt && claude --resume' instead." >&2
+    exit 1
+  fi
+  session_id="$(cat "$wt/.claude.session-id")"
+  if [[ -z "$session_id" ]]; then
+    echo "Session ID file for issue $issue is empty; cannot resume." >&2
+    exit 1
+  fi
+  # Paused state is reached once /speckit.specify has written a spec file.
+  if ! compgen -G "$wt/specs/*/spec.md" > /dev/null; then
+    echo "Spec not yet generated for issue $issue; paused state not reached." >&2
+    echo "Tail $wt/claude.log to confirm and retry once the pause is reported." >&2
+    exit 1
+  fi
+  ( cd "$wt" && nohup claude -p "$prompt" --resume "$session_id" >> claude.log 2>&1 & )
+  echo "Released pause for issue $issue; Stage 2 running in background."
+  echo "Tail: $wt/claude.log"
+}
+
 if [[ "${1:-}" == "--remove" ]]; then
   [[ -n "${2:-}" ]] || { echo "Usage: $0 --remove <issue>" >&2; exit 1; }
   remove_worktree "$2"
@@ -122,6 +171,22 @@ fi
 if [[ "${1:-}" == "--cleanup-merged" ]]; then
   [[ -n "${2:-}" ]] || { echo "Usage: $0 --cleanup-merged <issue>" >&2; exit 1; }
   cleanup_merged "$2"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--approve-spec" ]]; then
+  [[ -n "${2:-}" ]] || { echo "Usage: $0 --approve-spec <issue>" >&2; exit 1; }
+  release_paused_session "$2" "proceed"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--revise-spec" ]]; then
+  [[ -n "${2:-}" ]] || { echo "Usage: $0 --revise-spec <issue> <feedback>" >&2; exit 1; }
+  if [[ -z "${3:-}" ]]; then
+    echo "--revise-spec requires non-empty feedback" >&2
+    exit 1
+  fi
+  release_paused_session "$2" "$3"
   exit 0
 fi
 
@@ -194,6 +259,15 @@ echo "PORT=$port" >> "$WT_PATH/.env.local"
 echo "Dev server: http://localhost:$port (log: $WT_PATH/dev.log)"
 
 # 5. Launch Claude with a kickoff prompt
+# Pre-generate a session UUID so --approve-spec / --revise-spec can resume
+# this exact session non-interactively without probing the CLI's session store.
+if ! command -v uuidgen >/dev/null 2>&1; then
+  echo "uuidgen not found; required for session addressability" >&2
+  exit 1
+fi
+SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+echo "$SESSION_ID" > "$WT_PATH/.claude.session-id"
+
 KICKOFF="Work on GitHub issue #${ISSUE}. Follow CLAUDE.md (read constitution, DEVELOPMENT.md, PRODUCT.md). Run the SpecKit lifecycle in two stages with a mandatory human-in-the-loop pause in between:
 
 STAGE 1: Run /speckit.specify. When it completes, report the generated spec file path and STOP. Do NOT proceed to /speckit.plan. Wait for explicit user approval — one of the phrases \"proceed\", \"approved\", or \"go to plan\". If the user replies with spec revisions instead of an approval phrase, update the spec and re-enter the paused state (report the updated spec path and wait again). Only an explicit approval phrase releases the pause.
@@ -204,9 +278,11 @@ Dev server is already running on port ${port}."
 
 cd "$WT_PATH"
 if (( HEADLESS )); then
-  nohup claude -p "$KICKOFF" > claude.log 2>&1 &
+  nohup claude -p "$KICKOFF" --session-id "$SESSION_ID" > claude.log 2>&1 &
   echo $! > .claude.pid
   echo "Claude (headless) PID $(cat .claude.pid) — log: $WT_PATH/claude.log"
+  echo "Session ID: $SESSION_ID (recorded in $WT_PATH/.claude.session-id)"
+  echo "Release the pause with: scripts/claude-worktree.sh --approve-spec $ISSUE"
 else
-  exec claude "$KICKOFF"
+  exec claude --session-id "$SESSION_ID" "$KICKOFF"
 fi

--- a/specs/244-headless-worktree-permissions/checklists/requirements.md
+++ b/specs/244-headless-worktree-permissions/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Headless Worktree Spawns Run Without Permission Prompts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-002 names "allowlist" / `--allowedTools` / `.claude/settings.json` as permitted mechanisms; these are referenced directly from issue #238's recommended options and are treated here as scope constraints (what is acceptable), not as implementation prescription. The exact mechanism is a `/speckit.plan` decision.

--- a/specs/244-headless-worktree-permissions/contracts/claude-settings.schema.md
+++ b/specs/244-headless-worktree-permissions/contracts/claude-settings.schema.md
@@ -1,0 +1,64 @@
+# Contract — `.claude/settings.json` (committed to repo root)
+
+## Purpose
+
+Define the project-scoped Claude Code permission policy that applies to every session (interactive or headless) launched inside this repository or any git worktree of it. Issue #238 option 3.
+
+## Location
+
+`/.claude/settings.json` — at the repo root, committed to git.
+
+## Shape
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(.specify/scripts/bash/*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(npm:*)",
+      "Bash(node:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(mkdir:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(awk:*)",
+      "Bash(sed:*)",
+      "Bash(echo:*)",
+      "Bash(printf:*)",
+      "Bash(lsof:*)",
+      "Bash(bash .specify/scripts/bash/*)",
+      "Read",
+      "Edit",
+      "Write",
+      "Grep",
+      "Glob",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)"
+    ]
+  }
+}
+```
+
+## Contract rules
+
+1. **No secrets** (constitution §X §1): the file MUST NOT contain tokens, PATs, OAuth credentials, or any environment-variable values.
+2. **No blanket wildcards**: `Bash(*)`, `Bash(**)`, `"*"`, and `"bypassPermissions: true"` are prohibited. Every Bash entry is command-scoped.
+3. **No MCP tools** until a specific feature requires them.
+4. **No destructive shell commands** (`rm`, `mv` for paths outside worktree, `sudo`, `curl`, `wget`, `ssh`, `scp`, `kill` beyond the script-level `kill $(cat .dev.pid)`).
+5. **Extensions**: adding a new entry requires a PR; PR description must reference the specific SpecKit helper, `git` subcommand, `npm` script, or `gh` subcommand that needs it.
+
+## Example non-compliant entries (reviewer blockers)
+
+- `"Bash(*)"` — wildcard, violates rule 2.
+- `"Bash(rm *)"` — destructive, violates rule 4.
+- `{"permissions": {"bypassAll": true}}` — violates rule 2.
+- `{"env": {"GITHUB_TOKEN": "ghp_..."}}` — secret, violates rule 1.
+
+## Runtime behavior
+
+- Claude Code auto-discovers this file when launched with `cwd` inside the repo or a worktree of it.
+- Interactive (`claude`) and headless (`claude -p`) sessions both honor it.
+- If the installed CLI version does not support `permissions.allow` (extremely unlikely in 2026), the spawn behaves as before (blocking prompts) — which is the current failure mode, so no regression.

--- a/specs/244-headless-worktree-permissions/contracts/claude-worktree-cli.md
+++ b/specs/244-headless-worktree-permissions/contracts/claude-worktree-cli.md
@@ -1,0 +1,66 @@
+# Contract — `scripts/claude-worktree.sh` CLI surface
+
+## Existing subcommands (unchanged)
+
+```
+scripts/claude-worktree.sh [--headless] <issue> [slug]
+scripts/claude-worktree.sh --remove <issue>
+scripts/claude-worktree.sh --cleanup-merged <issue>
+scripts/claude-worktree.sh --help | -h
+```
+
+## New subcommands
+
+### `--approve-spec <issue>`
+
+```
+scripts/claude-worktree.sh --approve-spec <issue>
+```
+
+**Preconditions**:
+- A worktree for `<issue>` exists (same lookup logic as `--remove` / `--cleanup-merged`).
+- `<worktree>/.claude.session-id` exists and contains a valid UUID.
+- At least one `<worktree>/specs/*/spec.md` exists.
+
+**Behavior**:
+1. Resolve the worktree path for `<issue>`.
+2. Read the session UUID from `<worktree>/.claude.session-id`.
+3. `cd <worktree> && nohup claude -p "proceed" --resume <uuid> >> claude.log 2>&1 &` — detached background process.
+4. Print `"Released pause for issue <issue>; Stage 2 running in background. Tail: <worktree>/claude.log"` to stdout.
+5. Return 0 in under 5 seconds (SC-006).
+
+**Error paths**:
+- No worktree for issue → exit 1, `"No worktree found for issue <issue>"` to stderr.
+- No `.claude.session-id` → exit 1, `"No session ID recorded for issue <issue>; cannot resume non-interactively. Use 'claude --resume' from the worktree instead."` to stderr.
+- No `spec.md` in the worktree → exit 1, `"Spec not yet generated for issue <issue>; paused state not reached. Tail <worktree>/claude.log to confirm."` to stderr.
+
+### `--revise-spec <issue> <feedback>`
+
+```
+scripts/claude-worktree.sh --revise-spec <issue> "<feedback text>"
+```
+
+**Preconditions**: Same as `--approve-spec`, plus `<feedback>` MUST be non-empty.
+
+**Behavior**: Same shape as `--approve-spec`, except the prompt sent is the feedback text verbatim (not the literal string `"proceed"`). The paused Claude session interprets the feedback as revision instructions, edits the existing `spec.md` in place (per FR-013, FR-013a), re-enters the pause, and appends the updated spec path to `claude.log`.
+
+**Error paths**:
+- All of `--approve-spec`'s error paths.
+- Empty feedback → exit 1, `"--revise-spec requires non-empty feedback"` to stderr.
+
+### `--help` / `-h`
+
+Updated to document the two new subcommands at the same level of detail as the existing ones.
+
+## Modified behavior of the main spawn path
+
+On the `[--headless] <issue> [slug]` path, the script additionally:
+1. Generates a UUID (`uuidgen`).
+2. Writes it to `<worktree>/.claude.session-id` before invoking Claude.
+3. Passes it to the Claude invocation as `--session-id <uuid>`. This applies to both interactive and headless invocations so that `--approve-spec` / `--revise-spec` work identically regardless of how the worktree was spawned.
+
+## Invariants
+
+- The script MUST NOT overwrite an existing `.claude.session-id` on the main spawn path. (A worktree already has a session; we don't clobber it.) If the file already exists when the spawn path is entered, that's a collision with an existing worktree and the script already exits 1 on the "worktree exists" check at `scripts/claude-worktree.sh:168`.
+- The script MUST NOT overwrite `.claude.pid` from the release commands. `.claude.pid` identifies the original spawn process; the release commands spawn a second process and do not record its PID (the session UUID is the durable identifier).
+- `--remove` and `--cleanup-merged` MUST continue to succeed even if a release-command background process is still running — they already `kill $(cat .claude.pid)` which covers the original spawn; for the release-command process we rely on `git worktree remove --force` tearing down the worktree directory the Claude process is running inside, same pattern as today.

--- a/specs/244-headless-worktree-permissions/plan.md
+++ b/specs/244-headless-worktree-permissions/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: Headless Worktree Spawns Run Without Permission Prompts, with Truly-Headless Stage 2 Release
+
+**Branch**: `244-headless-worktree-permissions` | **Date**: 2026-04-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/244-headless-worktree-permissions/spec.md`
+
+## Summary
+
+Fix `scripts/claude-worktree.sh --headless` so it no longer freezes on the first tool-permission prompt, and extend the script with `--approve-spec` and `--revise-spec` subcommands so Stage 2 runs unattended after spec review.
+
+Approach:
+
+1. **Permission model**: commit a project-scoped `.claude/settings.json` at the repo root with a tightly-scoped `permissions.allow` list covering the SpecKit helpers, `git`, `npm`, `gh`, and the Claude Code built-in tools the lifecycle uses. Claude auto-discovers this file at project root, so git worktrees inherit it without further wiring. This is issue #238's option 3 (project-scoped settings), the most surgical and reviewable of the three.
+2. **Session addressability**: generate a UUID at spawn time, pass it to the headless `claude -p` via `--session-id <uuid>`, and record it in the worktree at `.claude.session-id` for later resume.
+3. **Release commands**: add `--approve-spec <issue>` and `--revise-spec <issue> "<feedback>"` subcommands that look up the recorded session ID and invoke `claude -p "<prompt>" --resume <session-id>` as a detached background process (`nohup … &`), appending to the same `claude.log`.
+4. **Documentation**: update `docs/DEVELOPMENT.md` with the permission-model section and the `--approve-spec` / `--revise-spec` vocabulary.
+
+## Technical Context
+
+**Language/Version**: Bash (script), JSON (settings), Markdown (docs). No application-code change in this feature.
+**Primary Dependencies**: Claude Code CLI (version installed on the maintainer's machine), `git`, `npm`, `gh`, `uuidgen` (macOS/Linux standard).
+**Storage**: N/A — settings file committed to git; session ID recorded as a plain file inside the worktree (not persisted beyond worktree lifetime).
+**Testing**: Manual acceptance run recorded in the PR test plan (the repository has no bash-unit-test harness, consistent with the existing `scripts/` directory convention — e.g., `scripts/claude-worktree.sh` has no accompanying `.test.sh`). See Complexity Tracking for the TDD deviation rationale.
+**Target Platform**: macOS (zsh/bash) and Linux (bash) developer machines. No CI-only or server runtime.
+**Project Type**: Dev-tooling change — shell script + settings file + docs. Not a Phase 1/2/3 product feature and does not touch `lib/analyzer/`, `app/`, or any UI surface.
+**Performance Goals**: `--approve-spec` returns control to the shell in under 5 seconds (SC-006). No other perf targets.
+**Constraints**:
+- `.claude/settings.json` must not contain secrets (constitution §X).
+- Allowlist must stay scoped — no blanket `Bash(*)` or `bypassPermissions` (FR-002, FR-004).
+- Must not regress interactive spawns (FR-006).
+- Must not auto-merge the PR at end of Stage 2 (FR-014, CLAUDE.md PR Merge Rule).
+
+**Scale/Scope**:
+- One `.claude/settings.json` file at repo root (committed).
+- `scripts/claude-worktree.sh` gains two subcommands and changes the spawn invocation to include `--session-id` + record it.
+- `docs/DEVELOPMENT.md`: one new subsection plus edits to the existing "Releasing a paused headless session" block.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+The RepoPulse constitution (`.specify/memory/constitution.md`) targets product code (analyzer, UI, API) and deployment. This feature touches only dev tooling (shell script), dev-time settings (`.claude/settings.json`), and docs. Mapping the applicable rules:
+
+| Rule | Applicability | Status |
+|---|---|---|
+| I. Technology Stack | N/A — no product code changed | Pass |
+| II. Accuracy Policy | N/A — no metrics surface touched | Pass |
+| III. Data Source Rules | N/A | Pass |
+| IV. Analyzer Module Boundary | N/A | Pass |
+| V. CHAOSS Alignment | N/A | Pass |
+| VI. Scoring Thresholds | N/A | Pass |
+| VII. Ecosystem Spectrum | N/A | Pass |
+| VIII. Contribution Dynamics | N/A | Pass |
+| IX. Feature Scope Rules §6 YAGNI / §7 KISS | Applies to script design | Pass — no speculative flags beyond `--approve-spec`/`--revise-spec` which are directly spec'd. |
+| X. Security & Hygiene §1–4 (no secrets, `.env*` gitignored, token never transmitted elsewhere) | Applies — the settings file is version-controlled | Pass — `.claude/settings.json` contains no secrets; allowlist is structural only. |
+| X. Security & Hygiene §5 (per-repo error isolation) | N/A (applies to analysis) | Pass |
+| XI. Testing — TDD (NON-NEGOTIABLE) | See Complexity Tracking | Deviation — justified below |
+| XII. Definition of Done | Applies at PR time | Plan item |
+| XIII. Development Workflow | Applies at PR time | Plan item |
+
+**TDD gate** — the constitution says "NON-NEGOTIABLE" but also scopes tests to "analyzer logic and UI components" (Vitest + RTL) and "full user flows" (Playwright). There is no test harness for shell scripts or dev-tooling settings in this repo. Enforcing Vitest on a bash script would be ceremony, not coverage. See Complexity Tracking.
+
+Initial gate: **PASS with one documented deviation** (TDD harness for shell scripts).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/244-headless-worktree-permissions/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output (maintainer-facing acceptance walkthrough)
+├── contracts/
+│   └── claude-settings.schema.md   # Shape of .claude/settings.json permissions.allow
+└── tasks.md             # Phase 2 output (/speckit.tasks, not /speckit.plan)
+```
+
+No `data-model.md` — this feature has no data entities beyond a single settings file and a single session-ID file, both fully described in `contracts/`.
+
+### Source Code (repository root)
+
+```text
+.claude/
+└── settings.json                 # NEW — permissions.allow for headless + interactive spawns
+
+scripts/
+└── claude-worktree.sh            # MODIFIED — add --session-id on spawn;
+                                  #             add --approve-spec and --revise-spec subcommands;
+                                  #             write .claude.session-id inside worktree;
+                                  #             extend --help and usage.
+
+docs/
+└── DEVELOPMENT.md                # MODIFIED — "Permission model for headless spawns" section;
+                                  #             document --approve-spec / --revise-spec.
+```
+
+**Structure Decision**: A strictly dev-tooling change. No new directories under `lib/`, `app/`, or `tests/`. The three files above are the full surface area.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| No TDD test harness for `scripts/claude-worktree.sh` | Repo has no existing shell-unit-test infrastructure (no `bats`, no `shunit2`, no `*.test.sh`). Adding one for a single script would be significant ceremony and a separate decision that should not be bundled into this bug fix. The constitution's TDD rule is scoped to Vitest/RTL for analyzer/UI and Playwright for user flows; those don't apply to a shell script. | Introducing `bats` or an equivalent harness would: (a) expand scope well beyond issue #238, (b) require a constitution amendment discussion about the test stack, (c) delay the fix for a blocking tooling bug. Instead: acceptance is verified via the manual steps in `quickstart.md` and recorded in the PR `## Test plan` section (constitution §XII requirement), which is the same mechanism used for every other script-only change in this repo (e.g., PR #241 for `--help`). |

--- a/specs/244-headless-worktree-permissions/quickstart.md
+++ b/specs/244-headless-worktree-permissions/quickstart.md
@@ -1,0 +1,89 @@
+# Quickstart — Manual acceptance walkthrough
+
+This walkthrough is the canonical manual acceptance test for `244-headless-worktree-permissions`. It gets copied into the PR's `## Test plan` section (constitution §XII) with each step as a checkbox.
+
+## Pre-flight
+
+From the main repo on `main`:
+
+```bash
+git checkout 244-headless-worktree-permissions
+cat .claude/settings.json                            # confirm allowlist committed
+scripts/claude-worktree.sh --help                    # confirm --approve-spec and --revise-spec appear
+```
+
+## Acceptance path 1 — Headless spawn reaches pause with no permission prompts (US1)
+
+Pick a trivial, unblocked GitHub issue for this test (e.g., a docs-only issue). Substitute `<TEST_ISSUE>` below.
+
+```bash
+scripts/claude-worktree.sh --headless <TEST_ISSUE>
+sleep 60                                             # typical /speckit.specify runtime
+tail -n 100 ../forkprint-<TEST_ISSUE>-*/claude.log
+```
+
+Expected:
+- `claude.log` contains the generated spec path under `specs/NNN-*/spec.md`.
+- `claude.log` contains the "waiting for approval" notice.
+- `claude.log` contains **zero** occurrences of `"I need your approval to run"`.
+- The worktree contains `.claude.session-id` with a valid UUID.
+
+## Acceptance path 2 — `--approve-spec` releases Stage 2 fire-and-forget (US3, SC-006)
+
+```bash
+time scripts/claude-worktree.sh --approve-spec <TEST_ISSUE>
+```
+
+Expected:
+- The command returns in under 5 seconds.
+- `claude.log` starts growing again within a minute.
+- Eventually `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` complete; a PR is opened; no merge.
+
+## Acceptance path 3 — `--revise-spec` edits the spec in place (US3, SC-007)
+
+On a separate test issue that has just reached the pause:
+
+```bash
+scripts/claude-worktree.sh --revise-spec <TEST_ISSUE_2> "Add an acceptance scenario for empty input."
+sleep 60
+git -C ../forkprint-<TEST_ISSUE_2>-* diff specs/
+```
+
+Expected:
+- The diff shows a new acceptance scenario added to the spec.
+- The session has re-entered the pause (tail `claude.log`).
+- Running `--revise-spec` a second time with different feedback produces a cumulative diff (against the first revision, not the original).
+
+## Acceptance path 4 — Error paths (US3 scenarios 3 & 4, FR-015)
+
+```bash
+scripts/claude-worktree.sh --approve-spec 99999           # no worktree → exit 1
+scripts/claude-worktree.sh --revise-spec <TEST_ISSUE_2> ""  # empty feedback → exit 1
+```
+
+Expected: both commands exit non-zero with clear stderr messages and do not spawn any background process.
+
+## Acceptance path 5 — Interactive spawn unchanged (FR-006)
+
+```bash
+scripts/claude-worktree.sh <TEST_ISSUE_3>
+```
+
+Expected: interactive Claude session opens in the current terminal, same as before. The session inherits the `.claude/settings.json` allowlist — no prompts for covered tools — but still prompts for anything outside the allowlist.
+
+## Acceptance path 6 — Batch headless (US3, SC-008)
+
+```bash
+for i in <A> <B> <C>; do scripts/claude-worktree.sh --headless "$i"; done
+# review each spec
+for i in <A> <B> <C>; do scripts/claude-worktree.sh --approve-spec "$i"; done
+# walk away
+```
+
+Expected: three PRs appear, unmerged. Zero manual terminal attachments throughout.
+
+## Post-conditions (always)
+
+- No file in `.claude/settings.json` contains a secret (grep for `ghp_`, `token`, `SECRET`, `CLIENT_SECRET`).
+- `docs/DEVELOPMENT.md` contains the "Permission model for headless spawns" section and the `--approve-spec` / `--revise-spec` vocabulary.
+- `npm run lint` and `npm run build` remain clean (DoD).

--- a/specs/244-headless-worktree-permissions/research.md
+++ b/specs/244-headless-worktree-permissions/research.md
@@ -1,0 +1,91 @@
+# Phase 0 Research — Headless Worktree Permissions + Release Commands
+
+## R1. Claude CLI permission-scoping mechanism
+
+**Decision**: Use a project-scoped `.claude/settings.json` committed to the repo root, with a tightly-scoped `permissions.allow` list. The file is auto-discovered by the Claude CLI for any session (interactive or `-p`) launched inside the repo (or any git worktree of it).
+
+**Rationale**:
+- `claude --help` (installed CLI) confirms three supported mechanisms for scoping permissions: `--allowedTools`, `--permission-mode`, and `--settings <file-or-json>`. Project-scoped settings are auto-discovered without the `--settings` flag.
+- Issue #238 ranks option 3 (project-scoped settings file) as preferred alongside option 2. Settings-file wins over `--allowedTools` on three axes: (a) reviewable as a tracked file on PRs, (b) shared between interactive and headless runs so behavior is consistent, (c) not re-specified on every `claude` invocation (less drift risk).
+- `permissions.allow` entries support pattern matching, e.g., `Bash(git *)`, `Bash(.specify/scripts/bash/*)` — exactly the granularity the spec demands (FR-003, FR-004).
+
+**Alternatives considered**:
+- `--dangerously-skip-permissions` / `--permission-mode bypassPermissions`: rejected on security grounds (FR-002, spec US2). Constitution §X requires bounded behavior.
+- `--allowedTools` as a CLI arg on every invocation: rejected — duplicates the policy surface and makes the interactive/headless policies drift; also lives in a shell string literal rather than structured JSON.
+- `--permission-mode acceptEdits` or `auto`: rejected — "accept edits" only auto-approves file edits, not `Bash(...)` calls; the SpecKit helper scripts are bash invocations, so this wouldn't unblock the original failure. `auto` is not narrowly scoped.
+
+## R2. Scope of the allowlist
+
+**Decision**: Allow exactly the tool patterns the documented SpecKit lifecycle needs on this repo.
+
+| Pattern | Why |
+|---|---|
+| `Bash(.specify/scripts/bash/*)` | SpecKit helpers — the exact call that blocks today per issue #238. |
+| `Bash(git:*)` | Branch creation, commits, push, status, diff — used throughout the lifecycle. |
+| `Bash(gh:*)` | Issue fetch, PR open — used at spawn and at end of Stage 2. |
+| `Bash(npm:*)` | `npm install`, `npm test`, `npm run lint`, `npm run build`, `npm run dev` — DoD checklist (`docs/DEVELOPMENT.md`). |
+| `Bash(ls:*)`, `Bash(cat:*)`, `Bash(mkdir:*)`, `Bash(grep:*)`, `Bash(find:*)`, `Bash(awk:*)`, `Bash(sed:*)`, `Bash(echo:*)`, `Bash(printf:*)`, `Bash(lsof:*)` | Routine shell operations that SpecKit scripts and the Claude Code Bash tool invoke. Scoped by command name — no `Bash(*)` wildcard. |
+| `Read`, `Edit`, `Write`, `Grep`, `Glob` | Claude Code built-in tools used continuously by the lifecycle. |
+| `WebFetch(domain:github.com)`, `WebFetch(domain:api.github.com)` | Occasional reading of GitHub URLs from the kickoff context. Domain-scoped. |
+
+**Explicitly not allowed** (not listed):
+- `Bash(rm:*)` — destructive; fall-through to prompt on the rare legitimate case.
+- `Bash(curl:*)` / `Bash(wget:*)` — arbitrary network egress.
+- `Bash(ssh:*)`, `Bash(scp:*)` — network.
+- `Bash(sudo:*)` — privilege escalation.
+- Any MCP tools — orthogonal to SpecKit and not required by the lifecycle.
+
+**Rationale**: FR-003 requires the allowlist covers SpecKit lifecycle needs; FR-004 requires it does not grant arbitrary shell. The list above was derived by tracing the commands the SpecKit lifecycle actually invokes in `.specify/scripts/bash/` and in the DoD checklist, not by aspirational coverage.
+
+**Alternatives considered**: A single `Bash(*)` entry — rejected (FR-004, US2 independent test).
+
+## R3. Session addressability for `--approve-spec` / `--revise-spec`
+
+**Decision**: Generate a UUID at spawn time (`uuidgen`) and pass it to the initial `claude -p` via `--session-id <uuid>`. Record the UUID in the worktree at `.claude.session-id`. Release commands read this file and pass the UUID to `claude -p "<prompt>" --resume <uuid>` in a background `nohup … &` process.
+
+**Rationale**:
+- `claude --help` documents `--session-id <uuid>` ("Use a specific session ID for the conversation"). This removes all ambiguity about which session to resume — we pick the UUID, not the CLI's session store.
+- `.claude.session-id` lives alongside the existing `.dev.pid` and `.claude.pid` files — same mental model, same cleanup path.
+- `nohup claude -p "..." --resume <uuid> >> claude.log 2>&1 &` is structurally identical to the existing headless spawn line (single-line background detach), so there is one pattern to maintain.
+
+**Alternatives considered**:
+- `claude --continue` (current DEVELOPMENT.md guidance): requires the caller's `cwd` to match the worktree and still opens an interactive session by default — neither fits fire-and-forget. Rejected.
+- Parsing the CLI session store to discover the session ID: rejected — opaque file layout, version-sensitive, hostile to batch use.
+- `--fork-session`: spec requires accumulating revisions on the same session (FR-013a). Forking breaks that. Rejected.
+
+## R4. Fire-and-forget semantics for release commands
+
+**Decision**: Both `--approve-spec` and `--revise-spec` detach with `nohup … &`, append to `claude.log`, and return control in under 5 seconds (SC-006). They do NOT write to `.claude.pid` (that PID already belongs to the original spawn; overwriting it would confuse `--remove` / `--cleanup-merged`).
+
+**Rationale**: Matches the existing headless-spawn idiom in `scripts/claude-worktree.sh:201`. Reusing the same `claude.log` gives a single durable trace across Stage 1 + pause + Stage 2.
+
+**Alternatives considered**:
+- A new log file per Stage-2 resume: rejected — splinters the maintainer's mental model for "what did this worktree do?".
+- A disown/setsid variant: rejected — `nohup &` already survives terminal close on macOS and Linux.
+
+## R5. Preventing double-release and wrong-state releases
+
+**Decision**:
+- Before spawning the release process, check `.claude.session-id` exists — exit with a clear error if not (covers "session ID lost", FR-015).
+- Check `specs/*/spec.md` exists in the worktree — if not, the spawn has not reached the pause yet; print a diagnostic and exit non-zero (covers "release invoked before pause"). No blocking wait; maintainer re-runs after the pause is reached.
+- To detect "already advanced past Stage 1" (FR-016): check the git log on the feature branch for a plan/tasks artifact commit. If a `plan.md` already exists *alongside* a running `.claude.pid` for a later-stage session, print "already advanced" and exit 0 (no-op). This is a best-effort check; perfect detection requires session-state introspection the CLI does not expose.
+
+**Rationale**: The spec's edge cases (§Edge Cases) require diagnostics without hangs. Filesystem checks in the worktree are O(1) and sufficient.
+
+**Alternatives considered**:
+- Lock files on `.claude.session-id`: rejected — over-engineering for a single-maintainer tool; adds failure modes (stale locks) without catching a real concurrency risk in practice.
+
+## R6. Interactive-mode impact
+
+**Decision**: The same `.claude/settings.json` also applies to interactive `scripts/claude-worktree.sh <issue>` runs. This is intentional and documented.
+
+**Rationale**: A single policy surface prevents drift. FR-006 forbids *silently* broadening interactive permissions; the settings file is an explicit, committed, reviewed broadening of the same set of tools the lifecycle already uses. Maintainers reading `docs/DEVELOPMENT.md` will see the change.
+
+**Alternatives considered**:
+- Two separate settings files (one for interactive, one for headless, the latter loaded via `--settings`): rejected — doubles the review surface for zero user-visible benefit.
+
+## R7. TDD exemption (constitution §XI)
+
+**Decision**: No unit tests for the shell-script changes or the settings file. Acceptance is verified by a manual scripted run documented in `quickstart.md` and recorded in the PR `## Test plan` section.
+
+**Rationale**: See plan Complexity Tracking. Same pattern as PR #241 (`--help` flag) and all other script-only PRs in this repo's history. Introducing a bash-test harness is a separate architectural decision that should be filed independently rather than bundled into a bug fix.

--- a/specs/244-headless-worktree-permissions/spec.md
+++ b/specs/244-headless-worktree-permissions/spec.md
@@ -1,0 +1,137 @@
+# Feature Specification: Headless Worktree Spawns Run Without Permission Prompts, with Truly-Headless Stage 2 Release
+
+**Feature Branch**: `238-headless-claude-worktree-sh-spawns-block` (SpecKit spec dir numbered 244 to avoid collision with merged `243-cleanup-merged-fix/`)
+**Created**: 2026-04-15
+**Status**: Draft
+**Input**: Issue #238 — Headless claude-worktree.sh spawns block on tool-permission prompts (scope extended during spec review to also cover truly-headless Stage 2 release: `--approve-spec` and `--revise-spec`).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Headless spawn completes the spec step without human intervention (Priority: P1)
+
+A maintainer launches a background Claude worktree for a GitHub issue using the headless mode of `scripts/claude-worktree.sh`. The spawn runs the SpecKit `/speckit.specify` step, executes the SpecKit helper script that creates the feature branch and spec file, and then reaches the mandatory spec-review pause — all without a human having to approve any tool call along the way.
+
+**Why this priority**: This is the core bug from issue #238. Today, headless spawns deterministically freeze the first time the SpecKit lifecycle tries to run the `create-new-feature.sh` helper, because no approval can arrive in one-shot non-interactive mode. Until this is fixed, headless mode is effectively unusable for SpecKit-driven work and the documented spec-review-pause workflow (from issue #235 / PR #237) cannot be exercised against headless spawns.
+
+**Independent Test**: Run `scripts/claude-worktree.sh --headless <issue>` against any issue whose SpecKit lifecycle will invoke the `/speckit.specify` helpers. Verify that `claude.log` progresses past `/speckit.specify`, that a `specs/NNN-*/spec.md` file is created in the worktree, and that the log ends with the documented "waiting for approval" notice — never with a "need your approval to run …" prompt for a routine SpecKit/dev tool call.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean checkout of `main` with no worktree for issue `X`, **When** the maintainer runs `scripts/claude-worktree.sh --headless X`, **Then** within the normal runtime of a `/speckit.specify` pass the worktree contains a generated `specs/NNN-*/spec.md` file and `claude.log` shows the spec-review pause message without any blocking permission prompt.
+2. **Given** a headless spawn already produced the spec, **When** the maintainer tails `claude.log`, **Then** the tail clearly shows the spec path and the pause notice and contains no "I need your approval to run …" lines for standard SpecKit tooling (the `.specify/scripts/bash/` helpers, `git`, `npm`, `gh`, or routine file reads and edits).
+
+---
+
+### User Story 2 - Headless spawns remain safe and auditable (Priority: P1)
+
+The permission-model change for headless spawns does not silently opt the entire project (including interactive sessions and unrelated Claude Code invocations) into an unrestricted tool policy. A maintainer inspecting the repository can see, in one place, which tools a headless spawn is allowed to run, and that allowlist stays scoped to the tooling the SpecKit lifecycle actually needs.
+
+**Why this priority**: Issue #238 explicitly calls out that the simplest fix — `--dangerously-skip-permissions` — has the widest blast radius and is the least preferred option on security grounds. Constitution section X (Security & Hygiene) requires that tokens and credentials are never leaked and that risky behavior is bounded. Any fix that trades "headless works" for "any spawned Claude can run any shell command anywhere" fails this story.
+
+**Independent Test**: Inspect the repository after the fix. The allowlist (or equivalent permission configuration) used by headless spawns is visible in a single, named, version-controlled location. Launch a headless spawn for an issue and confirm via `claude.log` that the spawn does not execute tools that are outside the documented allowlist (i.e., nothing that would be blocked under a normal interactive session with the documented permission scope).
+
+**Acceptance Scenarios**:
+
+1. **Given** the repository after this change, **When** a maintainer opens the permission-model documentation referenced from `docs/DEVELOPMENT.md`, **Then** they can identify exactly which tools headless SpecKit spawns are permitted to run and where that list lives.
+2. **Given** a headless spawn is running, **When** it attempts a tool that is outside the documented allowlist, **Then** the spawn does not silently execute the tool; the behavior is the same as an interactive session would see under the documented policy.
+
+---
+
+### User Story 3 - Stage 2 runs unattended after spec approval (Priority: P1)
+
+A maintainer, after reviewing a spec produced by a headless spawn, releases the spec-review pause without taking over a terminal. They invoke a single one-shot command against the worktree that sends the approval phrase to the paused session and continues the SpecKit lifecycle (`/speckit.plan → /speckit.tasks → /speckit.implement → push → open PR`) in the background, appending to the same `claude.log`. The maintainer's terminal is never attached to the running session; the release is fire-and-forget.
+
+**Why this priority**: Headless Stage 1 alone only solves half the problem. Today's documented release path (`claude --resume` in the worktree and typing `"proceed"`) drops the maintainer into an interactive session, which means Stage 2 inherits their terminal — the moment they close it, the lifecycle stops. That makes the "unattended from fan-out through PR" batch workflow impossible in practice: a maintainer who spawns N headless worktrees must then keep N terminals open to complete them. Truly-headless release at a single approval gate (the spec) is what makes the batch pattern real.
+
+**Independent Test**: After a headless spawn has produced a spec and reached the pause, run `scripts/claude-worktree.sh --approve-spec <issue>`. Confirm that the command returns control to the shell immediately (does not block for the duration of Stage 2), that `claude.log` continues to grow after the command returns, that `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` complete, that a PR is opened against the branch, and that no merge is performed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a headless spawn for issue `X` has reached the spec-review pause and written `specs/NNN-*/spec.md`, **When** the maintainer runs `scripts/claude-worktree.sh --approve-spec X`, **Then** the command returns control to the shell immediately, Stage 2 continues in the background, `claude.log` records the lifecycle through PR creation, and the PR is opened without being merged.
+2. **Given** the spec needs revisions before approval, **When** the maintainer runs `scripts/claude-worktree.sh --revise-spec X "<feedback text>"`, **Then** the paused session interprets the feedback text as revision instructions, edits `specs/NNN-*/spec.md` in place to reflect that feedback (adding, removing, or rewording stories, requirements, edge cases, success criteria, or assumptions as the feedback directs), re-enters the pause, and appends the updated spec path and pause notice to `claude.log` — without requiring an interactive terminal.
+3. **Given** a maintainer runs `--approve-spec` or `--revise-spec` against an issue with no matching worktree, **Then** the command exits non-zero with a clear error in stderr and no background process is spawned.
+4. **Given** the paused session cannot be located (e.g., session ID was lost), **When** the maintainer runs `--approve-spec`, **Then** the command exits non-zero with a clear error rather than starting a new unrelated session.
+
+---
+
+### User Story 4 - Documentation reflects the permission model (Priority: P2)
+
+`docs/DEVELOPMENT.md` explains — at the same level of detail as the existing "Spawning worktrees" and "Releasing a paused headless session" sections — the permission model for headless spawns: what is allowed, what is not, where the allowlist lives, and how to update it.
+
+**Why this priority**: The issue's acceptance list includes "`docs/DEVELOPMENT.md` documents the permission model for headless spawns." Without this, a future maintainer who needs to extend SpecKit tooling, add a script, or diagnose a newly blocked tool cannot reason about the system. Stage 2 release (`--approve-spec`, `--revise-spec`) must also be documented alongside the existing `--headless`, `--remove`, and `--cleanup-merged` vocabulary so the full batch workflow is discoverable.
+
+**Independent Test**: Read the "Spawning worktrees with `scripts/claude-worktree.sh`" section of `docs/DEVELOPMENT.md`. Confirm that it describes the permission model for headless spawns, names the file(s) where the allowlist is maintained, explains how to add a new allowed tool, and documents the `--approve-spec` and `--revise-spec` release commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** a maintainer who has never seen this change, **When** they read `docs/DEVELOPMENT.md` looking for how headless mode handles tool permissions, **Then** they find a clear explanation without needing to read the shell script.
+2. **Given** a maintainer who has just reviewed a spec produced by a headless spawn, **When** they read `docs/DEVELOPMENT.md` for how to release the pause without taking over a terminal, **Then** they find `--approve-spec` and `--revise-spec` documented with example invocations.
+
+---
+
+### Edge Cases
+
+- **Spawn attempts a tool outside the allowlist**: The spawn must not hang indefinitely waiting for a human approval that can never arrive. It should either fail fast with a clear log line (so the maintainer can update the allowlist) or refuse the call and continue — whichever the underlying CLI already supports. The "silent freeze until manually killed" outcome from today's behavior is not acceptable.
+- **Spawn needs a newly added SpecKit helper**: When SpecKit ships a new helper script under `.specify/scripts/`, the allowlist must cover it by pattern (e.g., directory-scoped) rather than requiring a per-script edit for every new helper, so ordinary SpecKit upgrades do not regress headless mode.
+- **Interactive spawns**: An interactive (non-`--headless`) spawn must continue to behave as it does today — the change must not silently broaden permissions for interactive sessions beyond what they already have.
+- **`.env.local` and secrets**: The permission model must not require committing any secret or token to the repository. Credentials continue to flow through `.env.local` (copied into the worktree by the existing script) and are never embedded in the allowlist or in any committed configuration.
+- **Batch spawns (`for i in 210 211 212; do …`)**: The fix must apply identically to each spawn in a batch. One permission prompt hanging one worktree in a batch is the same problem at a larger scale.
+- **Claude CLI does not support the chosen mechanism**: If the selected approach (e.g., a settings file at a specific path) is not supported by the installed Claude CLI version, the script must surface this to the maintainer at spawn time rather than silently falling back to the blocking default.
+- **Release command invoked before pause is reached**: If a maintainer runs `--approve-spec` or `--revise-spec` before the headless spawn has reached the spec-review pause (e.g., `/speckit.specify` is still running), the release command must either wait for the pause to be reached and then release it, or exit with a clear diagnostic — never silently drop the approval on the floor.
+- **Release command invoked twice**: Running `--approve-spec` against a worktree that has already advanced into Stage 2 must be a no-op with a clear message, not a spawn of a second competing session.
+- **`--revise-spec` called with empty feedback**: The command must require non-empty feedback text; otherwise it is indistinguishable from `--approve-spec` and confuses the paused session.
+- **Session ID is lost**: If the session identifier needed to resume the paused spawn cannot be located (worktree moved, session store cleared, Claude CLI upgraded in an incompatible way), the release commands must fail fast with a maintainer-actionable error — not start a new unrelated session.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Headless invocations of `scripts/claude-worktree.sh` MUST launch the Claude CLI in a mode where routine SpecKit lifecycle operations (running `.specify/scripts/bash/` helpers, reading and writing files under the worktree, running `git`, `npm`, and `gh` for the documented lifecycle, and invoking the standard Claude Code tools the lifecycle needs) proceed without prompting for human approval.
+- **FR-002**: The permission scope granted to a headless spawn MUST be expressed as an allowlist (either a `--allowedTools` argument, a project-scoped `.claude/settings.json`, or an equivalent named configuration) — not as a blanket "skip all permission checks" flag. The chosen mechanism MUST be the one recommended in issue #238 (option 2 or option 3).
+- **FR-003**: The allowlist MUST cover, at minimum, the tools the SpecKit lifecycle uses today: execution of scripts under `.specify/scripts/bash/`, `git`, `npm`, `gh`, filesystem reads and writes within the worktree, and the Claude Code built-in tools the lifecycle invokes (Read, Edit, Write, Grep, Glob, Bash for the above commands).
+- **FR-004**: The allowlist MUST NOT grant permission to run arbitrary shell commands outside the documented scope, and MUST NOT grant permission to read or write files outside the worktree or the repository it is hosted in.
+- **FR-005**: The allowlist configuration MUST live in a single, version-controlled location in the repository so that it can be reviewed, diffed, and amended via pull request.
+- **FR-006**: Interactive invocations of `scripts/claude-worktree.sh` (no `--headless` flag) MUST continue to work as they do today; the permission-model change MUST NOT regress the interactive flow or silently broaden its permissions.
+- **FR-007**: `docs/DEVELOPMENT.md` MUST document the permission model for headless spawns: what the allowlist contains, where it is maintained, and how to extend it when the SpecKit lifecycle legitimately needs a new tool.
+- **FR-008**: A headless spawn that encounters a tool outside the allowlist MUST NOT hang indefinitely; the outcome MUST be an entry in `claude.log` that the maintainer can diagnose without attaching a debugger or killing the process.
+- **FR-009**: The fix MUST NOT require committing any secret, token, OAuth credential, or personal access token into the allowlist or any other version-controlled file.
+- **FR-010**: A headless spawn launched against an issue that triggers the `/speckit.specify` pathway MUST reach the mandatory spec-review pause (introduced by issue #235) within the normal runtime of a single `/speckit.specify` pass, producing a `specs/NNN-*/spec.md` file in the worktree.
+- **FR-011**: The fix MUST apply identically to each spawn in a batch invocation (`for i in …; do scripts/claude-worktree.sh --headless "$i"; done`); no per-spawn manual permission step is required.
+- **FR-012**: `scripts/claude-worktree.sh` MUST expose a `--approve-spec <issue>` subcommand that, for a worktree matching `<issue>` whose headless spawn has reached the spec-review pause, releases the pause by sending the approval phrase to the paused session and continues Stage 2 (`/speckit.plan → /speckit.tasks → /speckit.implement → push branch → open PR`) in the background. The command MUST be fire-and-forget: it returns control to the caller's terminal without occupying it for the duration of Stage 2, and Stage 2 output MUST continue to append to the same `claude.log` used by the original spawn.
+- **FR-013**: `scripts/claude-worktree.sh` MUST expose a `--revise-spec <issue> "<feedback>"` subcommand that, for a worktree matching `<issue>` whose headless spawn has reached the spec-review pause, sends the feedback text to the paused session as revision instructions. The paused session MUST interpret that feedback, apply the corresponding edits directly to the existing `specs/NNN-*/spec.md` file (not append to a log, not defer to a human), and re-enter the paused state (awaiting a subsequent `--approve-spec` or further `--revise-spec`). The command MUST be fire-and-forget in the same sense as `--approve-spec`, and MUST reject empty feedback with a clear error.
+- **FR-013a**: The revision behavior MUST preserve the spec file path, frontmatter metadata (Feature Branch, Created, Input), and overall section ordering — revisions modify content within the template structure rather than regenerating the file from scratch. Repeated `--revise-spec` invocations against the same worktree MUST accumulate (each round edits the spec as it stands after the previous round), not reset to the original generated spec.
+- **FR-014**: Stage 2 launched via `--approve-spec` MUST NOT merge the opened PR. Merge remains a manual maintainer step, consistent with CLAUDE.md's PR Merge Rule.
+- **FR-015**: `--approve-spec` and `--revise-spec` MUST NOT silently spawn a new unrelated Claude session when the original paused session cannot be located; they MUST exit non-zero with a maintainer-actionable error identifying what was not found.
+- **FR-016**: Running `--approve-spec` against a worktree that has already advanced past Stage 1 MUST be a no-op with a clear message, not a second competing spawn.
+
+### Key Entities
+
+- **Headless spawn**: A background Claude CLI process launched by `scripts/claude-worktree.sh --headless`, whose stdout and stderr are appended to `claude.log` inside its worktree and which has no interactive channel for approving tool calls.
+- **Allowlist / permission configuration**: The named, version-controlled set of tools and command patterns that a headless spawn is permitted to run without human approval. Whether this lives in a CLI argument, a settings file, or both is an implementation detail; the contract is that it is explicit, scoped, and reviewable.
+- **Permission model documentation**: The section of `docs/DEVELOPMENT.md` that describes the allowlist for maintainers.
+- **Paused session**: A headless spawn that has completed `/speckit.specify`, written a spec file, reported the spec path, and is awaiting one of the approval phrases before continuing. Releasing the paused session requires a mechanism for resuming the same Claude session non-interactively (not starting a new one).
+- **Release command**: `--approve-spec <issue>` or `--revise-spec <issue> "<feedback>"` — the script-level surface that sends input to a paused session without requiring the maintainer's terminal to be attached for the duration of Stage 2.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A headless spawn launched via `scripts/claude-worktree.sh --headless <issue>` against an issue that exercises the full SpecKit lifecycle reaches the mandatory spec-review pause in 100% of runs, without producing a "need your approval to run …" line in `claude.log` for any standard SpecKit, `git`, `npm`, `gh`, or Claude Code built-in tool call.
+- **SC-002**: Zero secrets, tokens, OAuth credentials, or PATs appear in any file that this change adds or modifies in the repository.
+- **SC-003**: A maintainer reading `docs/DEVELOPMENT.md` can identify, in under one minute, the file that holds the headless-spawn allowlist and the procedure for extending it.
+- **SC-004**: Interactive spawns (no `--headless`) continue to pass their existing manual acceptance steps with no regression.
+- **SC-005**: The allowlist as committed grants no tool permission beyond what the documented SpecKit lifecycle, `git`, `npm`, `gh`, and the Claude Code built-in tools require — verifiable by a maintainer reviewing the committed allowlist against this spec.
+- **SC-006**: `scripts/claude-worktree.sh --approve-spec <issue>` returns control to the shell in under 5 seconds (it does not block for the duration of Stage 2), and the lifecycle subsequently completes through PR creation with no further manual intervention, in 100% of test runs.
+- **SC-007**: `scripts/claude-worktree.sh --revise-spec <issue> "<feedback>"` produces a `specs/NNN-*/spec.md` whose content visibly reflects the feedback (additions, removals, or rewordings that a reviewer can identify by reading the diff), and re-enters the paused state, in 100% of test runs, without the maintainer's terminal being attached for the revision pass. Two consecutive `--revise-spec` rounds against the same worktree produce cumulative edits (the second round's diff is against the first round's output, not against the original spec).
+- **SC-008**: A maintainer can spawn N headless worktrees (N ≥ 3), review all N specs, approve them via `--approve-spec`, and walk away — arriving later to find N opened (unmerged) PRs — using only the documented commands, with no background-terminal juggling.
+
+## Assumptions
+
+- The Claude CLI currently installed in maintainer environments supports at least one of the issue's recommended mechanisms for scoped tool permissions in headless mode (an `--allowedTools`-style argument or a project-scoped settings file). If neither is supported by the installed CLI, that is a blocker to be surfaced during `/speckit.plan`, not a reason to fall back to a blanket skip-all-permissions flag.
+- The set of tools the SpecKit lifecycle needs is bounded and can be enumerated from the current `.specify/scripts/` directory plus the standard Claude Code built-in tool names — no dynamic discovery mechanism is required for Phase 1 of the fix.
+- `scripts/claude-worktree.sh` remains the single entry point for spawning worktrees; no other entry point needs to be updated in parallel.
+- `DEV_GITHUB_PAT` and OAuth credentials continue to flow through `.env.local` as they do today; no change to the credentials pathway is required or permitted by this spec.
+- The fix targets the current repository layout (worktrees under `../forkprint-<issue>-<slug>/`) and does not need to work across unrelated repositories or arbitrary external paths.
+- The Claude CLI supports resuming an existing session non-interactively (e.g., `claude -p "<prompt>" --resume <session-id>`) so that `--approve-spec` and `--revise-spec` can send input to a paused session without starting a new one. If this is not available in the installed CLI, the implementation must surface the gap rather than regressing to a blocking default.
+- Resolving the paused session's identifier from a worktree is tractable — either by recording it at spawn time (e.g., writing it alongside `.claude.pid`) or by querying the CLI's session store. The exact mechanism is a `/speckit.plan` decision.
+- The spec-review pause is an intentional policy gate (CLAUDE.md, issue #235 / PR #237). This spec does not propose bypassing it; `--approve-spec` sends the same approval phrase a human would type, preserving the gate while removing the terminal-attachment requirement.

--- a/specs/244-headless-worktree-permissions/tasks.md
+++ b/specs/244-headless-worktree-permissions/tasks.md
@@ -1,0 +1,121 @@
+---
+description: "Task list for 244-headless-worktree-permissions"
+---
+
+# Tasks: Headless Worktree Spawns Run Without Permission Prompts, with Truly-Headless Stage 2 Release
+
+**Input**: Design documents from `/specs/244-headless-worktree-permissions/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, contracts/ ✓, quickstart.md ✓
+
+**Tests**: No automated tests (shell-script change; repo has no bash-test harness — see plan.md Complexity Tracking). Acceptance verified via `quickstart.md` and PR `## Test plan`.
+
+**Organization**: Tasks grouped by user story.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: None — this feature touches existing files only. No new tooling, directories, or dependencies.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Commit the permission-policy file that every subsequent story depends on.
+
+- [X] T001 Create `.claude/settings.json` at the repo root with the `permissions.allow` list from `specs/244-headless-worktree-permissions/contracts/claude-settings.schema.md`. Contents must match the schema exactly: no secrets, no wildcards, no `bypassPermissions`. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/.claude/settings.json`.
+- [X] T002 Verify `.claude/settings.json` is not excluded by `.gitignore`. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/.gitignore` (read-only verification; add an explicit `!.claude/settings.json` only if the existing rules would otherwise ignore it).
+
+**Checkpoint**: Allowlist is committed. Any new worktree created from this branch now inherits the policy, so the permission-prompt block from issue #238 is eliminated for covered tools.
+
+---
+
+## Phase 3: User Story 1 - Headless spawn completes the spec step without human intervention (Priority: P1) 🎯 MVP
+
+**Goal**: A headless spawn runs `/speckit.specify` and reaches the spec-review pause without a single "need your approval" prompt.
+
+**Independent Test**: `scripts/claude-worktree.sh --headless <TEST_ISSUE>` against a docs-only test issue; `claude.log` contains the spec path and pause notice, zero approval prompts.
+
+- [X] T003 [US1] Modify `scripts/claude-worktree.sh` spawn path to generate a UUID via `uuidgen` before launching Claude, store it in the local variable `SESSION_ID`, and write it to `<worktree>/.claude.session-id` before the `claude` invocation. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/scripts/claude-worktree.sh` (insert between the dev-server start and the `claude` launch, around line 190).
+- [X] T004 [US1] Modify both branches of the `claude` launch (interactive `exec claude "$KICKOFF"` and headless `nohup claude -p "$KICKOFF" …`) to pass `--session-id "$SESSION_ID"`. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/scripts/claude-worktree.sh` lines ~200–206.
+
+**Checkpoint**: A headless spawn now (a) inherits the allowlist from T001, and (b) is addressable by UUID for later resume. US1 is satisfied.
+
+---
+
+## Phase 4: User Story 2 - Headless spawns remain safe and auditable (Priority: P1)
+
+**Goal**: The allowlist is visible, scoped, and reviewable — no blanket permission grant is introduced.
+
+**Independent Test**: Read `.claude/settings.json` and confirm it contains only the entries listed in the contract; `grep` for forbidden patterns returns nothing.
+
+- [X] T005 [US2] Verify the committed `.claude/settings.json` against the contract in `specs/244-headless-worktree-permissions/contracts/claude-settings.schema.md`: no `Bash(*)`, no `bypassPermissions`, no secrets, no MCP tools, no destructive commands. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/.claude/settings.json` (review task, no edit unless a violation is found).
+
+**Checkpoint**: US2 is satisfied. The policy exists in one named file, reviewable on PRs, with contract-level guardrails.
+
+---
+
+## Phase 5: User Story 3 - Stage 2 runs unattended after spec approval (Priority: P1)
+
+**Goal**: `--approve-spec <issue>` and `--revise-spec <issue> "<feedback>"` release the paused session fire-and-forget, without the maintainer attaching a terminal.
+
+**Independent Test**: After a headless spawn reaches the pause, `time scripts/claude-worktree.sh --approve-spec <TEST_ISSUE>` returns in under 5 seconds and `claude.log` resumes growing; Stage 2 ends with an opened (unmerged) PR.
+
+- [X] T006 [US3] Add a `release_paused_session()` helper function to `scripts/claude-worktree.sh` that takes `(issue, prompt)`, resolves the worktree path using the same `worktree list --porcelain | awk` lookup already used by `remove_worktree()`, reads `<worktree>/.claude.session-id`, validates preconditions (worktree exists, session-id file exists, at least one `specs/*/spec.md` exists in the worktree), and spawns `nohup claude -p "$prompt" --resume "$session_id" >> claude.log 2>&1 &` from the worktree directory. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/scripts/claude-worktree.sh` (add before the main dispatch block, after `cleanup_merged()`).
+- [X] T007 [US3] Wire up `--approve-spec <issue>` in the main dispatch block: route to `release_paused_session "$2" "proceed"`, print `"Released pause for issue <issue>; Stage 2 running in background. Tail: <worktree>/claude.log"` on success, exit 0. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/scripts/claude-worktree.sh` (add alongside the existing `--remove` / `--cleanup-merged` dispatch branches, around lines 110–120).
+- [X] T008 [US3] Wire up `--revise-spec <issue> "<feedback>"` in the main dispatch block: reject empty `$3` with exit 1 + stderr `"--revise-spec requires non-empty feedback"`; otherwise route to `release_paused_session "$2" "$3"`. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/scripts/claude-worktree.sh` (same dispatch block as T007).
+- [X] T009 [US3] Implement the error paths from `contracts/claude-worktree-cli.md` inside `release_paused_session()`: (a) no worktree → stderr `"No worktree found for issue <issue>"`, exit 1; (b) no `.claude.session-id` → stderr `"No session ID recorded for issue <issue>; cannot resume non-interactively. Use 'claude --resume' from the worktree instead."`, exit 1; (c) no `spec.md` yet → stderr `"Spec not yet generated for issue <issue>; paused state not reached. Tail <worktree>/claude.log to confirm."`, exit 1. File path: same as T006.
+
+**Checkpoint**: US3 is satisfied. A maintainer can run `--approve-spec` or `--revise-spec` and walk away.
+
+---
+
+## Phase 6: User Story 4 - Documentation reflects the permission model (Priority: P2)
+
+**Goal**: `docs/DEVELOPMENT.md` documents the permission model and the new release subcommands.
+
+**Independent Test**: A maintainer reading `docs/DEVELOPMENT.md` can find the allowlist location and the `--approve-spec` / `--revise-spec` usage without opening the shell script.
+
+- [X] T010 [US4] Add a "Permission model for headless spawns" subsection to the "Spawning worktrees with `scripts/claude-worktree.sh`" section of `docs/DEVELOPMENT.md`. Covers: what `.claude/settings.json` contains, where it lives, the rule that additions require a PR referencing the specific tool needed, and the list of explicitly-denied patterns. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/docs/DEVELOPMENT.md`.
+- [X] T011 [US4] Replace the existing "Releasing a paused headless session" subsection with the new `--approve-spec` / `--revise-spec` vocabulary. Keep a short note that `claude --resume` still works for ad-hoc interactive revisions. Document both subcommands at the same level of detail as `--remove` and `--cleanup-merged`. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/docs/DEVELOPMENT.md` (section around lines 146–152).
+- [X] T012 [US4] Update `scripts/claude-worktree.sh --help` output to list `--approve-spec <issue>` and `--revise-spec <issue> "<feedback>"` in the Usage block and Options block, matching the style of the existing entries. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/scripts/claude-worktree.sh` (the `print_usage()` heredoc around lines 7–34).
+
+**Checkpoint**: US4 is satisfied. Documentation is discoverable from a single section.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [X] T013 [P] Run `npm run lint` and `npm run build` in the worktree and confirm both remain clean (DoD — constitution §XII). No file path; commands only.
+- [X] T014 [P] Execute `quickstart.md` acceptance paths 1, 2, 4, 5 against a live test issue; record results in the PR `## Test plan` section as checked boxes. File path: `/Users/arungupta/workspaces/forkprint-238-headless-claude-worktree-sh-spawns-block/specs/244-headless-worktree-permissions/quickstart.md` (reference; actual run is manual).
+- [X] T015 Commit all changes on the `244-headless-worktree-permissions` branch with messages that reference issue #238, push the branch, and open a PR whose body includes the `## Test plan` checklist derived from `quickstart.md`. Do NOT merge (CLAUDE.md PR Merge Rule). No file path; git commands only.
+
+---
+
+## Dependencies
+
+```
+T001 (commit settings.json)                ← blocking
+ └─ T002 (gitignore check)
+     └─ T005 (US2 verify)
+     └─ T003 → T004 (US1 spawn path changes)
+                 └─ T006 (US3 release helper)
+                     ├─ T007 (--approve-spec)
+                     └─ T008 (--revise-spec)
+                         └─ T009 (error paths)
+                             └─ T010 → T011 → T012 (US4 docs + --help)
+                                 └─ T013 [P] T014 [P]
+                                     └─ T015 (commit + PR)
+```
+
+US1 blocks US3 (release commands need `--session-id` on spawn path). US4 (docs) blocks final PR. US2 is a verification story with no implementation.
+
+## Parallel Execution Opportunities
+
+- T013 and T014 can run in parallel (different files, no shared state).
+- Within US3, T007 and T008 touch the same dispatch block and are NOT parallelizable.
+- Within US4, T010 and T011 both edit `docs/DEVELOPMENT.md` and are NOT parallelizable.
+
+## Implementation Strategy
+
+**MVP slice**: T001 → T002 → T003 → T004. That alone closes issue #238's primary acceptance criterion (headless spawn reaches the pause without approval prompts). US3 (`--approve-spec`, `--revise-spec`) and US4 (docs) are scope additions agreed during spec review and ship in the same PR.
+
+**Incremental delivery**: all stories are implemented in one PR because they share a single file (`scripts/claude-worktree.sh`) and a single doc (`docs/DEVELOPMENT.md`). Splitting into two PRs would force a merge-conflict dance for zero delivery benefit.

--- a/specs/98889-throwaway-test-pr-248-headless-approve/checklists/requirements.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Throwaway Test PR #248 Headless Approve
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan`.
+- This is a throwaway test issue — artifacts validate the headless workflow, not production functionality.

--- a/specs/98889-throwaway-test-pr-248-headless-approve/data-model.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/data-model.md
@@ -1,0 +1,7 @@
+# Data Model: Throwaway Test PR #248 Headless Approve
+
+**Date**: 2026-04-15
+
+## Entities
+
+No data entities are involved in this feature. This is a process validation issue that produces a placeholder file to prove the SpecKit lifecycle ran to completion.

--- a/specs/98889-throwaway-test-pr-248-headless-approve/placeholder.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/placeholder.md
@@ -1,0 +1,15 @@
+# Throwaway Test — Headless Approve Lifecycle Proof
+
+This file was created by the `/speckit.implement` step of the SpecKit lifecycle,
+running inside a headless Claude worktree session for issue #250.
+
+Its existence proves:
+1. `/speckit.specify` completed and paused (Stage 1)
+2. `--approve-spec` released the pause
+3. `/speckit.plan` ran
+4. `/speckit.tasks` ran
+5. `/speckit.implement` ran (this file)
+
+**Created**: 2026-04-15
+**Issue**: #250
+**Branch**: 98889-throwaway-test-pr-248-headless-approve

--- a/specs/98889-throwaway-test-pr-248-headless-approve/plan.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Throwaway Test PR #248 Headless Approve
+
+**Branch**: `98889-throwaway-test-pr-248-headless-approve` | **Date**: 2026-04-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/98889-throwaway-test-pr-248-headless-approve/spec.md`
+
+## Summary
+
+This is a throwaway test feature used to verify test plan items 4–6 on PR #248 (headless spawn + `--approve-spec`). The deliverable is a minimal placeholder file that exercises the full SpecKit lifecycle end-to-end — specify, plan, tasks, implement — so the headless workflow mechanics can be validated. No production functionality is delivered.
+
+## Technical Context
+
+**Language/Version**: Bash (POSIX-compatible portions + bash-specific features already used: `[[ ... ]]`, `set -euo pipefail`) + `git`, `gh` (GitHub CLI)
+**Primary Dependencies**: Claude Code CLI, `git`, `gh`, `npm`
+**Storage**: N/A — script operates on local git state and queries GitHub via `gh`
+**Testing**: Manual verification via `claude.log` inspection and PR state checks
+**Target Platform**: macOS / Linux development machines
+**Project Type**: Process validation (throwaway)
+**Performance Goals**: N/A
+**Constraints**: N/A
+**Scale/Scope**: Single-issue throwaway test
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| I. Technology Stack | PASS | Bash + git + gh are already in use in `scripts/claude-worktree.sh` |
+| II. Accuracy Policy | N/A | No metrics or data display involved |
+| III. Data Source Rules | N/A | No GitHub API data fetching |
+| IV. Analyzer Module Boundary | N/A | No analyzer changes |
+| V. CHAOSS Alignment | N/A | No scoring involved |
+| VI. Scoring Thresholds | N/A | No scoring involved |
+| IX. Feature Scope Rules | PASS | YAGNI: minimal placeholder only; no production code |
+| X. Security & Hygiene | PASS | No secrets involved |
+| XI. Testing | PASS | TDD not applicable — this is a process validation, not application code |
+| XII. Definition of Done | PASS | PR with test plan, no dead code, no TODOs |
+| XIII. Development Workflow | PASS | Feature branch, PR with test plan section |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/98889-throwaway-test-pr-248-headless-approve/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+specs/98889-throwaway-test-pr-248-headless-approve/
+└── placeholder.md       # Minimal throwaway artifact proving the lifecycle ran
+```
+
+**Structure Decision**: No application source code is modified. The only deliverable is a placeholder file within the spec directory that proves the full SpecKit lifecycle executed successfully from headless spawn through `--approve-spec` to PR.

--- a/specs/98889-throwaway-test-pr-248-headless-approve/quickstart.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/quickstart.md
@@ -1,0 +1,17 @@
+# Quickstart: Throwaway Test PR #248 Headless Approve
+
+**Date**: 2026-04-15
+
+## Overview
+
+This throwaway feature validates the headless SpecKit lifecycle: spawn → specify → pause → approve-spec → plan → tasks → implement → PR.
+
+## How to verify
+
+1. Check that the PR exists and contains the spec artifacts under `specs/98889-throwaway-test-pr-248-headless-approve/`.
+2. Confirm the PR body includes a `## Test plan` section.
+3. Verify `placeholder.md` exists in the spec directory — this proves the implement step ran.
+
+## Cleanup
+
+After verifying, use `scripts/claude-worktree.sh --cleanup-merged <issue>` (post-merge) or `scripts/claude-worktree.sh --remove <issue>` (to discard).

--- a/specs/98889-throwaway-test-pr-248-headless-approve/research.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/research.md
@@ -1,0 +1,21 @@
+# Research: Throwaway Test PR #248 Headless Approve
+
+**Date**: 2026-04-15
+
+## Research Summary
+
+No unknowns or NEEDS CLARIFICATION items were identified in the Technical Context. This is a throwaway test feature with no production dependencies.
+
+## Decision Log
+
+### Decision 1: Deliverable format
+
+- **Decision**: A single `placeholder.md` file in the spec directory
+- **Rationale**: The purpose of this issue is to validate the headless SpecKit lifecycle mechanics (spawn → specify → pause → approve-spec → plan → tasks → implement → PR). The deliverable needs only to prove the lifecycle ran to completion. A placeholder markdown file is the simplest artifact that achieves this.
+- **Alternatives considered**: Creating a dummy test file or script — rejected because it would add unnecessary code to the repo that must be cleaned up, while a markdown file in the spec directory is self-contained and clearly scoped as throwaway.
+
+### Decision 2: No application code changes
+
+- **Decision**: No changes to `src/`, `lib/`, `components/`, or any application code
+- **Rationale**: This is a process validation issue, not a product feature. Modifying application code would introduce unnecessary risk and review burden.
+- **Alternatives considered**: None — this was clear from the issue description.

--- a/specs/98889-throwaway-test-pr-248-headless-approve/spec.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Throwaway Test PR #248 Headless Approve
+
+**Feature Branch**: `98889-throwaway-test-pr-248-headless-approve`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**: User description: "Throwaway issue to verify test plan items 4-6 on PR #248 (headless spawn + --approve-spec)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Verify headless spawn completes Stage 1 (Priority: P1)
+
+A maintainer spawns a headless Claude worktree session for a GitHub issue. The session runs the SpecKit lifecycle Stage 1 (`/speckit.specify`), generates a spec, and pauses — waiting for explicit approval before proceeding.
+
+**Why this priority**: This is the core precondition for the entire headless workflow. If Stage 1 does not complete and pause correctly, the `--approve-spec` and `--revise-spec` release commands have nothing to act on.
+
+**Independent Test**: Can be verified by running `scripts/claude-worktree.sh --headless <issue>` and confirming a spec file exists in the worktree and `claude.log` shows the session is paused awaiting approval.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid GitHub issue number and the repo's permission allowlist, **When** the maintainer runs a headless spawn for that issue, **Then** the session creates a worktree, starts a dev server, runs the specify step, generates a spec file under `specs/`, and halts with a message requesting approval.
+2. **Given** the headless session has paused after Stage 1, **When** the maintainer inspects the session log in the worktree, **Then** the log contains the generated spec file path and an explicit pause message.
+
+---
+
+### User Story 2 - Release paused session with approve-spec (Priority: P1)
+
+A maintainer releases a paused headless session by running the approve-spec command, which resumes the session with an approval prompt so it continues through Stage 2 (plan, tasks, implement, PR).
+
+**Why this priority**: This validates the fire-and-forget release mechanism that allows batch approval of multiple worktrees without attaching a terminal.
+
+**Independent Test**: After a paused headless session exists, run the approve-spec command and confirm the session resumes, completes Stage 2, and opens a PR.
+
+**Acceptance Scenarios**:
+
+1. **Given** a paused headless session with a valid session ID and at least one spec file, **When** the maintainer runs the approve-spec command for that issue, **Then** the command returns control to the shell within 5 seconds and the session resumes in the background.
+2. **Given** the approve-spec command has been issued, **When** the resumed session completes Stage 2, **Then** a PR is opened on GitHub with a test plan section and the branch is pushed.
+
+---
+
+### User Story 3 - Send revision feedback with revise-spec (Priority: P2)
+
+A maintainer reviews the generated spec, finds it needs changes, and sends revision feedback to the paused session. The session applies the revisions and re-enters the paused state.
+
+**Why this priority**: This validates the iterative revision loop before approval, ensuring maintainers can refine specs without attaching a terminal.
+
+**Independent Test**: After a paused headless session exists, run the revise-spec command with feedback text and confirm the spec is updated and the session re-pauses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a paused headless session, **When** the maintainer runs the revise-spec command with feedback text, **Then** the session resumes, applies the revision to the spec, and re-enters the paused state awaiting approval.
+2. **Given** the revise-spec command is invoked with empty feedback, **When** the command runs, **Then** it exits with a non-zero status and a clear error message, and does not resume the session.
+
+---
+
+### Edge Cases
+
+- What happens when approve-spec is run but no worktree exists for the issue? The command exits non-zero with a clear error.
+- What happens when approve-spec is run but the session ID file is missing or empty? The command exits non-zero with a clear error.
+- What happens when approve-spec is run but no spec file exists (Stage 1 not yet complete)? The command exits non-zero with a clear error.
+- What happens when revise-spec is run multiple times in succession? Each round applies revisions to the spec as it stands after the previous round; revisions accumulate.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The headless spawn MUST complete Stage 1 (specify) and pause without manual intervention, relying on the project-scoped permission allowlist.
+- **FR-002**: The approve-spec command MUST locate the worktree for the given issue, read the session UUID, verify at least one spec file exists, and resume the session with an approval prompt.
+- **FR-003**: The approve-spec command MUST return control to the caller's shell within 5 seconds (fire-and-forget), running the resumed session as a detached background process.
+- **FR-004**: The revise-spec command MUST reject empty feedback with a non-zero exit and a descriptive error message.
+- **FR-005**: The revise-spec command MUST resume the paused session with the revision feedback, causing the session to update the spec and re-enter the paused state.
+- **FR-006**: Both approve-spec and revise-spec MUST exit non-zero with clear error messages when preconditions are unmet (no worktree, no session ID, no spec file).
+- **FR-007**: The resumed session (after approve-spec) MUST complete Stage 2 and open a PR on GitHub without merging it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A headless spawn for a valid issue completes Stage 1 and produces a spec file within the worktree without any interactive approval prompts blocking progress.
+- **SC-002**: The approve-spec command returns control to the shell in under 5 seconds and the background session opens a PR within a reasonable timeframe.
+- **SC-003**: The revise-spec command with valid feedback causes the spec to be updated and the session to re-pause, verifiable via the session log.
+- **SC-004**: All precondition failures (approve-spec or revise-spec with missing worktree, session ID, or spec file) produce non-zero exit codes and human-readable error messages.
+
+## Assumptions
+
+- The maintainer has the GitHub CLI authenticated and the Claude CLI installed.
+- The repo's project-scoped permission allowlist is sufficient for headless sessions to run SpecKit commands without interactive tool-approval prompts.
+- The dev server port auto-selection (3010-3100) works correctly in the test environment.
+- This is a throwaway test issue — the generated artifacts (spec, plan, tasks, code) serve only to validate the headless workflow mechanics, not to deliver production functionality.

--- a/specs/98889-throwaway-test-pr-248-headless-approve/tasks.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/tasks.md
@@ -53,7 +53,7 @@
 
 ### Implementation for User Story 2
 
-- [ ] T002 [US2] Push branch and open PR on GitHub with a test plan section in the body, referencing issue #250
+- [x] T002 [US2] Push branch and open PR on GitHub with a test plan section in the body, referencing issue #250
 
 **Checkpoint**: PR exists on GitHub, branch is pushed, test plan section present.
 
@@ -73,7 +73,7 @@
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T003 Verify all spec artifacts are committed (spec.md, plan.md, research.md, data-model.md, quickstart.md, tasks.md, checklists/requirements.md, placeholder.md)
+- [x] T003 Verify all spec artifacts are committed (spec.md, plan.md, research.md, data-model.md, quickstart.md, tasks.md, checklists/requirements.md, placeholder.md)
 
 ---
 

--- a/specs/98889-throwaway-test-pr-248-headless-approve/tasks.md
+++ b/specs/98889-throwaway-test-pr-248-headless-approve/tasks.md
@@ -1,0 +1,122 @@
+# Tasks: Throwaway Test PR #248 Headless Approve
+
+**Input**: Design documents from `/specs/98889-throwaway-test-pr-248-headless-approve/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories)
+
+**Tests**: Not requested — this is a process validation feature, not application code.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project setup needed — repo already exists and is configured.
+
+(No tasks — this is a throwaway feature in an existing repo.)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: No foundational work needed — the headless workflow infrastructure already exists in `scripts/claude-worktree.sh`.
+
+(No tasks — all infrastructure is already in place from PR #238.)
+
+---
+
+## Phase 3: User Story 1 - Verify headless spawn completes Stage 1 (Priority: P1) MVP
+
+**Goal**: Prove that a headless spawn runs `/speckit.specify`, generates a spec, and pauses.
+
+**Independent Test**: Check that `specs/*/spec.md` exists in the worktree and `claude.log` shows the pause message.
+
+### Implementation for User Story 1
+
+- [x] T001 [US1] Create placeholder file at specs/98889-throwaway-test-pr-248-headless-approve/placeholder.md proving the SpecKit lifecycle reached the implement step
+
+**Checkpoint**: The spec file already exists (created during `/speckit.specify`). The placeholder file proves the implement step ran.
+
+---
+
+## Phase 4: User Story 2 - Release paused session with approve-spec (Priority: P1)
+
+**Goal**: Prove that `--approve-spec` resumes the session and the lifecycle completes through to PR.
+
+**Independent Test**: After `--approve-spec`, verify the session opens a PR with a test plan section.
+
+### Implementation for User Story 2
+
+- [ ] T002 [US2] Push branch and open PR on GitHub with a test plan section in the body, referencing issue #250
+
+**Checkpoint**: PR exists on GitHub, branch is pushed, test plan section present.
+
+---
+
+## Phase 5: User Story 3 - Send revision feedback with revise-spec (Priority: P2)
+
+**Goal**: Prove that `--revise-spec` applies feedback and re-pauses.
+
+**Independent Test**: Not exercised in this run — this story validates via a separate `--revise-spec` invocation.
+
+### Implementation for User Story 3
+
+(No implementation tasks — this story is validated by running `--revise-spec` from a separate terminal, which is outside the scope of this session's lifecycle.)
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T003 Verify all spec artifacts are committed (spec.md, plan.md, research.md, data-model.md, quickstart.md, tasks.md, checklists/requirements.md, placeholder.md)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 3 (US1)**: No dependencies — can start immediately
+- **Phase 4 (US2)**: Depends on Phase 3 (need artifacts to push)
+- **Phase 5 (US3)**: No in-session tasks — validated externally
+- **Phase 6 (Polish)**: Depends on Phase 4
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Independent — create placeholder file
+- **User Story 2 (P1)**: Depends on US1 — needs artifacts to push and PR to open
+- **User Story 3 (P2)**: External validation — no in-session dependency
+
+### Parallel Opportunities
+
+- T001 and T002 are sequential (T002 depends on T001 being committed)
+- No parallel opportunities in this minimal task set
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Create placeholder.md (T001)
+2. **STOP and VALIDATE**: Confirm spec artifacts exist
+
+### Incremental Delivery
+
+1. T001 → placeholder proves implement ran
+2. T002 → PR proves full lifecycle completed
+3. T003 → all artifacts committed cleanly
+
+---
+
+## Notes
+
+- This is a throwaway test — all artifacts validate the headless workflow, not production functionality.
+- Total tasks: 3
+- Tasks per user story: US1=1, US2=1, Polish=1
+- US3 has no in-session tasks (validated externally via `--revise-spec`)


### PR DESCRIPTION
## Summary

- Throwaway PR to verify test plan items 4–6 on PR #248 (headless spawn + `--approve-spec`)
- Proves the full SpecKit lifecycle ran end-to-end in a headless worktree session: specify → pause → approve-spec → plan → tasks → implement → PR
- Contains only spec artifacts under `specs/98889-throwaway-test-pr-248-headless-approve/` and a `placeholder.md` proving the implement step executed

Closes #250

## Test plan

- [ ] PR was opened by the headless session (not manually)
- [ ] `specs/98889-throwaway-test-pr-248-headless-approve/spec.md` exists
- [ ] `specs/98889-throwaway-test-pr-248-headless-approve/placeholder.md` exists (proves implement ran)
- [ ] No application code was modified (only spec artifacts and CLAUDE.md agent context update)
- [ ] Branch was pushed automatically by the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)