### PR TITLE
[#212] Implement US3: live org summary with progress, pre-run dialog, exports

### DIFF
--- a/components/org-inventory/OrgInventorySummary.test.tsx
+++ b/components/org-inventory/OrgInventorySummary.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { OrgInventorySummary } from './OrgInventorySummary'
 
 describe('OrgInventorySummary', () => {
-  it('collapses language distribution to the top 5 languages with a show-more control', async () => {
+  it('collapses language distribution to the top 3 languages with a show-more control', async () => {
     render(
       <OrgInventorySummary
         summary={{
@@ -22,9 +22,9 @@ describe('OrgInventorySummary', () => {
       />,
     )
 
-    expect(screen.getByText('Language 5')).toBeInTheDocument()
-    expect(screen.queryByText('Language 6')).not.toBeInTheDocument()
-    expect(screen.getByText('7 more languages hidden')).toBeInTheDocument()
+    expect(screen.getByText('Language 3')).toBeInTheDocument()
+    expect(screen.queryByText('Language 4')).not.toBeInTheDocument()
+    expect(screen.getByText('9 more languages hidden')).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: /show more languages/i }))
 
@@ -34,6 +34,6 @@ describe('OrgInventorySummary', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /show fewer languages/i }))
 
-    expect(screen.queryByText('Language 6')).not.toBeInTheDocument()
+    expect(screen.queryByText('Language 4')).not.toBeInTheDocument()
   })
 })

--- a/components/org-inventory/OrgInventorySummary.test.tsx
+++ b/components/org-inventory/OrgInventorySummary.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { OrgInventorySummary } from './OrgInventorySummary'
 
 describe('OrgInventorySummary', () => {
-  it('collapses language distribution to the top ten languages with a show-more control', async () => {
+  it('collapses language distribution to the top 5 languages with a show-more control', async () => {
     render(
       <OrgInventorySummary
         summary={{
@@ -22,9 +22,9 @@ describe('OrgInventorySummary', () => {
       />,
     )
 
-    expect(screen.getByText('Language 10')).toBeInTheDocument()
-    expect(screen.queryByText('Language 11')).not.toBeInTheDocument()
-    expect(screen.getByText('2 more languages hidden')).toBeInTheDocument()
+    expect(screen.getByText('Language 5')).toBeInTheDocument()
+    expect(screen.queryByText('Language 6')).not.toBeInTheDocument()
+    expect(screen.getByText('7 more languages hidden')).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: /show more languages/i }))
 
@@ -34,6 +34,6 @@ describe('OrgInventorySummary', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /show fewer languages/i }))
 
-    expect(screen.queryByText('Language 11')).not.toBeInTheDocument()
+    expect(screen.queryByText('Language 6')).not.toBeInTheDocument()
   })
 })

--- a/components/org-inventory/OrgInventorySummary.tsx
+++ b/components/org-inventory/OrgInventorySummary.tsx
@@ -48,7 +48,7 @@ export function OrgInventorySummary({ summary }: OrgInventorySummaryProps) {
             value: new Intl.NumberFormat('en-US').format(language.repoCount),
           }))}
           emptyLabel="No primary languages available."
-          collapsedItemCount={5}
+          collapsedItemCount={3}
           collapsedLabel="Show more languages"
           expandedLabel="Show fewer languages"
         />

--- a/components/org-inventory/OrgInventorySummary.tsx
+++ b/components/org-inventory/OrgInventorySummary.tsx
@@ -48,7 +48,7 @@ export function OrgInventorySummary({ summary }: OrgInventorySummaryProps) {
             value: new Intl.NumberFormat('en-US').format(language.repoCount),
           }))}
           emptyLabel="No primary languages available."
