### PR TITLE
[#259] Compact landing page to fit single viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <strong>A single score that tells you how healthy your open source project really is.</strong><br/>
-  Calibrated against 1,600+ real GitHub repositories.
+  Calibrated against 2,400+ real GitHub repositories.
 </p>
 
 <p align="center">
@@ -37,7 +37,7 @@ RepoPulse is built for **community-oriented projects** — multi-contributor rep
 |---|---------|-------------|
 | :bar_chart: | **OSS Health Score** | Composite percentile with actionable recommendations |
 | :card_index_dividers: | **8-Dimension Scorecard** | Quick signals (Reach, Attention, Engagement) plus deep-dive dimensions |
-| :chart_with_upwards_trend: | **Percentile Scoring** | Every metric shows where the repo ranks vs. 1,600+ calibrated repos |
+| :chart_with_upwards_trend: | **Percentile Scoring** | Every metric shows where the repo ranks vs. 2,400+ calibrated repos |
 | :busts_in_silhouette: | **Multi-Repo Comparison** | Side-by-side analysis of up to 4 repositories |
 | :office: | **Org Inventory** | Browse and analyze all repos within a GitHub organization |
 | :bulb: | **Unified Recommendations** | Actionable improvement suggestions across all scoring dimensions |

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -46,59 +46,45 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (!session) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-slate-50 px-4 py-8 sm:gap-8">
+      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-slate-50 px-4 py-6 sm:gap-5">
         <div className="text-center">
-          <img src="/repo-pulse-banner.png" alt="RepoPulse" className="mx-auto h-24 rounded-xl shadow-lg sm:h-40" />
-          <h1 className="mt-4 text-2xl font-bold text-slate-900 sm:mt-6 sm:text-3xl">RepoPulse</h1>
-          <p className="mt-1 text-base text-slate-600 sm:mt-2 sm:text-lg">Know the real health of any open source project — in seconds</p>
+          <img src="/repo-pulse-banner.png" alt="RepoPulse" className="mx-auto h-16 rounded-xl shadow-lg sm:h-24" />
+          <h1 className="mt-2 text-2xl font-bold text-slate-900 sm:mt-3 sm:text-3xl">RepoPulse</h1>
+          <p className="mt-1 text-sm text-slate-600 sm:text-base">Know the real health of any open source project — in seconds</p>
         </div>
 
-        <div className="max-w-lg space-y-4">
+        <div className="max-w-lg space-y-3">
           <p className="text-center text-sm text-slate-600">
-            RepoPulse computes a single <span className="font-semibold text-slate-800">OSS Health Score</span> from
-            five dimensions — scored as percentiles against 1,600+ real GitHub repositories in the same star bracket.
+            A single <span className="font-semibold text-slate-800">OSS Health Score</span> from
+            five dimensions — percentile-ranked against 2,400+ real GitHub repos.
           </p>
 
-          <div className="flex flex-wrap justify-center gap-1.5 sm:grid sm:grid-cols-2 sm:gap-2">
-            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
-              <p className="font-semibold uppercase tracking-wide text-slate-500">👥 Contributors</p>
-              <p className="mt-0.5 hidden text-slate-600 sm:block">Contributor concentration, repeat and new contributor mix</p>
-            </div>
-            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
-              <p className="font-semibold uppercase tracking-wide text-slate-500">⚡ Activity</p>
-              <p className="mt-0.5 hidden text-slate-600 sm:block">PR throughput, issue flow, commit cadence, release frequency</p>
-            </div>
-            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
-              <p className="font-semibold uppercase tracking-wide text-slate-500">💬 Responsiveness</p>
-              <p className="mt-0.5 hidden text-slate-600 sm:block">Response times, resolution speed, backlog health</p>
-            </div>
-            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:rounded-lg sm:px-3 sm:py-2">
-              <p className="font-semibold uppercase tracking-wide text-slate-500">📄 Documentation</p>
-              <p className="mt-0.5 hidden text-slate-600 sm:block">Key project files, README quality, licensing compliance, inclusive naming</p>
-            </div>
-            <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-700 sm:col-span-2 sm:rounded-lg sm:px-3 sm:py-2">
-              <p className="font-semibold uppercase tracking-wide text-slate-500">🔒 Security</p>
-              <p className="mt-0.5 hidden text-slate-600 sm:block">OpenSSF Scorecard, dependency automation, branch protection</p>
-            </div>
+          <div className="flex flex-wrap justify-center gap-1.5">
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">👥 Contributors</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">⚡ Activity</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">💬 Responsiveness</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">📄 Documentation</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">🔒 Security</span>
           </div>
 
           <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-slate-500">
-            <span>Compare up to 4 repos side-by-side</span>
+            <span>Compare up to 4 repos</span>
             <span className="text-slate-300">|</span>
-            <span>Browse repos by GitHub org</span>
+            <span>Browse by org</span>
             <span className="text-slate-300">|</span>
-            <span>Export as JSON or Markdown</span>
+            <span>Export JSON / Markdown</span>
           </div>
-
-          <p className="text-center text-xs italic text-slate-500">
-            Built for community-oriented projects — multi-contributor and foundation-track.
-            Solo-maintainer projects are auto-detected and scored on Activity, Security, and
-            Documentation instead of Contributors and Responsiveness.
-          </p>
         </div>
 
         <SignInButton />
-        <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 transition">View scoring methodology</a>
+
+        <div className="max-w-md space-y-2 text-center">
+          <p className="text-xs italic text-slate-400">
+            Built for community-oriented projects. Solo-maintainer repos are auto-detected and
+            scored on Activity, Security, and Documentation instead.
+          </p>
+          <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 transition">View scoring methodology</a>
+        </div>
       </div>
     )
   }

