### PR TITLE
[#258] Hide rate-limit info box in org aggregation flow

### DIFF
--- a/components/comparison/ComparisonView.tsx
+++ b/components/comparison/ComparisonView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import type { AnalysisResult, RateLimitState } from '@/lib/analyzer/analysis-result'
+import { isRateLimitLow, type AnalysisResult, type RateLimitState } from '@/lib/analyzer/analysis-result'
 import {
   buildComparisonSections,
   getComparisonLimitMessage,
@@ -148,7 +148,7 @@ export function ComparisonView({ results, rateLimit }: ComparisonViewProps) {
         </div>
       )}
 
-      {rateLimit ? (
+      {rateLimit && isRateLimitLow(rateLimit) ? (
         <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
           <p>Remaining API calls: {rateLimit.remaining.toLocaleString('en-US')}</p>
           <p>Rate limit resets at: {new Date(rateLimit.resetAt).toLocaleTimeString()}</p>

--- a/components/org-inventory/OrgInventoryView.test.tsx
+++ b/components/org-inventory/OrgInventoryView.test.tsx
@@ -24,7 +24,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/react', { stars: 100 }),
           buildRepo('facebook/jest', { stars: 80, primaryLanguage: 'JavaScript' }),
         ]}
-
+        rateLimit={null}
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -57,7 +57,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 1,
         }}
         results={[buildRepo('facebook/react')]}
-
+        rateLimit={null}
         onAnalyzeRepo={onAnalyzeRepo}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -86,7 +86,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/react', { stars: 100, description: 'React UI library' }),
           buildRepo('facebook/jest', { stars: 80, description: 'Jest testing framework' }),
         ]}
-
+        rateLimit={null}
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={onAnalyzeSelected}
       />,
@@ -118,7 +118,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 1,
         }}
         results={[buildRepo('facebook/react')]}
-
+        rateLimit={null}
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -148,7 +148,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 30,
         }}
         results={repos}
-
+        rateLimit={null}
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -169,6 +169,53 @@ describe('OrgInventoryView', () => {
     expect(screen.getByText('facebook/repo-26')).toBeInTheDocument()
   })
 
+  it('shows the remaining API-call footer only when rate limit is low (<= 25%)', () => {
+    const { rerender } = render(
+      <OrgInventoryView
+        org="facebook"
+        summary={{
+          totalPublicRepos: 1,
+          totalStars: 100,
+          mostStarredRepos: [{ repo: 'facebook/react', stars: 100 }],
+          mostRecentlyActiveRepos: [{ repo: 'facebook/react', pushedAt: '2026-04-02T00:00:00Z' }],
+          languageDistribution: [{ language: 'TypeScript', repoCount: 1 }],
+          archivedRepoCount: 0,
+          activeRepoCount: 1,
+        }}
+        results={[buildRepo('facebook/react')]}
+        rateLimit={{ limit: 5000, remaining: 4963, resetAt: '2026-04-03T00:50:00Z', retryAfter: 'unavailable' }}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    // Above 25% — hidden
+    expect(screen.queryByText(/remaining api calls/i)).not.toBeInTheDocument()
+
+    rerender(
+      <OrgInventoryView
+        org="facebook"
+        summary={{
+          totalPublicRepos: 1,
+          totalStars: 100,
+          mostStarredRepos: [{ repo: 'facebook/react', stars: 100 }],
+          mostRecentlyActiveRepos: [{ repo: 'facebook/react', pushedAt: '2026-04-02T00:00:00Z' }],
+          languageDistribution: [{ language: 'TypeScript', repoCount: 1 }],
+          archivedRepoCount: 0,
+          activeRepoCount: 1,
+        }}
+        results={[buildRepo('facebook/react')]}
+        rateLimit={{ limit: 5000, remaining: 800, resetAt: '2026-04-03T00:50:00Z', retryAfter: 'unavailable' }}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    // At or below 25% — visible
+    expect(screen.getAllByText('Remaining API calls: 800')).toHaveLength(1)
+    expect(screen.getByText(/rate limit resets at:/i)).toBeInTheDocument()
+  })
+
   it('shows only the explicit empty state for organizations with no public repositories', () => {
     render(
       <OrgInventoryView
@@ -183,7 +230,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 0,
         }}
         results={[]}
-
+        rateLimit={null}
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -216,7 +263,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/relay', { isFork: true }),
           buildRepo('facebook/rocksdb'),
         ]}
-
+        rateLimit={null}
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
         onAnalyzeAllActive={onAnalyzeAllActive}
@@ -249,7 +296,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/jest', { archived: true }),
           buildRepo('facebook/relay', { isFork: true }),
         ]}