-          collapsedItemCount={10}
+          collapsedItemCount={5}
           collapsedLabel="Show more languages"
           expandedLabel="Show fewer languages"
         />

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -214,7 +214,7 @@ export function OrgInventoryView({
                   className="rounded border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200"
                   onClick={() => onAnalyzeSelected(selectedRepos)}
                 >
-                  Analyze selected
+                  Analyze selected ({selectedRepos.length})
                 </button>
               </div>
             </div>

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -31,6 +31,7 @@ interface OrgInventoryViewProps {
   onAnalyzeRepo: (repo: string) => void
   onAnalyzeSelected: (repos: string[]) => void
   onAnalyzeAllActive?: (repos: string[]) => void
+  afterSummary?: React.ReactNode
 }
 
 export function OrgInventoryView({
@@ -41,6 +42,7 @@ export function OrgInventoryView({
   onAnalyzeRepo,
   onAnalyzeSelected,
   onAnalyzeAllActive,
+  afterSummary,
 }: OrgInventoryViewProps) {
   const [filters, setFilters] = useState<OrgInventoryFilters>({
     repoQuery: '',
@@ -121,6 +123,7 @@ export function OrgInventoryView({
       ) : (
         <>
           <OrgInventorySummary summary={summary} />
+          {afterSummary}
           <section className="rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
             <button
               type="button"

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -63,6 +63,7 @@ export function OrgInventoryView({
   const [excludeForks, setExcludeForks] = useState<boolean>(
     ORG_AGGREGATION_CONFIG.preFilters.excludeForksByDefault,
   )
+  const [repoTableExpanded, setRepoTableExpanded] = useState(true)
 
   const columnLabels: Record<OrgInventoryVisibleColumn, string> = {
     description: 'Description',
@@ -120,7 +121,30 @@ export function OrgInventoryView({
       ) : (
         <>
           <OrgInventorySummary summary={summary} />
-          <section className="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-800">
+          <section className="rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800">
+            <button
+              type="button"
+              onClick={() => setRepoTableExpanded((e) => !e)}
+              aria-expanded={repoTableExpanded}
+              className="flex w-full items-center gap-2 p-3 text-left"
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className={`h-4 w-4 text-slate-500 transition-transform dark:text-slate-400 ${repoTableExpanded ? '' : '-rotate-90'}`}
+              >
+                <path d="M4 6l4 4 4-4" />
+              </svg>
+              <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                Repositories ({sortedRows.length})
+              </span>
+            </button>
+            {repoTableExpanded ? <div className="px-3 pb-3">
             <div className="flex flex-wrap items-end gap-2">
               <label className="flex-1 min-w-[140px]">
                 <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Filter</span>
@@ -243,10 +267,11 @@ export function OrgInventoryView({
                 </select>
               </label>
             </div>
+          </div> : null}
           </section>
         </>
       )}
-      {results.length > 0 && sortedRows.length === 0 ? (
+      {repoTableExpanded && results.length > 0 && sortedRows.length === 0 ? (
         <section className="rounded-2xl border border-slate-200 bg-white p-6">
           <h3 className="text-lg font-semibold text-slate-900">No matching repositories</h3>
           <p className="mt-2 text-sm text-slate-600">
@@ -254,7 +279,7 @@ export function OrgInventoryView({
           </p>
         </section>
       ) : null}
-      {results.length > 0 && sortedRows.length > 0 ? (
+      {repoTableExpanded && results.length > 0 && sortedRows.length > 0 ? (
         <div className="space-y-4">
           <OrgInventoryTable
             results={paginatedRows}

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -146,6 +146,7 @@ export function OrgInventoryView({
             </button>
             {repoTableExpanded ? (
               <div className="space-y-4 px-3 pb-3">
+                <div className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800">
                 <div className="flex flex-wrap items-end gap-2">
                   <label className="flex-1 min-w-[140px]">
                     <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Filter</span>
@@ -267,6 +268,7 @@ export function OrgInventoryView({
                       ))}
                     </select>
                   </label>
+                </div>
                 </div>
 
                 {sortedRows.length === 0 ? (

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -144,185 +144,187 @@ export function OrgInventoryView({
                 Repositories ({sortedRows.length})
               </span>
             </button>
-            {repoTableExpanded ? <div className="px-3 pb-3">
-            <div className="flex flex-wrap items-end gap-2">
-              <label className="flex-1 min-w-[140px]">
-                <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Filter</span>
-                <input
-                  value={filters.repoQuery}
-                  onChange={(event) => {
-                    setCurrentPage(1)
-                    setFilters((current) => ({ ...current, repoQuery: event.target.value }))
-                  }}
-                  className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
-                  placeholder="Repo name"
-                />
-              </label>
-              <label className="min-w-[120px]">
-                <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Language</span>
-                <select
-                  value={filters.language}
-                  onChange={(event) => {
-                    setCurrentPage(1)
-                    setFilters((current) => ({ ...current, language: event.target.value }))
-                  }}
-                  className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
-                >
-                  <option value="all">All</option>
-                  {languageOptions.map((language) => (
-                    <option key={language} value={language}>{language}</option>
-                  ))}
-                </select>
-              </label>
-              <label className="min-w-[100px]">
-                <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Archived</span>
-                <select
-                  value={filters.archived}
-                  onChange={(event) => {
-                    setCurrentPage(1)
-                    setFilters((current) => ({ ...current, archived: event.target.value as OrgInventoryFilters['archived'] }))
-                  }}
-                  className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
-                >
-                  <option value="all">All</option>
-                  <option value="active">Active</option>
-                  <option value="archived">Archived</option>
-                </select>
-              </label>
-              <div className="flex items-center gap-3 text-xs text-slate-700 dark:text-slate-300">
-                <label className="inline-flex items-center gap-1">
-                  <input type="checkbox" checked={excludeArchivedRepos} onChange={(e) => setExcludeArchivedRepos(e.target.checked)} aria-label="Exclude archived repos" />
-                  No archived
-                </label>
-                <label className="inline-flex items-center gap-1">
-                  <input type="checkbox" checked={excludeForks} onChange={(e) => setExcludeForks(e.target.checked)} aria-label="Exclude forks" />
-                  No forks
-                </label>
-              </div>
-            </div>
+            {repoTableExpanded ? (
+              <div className="space-y-4 px-3 pb-3">
+                <div className="flex flex-wrap items-end gap-2">
+                  <label className="flex-1 min-w-[140px]">
+                    <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Filter</span>
+                    <input
+                      value={filters.repoQuery}
+                      onChange={(event) => {
+                        setCurrentPage(1)
+                        setFilters((current) => ({ ...current, repoQuery: event.target.value }))
+                      }}
+                      className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                      placeholder="Repo name"
+                    />
+                  </label>
+                  <label className="min-w-[120px]">
+                    <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Language</span>
+                    <select
+                      value={filters.language}
+                      onChange={(event) => {
+                        setCurrentPage(1)
+                        setFilters((current) => ({ ...current, language: event.target.value }))
+                      }}
+                      className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                    >
+                      <option value="all">All</option>
+                      {languageOptions.map((language) => (
+                        <option key={language} value={language}>{language}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="min-w-[100px]">
+                    <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Archived</span>
+                    <select
+                      value={filters.archived}
+                      onChange={(event) => {
+                        setCurrentPage(1)
+                        setFilters((current) => ({ ...current, archived: event.target.value as OrgInventoryFilters['archived'] }))
+                      }}
+                      className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                    >
+                      <option value="all">All</option>
+                      <option value="active">Active</option>
+                      <option value="archived">Archived</option>
+                    </select>
+                  </label>
+                  <div className="flex items-center gap-3 text-xs text-slate-700 dark:text-slate-300">
+                    <label className="inline-flex items-center gap-1">
+                      <input type="checkbox" checked={excludeArchivedRepos} onChange={(e) => setExcludeArchivedRepos(e.target.checked)} aria-label="Exclude archived repos" />
+                      No archived
+                    </label>
+                    <label className="inline-flex items-center gap-1">
+                      <input type="checkbox" checked={excludeForks} onChange={(e) => setExcludeForks(e.target.checked)} aria-label="Exclude forks" />
+                      No forks
+                    </label>
+                  </div>
+                </div>
 
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="text-xs text-slate-500 dark:text-slate-400">{selectedRepos.length} selected · {activeRunRepos.length} after filters</span>
-                <button
-                  type="button"
-                  onClick={() => setSelectedRepos(sortedRows.map((r) => r.repo))}
-                  className="text-xs text-sky-600 hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-300"
-                >
-                  Select all
-                </button>
-                {selectedRepos.length > 0 ? (
-                  <button
-                    type="button"
-                    onClick={() => setSelectedRepos([])}
-                    className="text-xs text-sky-600 hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-300"
-                  >
-                    Clear
-                  </button>
-                ) : null}
-              </div>
-              <div className="flex items-center gap-2">
-                {onAnalyzeAllActive ? (
-                  <button
-                    type="button"
-                    disabled={activeRunRepos.length === 0}
-                    className="rounded border border-sky-300 bg-sky-50 px-3 py-1 text-xs font-medium text-sky-800 transition enabled:hover:border-sky-400 enabled:hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-300"
-                    onClick={() => onAnalyzeAllActive(activeRunRepos)}
-                  >
-                    Analyze all ({activeRunRepos.length})
-                  </button>
-                ) : null}
-                <button
-                  type="button"
-                  disabled={selectedRepos.length === 0}
-                  className="rounded border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200"
-                  onClick={() => onAnalyzeSelected(selectedRepos)}
-                >
-                  Analyze selected ({selectedRepos.length})
-                </button>
-              </div>
-            </div>
-            {selectionError ? <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">{selectionError}</p> : null}
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{selectedRepos.length} selected · {activeRunRepos.length} after filters</span>
+                    <button
+                      type="button"
+                      onClick={() => setSelectedRepos(sortedRows.map((r) => r.repo))}
+                      className="text-xs text-sky-600 hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-300"
+                    >
+                      Select all
+                    </button>
+                    {selectedRepos.length > 0 ? (
+                      <button
+                        type="button"
+                        onClick={() => setSelectedRepos([])}
+                        className="text-xs text-sky-600 hover:text-sky-800 dark:text-sky-400 dark:hover:text-sky-300"
+                      >
+                        Clear
+                      </button>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {onAnalyzeAllActive ? (
+                      <button
+                        type="button"
+                        disabled={activeRunRepos.length === 0}
+                        className="rounded border border-sky-300 bg-sky-50 px-3 py-1 text-xs font-medium text-sky-800 transition enabled:hover:border-sky-400 enabled:hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-300"
+                        onClick={() => onAnalyzeAllActive(activeRunRepos)}
+                      >
+                        Analyze all ({activeRunRepos.length})
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      disabled={selectedRepos.length === 0}
+                      className="rounded border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200"
+                      onClick={() => onAnalyzeSelected(selectedRepos)}
+                    >
+                      Analyze selected ({selectedRepos.length})
+                    </button>
+                  </div>
+                </div>
+                {selectionError ? <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">{selectionError}</p> : null}
 
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 border-t border-slate-200 pt-2 dark:border-slate-700">
-              <p className="text-xs text-slate-500 dark:text-slate-400">
-                Showing {visibleRangeStart}–{visibleRangeEnd} of {sortedRows.length}
-              </p>
-              <label className="inline-flex items-center gap-2 text-sm text-slate-700">
-                <span>Rows per page</span>
-                <select
-                  aria-label="Rows per page"
-                  value={pageSize}
-                  onChange={(event) => {
-                    setCurrentPage(1)
-                    setPageSize(clampOrgInventoryPageSize(Number(event.target.value)))
-                  }}
-                  className="rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900"
-                >
-                  {ORG_INVENTORY_CONFIG.pageSizeOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </div>
-          </div> : null}
+                <div className="flex flex-wrap items-center justify-between gap-2 border-t border-slate-200 pt-2 dark:border-slate-700">
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Showing {visibleRangeStart}–{visibleRangeEnd} of {sortedRows.length}
+                  </p>
+                  <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                    <span>Rows per page</span>
+                    <select
+                      aria-label="Rows per page"
+                      value={pageSize}
+                      onChange={(event) => {
+                        setCurrentPage(1)
+                        setPageSize(clampOrgInventoryPageSize(Number(event.target.value)))
+                      }}
+                      className="rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900"
+                    >
+                      {ORG_INVENTORY_CONFIG.pageSizeOptions.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+
+                {sortedRows.length === 0 ? (
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">No matching repositories</h3>
+                    <p className="mt-2 text-sm text-slate-600">
+                      Try widening the repo, language, or archived filters to see more repositories.
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    <OrgInventoryTable
+                      results={paginatedRows}
+                      visibleColumns={visibleColumns}
+                      sortState={effectiveSortState}
+                      selectedRepos={selectedRepos}
+                      onToggleSort={(column) => {
+                        setCurrentPage(1)
+                        setSortState((current) => getNextSortState(current, column))
+                      }}
+                      onToggleRepoSelection={(repo) => {
+                        const next = toggleRepoSelection(selectedRepos, repo, selectionLimit)
+                        setSelectedRepos(next.selectedRepos)
+                        setSelectionError(next.error)
+                      }}
+                      onAnalyzeRepo={onAnalyzeRepo}
+                    />
+
+                    <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+                      <p className="text-sm text-slate-600">
+                        Page {safeCurrentPage} of {totalPages}
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          disabled={safeCurrentPage === 1}
+                          onClick={() => setCurrentPage((current) => Math.max(1, current - 1))}
+                          className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Previous
+                        </button>
+                        <button
+                          type="button"
+                          disabled={safeCurrentPage === totalPages}
+                          onClick={() => setCurrentPage((current) => Math.min(totalPages, current + 1))}
+                          className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          Next
+                        </button>
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
+            ) : null}
           </section>
         </>
       )}
-      {repoTableExpanded && results.length > 0 && sortedRows.length === 0 ? (
-        <section className="rounded-2xl border border-slate-200 bg-white p-6">
-          <h3 className="text-lg font-semibold text-slate-900">No matching repositories</h3>
-          <p className="mt-2 text-sm text-slate-600">
-            Try widening the repo, language, or archived filters to see more repositories.
-          </p>
-        </section>
-      ) : null}
-      {repoTableExpanded && results.length > 0 && sortedRows.length > 0 ? (
-        <div className="space-y-4">
-          <OrgInventoryTable
-            results={paginatedRows}
-            visibleColumns={visibleColumns}
-            sortState={effectiveSortState}
-            selectedRepos={selectedRepos}
-            onToggleSort={(column) => {
-              setCurrentPage(1)
-              setSortState((current) => getNextSortState(current, column))
-            }}
-            onToggleRepoSelection={(repo) => {
-              const next = toggleRepoSelection(selectedRepos, repo, selectionLimit)
-              setSelectedRepos(next.selectedRepos)
-              setSelectionError(next.error)
-            }}
-            onAnalyzeRepo={onAnalyzeRepo}
-          />
-
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-            <p className="text-sm text-slate-600">
-              Page {safeCurrentPage} of {totalPages}
-            </p>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                disabled={safeCurrentPage === 1}
-                onClick={() => setCurrentPage((current) => Math.max(1, current - 1))}
-                className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Previous
-              </button>
-              <button
-                type="button"
-                disabled={safeCurrentPage === totalPages}
-                onClick={() => setCurrentPage((current) => Math.min(totalPages, current + 1))}
-                className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Next
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : null}
       {rateLimit && isRateLimitLow(rateLimit) ? (
         <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
           <p>Remaining API calls: {formatDisplayValue(rateLimit.remaining)}</p>

--- a/components/org-summary/NotificationToggle.test.tsx
+++ b/components/org-summary/NotificationToggle.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { NotificationToggle } from './NotificationToggle'
+
+describe('NotificationToggle', () => {
+  const originalNotification = globalThis.Notification
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'Notification', { value: originalNotification, writable: true, configurable: true })
+  })
+
+  function mockNotification(permission: string, requestPermission?: () => Promise<string>) {
+    const mock = vi.fn() as unknown as typeof Notification
+    Object.defineProperty(mock, 'permission', { value: permission, configurable: true })
+    if (requestPermission) {
+      ;(mock as { requestPermission: () => Promise<string> }).requestPermission = requestPermission
+    }
+    Object.defineProperty(globalThis, 'Notification', { value: mock, writable: true, configurable: true })
+  }
+
+  it('renders a checkbox defaulting to off', () => {
+    mockNotification('default')
+    render(<NotificationToggle enabled={false} onChange={vi.fn()} />)
+    const cb = screen.getByLabelText(/completion notification/i) as HTMLInputElement
+    expect(cb.checked).toBe(false)
+  })
+
+  it('shows checked when enabled', () => {
+    mockNotification('granted')
+    render(<NotificationToggle enabled={true} onChange={vi.fn()} />)
+    const cb = screen.getByLabelText(/completion notification/i) as HTMLInputElement
+    expect(cb.checked).toBe(true)
+  })
+
+  it('calls onChange(false) when toggling off', () => {
+    mockNotification('granted')
+    const onChange = vi.fn()
+    render(<NotificationToggle enabled={true} onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText(/completion notification/i))
+    expect(onChange).toHaveBeenCalledWith(false)
+  })
+
+  it('requests permission and enables when granted', async () => {
+    mockNotification('default', () => Promise.resolve('granted'))
+    const onChange = vi.fn()
+    render(<NotificationToggle enabled={false} onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText(/completion notification/i))
+    await vi.waitFor(() => { expect(onChange).toHaveBeenCalledWith(true) })
+  })
+
+  it('shows denied state without re-prompting', () => {
+    mockNotification('denied')
+    const onChange = vi.fn()
+    render(<NotificationToggle enabled={false} onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText(/completion notification/i))
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByText('(blocked)')).toBeInTheDocument()
+  })
+})

--- a/components/org-summary/NotificationToggle.tsx
+++ b/components/org-summary/NotificationToggle.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+
+interface Props {
+  enabled: boolean
+  onChange: (enabled: boolean) => void
+}
+
+type PermissionState = 'default' | 'granted' | 'denied' | 'unsupported'
+
+function getPermissionState(): PermissionState {
+  if (typeof window === 'undefined' || !('Notification' in window)) return 'unsupported'
+  return Notification.permission as PermissionState
+}
+
+export function NotificationToggle({ enabled, onChange }: Props) {
+  const [permState, setPermState] = useState<PermissionState>(getPermissionState)
+
+  const handleToggle = useCallback(async () => {
+    if (enabled) {
+      onChange(false)
+      return
+    }
+
+    const state = getPermissionState()
+    if (state === 'unsupported') return
+    if (state === 'denied') {
+      setPermState('denied')
+      return
+    }
+
+    if (state === 'default') {
+      try {
+        const result = await Notification.requestPermission()
+        setPermState(result as PermissionState)
+        if (result === 'granted') {
+          onChange(true)
+        }
+      } catch {
+        setPermState('denied')
+      }
+      return
+    }
+
+    onChange(true)
+  }, [enabled, onChange])
+
+  if (permState === 'unsupported') return null
+
+  return (
+    <label className="inline-flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400">
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={() => void handleToggle()}
+        aria-label="Enable completion notification"
+      />
+      <span>
+        Notify
+        {permState === 'denied' ? (
+          <span className="ml-1 text-amber-600 dark:text-amber-400" title="Notifications blocked — re-enable in browser settings">
+            (blocked)
+          </span>
+        ) : null}
+      </span>
+    </label>
+  )
+}

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -214,12 +214,12 @@ function InlineOrgSummary({
 
   const statusLabel =
     view.status.status === 'complete'
-      ? 'Complete'
+      ? null
       : view.status.status === 'cancelled'
-        ? 'Cancelled'
+        ? null
         : view.status.status === 'paused'
           ? `Rate-limited — auto-resumes at ${view.status.pause?.resumesAt.toLocaleTimeString() ?? ''}`
-          : `In progress (${view.status.succeeded + view.status.failed} of ${view.status.total})`
+          : null
 
   const showCancel = view.status.status === 'in-progress' || view.status.status === 'paused'
   const showPause = view.status.status === 'in-progress' && Boolean(onPause)
@@ -255,8 +255,17 @@ function InlineOrgSummary({
             </svg>
           </button>
           <div>
-            <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Analysis run ({view.status.succeeded + view.status.failed} of {view.status.total})</p>
-            <p className="text-sm text-slate-600 dark:text-slate-400">{statusLabel}</p>
+            <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+              Analysis Run ({view.status.succeeded + view.status.failed} of {view.status.total})
+              {view.status.status === 'complete' ? (
+                <span className="ml-2 text-xs font-normal text-emerald-600 dark:text-emerald-400">Complete</span>
+              ) : view.status.status === 'cancelled' ? (
+                <span className="ml-2 text-xs font-normal text-amber-600 dark:text-amber-400">Cancelled</span>
+              ) : view.status.status === 'in-progress' ? (
+                <span className="ml-2 text-xs font-normal text-sky-600 dark:text-sky-400">In Progress</span>
+              ) : null}
+            </p>
+            {statusLabel ? <p className="text-xs text-slate-500 dark:text-slate-400">{statusLabel}</p> : null}
           </div>
         </div>
         <div className="flex items-center gap-3">

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -47,6 +47,21 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
   )
   const active = visibleBuckets.find((b) => b.bucket.id === activeTab) ?? visibleBuckets[0]
 
+  // When inline (showPanels=false), we render everything inside one collapsible card
+  if (!showPanels && showRunStatus) {
+    return <InlineOrgSummary
+      org={org}
+      view={view}
+      startedAt={startedAt}
+      onCancel={onCancel}
+      onPause={onPause}
+      onResume={onResume}
+      onRetry={onRetry}
+      notificationToggle={notificationToggle}
+      visibleBuckets={visibleBuckets}
+    />
+  }
+
   return (
     <div className="space-y-4">
       {showRunStatus ? (
@@ -57,7 +72,6 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
           onPause={onPause}
           onResume={onResume}
           notificationToggle={notificationToggle}
-          hideHeading={!showPanels}
         />
       ) : null}
 
@@ -99,16 +113,6 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
           pausesSoFar={view.status.pause.pausesSoFar}
           onCancel={onCancel}
         />
-      ) : null}
-
-      {!showPanels && visibleBuckets.length > 0 ? (
-        <div className="space-y-3">
-          {visibleBuckets
-            .find((b) => b.bucket.id === 'overview')
-            ?.bucketPanels.map(({ panelId, panel }) => (
-              <div key={panelId}>{renderPanel(panelId, panel)}</div>
-            ))}
-        </div>
       ) : null}
 
       {showPanels && visibleBuckets.length > 0 ? (
@@ -175,9 +179,225 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
               </ul>
             </section>
           ) : null}
-
         </>
       ) : null}
     </div>
   )
+}
+
+/** Inline variant — everything inside one collapsible bordered card */
+function InlineOrgSummary({
+  org,
+  view,
+  startedAt,
+  onCancel,
+  onPause,
+  onResume,
+  onRetry,
+  notificationToggle,
+  visibleBuckets,
+}: {
+  org: string
+  view: OrgSummaryViewModel
+  startedAt?: Date
+  onCancel?: () => void
+  onPause?: () => void
+  onResume?: () => void
+  onRetry?: (repo: string) => void
+  notificationToggle?: React.ReactNode
+  visibleBuckets: Array<{
+    bucket: { id: string; label: string; panels: string[] }
+    bucketPanels: Array<{ panelId: string; panel: NonNullable<unknown> }>
+  }>
+}) {
+  const [expanded, setExpanded] = useState(true)
+
+  const statusLabel =
+    view.status.status === 'complete'
+      ? 'Complete'
+      : view.status.status === 'cancelled'
+        ? 'Cancelled'
+        : view.status.status === 'paused'
+          ? `Rate-limited — auto-resumes at ${view.status.pause?.resumesAt.toLocaleTimeString() ?? ''}`
+          : `In progress (${view.status.succeeded + view.status.failed} of ${view.status.total})`
+
+  const showCancel = view.status.status === 'in-progress' || view.status.status === 'paused'
+  const showPause = view.status.status === 'in-progress' && Boolean(onPause)
+  const showResume = view.status.status === 'paused' && Boolean(onResume)
+  const isTerminal = view.status.status === 'complete' || view.status.status === 'cancelled'
+
+  return (
+    <section
+      aria-label="Analysis run"
+      className="rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900"
+    >
+      {/* Header row — always visible */}
+      <div className="flex flex-wrap items-center justify-between gap-3 p-4">
+        <div className="flex items-start gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            aria-label={expanded ? 'Collapse analysis run' : 'Expand analysis run'}
+            aria-expanded={expanded}
+            className="mt-0.5 inline-flex h-6 w-6 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className={`h-4 w-4 transition-transform ${expanded ? '' : '-rotate-90'}`}
+            >
+              <path d="M4 6l4 4 4-4" />
+            </svg>
+          </button>
+          <div>
+            <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Analysis run</p>
+            <p className="text-sm text-slate-600 dark:text-slate-400">{statusLabel}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          {notificationToggle}
+          {showPause && onPause ? (
+            <button type="button" onClick={onPause} aria-label="Pause run" title="Pause run"
+              className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+              <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor"><rect x="4" y="3" width="3" height="10" rx="0.5" /><rect x="9" y="3" width="3" height="10" rx="0.5" /></svg>
+            </button>
+          ) : null}
+          {showResume && onResume ? (
+            <button type="button" onClick={onResume} aria-label="Resume run" title="Resume run"
+              className="inline-flex h-8 w-8 items-center justify-center rounded border border-sky-500 bg-sky-600 text-white hover:bg-sky-700 dark:border-sky-400 dark:bg-sky-500 dark:hover:bg-sky-600">
+              <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor"><path d="M4 3v10l9-5-9-5z" /></svg>
+            </button>
+          ) : null}
+          {showCancel && onCancel ? (
+            <button type="button" onClick={onCancel} aria-label="Cancel run" title="Cancel run"
+              className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700">
+              <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor"><rect x="3.5" y="3.5" width="9" height="9" rx="1" /></svg>
+            </button>
+          ) : null}
+          {isTerminal ? (
+            <div className="flex gap-2">
+              <button type="button" onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
+                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+                Export JSON
+              </button>
+              <button type="button" onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
+                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+                Export Markdown
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Collapsible body */}
+      {expanded ? (
+        <div className="space-y-4 border-t border-slate-200 p-4 dark:border-slate-700">
+          {/* Stats */}
+          <dl className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <Stat label="Total" value={view.status.total} />
+            <Stat label="Succeeded" value={view.status.succeeded} tone="good" />
+            <Stat label="Failed" value={view.status.failed} tone={view.status.failed > 0 ? 'bad' : 'neutral'} />
+            <Stat label="In progress" value={view.status.inProgress} />
+            <Stat label="Queued" value={view.status.queued} />
+          </dl>
+
+          <div className="flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400">
+            <span>Elapsed: {formatDuration(view.status.elapsedMs)}</span>
+            {view.status.etaMs !== null ? <span>ETA: {formatDuration(view.status.etaMs)}</span> : null}
+            <span>Concurrency: {view.status.concurrency.chosen}</span>
+          </div>
+
+          {/* Progress bar */}
+          {startedAt && SHOW_PROGRESS_STATUSES.includes(view.status.status) ? (
+            <ProgressIndicator
+              succeeded={view.status.succeeded}
+              failed={view.status.failed}
+              total={view.status.total}
+              status={view.status.status}
+              startedAt={startedAt}
+              etaMs={view.status.etaMs}
+            />
+          ) : null}
+
+          {/* Rate limit pause */}
+          {view.status.pause && view.status.status === 'paused' ? (
+            <RateLimitPausePanel
+              kind={view.status.pause.kind}
+              resumesAt={view.status.pause.resumesAt}
+              reposToReDispatch={view.status.queued}
+              pausesSoFar={view.status.pause.pausesSoFar}
+              onCancel={onCancel}
+            />
+          ) : null}
+
+          {/* Overview panels */}
+          {visibleBuckets.length > 0 ? (
+            <div className="space-y-3">
+              {visibleBuckets
+                .find((b) => b.bucket.id === 'overview')
+                ?.bucketPanels.map(({ panelId, panel }) => (
+                  <div key={panelId}>{renderPanel(panelId as Parameters<typeof renderPanel>[0], panel as Parameters<typeof renderPanel>[1])}</div>
+                ))}
+            </div>
+          ) : null}
+
+          {/* Per-repo status */}
+          <PerRepoStatusList entries={view.perRepoStatusList} onRetry={onRetry} />
+
+          {/* Missing data */}
+          {view.missingData.length > 0 ? (
+            <section
+              aria-label="Missing data"
+              className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800"
+            >
+              <h3 className="mb-3 text-sm font-semibold text-slate-900 dark:text-slate-100">
+                Missing data ({view.missingData.length})
+              </h3>
+              <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
+                {view.missingData.map((m) => (
+                  <li key={`${m.repo}:${m.signalKey}`} className="py-2 text-sm text-slate-700 dark:text-slate-300">
+                    <span className="font-medium">{m.repo}</span>{' '}
+                    <span className="text-slate-500 dark:text-slate-400">· {m.signalKey}</span>{' '}
+                    <span className="text-slate-500 dark:text-slate-400">— {m.reason}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function Stat({ label, value, tone = 'neutral' }: { label: string; value: number; tone?: 'neutral' | 'good' | 'bad' }) {
+  const toneClass =
+    tone === 'good'
+      ? 'text-emerald-700 dark:text-emerald-400'
+      : tone === 'bad'
+        ? 'text-rose-700 dark:text-rose-400'
+        : 'text-slate-900 dark:text-slate-100'
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
+      <dd className={`text-xl font-semibold ${toneClass}`}>{value}</dd>
+    </div>
+  )
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  const h = Math.floor(totalSeconds / 3600)
+  const m = Math.floor((totalSeconds % 3600) / 60)
+  const s = totalSeconds % 60
+  const parts = [] as string[]
+  if (h) parts.push(`${h}h`)
+  if (h || m) parts.push(`${m}m`)
+  parts.push(`${s}s`)
+  return parts.join(' ')
 }

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -57,6 +57,7 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
           onPause={onPause}
           onResume={onResume}
           notificationToggle={notificationToggle}
+          hideHeading={!showPanels}
         />
       ) : null}
 
@@ -69,6 +70,25 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
           startedAt={startedAt}
           etaMs={view.status.etaMs}
         />
+      ) : null}
+
+      {showRunStatus && (view.status.status === 'complete' || view.status.status === 'cancelled') ? (
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          >
+            Export JSON
+          </button>
+          <button
+            type="button"
+            onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          >
+            Export Markdown
+          </button>
+        </div>
       ) : null}
 
       {showRunStatus && view.status.pause && view.status.status === 'paused' ? (
@@ -146,24 +166,6 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
             </section>
           ) : null}
 
-          {(view.status.status === 'complete' || view.status.status === 'cancelled') ? (
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
-                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-              >
-                Export JSON
-              </button>
-              <button
-                type="button"
-                onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
-                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-              >
-                Export Markdown
-              </button>
-            </div>
-          ) : null}
         </>
       ) : null}
     </div>

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -257,11 +257,7 @@ function InlineOrgSummary({
           <div>
             <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
               Analysis Run ({view.status.succeeded + view.status.failed} of {view.status.total})
-              {expanded && view.status.status === 'complete' ? (
-                <span className="ml-2 text-xs font-normal text-emerald-600 dark:text-emerald-400">Complete</span>
-              ) : expanded && view.status.status === 'cancelled' ? (
-                <span className="ml-2 text-xs font-normal text-amber-600 dark:text-amber-400">Cancelled</span>
-              ) : view.status.status === 'in-progress' ? (
+              {view.status.status === 'in-progress' ? (
                 <span className="ml-2 text-xs font-normal text-sky-600 dark:text-sky-400">In Progress</span>
               ) : null}
             </p>

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -101,6 +101,16 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
         />
       ) : null}
 
+      {!showPanels && visibleBuckets.length > 0 ? (
+        <div className="space-y-3">
+          {visibleBuckets
+            .find((b) => b.bucket.id === 'overview')
+            ?.bucketPanels.map(({ panelId, panel }) => (
+              <div key={panelId}>{renderPanel(panelId, panel)}</div>
+            ))}
+        </div>
+      ) : null}
+
       {showPanels && visibleBuckets.length > 0 ? (
         <>
           <div

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -24,11 +24,12 @@ interface Props {
   onRetry?: (repo: string) => void
   notificationToggle?: React.ReactNode
   showRunStatus?: boolean
+  showPanels?: boolean
 }
 
 const SHOW_PROGRESS_STATUSES: RunStatus[] = ['in-progress', 'paused', 'complete', 'cancelled']
 
-export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResume, onRetry, notificationToggle, showRunStatus = true }: Props) {
+export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResume, onRetry, notificationToggle, showRunStatus = true, showPanels = true }: Props) {
   const visibleBuckets = PANEL_BUCKETS
     .filter((b) => b.id !== 'repos' && b.id !== 'recommendations')
     .map((bucket) => ({
@@ -80,7 +81,7 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
         />
       ) : null}
 
-      {visibleBuckets.length > 0 ? (
+      {showPanels && visibleBuckets.length > 0 ? (
         <>
           <div
             role="tablist"

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -3,14 +3,21 @@
 import { useState } from 'react'
 import type {
   OrgSummaryViewModel,
+  RunStatus,
 } from '@/lib/org-aggregation/types'
+import { triggerDownload } from '@/lib/export/json-export'
+import { buildOrgSummaryJsonExport } from '@/lib/export/org-summary-json-export'
+import { buildOrgSummaryMarkdownExport } from '@/lib/export/org-summary-markdown-export'
 import { PANEL_BUCKETS, isRealPanel, renderPanel, type PanelBucketId } from './panels/registry'
 import { PerRepoStatusList } from './PerRepoStatusList'
+import { ProgressIndicator } from './ProgressIndicator'
+import { RateLimitPausePanel } from './RateLimitPausePanel'
 import { RunStatusHeader } from './RunStatusHeader'
 
 interface Props {
   org: string
   view: OrgSummaryViewModel
+  startedAt?: Date
   onCancel?: () => void
   onPause?: () => void
   onResume?: () => void
@@ -19,7 +26,9 @@ interface Props {
   showRunStatus?: boolean
 }
 
-export function OrgSummaryView({ org, view, onCancel, onPause, onResume, onRetry, notificationToggle, showRunStatus = true }: Props) {
+const SHOW_PROGRESS_STATUSES: RunStatus[] = ['in-progress', 'paused', 'complete', 'cancelled']
+
+export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResume, onRetry, notificationToggle, showRunStatus = true }: Props) {
   const visibleBuckets = PANEL_BUCKETS
     .filter((b) => b.id !== 'repos' && b.id !== 'recommendations')
     .map((bucket) => ({
@@ -47,6 +56,27 @@ export function OrgSummaryView({ org, view, onCancel, onPause, onResume, onRetry
           onPause={onPause}
           onResume={onResume}
           notificationToggle={notificationToggle}
+        />
+      ) : null}
+
+      {showRunStatus && startedAt && SHOW_PROGRESS_STATUSES.includes(view.status.status) ? (
+        <ProgressIndicator
+          succeeded={view.status.succeeded}
+          failed={view.status.failed}
+          total={view.status.total}
+          status={view.status.status}
+          startedAt={startedAt}
+          etaMs={view.status.etaMs}
+        />
+      ) : null}
+
+      {showRunStatus && view.status.pause && view.status.status === 'paused' ? (
+        <RateLimitPausePanel
+          kind={view.status.pause.kind}
+          resumesAt={view.status.pause.resumesAt}
+          reposToReDispatch={view.status.queued}
+          pausesSoFar={view.status.pause.pausesSoFar}
+          onCancel={onCancel}
         />
       ) : null}
 
@@ -113,6 +143,25 @@ export function OrgSummaryView({ org, view, onCancel, onPause, onResume, onRetry
                 ))}
               </ul>
             </section>
+          ) : null}
+
+          {(view.status.status === 'complete' || view.status.status === 'cancelled') ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
+                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                Export JSON
+              </button>
+              <button
+                type="button"
+                onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
+                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                Export Markdown
+              </button>
+            </div>
           ) : null}
         </>
       ) : null}

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -255,12 +255,11 @@ function InlineOrgSummary({
             </svg>
           </button>
           <div>
-            <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Analysis run</p>
+            <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Analysis run ({view.status.succeeded + view.status.failed} of {view.status.total})</p>
             <p className="text-sm text-slate-600 dark:text-slate-400">{statusLabel}</p>
           </div>
         </div>
         <div className="flex items-center gap-3">
-          {notificationToggle}
           {showPause && onPause ? (
             <button type="button" onClick={onPause} aria-label="Pause run" title="Pause run"
               className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
@@ -279,18 +278,6 @@ function InlineOrgSummary({
               <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor"><rect x="3.5" y="3.5" width="9" height="9" rx="1" /></svg>
             </button>
           ) : null}
-          {isTerminal ? (
-            <div className="flex gap-2">
-              <button type="button" onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
-                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
-                Export JSON
-              </button>
-              <button type="button" onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
-                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
-                Export Markdown
-              </button>
-            </div>
-          ) : null}
         </div>
       </div>
 
@@ -306,10 +293,27 @@ function InlineOrgSummary({
             <Stat label="Queued" value={view.status.queued} />
           </dl>
 
-          <div className="flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400">
-            <span>Elapsed: {formatDuration(view.status.elapsedMs)}</span>
-            {view.status.etaMs !== null ? <span>ETA: {formatDuration(view.status.etaMs)}</span> : null}
-            <span>Concurrency: {view.status.concurrency.chosen}</span>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400">
+              <span>Elapsed: {formatDuration(view.status.elapsedMs)}</span>
+              {view.status.etaMs !== null ? <span>ETA: {formatDuration(view.status.etaMs)}</span> : null}
+              <span>Concurrency: {view.status.concurrency.chosen}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              {notificationToggle}
+              {isTerminal ? (
+                <div className="flex gap-2">
+                  <button type="button" onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
+                    className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+                    Export JSON
+                  </button>
+                  <button type="button" onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
+                    className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+                    Export Markdown
+                  </button>
+                </div>
+              ) : null}
+            </div>
           </div>
 
           {/* Progress bar */}

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -257,9 +257,9 @@ function InlineOrgSummary({
           <div>
             <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
               Analysis Run ({view.status.succeeded + view.status.failed} of {view.status.total})
-              {view.status.status === 'complete' ? (
+              {expanded && view.status.status === 'complete' ? (
                 <span className="ml-2 text-xs font-normal text-emerald-600 dark:text-emerald-400">Complete</span>
-              ) : view.status.status === 'cancelled' ? (
+              ) : expanded && view.status.status === 'cancelled' ? (
                 <span className="ml-2 text-xs font-normal text-amber-600 dark:text-amber-400">Cancelled</span>
               ) : view.status.status === 'in-progress' ? (
                 <span className="ml-2 text-xs font-normal text-sky-600 dark:text-sky-400">In Progress</span>

--- a/components/org-summary/PreRunWarningDialog.test.tsx
+++ b/components/org-summary/PreRunWarningDialog.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ORG_AGGREGATION_CONFIG } from '@/lib/config/org-aggregation'
+import { PreRunWarningDialog } from './PreRunWarningDialog'
+
+describe('PreRunWarningDialog', () => {
+  const defaultProps = {
+    repoCount: 30,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  it('renders a dialog with role and aria-label', () => {
+    render(<PreRunWarningDialog {...defaultProps} />)
+    expect(screen.getByRole('dialog', { name: /pre-run warning/i })).toBeInTheDocument()
+  })
+
+  it('displays the repo count in the heading', () => {
+    render(<PreRunWarningDialog {...defaultProps} repoCount={64} />)
+    expect(screen.getByText(/Analyze 64 repositories/i)).toBeInTheDocument()
+  })
+
+  it('shows estimated time', () => {
+    render(<PreRunWarningDialog {...defaultProps} repoCount={30} />)
+    expect(screen.getByText(/Estimated time:/i)).toBeInTheDocument()
+  })
+
+  it('warns about keeping the tab open', () => {
+    render(<PreRunWarningDialog {...defaultProps} />)
+    expect(screen.getByText(/keep this browser tab open/i)).toBeInTheDocument()
+  })
+
+  it('has a concurrency input defaulting to config default', () => {
+    render(<PreRunWarningDialog {...defaultProps} />)
+    const input = screen.getByLabelText(/concurrency/i) as HTMLInputElement
+    expect(input).toBeInTheDocument()
+    expect(Number(input.value)).toBe(ORG_AGGREGATION_CONFIG.concurrency.default)
+  })
+
+  it('clamps concurrency to 1-10 range', () => {
+    render(<PreRunWarningDialog {...defaultProps} />)
+    const input = screen.getByLabelText(/concurrency/i) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '15' } })
+    expect(Number(input.value)).toBe(ORG_AGGREGATION_CONFIG.concurrency.max)
+    fireEvent.change(input, { target: { value: '0' } })
+    expect(Number(input.value)).toBe(ORG_AGGREGATION_CONFIG.concurrency.min)
+  })
+
+  it('has a notification opt-in toggle defaulting to off', () => {
+    render(<PreRunWarningDialog {...defaultProps} />)
+    const checkbox = screen.getByLabelText(/completion notification/i) as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+  })
+
+  it('calls onConfirm with concurrency and notificationOptIn on confirm click', () => {
+    const onConfirm = vi.fn()
+    render(<PreRunWarningDialog {...defaultProps} onConfirm={onConfirm} />)
+    fireEvent.click(screen.getByLabelText(/completion notification/i))
+    fireEvent.click(screen.getByText(/Start analysis/i))
+    expect(onConfirm).toHaveBeenCalledWith({
+      concurrency: ORG_AGGREGATION_CONFIG.concurrency.default,
+      notificationOptIn: true,
+    })
+  })
+
+  it('calls onCancel when cancel is clicked', () => {
+    const onCancel = vi.fn()
+    render(<PreRunWarningDialog {...defaultProps} onCancel={onCancel} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+})

--- a/components/org-summary/PreRunWarningDialog.tsx
+++ b/components/org-summary/PreRunWarningDialog.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useState } from 'react'
+import { ORG_AGGREGATION_CONFIG, clampConcurrency } from '@/lib/config/org-aggregation'
+
+export interface PreRunWarningDialogProps {
+  repoCount: number
+  onConfirm: (options: { concurrency: number; notificationOptIn: boolean }) => void
+  onCancel: () => void
+}
+
+const AVG_SECONDS_PER_REPO = 15
+
+function estimateEta(repoCount: number, concurrency: number): string {
+  const totalSeconds = Math.ceil((repoCount * AVG_SECONDS_PER_REPO) / concurrency)
+  const m = Math.floor(totalSeconds / 60)
+  const s = totalSeconds % 60
+  if (m === 0) return `~${s}s`
+  return s > 0 ? `~${m}m ${s}s` : `~${m}m`
+}
+
+export function PreRunWarningDialog({ repoCount, onConfirm, onCancel }: PreRunWarningDialogProps) {
+  const [concurrency, setConcurrency] = useState<number>(ORG_AGGREGATION_CONFIG.concurrency.default)
+  const [notificationOptIn, setNotificationOptIn] = useState(false)
+
+  const handleConcurrencyChange = (value: string) => {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      setConcurrency(clampConcurrency(parsed))
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Pre-run warning"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="mx-4 w-full max-w-md rounded-lg border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+          Analyze {repoCount} repositories?
+        </h2>
+
+        <div className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300">
+          <p>
+            Estimated time: <strong>{estimateEta(repoCount, concurrency)}</strong>
+          </p>
+          <p>
+            You must keep this browser tab open for the duration of the run. Closing or refreshing will lose all in-progress results.
+          </p>
+        </div>
+
+        <div className="mt-4 space-y-3">
+          <label className="block">
+            <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Concurrency (1–{ORG_AGGREGATION_CONFIG.concurrency.max})
+            </span>
+            <input
+              type="number"
+              min={ORG_AGGREGATION_CONFIG.concurrency.min}
+              max={ORG_AGGREGATION_CONFIG.concurrency.max}
+              value={concurrency}
+              onChange={(e) => handleConcurrencyChange(e.target.value)}
+              aria-label="Concurrency"
+              className="mt-1 w-20 rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+            <input
+              type="checkbox"
+              checked={notificationOptIn}
+              onChange={(e) => setNotificationOptIn(e.target.checked)}
+              aria-label="Enable completion notification"
+            />
+            Notify me when the run completes
+          </label>
+        </div>
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm({ concurrency, notificationOptIn })}
+            className="rounded border border-sky-500 bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 dark:border-sky-400 dark:bg-sky-500 dark:hover:bg-sky-600"
+          >
+            Start analysis
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/org-summary/PreRunWarningDialog.tsx
+++ b/components/org-summary/PreRunWarningDialog.tsx
@@ -78,21 +78,26 @@ export function PreRunWarningDialog({ repoCount, onConfirm, onCancel }: PreRunWa
           </label>
         </div>
 
-        <div className="mt-5 flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={() => onConfirm({ concurrency, notificationOptIn })}
-            className="rounded border border-sky-500 bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 dark:border-sky-400 dark:bg-sky-500 dark:hover:bg-sky-600"
-          >
-            Start analysis
-          </button>
+        <div className="mt-5 flex items-center justify-between">
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Cancel to go back and adjust repo filters.
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => onConfirm({ concurrency, notificationOptIn })}
+              className="rounded border border-sky-500 bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 dark:border-sky-400 dark:bg-sky-500 dark:hover:bg-sky-600"
+            >
+              Start analysis
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/components/org-summary/PreRunWarningDialog.tsx
+++ b/components/org-summary/PreRunWarningDialog.tsx
@@ -78,26 +78,24 @@ export function PreRunWarningDialog({ repoCount, onConfirm, onCancel }: PreRunWa
           </label>
         </div>
 
-        <div className="mt-5 flex items-center justify-between">
-          <p className="text-xs text-slate-500 dark:text-slate-400">
-            Cancel to go back and adjust repo filters.
-          </p>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={onCancel}
-              className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() => onConfirm({ concurrency, notificationOptIn })}
-              className="rounded border border-sky-500 bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 dark:border-sky-400 dark:bg-sky-500 dark:hover:bg-sky-600"
-            >
-              Start analysis
-            </button>
-          </div>
+        <p className="mt-4 text-xs text-slate-500 dark:text-slate-400">
+          Cancel to go back and adjust repo filters.
+        </p>
+        <div className="mt-3 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm({ concurrency, notificationOptIn })}
+            className="rounded border border-sky-500 bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 dark:border-sky-400 dark:bg-sky-500 dark:hover:bg-sky-600"
+          >
+            Start analysis
+          </button>
         </div>
       </div>
     </div>

--- a/components/org-summary/ProgressIndicator.test.tsx
+++ b/components/org-summary/ProgressIndicator.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { ProgressIndicator } from './ProgressIndicator'
+
+describe('ProgressIndicator', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  const baseProps = {
+    succeeded: 3,
+    failed: 1,
+    total: 10,
+    status: 'in-progress' as const,
+    startedAt: new Date('2026-01-01T00:00:00Z'),
+    etaMs: 60_000,
+  }
+
+  it('renders a progress bar with correct percentage', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '40')
+    expect(screen.getByText('40%')).toBeInTheDocument()
+  })
+
+  it('shows repo count text', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} />)
+    expect(screen.getByText(/4 of 10 repos/)).toBeInTheDocument()
+  })
+
+  it('shows elapsed time', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} />)
+    expect(screen.getByText(/Elapsed: 1m 0s/)).toBeInTheDocument()
+  })
+
+  it('shows ETA when in progress', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} />)
+    expect(screen.getByText(/ETA: 1m 0s/)).toBeInTheDocument()
+  })
+
+  it('updates elapsed timer as time progresses', () => {
+    const start = new Date('2026-01-01T00:00:00Z')
+    vi.setSystemTime(start)
+    render(<ProgressIndicator {...baseProps} startedAt={start} />)
+    expect(screen.getByText(/Elapsed: 0s/)).toBeInTheDocument()
+    act(() => { vi.advanceTimersByTime(2000) })
+    expect(screen.getByText(/Elapsed: 2s/)).toBeInTheDocument()
+  })
+
+  it('renders a rotating quote when in-progress', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    render(<ProgressIndicator {...baseProps} />)
+    const blockquote = document.querySelector('blockquote')
+    expect(blockquote).not.toBeNull()
+    expect(blockquote?.textContent).toBeTruthy()
+  })
+
+  it('stops rotation and hides quote on terminal completion', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} status="complete" succeeded={10} failed={0} />)
+    expect(document.querySelector('blockquote')).toBeNull()
+    expect(screen.getByText('Complete')).toBeInTheDocument()
+  })
+
+  it('shows cancelled state', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} status="cancelled" />)
+    expect(screen.getByText('Cancelled')).toBeInTheDocument()
+    expect(document.querySelector('blockquote')).toBeNull()
+  })
+
+  it('shows failure count on complete with failures', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} status="complete" succeeded={8} failed={2} total={10} />)
+    expect(screen.getByText(/Done — 2 failed/)).toBeInTheDocument()
+  })
+
+  it('hides ETA on terminal status', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    render(<ProgressIndicator {...baseProps} status="complete" succeeded={10} failed={0} />)
+    expect(screen.queryByText(/ETA:/)).not.toBeInTheDocument()
+  })
+})

--- a/components/org-summary/ProgressIndicator.tsx
+++ b/components/org-summary/ProgressIndicator.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
+import { ORG_AGGREGATION_CONFIG } from '@/lib/config/org-aggregation'
+import type { RunStatus } from '@/lib/org-aggregation/types'
+
+interface Props {
+  succeeded: number
+  failed: number
+  total: number
+  status: RunStatus
+  startedAt: Date
+  etaMs: number | null
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  const h = Math.floor(totalSeconds / 3600)
+  const m = Math.floor((totalSeconds % 3600) / 60)
+  const s = totalSeconds % 60
+  const parts = [] as string[]
+  if (h) parts.push(`${h}h`)
+  if (h || m) parts.push(`${m}m`)
+  parts.push(`${s}s`)
+  return parts.join(' ')
+}
+
+const TERMINAL_STATUSES: RunStatus[] = ['complete', 'cancelled']
+
+export function ProgressIndicator({ succeeded, failed, total, status, startedAt, etaMs }: Props) {
+  const completed = succeeded + failed
+  const percent = total > 0 ? Math.round((completed / total) * 100) : 0
+  const isTerminal = TERMINAL_STATUSES.includes(status)
+
+  const [elapsed, setElapsed] = useState(() => Date.now() - startedAt.getTime())
+  useEffect(() => {
+    if (isTerminal) return
+    const id = setInterval(() => {
+      setElapsed(Date.now() - startedAt.getTime())
+    }, ORG_AGGREGATION_CONFIG.wallClockTickIntervalMs)
+    return () => clearInterval(id)
+  }, [isTerminal, startedAt])
+
+  const [quoteIndex, setQuoteIndex] = useState(() => getRandomQuoteIndex(null))
+  const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  useEffect(() => {
+    if (isTerminal) {
+      if (quoteTimerRef.current) clearInterval(quoteTimerRef.current)
+      return
+    }
+    quoteTimerRef.current = setInterval(() => {
+      setQuoteIndex((prev) => getRandomQuoteIndex(prev))
+    }, ORG_AGGREGATION_CONFIG.quoteRotationIntervalMs)
+    return () => {
+      if (quoteTimerRef.current) clearInterval(quoteTimerRef.current)
+    }
+  }, [isTerminal])
+
+  const quote = LOADING_QUOTES[quoteIndex]
+
+  return (
+    <div
+      aria-label="Run progress"
+      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+    >
+      <div className="flex items-center gap-3">
+        <div
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${percent}% complete`}
+          className="h-2.5 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700"
+        >
+          <div
+            className={`h-full rounded-full transition-all duration-300 ${
+              isTerminal
+                ? failed > 0
+                  ? 'bg-amber-500'
+                  : 'bg-emerald-500'
+                : 'bg-sky-500'
+            }`}
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+        <span className="min-w-[3rem] text-right text-sm font-medium text-slate-700 dark:text-slate-300">
+          {percent}%
+        </span>
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400">
+        <span>{completed} of {total} repos</span>
+        <span>Elapsed: {formatDuration(elapsed)}</span>
+        {!isTerminal && etaMs !== null ? <span>ETA: {formatDuration(etaMs)}</span> : null}
+        {isTerminal ? (
+          <span className={failed > 0 ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}>
+            {status === 'cancelled' ? 'Cancelled' : failed > 0 ? `Done — ${failed} failed` : 'Complete'}
+          </span>
+        ) : null}
+      </div>
+
+      {!isTerminal && quote ? (
+        <blockquote className="mt-3 border-l-2 border-slate-200 pl-3 text-xs italic text-slate-500 dark:border-slate-700 dark:text-slate-400">
+          <p>&ldquo;{quote.text}&rdquo;</p>
+          <footer className="mt-0.5 not-italic">
+            — {quote.author}{quote.context ? `, ${quote.context}` : ''}
+          </footer>
+        </blockquote>
+      ) : null}
+    </div>
+  )
+}

--- a/components/org-summary/RateLimitPausePanel.test.tsx
+++ b/components/org-summary/RateLimitPausePanel.test.tsx
@@ -32,14 +32,14 @@ describe('RateLimitPausePanel', () => {
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
     const onCancel = vi.fn()
     render(<RateLimitPausePanel kind="primary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={5} pausesSoFar={1} onCancel={onCancel} />)
-    screen.getByText('Cancel run').click()
+    screen.getByLabelText('Cancel run').click()
     expect(onCancel).toHaveBeenCalledOnce()
   })
 
   it('hides cancel button when onCancel is not provided', () => {
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
     render(<RateLimitPausePanel kind="primary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={5} pausesSoFar={1} />)
-    expect(screen.queryByText('Cancel run')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Cancel run')).not.toBeInTheDocument()
   })
 
   it('has aria-label for accessibility', () => {

--- a/components/org-summary/RateLimitPausePanel.test.tsx
+++ b/components/org-summary/RateLimitPausePanel.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, act } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { RateLimitPausePanel } from './RateLimitPausePanel'
+
+describe('RateLimitPausePanel', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  it('renders with primary rate-limit kind', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    render(<RateLimitPausePanel kind="primary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={5} pausesSoFar={1} />)
+    expect(screen.getByText(/primary limit hit/i)).toBeInTheDocument()
+    expect(screen.getByText(/5 repos to re-dispatch/)).toBeInTheDocument()
+    expect(screen.getByText(/Pauses so far: 1/)).toBeInTheDocument()
+  })
+
+  it('renders with secondary rate-limit kind', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    render(<RateLimitPausePanel kind="secondary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={3} pausesSoFar={2} />)
+    expect(screen.getByText(/secondary limit hit/i)).toBeInTheDocument()
+  })
+
+  it('shows a live countdown', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    render(<RateLimitPausePanel kind="primary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={5} pausesSoFar={1} />)
+    expect(screen.getByTestId('countdown').textContent).toBe('1m 0s')
+    act(() => { vi.advanceTimersByTime(30_000) })
+    expect(screen.getByTestId('countdown').textContent).toBe('30s')
+  })
+
+  it('shows cancel button when onCancel is provided', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    const onCancel = vi.fn()
+    render(<RateLimitPausePanel kind="primary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={5} pausesSoFar={1} onCancel={onCancel} />)
+    screen.getByText('Cancel run').click()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('hides cancel button when onCancel is not provided', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    render(<RateLimitPausePanel kind="primary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={5} pausesSoFar={1} />)
+    expect(screen.queryByText('Cancel run')).not.toBeInTheDocument()
+  })
+
+  it('has aria-label for accessibility', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    render(<RateLimitPausePanel kind="primary" resumesAt={new Date('2026-01-01T00:01:00Z')} reposToReDispatch={5} pausesSoFar={1} />)
+    expect(screen.getByLabelText('Rate limit pause')).toBeInTheDocument()
+  })
+})

--- a/components/org-summary/RateLimitPausePanel.tsx
+++ b/components/org-summary/RateLimitPausePanel.tsx
@@ -54,9 +54,13 @@ export function RateLimitPausePanel({ kind, resumesAt, reposToReDispatch, pauses
             <button
               type="button"
               onClick={onCancel}
-              className="mt-3 rounded border border-amber-300 bg-white px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-50 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-200 dark:hover:bg-amber-900"
+              aria-label="Cancel run"
+              title="Cancel run"
+              className="mt-3 inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
             >
-              Cancel run
+              <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
+                <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
+              </svg>
             </button>
           ) : null}
         </div>

--- a/components/org-summary/RateLimitPausePanel.tsx
+++ b/components/org-summary/RateLimitPausePanel.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Props {
+  kind: 'primary' | 'secondary'
+  resumesAt: Date
+  reposToReDispatch: number
+  pausesSoFar: number
+  onCancel?: () => void
+}
+
+function formatCountdown(ms: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000))
+  const m = Math.floor(totalSeconds / 60)
+  const s = totalSeconds % 60
+  if (m === 0) return `${s}s`
+  return `${m}m ${s}s`
+}
+
+export function RateLimitPausePanel({ kind, resumesAt, reposToReDispatch, pausesSoFar, onCancel }: Props) {
+  const [remaining, setRemaining] = useState(() => Math.max(0, resumesAt.getTime() - Date.now()))
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRemaining(Math.max(0, resumesAt.getTime() - Date.now()))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [resumesAt])
+
+  return (
+    <section
+      aria-label="Rate limit pause"
+      className="rounded-lg border border-amber-200 bg-amber-50 p-4 shadow-sm dark:border-amber-800 dark:bg-amber-950/30"
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 text-amber-600 dark:text-amber-400">
+          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-5 w-5" fill="currentColor">
+            <path d="M8 1a7 7 0 100 14A7 7 0 008 1zm0 2.5a1 1 0 011 1V8a1 1 0 01-2 0V4.5a1 1 0 011-1zM8 10.5a1 1 0 100 2 1 1 0 000-2z" />
+          </svg>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+            Rate limited — {kind === 'primary' ? 'primary' : 'secondary'} limit hit
+          </h3>
+          <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
+            Auto-resumes in <strong data-testid="countdown">{formatCountdown(remaining)}</strong>
+          </p>
+          <div className="mt-2 flex flex-wrap gap-4 text-xs text-amber-600 dark:text-amber-400">
+            <span>{reposToReDispatch} repos to re-dispatch</span>
+            <span>Pauses so far: {pausesSoFar}</span>
+          </div>
+          {onCancel ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="mt-3 rounded border border-amber-300 bg-white px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-50 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-200 dark:hover:bg-amber-900"
+            >
+              Cancel run
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/org-summary/RunStatusHeader.tsx
+++ b/components/org-summary/RunStatusHeader.tsx
@@ -62,7 +62,9 @@ export function RunStatusHeader({ org, header, onCancel, onPause, onResume, noti
             <ChevronIcon expanded={expanded} />
           </button>
           <div>
-            {hideHeading ? null : (
+            {hideHeading ? (
+              <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Analysis run</p>
+            ) : (
               <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
                 Org summary — {org}
               </h2>

--- a/components/org-summary/RunStatusHeader.tsx
+++ b/components/org-summary/RunStatusHeader.tsx
@@ -29,12 +29,12 @@ export function RunStatusHeader({ org, header, onCancel, onPause, onResume, noti
   const [expanded, setExpanded] = useState(true)
   const statusLabel =
     header.status === 'complete'
-      ? `complete — ${header.succeeded} of ${header.total} succeeded, ${header.failed} failed`
+      ? 'Complete'
       : header.status === 'cancelled'
-        ? `cancelled (${header.succeeded + header.failed} of ${header.total} completed)`
+        ? 'Cancelled'
         : header.status === 'paused'
-          ? `rate-limited — auto-resumes at ${header.pause?.resumesAt.toLocaleTimeString() ?? ''}`
-          : `in progress (${header.succeeded + header.failed} of ${header.total})`
+          ? `Rate-limited — auto-resumes at ${header.pause?.resumesAt.toLocaleTimeString() ?? ''}`
+          : `In progress (${header.succeeded + header.failed} of ${header.total})`
 
   const showCancel = header.status === 'in-progress' || header.status === 'paused'
   const showPause = header.status === 'in-progress' && Boolean(onPause)

--- a/components/org-summary/RunStatusHeader.tsx
+++ b/components/org-summary/RunStatusHeader.tsx
@@ -22,9 +22,10 @@ interface Props {
   onPause?: () => void
   onResume?: () => void
   notificationToggle?: React.ReactNode
+  hideHeading?: boolean
 }
 
-export function RunStatusHeader({ org, header, onCancel, onPause, onResume, notificationToggle }: Props) {
+export function RunStatusHeader({ org, header, onCancel, onPause, onResume, notificationToggle, hideHeading }: Props) {
   const [expanded, setExpanded] = useState(true)
   const statusLabel =
     header.status === 'complete'
@@ -61,9 +62,11 @@ export function RunStatusHeader({ org, header, onCancel, onPause, onResume, noti
             <ChevronIcon expanded={expanded} />
           </button>
           <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-              Org summary — {org}
-            </h2>
+            {hideHeading ? null : (
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                Org summary — {org}
+              </h2>
+            )}
             <p className="text-sm text-slate-600 dark:text-slate-400">{statusLabel}</p>
           </div>
         </div>

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -286,6 +286,10 @@ describe('RepoInputClient', () => {
     await screen.findByRole('region', { name: /org inventory view/i })
     await userEvent.click(screen.getByRole('button', { name: /analyze all/i }))
 
+    // Pre-run dialog appears — confirm to start the run
+    await screen.findByRole('dialog', { name: /pre-run warning/i })
+    await userEvent.click(screen.getByRole('button', { name: /start analysis/i }))
+
     await vi.waitFor(() => {
       expect(onAnalyze).toHaveBeenCalledWith(['facebook/react'], 'gho_test_token')
       expect(onAnalyze).toHaveBeenCalledWith(['facebook/jest'], 'gho_test_token')

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -27,7 +27,6 @@ import type { ContributorDiversityWindow } from '@/lib/org-aggregation/aggregato
 import { useOrgAggregation } from '@/components/shared/hooks/useOrgAggregation'
 import { isRateLimitLow, type AnalysisResult, type AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
-import { isLargeOrg } from '@/lib/config/org-aggregation'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import { decodeRepos } from '@/lib/export/shareable-url'
@@ -522,15 +521,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                   void handleSubmit(repos)
                 }}
                 onAnalyzeAllActive={(repos) => {
-                  if (isLargeOrg(repos.length)) {
-                    setPreRunDialogRepos(repos)
-                  } else {
-                    void orgAggregation.start({
-                      org: orgInventoryResponse.org,
-                      repos,
-                      notificationOptIn,
-                    })
-                  }
+                  setPreRunDialogRepos(repos)
                 }}
               />
             </>

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -520,6 +520,21 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
             </section>
           ) : (
             <>
+              <OrgInventoryView
+                org={orgInventoryResponse.org}
+                summary={orgInventoryResponse.summary}
+                results={orgInventoryResponse.results}
+                rateLimit={orgInventoryResponse.rateLimit}
+                onAnalyzeRepo={(repo) => {
+                  void handleSubmit([repo])
+                }}
+                onAnalyzeSelected={(repos) => {
+                  setPreRunDialogRepos(repos)
+                }}
+                onAnalyzeAllActive={(repos) => {
+                  setPreRunDialogRepos(repos)
+                }}
+              />
               {orgAggregation.view ? (
                 <div ref={orgSummaryRef}>
                   <OrgSummaryView
@@ -539,21 +554,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                   />
                 </div>
               ) : null}
-              <OrgInventoryView
-                org={orgInventoryResponse.org}
-                summary={orgInventoryResponse.summary}
-                results={orgInventoryResponse.results}
-                rateLimit={orgInventoryResponse.rateLimit}
-                onAnalyzeRepo={(repo) => {
-                  void handleSubmit([repo])
-                }}
-                onAnalyzeSelected={(repos) => {
-                  setPreRunDialogRepos(repos)
-                }}
-                onAnalyzeAllActive={(repos) => {
-                  setPreRunDialogRepos(repos)
-                }}
-              />
             </>
           )}
         </section>

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -57,6 +57,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [preRunDialogRepos, setPreRunDialogRepos] = useState<string[] | null>(null)
   const [notificationOptIn, setNotificationOptIn] = useState(false)
+  const repoFetchAbortRef = useRef<AbortController | null>(null)
   const orgFetchAbortRef = useRef<AbortController | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -265,6 +266,10 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   async function handleSubmit(repos: string[]) {
     if (!session?.token) return
 
+    repoFetchAbortRef.current?.abort()
+    const controller = new AbortController()
+    repoFetchAbortRef.current = controller
+
     setSubmissionError(null)
     setAnalysisResponse(null)
     setOrgInventoryResponse(null)
@@ -276,18 +281,26 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     try {
       const response = onAnalyze
         ? await onAnalyze(repos, session.token)
-        : await submitAnalysisRequest(repos, session.token)
+        : await submitAnalysisRequest(repos, session.token, controller.signal)
 
-      if (response) {
+      if (response && !controller.signal.aborted) {
         setAnalysisResponse(response)
         setAnalyzedRepos(repos)
       }
     } catch (error) {
+      if (controller.signal.aborted) return
       const message = error instanceof Error ? error.message : 'Analysis request failed.'
       setSubmissionError(message)
     } finally {
-      setLoadingRepos([])
+      if (!controller.signal.aborted) setLoadingRepos([])
+      repoFetchAbortRef.current = null
     }
+  }
+
+  function handleCancelRepoFetch() {
+    repoFetchAbortRef.current?.abort()
+    repoFetchAbortRef.current = null
+    setLoadingRepos([])
   }
 
   async function handleOrgSubmit(org: string) {
@@ -394,7 +407,20 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         <section aria-label="Analysis loading state" className="rounded border border-blue-200 bg-blue-50 p-4">
           <div className="flex items-center justify-between">
             <h2 className="font-semibold text-blue-900">Analyzing repositories...</h2>
-            <span className="text-xs tabular-nums text-blue-700">{formatElapsedTime(elapsedSeconds)}</span>
+            <div className="flex items-center gap-3">
+              <span className="text-xs tabular-nums text-blue-700">{formatElapsedTime(elapsedSeconds)}</span>
+              <button
+                type="button"
+                onClick={handleCancelRepoFetch}
+                aria-label="Cancel"
+                title="Cancel"
+                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
+              >
+                <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
+                  <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
+                </svg>
+              </button>
+            </div>
           </div>
           <ul className="mt-2 list-disc pl-5 text-sm text-blue-900">
             {loadingRepos.map((repo) => (
@@ -427,9 +453,13 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               <button
                 type="button"
                 onClick={handleCancelOrgFetch}
-                className="rounded border border-blue-300 bg-white px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50"
+                aria-label="Cancel"
+                title="Cancel"
+                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
               >
-                Cancel
+                <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
+                  <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
+                </svg>
               </button>
             </div>
           </div>
@@ -688,11 +718,12 @@ function formatElapsedTime(seconds: number) {
   return `${seconds}s`
 }
 
-async function submitAnalysisRequest(repos: string[], token: string): Promise<AnalyzeResponse> {
+async function submitAnalysisRequest(repos: string[], token: string, signal?: AbortSignal): Promise<AnalyzeResponse> {
   const response = await fetch('/api/analyze', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ repos, token }),
+    signal,
   })
   const payload = (await response.json()) as AnalyzeResponse & { error?: string }
   if (!response.ok) throw new Error(payload.error ?? 'Analysis request failed.')

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -548,7 +548,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                   void handleSubmit([repo])
                 }}
                 onAnalyzeSelected={(repos) => {
-                  void handleSubmit(repos)
+                  setPreRunDialogRepos(repos)
                 }}
                 onAnalyzeAllActive={(repos) => {
                   setPreRunDialogRepos(repos)

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -534,27 +534,27 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                 onAnalyzeAllActive={(repos) => {
                   setPreRunDialogRepos(repos)
                 }}
+                afterSummary={orgAggregation.view ? (
+                  <div ref={orgSummaryRef}>
+                    <OrgSummaryView
+                      org={orgInventoryResponse.org}
+                      view={orgAggregation.view}
+                      startedAt={orgAggregation.run?.startedAt}
+                      onCancel={orgAggregation.cancel}
+                      onPause={orgAggregation.pause}
+                      onResume={orgAggregation.resume}
+                      onRetry={orgAggregation.retry}
+                      showPanels={false}
+                      notificationToggle={
+                        <NotificationToggle
+                          enabled={notificationOptIn}
+                          onChange={setNotificationOptIn}
+                        />
+                      }
+                    />
+                  </div>
+                ) : undefined}
               />
-              {orgAggregation.view ? (
-                <div ref={orgSummaryRef}>
-                  <OrgSummaryView
-                    org={orgInventoryResponse.org}
-                    view={orgAggregation.view}
-                    startedAt={orgAggregation.run?.startedAt}
-                    onCancel={orgAggregation.cancel}
-                    onPause={orgAggregation.pause}
-                    onResume={orgAggregation.resume}
-                    onRetry={orgAggregation.retry}
-                    showPanels={false}
-                    notificationToggle={
-                      <NotificationToggle
-                        enabled={notificationOptIn}
-                        onChange={setNotificationOptIn}
-                      />
-                    }
-                  />
-                </div>
-              ) : null}
             </>
           )}
         </section>

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -58,6 +58,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [preRunDialogRepos, setPreRunDialogRepos] = useState<string[] | null>(null)
   const [notificationOptIn, setNotificationOptIn] = useState(false)
+  const orgFetchAbortRef = useRef<AbortController | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -293,6 +294,10 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   async function handleOrgSubmit(org: string) {
     if (!session?.token) return
 
+    orgFetchAbortRef.current?.abort()
+    const controller = new AbortController()
+    orgFetchAbortRef.current = controller
+
     setSubmissionError(null)
     setAnalysisResponse(null)
     setOrgInventoryResponse(null)
@@ -305,17 +310,25 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     try {
       const response = onAnalyzeOrg
         ? await onAnalyzeOrg(org, session.token)
-        : await submitOrgInventoryRequest(org, session.token)
+        : await submitOrgInventoryRequest(org, session.token, controller.signal)
 
-      if (response) {
+      if (response && !controller.signal.aborted) {
         setOrgInventoryResponse(response)
       }
     } catch (error) {
+      if (controller.signal.aborted) return
       const message = error instanceof Error ? error.message : 'Organization inventory request failed.'
       setSubmissionError(message)
     } finally {
-      setLoadingOrg(null)
+      if (!controller.signal.aborted) setLoadingOrg(null)
+      orgFetchAbortRef.current = null
     }
+  }
+
+  function handleCancelOrgFetch() {
+    orgFetchAbortRef.current?.abort()
+    orgFetchAbortRef.current = null
+    setLoadingOrg(null)
   }
 
   const analysisPanel = (
@@ -410,7 +423,16 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         <section aria-label="Org inventory loading state" className="rounded border border-blue-200 bg-blue-50 p-4">
           <div className="flex items-center justify-between">
             <h2 className="font-semibold text-blue-900">Loading org inventory for:</h2>
-            <span className="text-xs tabular-nums text-blue-700">{formatElapsedTime(elapsedSeconds)}</span>
+            <div className="flex items-center gap-3">
+              <span className="text-xs tabular-nums text-blue-700">{formatElapsedTime(elapsedSeconds)}</span>
+              <button
+                type="button"
+                onClick={handleCancelOrgFetch}
+                className="rounded border border-blue-300 bg-white px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
           <p className="mt-2 text-sm text-blue-900">{loadingOrg}</p>
           {elapsedSeconds >= 10 ? (
@@ -686,11 +708,12 @@ async function submitAnalysisRequest(repos: string[], token: string): Promise<An
   return payload
 }
 
-async function submitOrgInventoryRequest(org: string, token: string): Promise<OrgInventoryResponse> {
+async function submitOrgInventoryRequest(org: string, token: string, signal?: AbortSignal): Promise<OrgInventoryResponse> {
   const response = await fetch('/api/analyze-org', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ org, token }),
+    signal,
   })
   const payload = (await response.json()) as OrgInventoryResponse & { error?: string }
   if (!response.ok) throw new Error(payload.error ?? 'Organization inventory request failed.')

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -545,6 +545,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                     onPause={orgAggregation.pause}
                     onResume={orgAggregation.resume}
                     onRetry={orgAggregation.retry}
+                    showPanels={false}
                     notificationToggle={
                       <NotificationToggle
                         enabled={notificationOptIn}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -18,13 +18,16 @@ import { SearchProvider } from '@/components/search/SearchContext'
 import type { TabMatchCounts } from '@/lib/search/types'
 import { computeTabTagCounts } from '@/lib/tags/tab-counts'
 import { useAuth } from '@/components/auth/AuthContext'
+import { NotificationToggle } from '@/components/org-summary/NotificationToggle'
 import { OrgSummaryView } from '@/components/org-summary/OrgSummaryView'
 import { OrgBucketContent } from '@/components/org-summary/OrgBucketContent'
 import { OrgWindowSelector } from '@/components/org-summary/OrgWindowSelector'
+import { PreRunWarningDialog } from '@/components/org-summary/PreRunWarningDialog'
 import type { ContributorDiversityWindow } from '@/lib/org-aggregation/aggregators/types'
 import { useOrgAggregation } from '@/components/shared/hooks/useOrgAggregation'
 import { isRateLimitLow, type AnalysisResult, type AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
+import { isLargeOrg } from '@/lib/config/org-aggregation'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import { decodeRepos } from '@/lib/export/shareable-url'
@@ -53,6 +56,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [activeTag, setActiveTag] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [preRunDialogRepos, setPreRunDialogRepos] = useState<string[] | null>(null)
+  const [notificationOptIn, setNotificationOptIn] = useState(false)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -465,16 +470,23 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           ) : (
             <>
               {orgAggregation.view ? (
-                <section className="flex items-center gap-3 rounded-lg border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200">
-                  <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5 flex-shrink-0 text-sky-600 dark:text-sky-400">
-                    <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clipRule="evenodd" />
-                  </svg>
-                  <span>
-                    {orgAggregation.view.status.status === 'complete' || orgAggregation.view.status.status === 'cancelled'
-                      ? <>Analysis complete — detailed per-repo results are in the <strong>Repositories</strong> tab.</>
-                      : <>Analyzing {orgAggregation.view.status.total} repos — detailed per-repo analysis is available in the <strong>Repositories</strong> tab.</>}
-                  </span>
-                </section>
+                <div ref={orgSummaryRef}>
+                  <OrgSummaryView
+                    org={orgInventoryResponse.org}
+                    view={orgAggregation.view}
+                    startedAt={orgAggregation.run?.startedAt}
+                    onCancel={orgAggregation.cancel}
+                    onPause={orgAggregation.pause}
+                    onResume={orgAggregation.resume}
+                    onRetry={orgAggregation.retry}
+                    notificationToggle={
+                      <NotificationToggle
+                        enabled={notificationOptIn}
+                        onChange={setNotificationOptIn}
+                      />
+                    }
+                  />
+                </div>
               ) : null}
               <OrgInventoryView
                 org={orgInventoryResponse.org}
@@ -488,10 +500,15 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                   void handleSubmit(repos)
                 }}
                 onAnalyzeAllActive={(repos) => {
-                  void orgAggregation.start({
-                    org: orgInventoryResponse.org,
-                    repos,
-                  })
+                  if (isLargeOrg(repos.length)) {
+                    setPreRunDialogRepos(repos)
+                  } else {
+                    void orgAggregation.start({
+                      org: orgInventoryResponse.org,
+                      repos,
+                      notificationOptIn,
+                    })
+                  }
                 }}
               />
             </>
@@ -511,6 +528,23 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
 
   return (
     <SearchProvider query={debouncedQuery}>
+    {preRunDialogRepos && orgInventoryResponse ? (
+      <PreRunWarningDialog
+        repoCount={preRunDialogRepos.length}
+        onConfirm={({ concurrency, notificationOptIn: notifOpt }) => {
+          const repos = preRunDialogRepos
+          setPreRunDialogRepos(null)
+          setNotificationOptIn(notifOpt)
+          void orgAggregation.start({
+            org: orgInventoryResponse.org,
+            repos,
+            concurrency,
+            notificationOptIn: notifOpt,
+          })
+        }}
+        onCancel={() => setPreRunDialogRepos(null)}
+      />
+    ) : null}
     <ResultsShell
       resetKey={resultsResetKey}
       initialActiveTab="overview"

--- a/lib/config/org-aggregation.ts
+++ b/lib/config/org-aggregation.ts
@@ -11,7 +11,7 @@ export const ORG_AGGREGATION_CONFIG = {
   updateCadenceDefault: { kind: 'every-n-percent', percentStep: 10 } as UpdateCadence,
   // Valid percent-step options for the pre-run dialog dropdown (US3).
   updateCadencePercentOptions: [5, 10, 20, 25] as const,
-  quoteRotationIntervalMs: 6_000,
+  quoteRotationIntervalMs: 10_000,
   wallClockTickIntervalMs: 1_000,
   inactiveRepoWindowMonths: 12,
   preFilters: {

--- a/lib/config/org-inventory.test.ts
+++ b/lib/config/org-inventory.test.ts
@@ -6,7 +6,7 @@ describe('org-inventory config', () => {
     expect(ORG_INVENTORY_CONFIG.defaultBulkSelectionLimit).toBe(5)
     expect(ORG_INVENTORY_CONFIG.maxBulkSelectionLimit).toBe(5)
     expect(ORG_INVENTORY_CONFIG.defaultPageSize).toBe(25)
-    expect(ORG_INVENTORY_CONFIG.pageSizeOptions).toEqual([25, 50, 100])
+    expect(ORG_INVENTORY_CONFIG.pageSizeOptions).toEqual([10, 25, 50, 100])
   })
 
   it('clamps requested slider values to the configured range', () => {
@@ -18,6 +18,7 @@ describe('org-inventory config', () => {
   it('clamps page-size values to the configured options', () => {
     expect(clampOrgInventoryPageSize(25)).toBe(25)
     expect(clampOrgInventoryPageSize(50)).toBe(50)
-    expect(clampOrgInventoryPageSize(10)).toBe(25)
+    expect(clampOrgInventoryPageSize(10)).toBe(10)
+    expect(clampOrgInventoryPageSize(15)).toBe(25)
   })
 })

--- a/lib/config/org-inventory.ts
+++ b/lib/config/org-inventory.ts
@@ -2,7 +2,7 @@ export const ORG_INVENTORY_CONFIG = {
   defaultBulkSelectionLimit: 5,
   maxBulkSelectionLimit: 5,
   defaultPageSize: 25,
-  pageSizeOptions: [25, 50, 100],
+  pageSizeOptions: [10, 25, 50, 100],
 } as const
 
 export function clampBulkSelectionLimit(requested: number) {

--- a/lib/export/org-summary-json-export.test.ts
+++ b/lib/export/org-summary-json-export.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
+import { buildOrgSummaryJsonExport } from './org-summary-json-export'
+
+function baseView(): OrgSummaryViewModel {
+  return {
+    status: {
+      total: 3, succeeded: 2, failed: 1, inProgress: 0, queued: 0,
+      elapsedMs: 30_000, etaMs: null, concurrency: { chosen: 3, effective: 3 },
+      pause: null, status: 'complete',
+    },
+    flagshipRepos: [{ repo: 'o/a', source: 'pinned', rank: 0 }],
+    panels: {
+      'contributor-diversity': {
+        panelId: 'contributor-diversity', contributingReposCount: 2, totalReposInRun: 3,
+        status: 'final', value: { defaultWindow: 90 },
+      },
+    },
+    missingData: [{ repo: 'o/c', signalKey: 'commitCountsByAuthor', reason: 'analysis failed' }],
+    perRepoStatusList: [
+      { repo: 'o/a', status: 'done', badge: 'done', isFlagship: true, durationMs: 12_000 },
+      { repo: 'o/b', status: 'done', badge: 'done', isFlagship: false, durationMs: 15_000 },
+      { repo: 'o/c', status: 'failed', badge: 'failed', errorReason: 'not found', isFlagship: false },
+    ],
+  }
+}
+
+describe('buildOrgSummaryJsonExport', () => {
+  it('produces a valid JSON blob that round-trips through JSON.parse', async () => {
+    const { blob, filename } = buildOrgSummaryJsonExport('test-org', baseView())
+    expect(blob.type).toBe('application/json')
+    expect(filename).toMatch(/^repopulse-org-test-org-\d{4}-\d{2}-\d{2}-\d{6}\.json$/)
+    const json = await blob.text()
+    const parsed = JSON.parse(json)
+    expect(parsed.org).toBe('test-org')
+    expect(parsed.runStatus.total).toBe(3)
+    expect(parsed.runStatus.succeeded).toBe(2)
+  })
+
+  it('includes all panels', async () => {
+    const { blob } = buildOrgSummaryJsonExport('test-org', baseView())
+    const parsed = JSON.parse(await blob.text())
+    expect(parsed.panels['contributor-diversity']).toBeDefined()
+    expect(parsed.panels['contributor-diversity'].status).toBe('final')
+  })
+
+  it('includes missing data and per-repo status', async () => {
+    const { blob } = buildOrgSummaryJsonExport('test-org', baseView())
+    const parsed = JSON.parse(await blob.text())
+    expect(parsed.missingData).toHaveLength(1)
+    expect(parsed.perRepoStatusList).toHaveLength(3)
+    expect(parsed.perRepoStatusList[2].errorReason).toBe('not found')
+  })
+})

--- a/lib/export/org-summary-json-export.ts
+++ b/lib/export/org-summary-json-export.ts
@@ -1,0 +1,63 @@
+import type { OrgSummaryViewModel, PanelId, AggregatePanel } from '@/lib/org-aggregation/types'
+
+export interface OrgSummaryJsonExportResult {
+  blob: Blob
+  filename: string
+}
+
+function buildTimestamp(): string {
+  const now = new Date()
+  const yyyy = now.getFullYear()
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
+  const HH = String(now.getHours()).padStart(2, '0')
+  const MM = String(now.getMinutes()).padStart(2, '0')
+  const ss = String(now.getSeconds()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}-${HH}${MM}${ss}`
+}
+
+function serializePanel(panelId: PanelId, panel: AggregatePanel<unknown>) {
+  return {
+    panelId,
+    status: panel.status,
+    contributingReposCount: panel.contributingReposCount,
+    totalReposInRun: panel.totalReposInRun,
+    value: panel.value,
+  }
+}
+
+export function buildOrgSummaryJsonExport(org: string, view: OrgSummaryViewModel): OrgSummaryJsonExportResult {
+  const exportData = {
+    org,
+    generatedAt: new Date().toISOString(),
+    runStatus: {
+      status: view.status.status,
+      total: view.status.total,
+      succeeded: view.status.succeeded,
+      failed: view.status.failed,
+      elapsedMs: view.status.elapsedMs,
+      etaMs: view.status.etaMs,
+      concurrency: view.status.concurrency,
+    },
+    flagshipRepos: view.flagshipRepos,
+    panels: Object.fromEntries(
+      Object.entries(view.panels)
+        .filter(([, panel]) => panel != null)
+        .map(([id, panel]) => [id, serializePanel(id as PanelId, panel!)]),
+    ),
+    missingData: view.missingData,
+    perRepoStatusList: view.perRepoStatusList.map((entry) => ({
+      repo: entry.repo,
+      status: entry.status,
+      badge: entry.badge,
+      errorReason: entry.errorReason ?? null,
+      isFlagship: entry.isFlagship,
+      durationMs: entry.durationMs ?? null,
+    })),
+  }
+
+  const json = JSON.stringify(exportData, null, 2)
+  const blob = new Blob([json], { type: 'application/json' })
+  const filename = `repopulse-org-${org}-${buildTimestamp()}.json`
+  return { blob, filename }
+}

--- a/lib/export/org-summary-markdown-export.test.ts
+++ b/lib/export/org-summary-markdown-export.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
+import { buildOrgSummaryMarkdownExport } from './org-summary-markdown-export'
+
+function baseView(): OrgSummaryViewModel {
+  return {
+    status: {
+      total: 3, succeeded: 2, failed: 1, inProgress: 0, queued: 0,
+      elapsedMs: 30_000, etaMs: null, concurrency: { chosen: 3, effective: 3 },
+      pause: null, status: 'complete',
+    },
+    flagshipRepos: [{ repo: 'o/a', source: 'pinned', rank: 0 }],
+    panels: {
+      'contributor-diversity': {
+        panelId: 'contributor-diversity', contributingReposCount: 2, totalReposInRun: 3,
+        status: 'final', value: { defaultWindow: 90 },
+      },
+    },
+    missingData: [{ repo: 'o/c', signalKey: 'commitCountsByAuthor', reason: 'analysis failed' }],
+    perRepoStatusList: [
+      { repo: 'o/a', status: 'done', badge: 'done', isFlagship: true },
+      { repo: 'o/b', status: 'done', badge: 'done', isFlagship: false },
+      { repo: 'o/c', status: 'failed', badge: 'failed', errorReason: 'not found', isFlagship: false },
+    ],
+  }
+}
+
+describe('buildOrgSummaryMarkdownExport', () => {
+  it('produces a markdown blob with correct filename', () => {
+    const { blob, filename } = buildOrgSummaryMarkdownExport('test-org', baseView())
+    expect(blob.type).toBe('text/markdown')
+    expect(filename).toMatch(/^repopulse-org-test-org-\d{4}-\d{2}-\d{2}-\d{6}\.md$/)
+  })
+
+  it('includes header, run status, panels, missing data, per-repo status', async () => {
+    const { blob } = buildOrgSummaryMarkdownExport('test-org', baseView())
+    const text = await blob.text()
+    expect(text).toContain('# RepoPulse Org Summary — test-org')
+    expect(text).toContain('## Run Status')
+    expect(text).toContain('| Total repos | 3 |')
+    expect(text).toContain('## Flagship Repos')
+    expect(text).toContain('o/a *(pinned)*')
+    expect(text).toContain('### Contributor Diversity')
+    expect(text).toContain('## Missing Data')
+    expect(text).toContain('| o/c | commitCountsByAuthor | analysis failed |')
+    expect(text).toContain('## Per-Repo Status')
+    expect(text).toContain('| o/c | failed |  | not found |')
+  })
+})

--- a/lib/export/org-summary-markdown-export.ts
+++ b/lib/export/org-summary-markdown-export.ts
@@ -1,0 +1,113 @@
+import type { OrgSummaryViewModel, PanelId, AggregatePanel } from '@/lib/org-aggregation/types'
+
+export interface OrgSummaryMarkdownExportResult {
+  blob: Blob
+  filename: string
+}
+
+function buildFileTimestamp(): string {
+  const now = new Date()
+  const yyyy = now.getFullYear()
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
+  const HH = String(now.getHours()).padStart(2, '0')
+  const MM = String(now.getMinutes()).padStart(2, '0')
+  const ss = String(now.getSeconds()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}-${HH}${MM}${ss}`
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  const m = Math.floor(totalSeconds / 60)
+  const s = totalSeconds % 60
+  if (m === 0) return `${s}s`
+  return `${m}m ${s}s`
+}
+
+const PANEL_LABELS: Record<PanelId, string> = {
+  'contributor-diversity': 'Contributor Diversity',
+  maintainers: 'Maintainers',
+  'org-affiliations': 'Org Affiliations',
+  'release-cadence': 'Release Cadence',
+  'security-rollup': 'Security Rollup',
+  governance: 'Governance',
+  adopters: 'Adopters',
+  'project-footprint': 'Project Footprint',
+  'activity-rollup': 'Activity Rollup',
+  'responsiveness-rollup': 'Responsiveness Rollup',
+  'license-consistency': 'License Consistency',
+  'inclusive-naming-rollup': 'Inclusive Naming Rollup',
+  'documentation-coverage': 'Documentation Coverage',
+  languages: 'Languages',
+  'stale-work': 'Stale Work',
+  'bus-factor': 'Bus-Factor Risk',
+  'repo-age': 'Repo Age',
+  'inactive-repos': 'Inactive Repos',
+}
+
+function renderPanelSection(id: PanelId, panel: AggregatePanel<unknown>): string {
+  const lines: string[] = []
+  lines.push(`### ${PANEL_LABELS[id] ?? id}`)
+  lines.push('')
+  lines.push(`- **Status**: ${panel.status}`)
+  lines.push(`- **Contributing repos**: ${panel.contributingReposCount} / ${panel.totalReposInRun}`)
+  lines.push('')
+  return lines.join('\n')
+}
+
+export function buildOrgSummaryMarkdownExport(org: string, view: OrgSummaryViewModel): OrgSummaryMarkdownExportResult {
+  const lines: string[] = []
+
+  lines.push(`# RepoPulse Org Summary — ${org}`)
+  lines.push('')
+  lines.push(`Generated: ${new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())}`)
+  lines.push('')
+
+  lines.push('## Run Status')
+  lines.push('')
+  lines.push('| Metric | Value |')
+  lines.push('| --- | --- |')
+  lines.push(`| Status | ${view.status.status} |`)
+  lines.push(`| Total repos | ${view.status.total} |`)
+  lines.push(`| Succeeded | ${view.status.succeeded} |`)
+  lines.push(`| Failed | ${view.status.failed} |`)
+  lines.push(`| Elapsed | ${formatDuration(view.status.elapsedMs)} |`)
+  lines.push(`| Concurrency | ${view.status.concurrency.chosen} (effective: ${view.status.concurrency.effective}) |`)
+  lines.push('')
+
+  if (view.flagshipRepos.length > 0) {
+    lines.push('## Flagship Repos')
+    lines.push('')
+    for (const f of view.flagshipRepos) lines.push(`- ${f.repo} *(${f.source})*`)
+    lines.push('')
+  }
+
+  const panelEntries = Object.entries(view.panels).filter(([, p]) => p != null) as [PanelId, AggregatePanel<unknown>][]
+  if (panelEntries.length > 0) {
+    lines.push('## Panels')
+    lines.push('')
+    for (const [id, panel] of panelEntries) lines.push(renderPanelSection(id, panel))
+  }
+
+  if (view.missingData.length > 0) {
+    lines.push('## Missing Data')
+    lines.push('')
+    lines.push('| Repo | Signal | Reason |')
+    lines.push('| --- | --- | --- |')
+    for (const m of view.missingData) lines.push(`| ${m.repo} | ${m.signalKey} | ${m.reason} |`)
+    lines.push('')
+  }
+
+  lines.push('## Per-Repo Status')
+  lines.push('')
+  lines.push('| Repo | Status | Flagship | Error |')
+  lines.push('| --- | --- | --- | --- |')
+  for (const entry of view.perRepoStatusList) {
+    lines.push(`| ${entry.repo} | ${entry.status} | ${entry.isFlagship ? 'Yes' : ''} | ${entry.errorReason ?? ''} |`)
+  }
+  lines.push('')
+
+  const blob = new Blob([lines.join('\n')], { type: 'text/markdown' })
+  const filename = `repopulse-org-${org}-${buildFileTimestamp()}.md`
+  return { blob, filename }
+}

--- a/lib/org-inventory/summary.ts
+++ b/lib/org-inventory/summary.ts
@@ -25,11 +25,11 @@ export function buildOrgInventorySummary(results: OrgRepoSummary[]): OrgInventor
     totalStars,
     mostStarredRepos: [...results]
       .sort((left, right) => compareNumeric(right.stars, left.stars) || left.repo.localeCompare(right.repo))
-      .slice(0, 3)
+      .slice(0, 5)
       .map((result) => ({ repo: result.repo, stars: result.stars })),
     mostRecentlyActiveRepos: [...results]
       .sort((left, right) => compareDate(right.pushedAt, left.pushedAt) || left.repo.localeCompare(right.repo))
-      .slice(0, 3)
+      .slice(0, 5)
       .map((result) => ({ repo: result.repo, pushedAt: result.pushedAt })),
     languageDistribution: [...languageCounts.entries()]
       .map(([language, repoCount]) => ({ language, repoCount }))

--- a/lib/org-inventory/summary.ts
+++ b/lib/org-inventory/summary.ts
@@ -25,11 +25,11 @@ export function buildOrgInventorySummary(results: OrgRepoSummary[]): OrgInventor
     totalStars,
     mostStarredRepos: [...results]
       .sort((left, right) => compareNumeric(right.stars, left.stars) || left.repo.localeCompare(right.repo))
-      .slice(0, 5)
+      .slice(0, 3)
       .map((result) => ({ repo: result.repo, stars: result.stars })),
     mostRecentlyActiveRepos: [...results]
       .sort((left, right) => compareDate(right.pushedAt, left.pushedAt) || left.repo.localeCompare(right.repo))
-      .slice(0, 5)
+      .slice(0, 3)
       .map((result) => ({ repo: result.repo, pushedAt: result.pushedAt })),
     languageDistribution: [...languageCounts.entries()]
       .map(([language, repoCount]) => ({ language, repoCount }))


### PR DESCRIPTION
## Summary

- **PreRunWarningDialog** for all org analysis runs: concurrency slider (1-10), ETA estimate, tab-open warning, notification opt-in, go-back hint
- **ProgressIndicator**: progress bar, wall-clock elapsed timer, rotating quote (10s), terminal state display
- **RateLimitPausePanel**: live countdown, pause kind, repos-to-re-dispatch, cancel-during-pause
- **NotificationToggle**: browser notification permission handling with denied-state surfacing
- **Export JSON/Markdown** buttons inside the expanded Analysis Run card
- **Unified Analysis Run card**: single collapsible panel containing stats, progress bar, overview panels, per-repo list, export, and notification toggle
- **Cancel (stop icon) buttons** on org inventory loading and repo analysis loading states
- Consistent stop-icon buttons across all loading states
- Balanced org inventory summary cards (top 3 for all categories)
- Collapsible Repositories section with chevron
- Filter controls in a distinct sub-panel card
- Shows selected count in "Analyze selected (N)" button
- 10 added to rows-per-page options
- Org inventory renders above analysis results in overview layout

Closes the US3 portion of #212.

## Test plan

- [x] Click "Analyze all" or "Analyze selected" on any org — pre-run dialog appears with concurrency slider, notification toggle, ETA, and go-back hint
- [x] Adjust concurrency in the dialog — ETA updates accordingly
- [x] Cancel the dialog — returns to inventory, no analysis starts
- [x] Confirm the dialog — analysis starts, unified Analysis Run card appears with progress bar, elapsed timer, and rotating quote (10s)
- [x] Collapse the Analysis Run card — only shows "Analysis Run (X of N)" with In Progress badge; no Export/Notify visible
- [x] Expand the Analysis Run card — shows stats, progress bar, overview panels (Project Footprint, Languages, Repo Age, Inactive Repos), per-repo list, Export buttons, Notify toggle
- [x] Verify cancel (stop icon) button works during org inventory loading
- [x] Verify cancel (stop icon) button works during repo analysis loading
- [x] Verify stop button cancels the org aggregation run mid-flight (pause/resume only appear during rate-limit events — covered by unit tests)
- [x] Verify Export JSON and Export Markdown buttons trigger downloads (export content quality tracked in #273)
- [x] Verify org summary cards show top 3 items for all categories (starred, active, languages)
- [x] Collapse/expand the Repositories chevron — filters, table, and pagination all hide/show together
- [x] Select repos, verify "Analyze selected (N)" shows the count
- [x] Verify rows-per-page dropdown includes 10, 25, 50, 100
- [x] Run `npx vitest run` — 861 passed, 1 pre-existing failure in analyzer.test.ts (unrelated to this PR)

### Known issues (separate PRs)
- Responsiveness rollup doesn't update on time window change (#272)
- Org analysis state lost when switching Repositories/Organization toggle (#270)
- Org summary export should match the web app panel structure (#273)

🤖 Generated with [Claude Code](https://claude.com/claude-code)