--- a/docs/oss-health-42-signals/README.md
+++ b/docs/oss-health-42-signals/README.md
@@ -27,7 +27,7 @@ Measuring open source health is harder than scanning a README. A few of the top 
 - **Health is multidimensional** — Activity, responsiveness, **Contributors** (read through a sustainability lens), documentation, and security overlap but are not interchangeable; collapsing them without structure hides tradeoffs.
 - **Trust requires transparency** — Any score is only useful if people can see what it is built from and what was left out because the data is not publicly verifiable.
 
-[RepoPulse](https://repopulse-arun-gupta.vercel.app) tackles those constraints directly: it analyzes a public GitHub repository and returns a composite **OSS Health Score** — percentile-based, calibrated against 1,600+ repositories, with dimensions and recommendations tied to explicit signals.
+[RepoPulse](https://repopulse-arun-gupta.vercel.app) tackles those constraints directly: it analyzes a public GitHub repository and returns a composite **OSS Health Score** — percentile-based, calibrated against 2,400+ repositories, with dimensions and recommendations tied to explicit signals.
 
 <p align="center">
   <a href="https://repopulse-arun-gupta.vercel.app">
@@ -335,7 +335,7 @@ Each repo is evaluated across these health **dimensions**; each contributes the 
 
 This section expands on **strata** and **diversity caps** from [The Scoring Framework](#the-scoring-framework).
 
-RepoPulse does not use arbitrary "good/bad" thresholds. Every score is a **percentile ranking** against 1,600+ calibrated GitHub repositories. Filters, sort strategy, and stratum boundaries are documented in [Scoring and calibration](../scoring-and-calibration.md); bracket-level language and organization mix is in [Calibration diversity](../calibrate-diversity.md). Comparisons are layered so percentiles stay interpretable:
+RepoPulse does not use arbitrary "good/bad" thresholds. Every score is a **percentile ranking** against 2,400+ calibrated GitHub repositories. Filters, sort strategy, and stratum boundaries are documented in [Scoring and calibration](../scoring-and-calibration.md); bracket-level language and organization mix is in [Calibration diversity](../calibrate-diversity.md). Comparisons are layered so percentiles stay interpretable:
 
 - **Star bracket** — You are ranked against similar-sized projects, not the whole of GitHub.
 - **Strata within the bracket** — Each bracket is split into sub-ranges (with linear or log boundaries depending on scale). Targets are drawn per stratum so skewed star distributions do not collapse the baseline to “only the crowded low end.”


### PR DESCRIPTION
## Summary
- Shrink banner image and heading spacing so the hero section takes less vertical space
- Collapse the five dimension cards from a 2-column grid with descriptions into a single row of compact icon+label pills (descriptions were already hidden on mobile)
- Move fine-print text and methodology link below the sign-in button so the CTA is always above the fold
- Tighten overall gaps (`gap-4/sm:gap-8` → `gap-3/sm:gap-5`) and padding
- Correct stale "1,600+" repo count to "2,400+" in the landing page, README, and blog post to reflect the current calibration dataset (6 tiers including solo)

Closes #259

## Test plan
- [x] Landing page fits in a single viewport on 1080p desktop without scrolling
- [x] Sign-in button is visible above the fold
- [x] All five dimension pills render in a wrapping row
- [x] Fine-print and "View scoring methodology" link appear below the sign-in button
- [x] Mobile layout stacks correctly (narrow viewport)
- [x] Auth error state still renders correctly
- [x] Clicking sign-in still triggers OAuth flow
- [x] "2,400+" appears on landing page, README, and blog post (no stale "1,600+" references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)