-
+        rateLimit={null}
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
         onAnalyzeAllActive={vi.fn()}

--- a/components/org-inventory/OrgInventoryView.test.tsx
+++ b/components/org-inventory/OrgInventoryView.test.tsx
@@ -24,7 +24,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/react', { stars: 100 }),
           buildRepo('facebook/jest', { stars: 80, primaryLanguage: 'JavaScript' }),
         ]}
-        rateLimit={null}
+
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -57,7 +57,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 1,
         }}
         results={[buildRepo('facebook/react')]}
-        rateLimit={null}
+
         onAnalyzeRepo={onAnalyzeRepo}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -86,7 +86,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/react', { stars: 100, description: 'React UI library' }),
           buildRepo('facebook/jest', { stars: 80, description: 'Jest testing framework' }),
         ]}
-        rateLimit={null}
+
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={onAnalyzeSelected}
       />,
@@ -118,7 +118,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 1,
         }}
         results={[buildRepo('facebook/react')]}
-        rateLimit={null}
+
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -148,7 +148,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 30,
         }}
         results={repos}
-        rateLimit={null}
+
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -169,30 +169,6 @@ describe('OrgInventoryView', () => {
     expect(screen.getByText('facebook/repo-26')).toBeInTheDocument()
   })
 
-  it('shows the remaining API-call footer when rate-limit metadata is available', () => {
-    render(
-      <OrgInventoryView
-        org="facebook"
-        summary={{
-          totalPublicRepos: 1,
-          totalStars: 100,
-          mostStarredRepos: [{ repo: 'facebook/react', stars: 100 }],
-          mostRecentlyActiveRepos: [{ repo: 'facebook/react', pushedAt: '2026-04-02T00:00:00Z' }],
-          languageDistribution: [{ language: 'TypeScript', repoCount: 1 }],
-          archivedRepoCount: 0,
-          activeRepoCount: 1,
-        }}
-        results={[buildRepo('facebook/react')]}
-        rateLimit={{ remaining: 4963, resetAt: '2026-04-03T00:50:00Z', retryAfter: 'unavailable' }}
-        onAnalyzeRepo={vi.fn()}
-        onAnalyzeSelected={vi.fn()}
-      />,
-    )
-
-    expect(screen.getAllByText('Remaining API calls: 4,963')).toHaveLength(1)
-    expect(screen.getByText(/rate limit resets at:/i)).toBeInTheDocument()
-  })
-
   it('shows only the explicit empty state for organizations with no public repositories', () => {
     render(
       <OrgInventoryView
@@ -207,7 +183,7 @@ describe('OrgInventoryView', () => {
           activeRepoCount: 0,
         }}
         results={[]}
-        rateLimit={null}
+
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
       />,
@@ -240,7 +216,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/relay', { isFork: true }),
           buildRepo('facebook/rocksdb'),
         ]}
-        rateLimit={null}
+
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
         onAnalyzeAllActive={onAnalyzeAllActive}
@@ -273,7 +249,7 @@ describe('OrgInventoryView', () => {
           buildRepo('facebook/jest', { archived: true }),
           buildRepo('facebook/relay', { isFork: true }),
         ]}
-        rateLimit={null}
+
         onAnalyzeRepo={vi.fn()}
         onAnalyzeSelected={vi.fn()}
         onAnalyzeAllActive={vi.fn()}

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { isRateLimitLow } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import { ORG_AGGREGATION_CONFIG } from '@/lib/config/org-aggregation'
 import { clampOrgInventoryPageSize, ORG_INVENTORY_CONFIG } from '@/lib/config/org-inventory'
@@ -26,6 +27,7 @@ interface OrgInventoryViewProps {
   org: string
   summary: OrgInventoryResponse['summary']
   results: OrgInventoryResponse['results']
+  rateLimit: OrgInventoryResponse['rateLimit']
   onAnalyzeRepo: (repo: string) => void
   onAnalyzeSelected: (repos: string[]) => void
   onAnalyzeAllActive?: (repos: string[]) => void
@@ -35,6 +37,7 @@ export function OrgInventoryView({
   org,
   summary,
   results,
+  rateLimit,
   onAnalyzeRepo,
   onAnalyzeSelected,
   onAnalyzeAllActive,
@@ -295,6 +298,41 @@ export function OrgInventoryView({
           </div>
         </div>
       ) : null}
+      {rateLimit && isRateLimitLow(rateLimit) ? (
+        <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          <p>Remaining API calls: {formatDisplayValue(rateLimit.remaining)}</p>
+          <p>Rate limit resets at: {formatRateLimitReset(rateLimit.resetAt)}</p>
+          {rateLimit.retryAfter !== 'unavailable' ? <p>Retry after: {formatRetryAfter(rateLimit.retryAfter)}</p> : null}
+        </section>
+      ) : null}
     </section>
   )
+}
+
+function formatDisplayValue(value: number | string) {
+  if (typeof value === 'number') {
+    return new Intl.NumberFormat('en-US').format(value)
+  }
+  return value
+}
+
+function formatRateLimitReset(value: string) {
+  if (value === 'unavailable') {
+    return value
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+function formatRetryAfter(value: number | string) {
+  if (typeof value !== 'number') {
+    return value
+  }
+  return `${new Intl.NumberFormat('en-US').format(value)}s`
 }

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -26,7 +26,6 @@ interface OrgInventoryViewProps {
   org: string
   summary: OrgInventoryResponse['summary']
   results: OrgInventoryResponse['results']
-  rateLimit: OrgInventoryResponse['rateLimit']
   onAnalyzeRepo: (repo: string) => void
   onAnalyzeSelected: (repos: string[]) => void
   onAnalyzeAllActive?: (repos: string[]) => void
@@ -36,7 +35,6 @@ export function OrgInventoryView({
   org,
   summary,
   results,
-  rateLimit,
   onAnalyzeRepo,
   onAnalyzeSelected,
   onAnalyzeAllActive,
@@ -297,45 +295,6 @@ export function OrgInventoryView({
           </div>
         </div>
       ) : null}
-      {rateLimit ? (
-        <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
-          <p>Remaining API calls: {formatDisplayValue(rateLimit.remaining)}</p>
-          <p>Rate limit resets at: {formatRateLimitReset(rateLimit.resetAt)}</p>
-          {rateLimit.retryAfter !== 'unavailable' ? <p>Retry after: {formatRetryAfter(rateLimit.retryAfter)}</p> : null}
-        </section>
-      ) : null}
     </section>
   )
-}
-
-function formatDisplayValue(value: number | string) {
-  if (typeof value === 'number') {
-    return new Intl.NumberFormat('en-US').format(value)
-  }
-
-  return value
-}
-
-function formatRateLimitReset(value: string) {
-  if (value === 'unavailable') {
-    return value
-  }
-
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
-
-  return new Intl.DateTimeFormat('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(date)
-}
-
-function formatRetryAfter(value: number | string) {
-  if (typeof value !== 'number') {
-    return value
-  }
-
-  return `${new Intl.NumberFormat('en-US').format(value)}s`
 }

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -320,7 +320,7 @@ describe('RepoInputClient', () => {
     let resolveAnalysis: ((value: {
       results: never[]
       failures: never[]
-      rateLimit: { remaining: number; resetAt: string; retryAfter: 'unavailable' }
+      rateLimit: { limit: number; remaining: number; resetAt: string; retryAfter: 'unavailable' }
     }) => void) | null = null
     const onAnalyze = vi.fn(
       () =>
@@ -341,10 +341,10 @@ describe('RepoInputClient', () => {
     resolveAnalysis?.({
       results: [],
       failures: [],
-      rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+      rateLimit: { limit: 5000, remaining: 800, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
     })
 
-    expect(await screen.findByText(/remaining api calls: 4,999/i)).toBeInTheDocument()
+    expect(await screen.findByText(/remaining api calls: 800/i)).toBeInTheDocument()
     expect(screen.getByText(/rate limit resets at:/i)).toBeInTheDocument()
     expect(screen.queryByText(/retry after:/i)).not.toBeInTheDocument()
   })
@@ -353,7 +353,7 @@ describe('RepoInputClient', () => {
     const onAnalyze = vi.fn().mockResolvedValue({
       results: [],
       failures: [],
-      rateLimit: { remaining: 'unavailable', resetAt: 'unavailable', retryAfter: 60 },
+      rateLimit: { limit: 5000, remaining: 500, resetAt: '2026-03-31T23:59:59Z', retryAfter: 60 },
     })
 
     renderWithAuth(<RepoInputClient onAnalyze={onAnalyze} />)

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -480,6 +480,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                 org={orgInventoryResponse.org}
                 summary={orgInventoryResponse.summary}
                 results={orgInventoryResponse.results}
+                rateLimit={orgInventoryResponse.rateLimit}
                 onAnalyzeRepo={(repo) => {
                   void handleSubmit([repo])
                 }}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -445,7 +445,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               </ul>
             </section>
           ) : null}
-          {analysisResponse.rateLimit ? (
+          {analysisResponse.rateLimit && !orgInventoryResponse ? (
             <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
               <p>Remaining API calls: {formatDisplayValue(analysisResponse.rateLimit.remaining)}</p>
               <p>Rate limit resets at: {formatRateLimitReset(analysisResponse.rateLimit.resetAt)}</p>
@@ -480,7 +480,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                 org={orgInventoryResponse.org}
                 summary={orgInventoryResponse.summary}
                 results={orgInventoryResponse.results}
-                rateLimit={orgInventoryResponse.rateLimit}
                 onAnalyzeRepo={(repo) => {
                   void handleSubmit([repo])
                 }}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -23,7 +23,7 @@ import { OrgBucketContent } from '@/components/org-summary/OrgBucketContent'
 import { OrgWindowSelector } from '@/components/org-summary/OrgWindowSelector'
 import type { ContributorDiversityWindow } from '@/lib/org-aggregation/aggregators/types'
 import { useOrgAggregation } from '@/components/shared/hooks/useOrgAggregation'
-import type { AnalysisResult, AnalyzeResponse } from '@/lib/analyzer/analysis-result'
+import { isRateLimitLow, type AnalysisResult, type AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
@@ -445,7 +445,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               </ul>
             </section>
           ) : null}
-          {analysisResponse.rateLimit && !orgInventoryResponse ? (
+          {analysisResponse.rateLimit && !orgInventoryResponse && isRateLimitLow(analysisResponse.rateLimit) ? (
             <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
               <p>Remaining API calls: {formatDisplayValue(analysisResponse.rateLimit.remaining)}</p>
               <p>Rate limit resets at: {formatRateLimitReset(analysisResponse.rateLimit.resetAt)}</p>

--- a/lib/analyzer/analysis-result.ts
+++ b/lib/analyzer/analysis-result.ts
@@ -212,9 +212,18 @@ export interface AnalysisDiagnostic {
 }
 
 export interface RateLimitState {
+  limit: number | Unavailable
   remaining: number | Unavailable
   resetAt: string | Unavailable
   retryAfter: number | Unavailable
+}
+
+/** Returns true when remaining calls are at or below 25% of the total limit. */
+export function isRateLimitLow(rateLimit: RateLimitState): boolean {
+  if (typeof rateLimit.limit !== 'number' || typeof rateLimit.remaining !== 'number') {
+    return false
+  }
+  return rateLimit.remaining <= rateLimit.limit * 0.25
 }
 
 export interface AnalyzeResponse {

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -584,6 +584,7 @@ function extractRateLimitFromError(error: unknown): RateLimitState | null {
   }
 
   return {
+    limit: 'unavailable',
     remaining: 'unavailable',
     resetAt: 'unavailable',
     retryAfter: maybeError.retryAfter ?? 'unavailable',

--- a/lib/analyzer/analyzer.test.ts
+++ b/lib/analyzer/analyzer.test.ts
@@ -31,7 +31,7 @@ describe('analyze', () => {
     vi.clearAllMocks()
     fetchContributorCountMock.mockResolvedValue({
       data: 1742,
-      rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+      rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
     })
     fetchMaintainerCountMock.mockResolvedValue({
       data: {
@@ -43,11 +43,11 @@ describe('analyze', () => {
           { token: 'dave', kind: 'user' },
         ],
       },
-      rateLimit: { remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+      rateLimit: { limit: 5000, remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
     })
     fetchPublicUserOrganizationsMock.mockResolvedValue({
       data: ['meta'],
-      rateLimit: { remaining: 4995, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+      rateLimit: { limit: 5000, remaining: 4995, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
     })
   })
 
@@ -65,9 +65,9 @@ describe('analyze', () => {
             watchers: { totalCount: 10 },
             issues: { totalCount: 5 },
           },
-          rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z' },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z' },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Activity pass 1: commit history + releases
       .mockResolvedValueOnce({
@@ -100,9 +100,9 @@ describe('analyze', () => {
               },
             },
           },
-          rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z' },
+          rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z' },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Activity pass 2: search-based counts
       .mockResolvedValueOnce({
@@ -114,9 +114,9 @@ describe('analyze', () => {
           staleIssues30: { issueCount: 0 }, staleIssues60: { issueCount: 0 }, staleIssues90: { issueCount: 0 }, staleIssues180: { issueCount: 0 }, staleIssues365: { issueCount: 0 },
           recentMergedPullRequests: { nodes: [] },
           recentClosedIssues: { nodes: [] },
-          rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z' },
+          rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z' },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Responsiveness metadata query (pass 1) — empty for this test
       .mockResolvedValueOnce({
@@ -130,9 +130,9 @@ describe('analyze', () => {
           staleOpenPullRequests90: { issueCount: 0 },
           staleOpenPullRequests180: { issueCount: 0 },
           staleOpenPullRequests365: { issueCount: 0 },
-          rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z' },
+          rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z' },
         },
-        rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({
@@ -178,6 +178,7 @@ describe('analyze', () => {
     expect(result.results[0]?.missingFields).not.toContain('commitCountsByAuthor')
     expect(result.results[0]?.missingFields).not.toContain('commitCountsByExperimentalOrg')
     expect(result.rateLimit).toEqual({
+      limit: 5000,
       remaining: 4995,
       resetAt: '2026-03-31T23:59:59Z',
       retryAfter: 'unavailable',
@@ -208,7 +209,7 @@ describe('analyze', () => {
             issues: { totalCount: 5 },
           },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Activity pass 1: commit history + releases
       .mockResolvedValueOnce({
@@ -229,7 +230,7 @@ describe('analyze', () => {
             },
           },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Activity pass 2: search-based counts
       .mockResolvedValueOnce({
@@ -242,7 +243,7 @@ describe('analyze', () => {
           recentMergedPullRequests: { nodes: [] },
           recentClosedIssues: { nodes: [] },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockResolvedValueOnce({
         data: {
@@ -256,7 +257,7 @@ describe('analyze', () => {
           staleOpenPullRequests180: { issueCount: 0 },
           staleOpenPullRequests365: { issueCount: 0 },
         },
-        rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockResolvedValueOnce({
         data: {
@@ -271,7 +272,7 @@ describe('analyze', () => {
             },
           },
         },
-        rateLimit: { remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({
@@ -298,7 +299,7 @@ describe('analyze', () => {
             pullRequests: { totalCount: 4 },
           },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Activity pass 1: commit history + releases
       .mockResolvedValueOnce({
@@ -324,7 +325,7 @@ describe('analyze', () => {
             },
           },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Activity pass 2: search-based counts
       .mockResolvedValueOnce({
@@ -337,7 +338,7 @@ describe('analyze', () => {
           recentMergedPullRequests: { nodes: [{ createdAt: '2026-03-01T00:00:00Z', mergedAt: '2026-03-02T12:00:00Z' }] },
           recentClosedIssues: { nodes: [{ createdAt: '2026-03-03T00:00:00Z', closedAt: '2026-03-05T00:00:00Z' }] },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Responsiveness pass 1: metadata (no nested comment/review nodes)
       .mockResolvedValueOnce({
@@ -366,9 +367,9 @@ describe('analyze', () => {
           staleOpenPullRequests90: { issueCount: 1 },
           staleOpenPullRequests180: { issueCount: 1 },
           staleOpenPullRequests365: { issueCount: 1 },
-          rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z' },
+          rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z' },
         },
-        rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // Responsiveness pass 2: detail query for nodes with comments/reviews
       .mockResolvedValueOnce({
@@ -386,9 +387,9 @@ describe('analyze', () => {
             comments: { totalCount: 0, nodes: [] },
             reviews: { totalCount: 2, nodes: [{ createdAt: '2026-03-12T12:00:00Z', author: { login: 'erin' } }] },
           },
-          rateLimit: { remaining: 4996, resetAt: '2026-03-31T23:59:59Z' },
+          rateLimit: { limit: 5000, remaining: 4996, resetAt: '2026-03-31T23:59:59Z' },
         },
-        rateLimit: { remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({
@@ -436,9 +437,9 @@ describe('analyze', () => {
             watchers: { totalCount: 10 },
             issues: { totalCount: 5 },
           },
-          rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z' },
+          rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z' },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // react: activity pass 1
       .mockResolvedValueOnce({
@@ -464,7 +465,7 @@ describe('analyze', () => {
             },
           },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // react: activity pass 2
       .mockResolvedValueOnce({
@@ -477,7 +478,7 @@ describe('analyze', () => {
           recentMergedPullRequests: { nodes: [] },
           recentClosedIssues: { nodes: [] },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // react: responsiveness pass 1
       .mockResolvedValueOnce({
@@ -492,7 +493,7 @@ describe('analyze', () => {
           staleOpenPullRequests180: { issueCount: 0 },
           staleOpenPullRequests365: { issueCount: 0 },
         },
-        rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       // missing-repo: overview fails
       .mockRejectedValueOnce(new Error('not found'))
@@ -554,7 +555,7 @@ describe('analyze', () => {
             issues: { totalCount: 5 },
           },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockResolvedValueOnce({
         data: {
@@ -574,7 +575,7 @@ describe('analyze', () => {
           prsMerged: { issueCount: 3 },
           issuesClosed: { issueCount: 6 },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({
@@ -596,7 +597,7 @@ describe('analyze', () => {
   it('falls back to commit-based contributor count when REST API contributor count is unavailable', async () => {
     fetchContributorCountMock.mockResolvedValueOnce({
       data: 'unavailable',
-      rateLimit: { remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+      rateLimit: { limit: 5000, remaining: 4997, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
     })
 
     queryGitHubGraphQLMock
@@ -613,7 +614,7 @@ describe('analyze', () => {
             issues: { totalCount: 5 },
           },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockResolvedValueOnce({
         data: {
@@ -638,7 +639,7 @@ describe('analyze', () => {
           prsMerged: { issueCount: 3 },
           issuesClosed: { issueCount: 6 },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({
@@ -656,7 +657,7 @@ describe('analyze', () => {
   it('keeps maintainer count unavailable when no supported maintainer or owner file can be verified', async () => {
     fetchMaintainerCountMock.mockResolvedValueOnce({
       data: { count: 'unavailable', tokens: 'unavailable' },
-      rateLimit: { remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+      rateLimit: { limit: 5000, remaining: 4996, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
     })
 
     queryGitHubGraphQLMock
@@ -673,7 +674,7 @@ describe('analyze', () => {
             issues: { totalCount: 5 },
           },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockResolvedValueOnce({
         data: {
@@ -698,7 +699,7 @@ describe('analyze', () => {
           prsMerged: { issueCount: 3 },
           issuesClosed: { issueCount: 6 },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({
@@ -715,7 +716,7 @@ describe('analyze', () => {
   it('shows Unaffiliated in org metrics when contributors have no public organization', async () => {
     fetchPublicUserOrganizationsMock.mockResolvedValueOnce({
       data: [],
-      rateLimit: { remaining: 4995, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+      rateLimit: { limit: 5000, remaining: 4995, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
     })
 
     queryGitHubGraphQLMock
@@ -732,7 +733,7 @@ describe('analyze', () => {
             issues: { totalCount: 5 },
           },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockResolvedValueOnce({
         data: {
@@ -757,7 +758,7 @@ describe('analyze', () => {
           prsMerged: { issueCount: 3 },
           issuesClosed: { issueCount: 6 },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({
@@ -774,7 +775,7 @@ describe('analyze', () => {
     fetchPublicUserOrganizationsMock
       .mockResolvedValueOnce({
         data: ['kubernetes'],
-        rateLimit: { remaining: 4995, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4995, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockRejectedValueOnce(Object.assign(new Error('GitHub REST request failed with status 404'), { status: 404 }))
 
@@ -792,7 +793,7 @@ describe('analyze', () => {
             issues: { totalCount: 7 },
           },
         },
-        rateLimit: { remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4999, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
       .mockResolvedValueOnce({
         data: {
@@ -821,7 +822,7 @@ describe('analyze', () => {
           prsMerged: { issueCount: 1 },
           issuesClosed: { issueCount: 1 },
         },
-        rateLimit: { remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
+        rateLimit: { limit: 5000, remaining: 4998, resetAt: '2026-03-31T23:59:59Z', retryAfter: 'unavailable' },
       })
 
     const result = await analyze({

--- a/lib/analyzer/github-graphql.ts
+++ b/lib/analyzer/github-graphql.ts
@@ -57,9 +57,10 @@ function extractRateLimit(data: unknown): RateLimitState | null {
     return null
   }
 
-  const rateLimit = (data as { rateLimit?: { remaining?: number; resetAt?: string } }).rateLimit
+  const rateLimit = (data as { rateLimit?: { limit?: number; remaining?: number; resetAt?: string } }).rateLimit
 
   return {
+    limit: typeof rateLimit?.limit === 'number' ? rateLimit.limit : 'unavailable',
     remaining: typeof rateLimit?.remaining === 'number' ? rateLimit.remaining : 'unavailable',
     resetAt: typeof rateLimit?.resetAt === 'string' ? rateLimit.resetAt : 'unavailable',
     retryAfter: 'unavailable',

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -287,10 +287,12 @@ function isLikelyMaintainerToken(token: string) {
 }
 
 function extractRateLimit(response: Response): RateLimitState | null {
+  const limit = response.headers.get('X-RateLimit-Limit')
   const remaining = response.headers.get('X-RateLimit-Remaining')
   const resetAt = response.headers.get('X-RateLimit-Reset')
 
   return {
+    limit: limit ? Number(limit) : 'unavailable',
     remaining: remaining ? Number(remaining) : 'unavailable',
     resetAt: resetAt ? new Date(Number(resetAt) * 1000).toISOString() : 'unavailable',
     retryAfter: 'unavailable',

--- a/lib/analyzer/org-inventory.ts
+++ b/lib/analyzer/org-inventory.ts
@@ -218,6 +218,7 @@ const ORG_INVENTORY_QUERY = `
       }
     }
     rateLimit {
+      limit
       remaining
       resetAt
     }

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -97,6 +97,7 @@ export const REPO_OVERVIEW_QUERY = `
       }
     }
     rateLimit {
+      limit
       remaining
       resetAt
     }
@@ -164,6 +165,7 @@ export const REPO_COMMIT_AND_RELEASES_QUERY = `
       }
     }
     rateLimit {
+      limit
       remaining
       resetAt
     }
@@ -290,6 +292,7 @@ export const REPO_ACTIVITY_COUNTS_QUERY = `
       }
     }
     rateLimit {
+      limit
       remaining
       resetAt
     }
@@ -329,6 +332,7 @@ export const REPO_COMMIT_HISTORY_PAGE_QUERY = `
       }
     }
     rateLimit {
+      limit
       remaining
       resetAt
     }
@@ -348,6 +352,7 @@ export const REPO_DISCUSSIONS_PAGE_QUERY = `
       }
     }
     rateLimit {
+      limit
       remaining
       resetAt
     }
@@ -446,6 +451,7 @@ export const REPO_RESPONSIVENESS_METADATA_QUERY = `
       issueCount
     }
     rateLimit {
+      limit
       remaining
       resetAt
     }
@@ -497,6 +503,6 @@ export function buildResponsivenessDetailQuery(
 
   return `{
     ${aliases}
-    rateLimit { remaining resetAt }
+    rateLimit { limit remaining resetAt }
   }`
 }

--- a/lib/export/json-export.test.ts
+++ b/lib/export/json-export.test.ts
@@ -43,7 +43,7 @@ const MINIMAL_RESPONSE: AnalyzeResponse = {
     },
   ],
   failures: [],
-  rateLimit: { remaining: 4000, resetAt: '2026-04-06T20:00:00Z', retryAfter: 'unavailable' },
+  rateLimit: { limit: 5000, remaining: 4000, resetAt: '2026-04-06T20:00:00Z', retryAfter: 'unavailable' },
 }
 
 describe('buildJsonExport', () => {


### PR DESCRIPTION
## Summary
- Add `limit` field to `RateLimitState` and extract it from both GraphQL and REST API responses
- Add `isRateLimitLow()` helper — returns true when remaining calls <= 25% of the total limit
- Apply the 25% threshold consistently across all three rate-limit display locations:
  - **Repositories tab** (non-org flow)
  - **Organization tab** (`OrgInventoryView`)
  - **Comparison tab** (`ComparisonView`)
- Rate-limit box is hidden entirely when remaining calls are above 25%

Closes #258

## Test plan
- [ ] Run org aggregation flow with plenty of API calls remaining — verify no rate-limit box
- [ ] Run single/multi-repo analysis with plenty of API calls remaining — verify no rate-limit box
- [ ] Run analysis when API calls are low (<= 25% remaining) — verify rate-limit box appears in all applicable tabs
- [ ] `npx vitest run` passes (55 tests across 4 affected test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)