### PR TITLE
[#249] Align SpecKit branch/spec numbering with GitHub issue number

### DIFF
--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -88,6 +88,7 @@ Given that feature description, do this:
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
+   - If the current branch already matches `gh<N>-<slug>`, `<NNN>-<slug>`, or a timestamp prefix (e.g. `claude-worktree.sh` has pre-created the branch for an issue-driven spawn), `create-new-feature.sh` detects and reuses it — no branch-switch happens and the spec directory is created to match. You do not need to pass any extra flag; the default invocation works in both the worktree-driven and manual paths.
 
 3. Load `.specify/templates/spec-template.md` to understand required sections.
 

--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -88,7 +88,7 @@ Given that feature description, do this:
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
-   - If the current branch already matches `gh<N>-<slug>`, `<NNN>-<slug>`, or a timestamp prefix (e.g. `claude-worktree.sh` has pre-created the branch for an issue-driven spawn), `create-new-feature.sh` detects and reuses it — no branch-switch happens and the spec directory is created to match. You do not need to pass any extra flag; the default invocation works in both the worktree-driven and manual paths.
+   - If the current branch already matches `<N>-<slug>` or `<YYYYMMDD>-<HHMMSS>-<slug>` (e.g. `claude-worktree.sh` has pre-created the branch for an issue-driven spawn), `create-new-feature.sh` detects and reuses it — no branch-switch happens and the spec directory is created to match. You do not need to pass any extra flag; the default invocation works in both the worktree-driven and manual paths.
 
 3. Load `.specify/templates/spec-template.md` to understand required sections.
 

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -78,17 +78,8 @@ get_current_branch() {
                         latest_timestamp="$ts"
                         latest_feature=$dirname
                     fi
-                elif [[ "$dirname" =~ ^gh([0-9]+)- ]]; then
-                    # Issue-driven branch (GitHub issue number): rank numerically with sequential.
-                    local number=${BASH_REMATCH[1]}
-                    number=$((10#$number))
-                    if [[ "$number" -gt "$highest" ]]; then
-                        highest=$number
-                        if [[ -z "$latest_timestamp" ]]; then
-                            latest_feature=$dirname
-                        fi
-                    fi
-                elif [[ "$dirname" =~ ^([0-9]{3})- ]]; then
+                elif [[ "$dirname" =~ ^([0-9]+)- ]]; then
+                    # Sequential / issue-driven: rank numerically (any width).
                     local number=${BASH_REMATCH[1]}
                     number=$((10#$number))
                     if [[ "$number" -gt "$highest" ]]; then
@@ -134,9 +125,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^gh[0-9]+- ]] && [[ ! "$branch" =~ ^[0-9]{3}- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+    if [[ ! "$branch" =~ ^[0-9]+- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: gh249-feature-name, 001-feature-name, or 20260319-143022-feature-name" >&2
+        echo "Feature branches should be named like: 249-feature-name or 20260319-143022-feature-name" >&2
         return 1
     fi
 
@@ -153,15 +144,14 @@ find_feature_dir_by_prefix() {
     local specs_dir="$repo_root/specs"
 
     # Extract prefix from branch. Recognised forms:
-    #   - Issue-driven: "gh249-whatever" → prefix "gh249" (GitHub issue #249)
-    #   - Sequential:   "004-whatever"   → prefix "004"
-    #   - Timestamp:    "20260319-143022-whatever" → prefix "20260319-143022"
+    #   - Timestamp:  "20260319-143022-whatever" → prefix "20260319-143022"
+    #   - Sequential: "249-whatever" / "004-whatever" → prefix "249" / "004"
+    # Timestamp must be checked first (more specific) so its leading digit-run
+    # isn't greedily consumed by the sequential regex.
     local prefix=""
-    if [[ "$branch_name" =~ ^(gh[0-9]+)- ]]; then
+    if [[ "$branch_name" =~ ^([0-9]{8}-[0-9]{6})- ]]; then
         prefix="${BASH_REMATCH[1]}"
-    elif [[ "$branch_name" =~ ^([0-9]{8}-[0-9]{6})- ]]; then
-        prefix="${BASH_REMATCH[1]}"
-    elif [[ "$branch_name" =~ ^([0-9]{3})- ]]; then
+    elif [[ "$branch_name" =~ ^([0-9]+)- ]]; then
         prefix="${BASH_REMATCH[1]}"
     else
         # If branch doesn't have a recognized prefix, fall back to exact match

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -78,6 +78,16 @@ get_current_branch() {
                         latest_timestamp="$ts"
                         latest_feature=$dirname
                     fi
+                elif [[ "$dirname" =~ ^gh([0-9]+)- ]]; then
+                    # Issue-driven branch (GitHub issue number): rank numerically with sequential.
+                    local number=${BASH_REMATCH[1]}
+                    number=$((10#$number))
+                    if [[ "$number" -gt "$highest" ]]; then
+                        highest=$number
+                        if [[ -z "$latest_timestamp" ]]; then
+                            latest_feature=$dirname
+                        fi
+                    fi
                 elif [[ "$dirname" =~ ^([0-9]{3})- ]]; then
                     local number=${BASH_REMATCH[1]}
                     number=$((10#$number))
@@ -124,9 +134,9 @@ check_feature_branch() {
         return 0
     fi
 
-    if [[ ! "$branch" =~ ^[0-9]{3}- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+    if [[ ! "$branch" =~ ^gh[0-9]+- ]] && [[ ! "$branch" =~ ^[0-9]{3}- ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
         echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-        echo "Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name" >&2
+        echo "Feature branches should be named like: gh249-feature-name, 001-feature-name, or 20260319-143022-feature-name" >&2
         return 1
     fi
 
@@ -142,9 +152,14 @@ find_feature_dir_by_prefix() {
     local branch_name="$2"
     local specs_dir="$repo_root/specs"
 
-    # Extract prefix from branch (e.g., "004" from "004-whatever" or "20260319-143022" from timestamp branches)
+    # Extract prefix from branch. Recognised forms:
+    #   - Issue-driven: "gh249-whatever" → prefix "gh249" (GitHub issue #249)
+    #   - Sequential:   "004-whatever"   → prefix "004"
+    #   - Timestamp:    "20260319-143022-whatever" → prefix "20260319-143022"
     local prefix=""
-    if [[ "$branch_name" =~ ^([0-9]{8}-[0-9]{6})- ]]; then
+    if [[ "$branch_name" =~ ^(gh[0-9]+)- ]]; then
+        prefix="${BASH_REMATCH[1]}"
+    elif [[ "$branch_name" =~ ^([0-9]{8}-[0-9]{6})- ]]; then
         prefix="${BASH_REMATCH[1]}"
     elif [[ "$branch_name" =~ ^([0-9]{3})- ]]; then
         prefix="${BASH_REMATCH[1]}"

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -251,26 +251,21 @@ fi
 
 # Detect whether the currently checked-out branch already has a recognised
 # feature prefix — if so, reuse it verbatim instead of creating a new branch.
-# This is what aligns spec dir + branch with the GitHub issue number when
-# claude-worktree.sh has already created the gh<N>-<slug> branch for us.
-# Recognised prefixes (order matters — gh<N>- is checked first so it isn't
-# mistakenly consumed by the sequential <NNN>- regex):
-#   gh<N>-<slug>   — issue-driven work (e.g. gh249-align-spec-numbering)
-#   <NNN>-<slug>   — sequential/manual (e.g. 001-repo-input)
-#   <YYYYMMDD>-<HHMMSS>-<slug> — timestamp mode
+# This is what aligns spec dir + branch + GitHub issue number when
+# claude-worktree.sh has already created the <N>-<slug> branch for us.
+# Recognised prefixes (order matters — timestamp is checked first so its
+# leading digit-run isn't greedily consumed by the sequential regex):
+#   <YYYYMMDD>-<HHMMSS>-<slug>  — timestamp mode
+#   <N>-<slug>                  — issue-driven or legacy sequential (any width)
 REUSE_CURRENT_BRANCH=false
 CURRENT_BRANCH=""
 if [ "$HAS_GIT" = true ] && [ "$USE_TIMESTAMP" = false ] && [ -z "$BRANCH_NUMBER" ]; then
     CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-    if [[ "$CURRENT_BRANCH" =~ ^gh([0-9]+)-.+$ ]]; then
+    if [[ "$CURRENT_BRANCH" =~ ^([0-9]{8}-[0-9]{6})-.+$ ]]; then
         REUSE_CURRENT_BRANCH=true
         BRANCH_NAME="$CURRENT_BRANCH"
         FEATURE_NUM="${BASH_REMATCH[1]}"
-    elif [[ "$CURRENT_BRANCH" =~ ^([0-9]{8}-[0-9]{6})-.+$ ]]; then
-        REUSE_CURRENT_BRANCH=true
-        BRANCH_NAME="$CURRENT_BRANCH"
-        FEATURE_NUM="${BASH_REMATCH[1]}"
-    elif [[ "$CURRENT_BRANCH" =~ ^([0-9]{3,})-.+$ ]]; then
+    elif [[ "$CURRENT_BRANCH" =~ ^([0-9]+)-.+$ ]]; then
         REUSE_CURRENT_BRANCH=true
         BRANCH_NAME="$CURRENT_BRANCH"
         FEATURE_NUM="${BASH_REMATCH[1]}"
@@ -335,7 +330,7 @@ if [ "$HAS_GIT" = true ]; then
                 >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Rerun to get a new timestamp or use a different --short-name."
             else
                 >&2 echo "Error: Branch '$BRANCH_NAME' already exists but is not the currently checked-out branch."
-                >&2 echo "Accepted feature-branch forms: gh<N>-<slug>, <NNN>-<slug>, <YYYYMMDD>-<HHMMSS>-<slug>."
+                >&2 echo "Accepted feature-branch forms: <N>-<slug>, <YYYYMMDD>-<HHMMSS>-<slug>."
                 >&2 echo "Resolution: check out '$BRANCH_NAME' to reuse it, delete it, or pick a different --number/--short-name."
             fi
             exit 1

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -233,32 +233,72 @@ else
     BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
 fi
 
+# Validate --number input (must be a positive integer) before any mutation.
+# Accepts forms that decode to >= 1 in base 10; rejects non-numeric, zero,
+# negatives, and leading-zero forms that decode to 0.
+if [ -n "$BRANCH_NUMBER" ]; then
+    if ! [[ "$BRANCH_NUMBER" =~ ^[0-9]+$ ]] || [ "$((10#$BRANCH_NUMBER))" -lt 1 ]; then
+        >&2 echo "Error: --number must be a positive integer (got: '$BRANCH_NUMBER')"
+        exit 1
+    fi
+fi
+
 # Warn if --number and --timestamp are both specified
 if [ "$USE_TIMESTAMP" = true ] && [ -n "$BRANCH_NUMBER" ]; then
     >&2 echo "[specify] Warning: --number is ignored when --timestamp is used"
     BRANCH_NUMBER=""
 fi
 
-# Determine branch prefix
-if [ "$USE_TIMESTAMP" = true ]; then
-    FEATURE_NUM=$(date +%Y%m%d-%H%M%S)
-    BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
-else
-    # Determine branch number
-    if [ -z "$BRANCH_NUMBER" ]; then
-        if [ "$HAS_GIT" = true ]; then
-            # Check existing branches on remotes
-            BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
-        else
-            # Fall back to local directory check
-            HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
-            BRANCH_NUMBER=$((HIGHEST + 1))
-        fi
+# Detect whether the currently checked-out branch already has a recognised
+# feature prefix — if so, reuse it verbatim instead of creating a new branch.
+# This is what aligns spec dir + branch with the GitHub issue number when
+# claude-worktree.sh has already created the gh<N>-<slug> branch for us.
+# Recognised prefixes (order matters — gh<N>- is checked first so it isn't
+# mistakenly consumed by the sequential <NNN>- regex):
+#   gh<N>-<slug>   — issue-driven work (e.g. gh249-align-spec-numbering)
+#   <NNN>-<slug>   — sequential/manual (e.g. 001-repo-input)
+#   <YYYYMMDD>-<HHMMSS>-<slug> — timestamp mode
+REUSE_CURRENT_BRANCH=false
+CURRENT_BRANCH=""
+if [ "$HAS_GIT" = true ] && [ "$USE_TIMESTAMP" = false ] && [ -z "$BRANCH_NUMBER" ]; then
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ "$CURRENT_BRANCH" =~ ^gh([0-9]+)-.+$ ]]; then
+        REUSE_CURRENT_BRANCH=true
+        BRANCH_NAME="$CURRENT_BRANCH"
+        FEATURE_NUM="${BASH_REMATCH[1]}"
+    elif [[ "$CURRENT_BRANCH" =~ ^([0-9]{8}-[0-9]{6})-.+$ ]]; then
+        REUSE_CURRENT_BRANCH=true
+        BRANCH_NAME="$CURRENT_BRANCH"
+        FEATURE_NUM="${BASH_REMATCH[1]}"
+    elif [[ "$CURRENT_BRANCH" =~ ^([0-9]{3,})-.+$ ]]; then
+        REUSE_CURRENT_BRANCH=true
+        BRANCH_NAME="$CURRENT_BRANCH"
+        FEATURE_NUM="${BASH_REMATCH[1]}"
     fi
+fi
 
-    # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
-    FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
-    BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+# Determine branch prefix (only if we aren't reusing the current branch)
+if [ "$REUSE_CURRENT_BRANCH" = false ]; then
+    if [ "$USE_TIMESTAMP" = true ]; then
+        FEATURE_NUM=$(date +%Y%m%d-%H%M%S)
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    else
+        # Determine branch number
+        if [ -z "$BRANCH_NUMBER" ]; then
+            if [ "$HAS_GIT" = true ]; then
+                # Check existing branches on remotes
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+            else
+                # Fall back to local directory check
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            fi
+        fi
+
+        # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
+        FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    fi
 fi
 
 # GitHub enforces a 244-byte limit on branch names
@@ -284,13 +324,19 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
 fi
 
 if [ "$HAS_GIT" = true ]; then
-    if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
+    if [ "$REUSE_CURRENT_BRANCH" = true ]; then
+        # The branch was already created and checked out (e.g. by claude-worktree.sh).
+        # Nothing to do — reusing verbatim is the whole point of this path.
+        :
+    elif ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
         # Check if branch already exists
         if git branch --list "$BRANCH_NAME" | grep -q .; then
             if [ "$USE_TIMESTAMP" = true ]; then
                 >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Rerun to get a new timestamp or use a different --short-name."
             else
-                >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+                >&2 echo "Error: Branch '$BRANCH_NAME' already exists but is not the currently checked-out branch."
+                >&2 echo "Accepted feature-branch forms: gh<N>-<slug>, <NNN>-<slug>, <YYYYMMDD>-<HHMMSS>-<slug>."
+                >&2 echo "Resolution: check out '$BRANCH_NAME' to reuse it, delete it, or pick a different --number/--short-name."
             fi
             exit 1
         else
@@ -303,10 +349,20 @@ else
 fi
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
+SPEC_FILE="$FEATURE_DIR/spec.md"
+
+# Collision check: if the target spec directory already has a populated
+# spec.md, refuse rather than overwrite. An empty or missing spec.md (e.g.
+# from a prior partial run) is fine — we fall through and write the template.
+if [ -s "$SPEC_FILE" ]; then
+    >&2 echo "Error: $SPEC_FILE already exists and is non-empty."
+    >&2 echo "Resolution: rename or remove $FEATURE_DIR, or run /speckit.specify for a different feature."
+    exit 1
+fi
+
 mkdir -p "$FEATURE_DIR"
 
 TEMPLATE=$(resolve_template "spec-template" "$REPO_ROOT") || true
-SPEC_FILE="$FEATURE_DIR/spec.md"
 if [ -n "$TEMPLATE" ] && [ -f "$TEMPLATE" ]; then
     cp "$TEMPLATE" "$SPEC_FILE"
 else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,25 +38,3 @@ stop and ask. Do not infer. Do not proceed.
 ## Signoff Metadata
 When filling manual checklist signoff or similar metadata, use the authenticated GitHub username when it can be verified locally. Do not infer identity from the filesystem path alone. If no verified username is available, leave the field blank or ask the user.
 
-## Active Technologies
-- TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Vitest, React Testing Library (032-doc-scoring)
-- N/A (stateless) (032-doc-scoring)
-- TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Reac (128-licensing-compliance)
-- N/A (stateless, on-demand analysis) (128-licensing-compliance)
-- TypeScript 5.x (Next.js 16+) + React, Tailwind CSS (174-report-search)
-- N/A (stateless, in-memory only) (174-report-search)
-- TypeScript 5.x (Next.js 16+) + Next.js (App Router), React, Tailwind CSS (180-community-scoring)
-- N/A (stateless, on-demand analysis per the constitution) (180-community-scoring)
-- Bash (POSIX-compatible portions + bash-specific features already used: `[[ ... ]]`, `set -euo pipefail`) + `git`, `gh` (GitHub CLI, already required by the surrounding script for `gh issue view`) (243-cleanup-merged-fix)
-- N/A (script operates on local git state and queries GitHub via `gh`) (243-cleanup-merged-fix)
-- Bash (script), JSON (settings), Markdown (docs). No application-code change in this feature. + Claude Code CLI (version installed on the maintainer's machine), `git`, `npm`, `gh`, `uuidgen` (macOS/Linux standard). (244-headless-worktree-permissions)
-- N/A — settings file committed to git; session ID recorded as a plain file inside the worktree (not persisted beyond worktree lifetime). (244-headless-worktree-permissions)
-- TypeScript 5.x, Next.js 16+ (App Router) — matches existing stack + React 18, Tailwind CSS, Vitest, React Testing Library, Playwright (E2E). No new runtime dependencies. (231-org-aggregation)
-- N/A (stateless — in-browser memory only for the duration of the run, per constitution §I) (231-org-aggregation)
-- Bash (POSIX-compatible for portable bits, bash-specific features already in use: `[[ ... ]]`, `set -euo pipefail`, `${BASH_REMATCH}`) + `git`, `gh` (GitHub CLI, already required by the surrounding tooling), `uuidgen` (macOS/Linux standard) (249-speckit-branch-spec-numbering-should-ali)
-- N/A (all state lives in git + local filesystem: spec dirs under `specs/`, worktrees as siblings of the repo) (249-speckit-branch-spec-numbering-should-ali)
-- TypeScript 5.x on Node 20+ (Next.js 16+, App Router) + React, `@testing-library/react` (`renderHook`, `act`, `waitFor`), Vitest — all already in `package.json` (264-investigate-skipped-test-per-repo-status)
-- N/A (stateless hook; test uses injected deferred promises) (264-investigate-skipped-test-per-repo-status)
-
-## Recent Changes
-- 032-doc-scoring: Added TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Vitest, React Testing Library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ When filling manual checklist signoff or similar metadata, use the authenticated
 - N/A — settings file committed to git; session ID recorded as a plain file inside the worktree (not persisted beyond worktree lifetime). (244-headless-worktree-permissions)
 - TypeScript 5.x, Next.js 16+ (App Router) — matches existing stack + React 18, Tailwind CSS, Vitest, React Testing Library, Playwright (E2E). No new runtime dependencies. (231-org-aggregation)
 - N/A (stateless — in-browser memory only for the duration of the run, per constitution §I) (231-org-aggregation)
+- Bash (POSIX-compatible for portable bits, bash-specific features already in use: `[[ ... ]]`, `set -euo pipefail`, `${BASH_REMATCH}`) + `git`, `gh` (GitHub CLI, already required by the surrounding tooling), `uuidgen` (macOS/Linux standard) (249-speckit-branch-spec-numbering-should-ali)
+- N/A (all state lives in git + local filesystem: spec dirs under `specs/`, worktrees as siblings of the repo) (249-speckit-branch-spec-numbering-should-ali)
 
 ## Recent Changes
 - 032-doc-scoring: Added TypeScript 5.x (Next.js 16+) + Next.js (App Router), Tailwind CSS, Vitest, React Testing Library

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,19 +139,21 @@ scripts/claude-worktree.sh --headless 207
 for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done
 ```
 
-The script creates `../forkprint-gh<issue>-<slug>/` on a new branch named `gh<issue>-<slug>`, picks the next free port in `3010–3100`, runs `npm install`, starts `next dev` in the background (log: `dev.log`, PID: `.dev.pid`), and launches `claude` with a prompt that runs the SpecKit lifecycle and opens a PR (never merges — see CLAUDE.md).
+The script creates `../forkprint-<issue>-<slug>/` on a new branch named `<issue>-<slug>`, picks the next free port in `3010–3100`, runs `npm install`, starts `next dev` in the background (log: `dev.log`, PID: `.dev.pid`), and launches `claude` with a prompt that runs the SpecKit lifecycle and opens a PR (never merges — see CLAUDE.md).
 
-### Naming convention
+### Numbering rule
 
-Issue-driven worktrees, branches, and spec directories all use the `gh<issue>-<slug>` prefix. Manual sequential SpecKit work (invoked outside the worktree flow) continues to use the legacy `<NNN>-<slug>` prefix. The two namespaces are disjoint by construction: a name starting with `gh` cannot also start with a digit, so collisions are impossible regardless of how issue numbers or sequential counters grow.
+The branch, worktree, and spec directory for a feature always share the same numeric prefix. Two paths, one convention:
 
 | Flow | Worktree path | Branch | Spec directory |
 |---|---|---|---|
-| Worktree-driven (issue) | `../forkprint-gh249-align-numbering` | `gh249-align-numbering` | `specs/gh249-align-numbering/` |
+| Worktree-driven (issue) | `../forkprint-249-align-numbering` | `249-align-numbering` | `specs/249-align-numbering/` |
 | Manual sequential | *(none)* | `230-some-refactor` | `specs/230-some-refactor/` |
 | Timestamp (opt-in) | *(none)* | `20260416-143022-refactor` | `specs/20260416-143022-refactor/` |
 
-`--cleanup-merged` and `--remove` accept both `gh<issue>-` and legacy unprefixed `<issue>-` worktree paths during the transition, so in-flight worktrees spawned before the `gh`-prefix convention shipped remain cleanable.
+When `scripts/claude-worktree.sh <N>` pre-creates the branch `<N>-<slug>`, `/speckit.specify` inside the worktree detects the `^[0-9]+-` prefix on the current HEAD and reuses it verbatim — it does not scan `specs/` for the next free sequential number. Outside the worktree flow (a manual `/speckit.specify` on `main`), the sequential-scan fallback applies unchanged.
+
+The rare collision — manual sequential claims slot N just before issue #N is filed and worktree-spawned — surfaces as a loud error naming the conflicting branch or spec directory. Resolution: rename/remove the colliding entity, or pick a different issue number. `/speckit.specify` never silently renumbers.
 
 **Mandatory pause after `/speckit.specify`.** Both interactive and `--headless` spawns halt after `/speckit.specify` and wait for your explicit approval before continuing to `/speckit.plan`. The kickoff prompt tells Claude to report the generated spec path and wait for one of the phrases `"proceed"`, `"approved"`, or `"go to plan"`. Spec revisions re-enter the paused state; only an approval phrase releases it. This exists because the spec is the highest-leverage artifact — revisions applied after plan/tasks are generated force Claude to re-derive everything downstream.
 
@@ -189,7 +191,7 @@ Preconditions (both commands exit non-zero with a clear error if unmet):
 
 Additional rule for `--revise-spec`: empty feedback is rejected. Repeated `--revise-spec` rounds accumulate — each round edits the spec as it stands after the previous round.
 
-Manual fallback (still supported): `cd ../forkprint-gh<issue>-<slug> && claude --resume` opens an interactive session if you want to review and revise the spec conversationally. This attaches your terminal; `--approve-spec` / `--revise-spec` do not.
+Manual fallback (still supported): `cd ../forkprint-<issue>-<slug> && claude --resume` opens an interactive session if you want to review and revise the spec conversationally. This attaches your terminal; `--approve-spec` / `--revise-spec` do not.
 
 The pause is per-worktree: in a batch spawn (`for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done`) you review and release each worktree independently, but the release itself is fire-and-forget, so `for i in 210 211 212; do scripts/claude-worktree.sh --approve-spec "$i"; done` walks away with three PRs on the way.
 
@@ -205,8 +207,6 @@ scripts/claude-worktree.sh --remove 207
 ```
 
 `--cleanup-merged` verifies merge status by querying the associated PR's state via `gh pr view <branch> --json state` — **not** by local ancestry. This matters because squash-merges and rebase-merges on GitHub produce a merge commit that is not an ancestor of the local feature branch, so the older ancestry check (`git branch -d`) would silently refuse even after a real merge. When the PR state is `MERGED`, the local branch is force-deleted. When the PR is `OPEN`, `CLOSED` without merge, missing, or `gh` cannot reach GitHub, the command refuses and points to `--remove`. Use `--remove` as the escape hatch for unmerged branches.
-
-The worktree lookup accepts both `forkprint-gh<issue>-*` (current convention) and legacy `forkprint-<issue>-*` (pre-`gh`-prefix worktrees) so that in-flight legacy worktrees remain cleanable during the transition. The legacy fallback can be removed from `claude-worktree.sh` once no pre-fix worktrees remain in the parent directory.
 
 If something gets stuck:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,7 +139,19 @@ scripts/claude-worktree.sh --headless 207
 for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done
 ```
 
-The script creates `../forkprint-<issue>-<slug>/` on a new branch, picks the next free port in `3010–3100`, runs `npm install`, starts `next dev` in the background (log: `dev.log`, PID: `.dev.pid`), and launches `claude` with a prompt that runs the SpecKit lifecycle and opens a PR (never merges — see CLAUDE.md).
+The script creates `../forkprint-gh<issue>-<slug>/` on a new branch named `gh<issue>-<slug>`, picks the next free port in `3010–3100`, runs `npm install`, starts `next dev` in the background (log: `dev.log`, PID: `.dev.pid`), and launches `claude` with a prompt that runs the SpecKit lifecycle and opens a PR (never merges — see CLAUDE.md).
+
+### Naming convention
+
+Issue-driven worktrees, branches, and spec directories all use the `gh<issue>-<slug>` prefix. Manual sequential SpecKit work (invoked outside the worktree flow) continues to use the legacy `<NNN>-<slug>` prefix. The two namespaces are disjoint by construction: a name starting with `gh` cannot also start with a digit, so collisions are impossible regardless of how issue numbers or sequential counters grow.
+
+| Flow | Worktree path | Branch | Spec directory |
+|---|---|---|---|
+| Worktree-driven (issue) | `../forkprint-gh249-align-numbering` | `gh249-align-numbering` | `specs/gh249-align-numbering/` |
+| Manual sequential | *(none)* | `230-some-refactor` | `specs/230-some-refactor/` |
+| Timestamp (opt-in) | *(none)* | `20260416-143022-refactor` | `specs/20260416-143022-refactor/` |
+
+`--cleanup-merged` and `--remove` accept both `gh<issue>-` and legacy unprefixed `<issue>-` worktree paths during the transition, so in-flight worktrees spawned before the `gh`-prefix convention shipped remain cleanable.
 
 **Mandatory pause after `/speckit.specify`.** Both interactive and `--headless` spawns halt after `/speckit.specify` and wait for your explicit approval before continuing to `/speckit.plan`. The kickoff prompt tells Claude to report the generated spec path and wait for one of the phrases `"proceed"`, `"approved"`, or `"go to plan"`. Spec revisions re-enter the paused state; only an approval phrase releases it. This exists because the spec is the highest-leverage artifact — revisions applied after plan/tasks are generated force Claude to re-derive everything downstream.
 
@@ -177,7 +189,7 @@ Preconditions (both commands exit non-zero with a clear error if unmet):
 
 Additional rule for `--revise-spec`: empty feedback is rejected. Repeated `--revise-spec` rounds accumulate — each round edits the spec as it stands after the previous round.
 
-Manual fallback (still supported): `cd ../forkprint-<issue>-<slug> && claude --resume` opens an interactive session if you want to review and revise the spec conversationally. This attaches your terminal; `--approve-spec` / `--revise-spec` do not.
+Manual fallback (still supported): `cd ../forkprint-gh<issue>-<slug> && claude --resume` opens an interactive session if you want to review and revise the spec conversationally. This attaches your terminal; `--approve-spec` / `--revise-spec` do not.
 
 The pause is per-worktree: in a batch spawn (`for i in 210 211 212; do scripts/claude-worktree.sh --headless "$i"; done`) you review and release each worktree independently, but the release itself is fire-and-forget, so `for i in 210 211 212; do scripts/claude-worktree.sh --approve-spec "$i"; done` walks away with three PRs on the way.
 
@@ -193,6 +205,8 @@ scripts/claude-worktree.sh --remove 207
 ```
 
 `--cleanup-merged` verifies merge status by querying the associated PR's state via `gh pr view <branch> --json state` — **not** by local ancestry. This matters because squash-merges and rebase-merges on GitHub produce a merge commit that is not an ancestor of the local feature branch, so the older ancestry check (`git branch -d`) would silently refuse even after a real merge. When the PR state is `MERGED`, the local branch is force-deleted. When the PR is `OPEN`, `CLOSED` without merge, missing, or `gh` cannot reach GitHub, the command refuses and points to `--remove`. Use `--remove` as the escape hatch for unmerged branches.
+
+The worktree lookup accepts both `forkprint-gh<issue>-*` (current convention) and legacy `forkprint-<issue>-*` (pre-`gh`-prefix worktrees) so that in-flight legacy worktrees remain cleanable during the transition. The legacy fallback can be removed from `claude-worktree.sh` once no pre-fix worktrees remain in the parent directory.
 
 If something gets stuck:
 

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -31,12 +31,11 @@ Options:
   -h, --help          Show this help and exit
 
 Behavior:
-  1. Creates ../forkprint-gh<issue>-<slug> as a git worktree on a new branch
-     named gh<issue>-<slug> (slug auto-derived from the issue title via gh
-     when omitted). The gh<issue>- prefix gives issue-driven work a namespace
-     disjoint from manual sequential (<NNN>-) and timestamp specs, so the
-     branch, spec directory, and worktree path always agree on the issue
-     number. See docs/DEVELOPMENT.md for the full naming convention.
+  1. Creates ../forkprint-<issue>-<slug> as a git worktree on a new branch
+     named <issue>-<slug> (slug auto-derived from the issue title via gh
+     when omitted). /speckit.specify inside the worktree reuses this branch
+     verbatim so branch, spec directory, and issue number all agree — see
+     docs/DEVELOPMENT.md for the numbering rule.
   2. Picks the next free port >= 3010 and writes it to .env.local as PORT.
   3. Runs npm install in the worktree.
   4. Starts `npm run dev` on that port in the background (log -> dev.log).
@@ -71,10 +70,8 @@ MAX_PORT=3100
 remove_worktree() {
   local issue="$1"
   local wt
-  # Match both new gh<issue>- worktrees and legacy <issue>- worktrees (transition
-  # compat — legacy fallback can be dropped once no pre-fix worktrees remain).
   wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
-    | awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}')"
+    | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
   if [[ -z "${wt:-}" ]]; then
     echo "No worktree found for issue $issue" >&2
     exit 1
@@ -92,10 +89,8 @@ remove_worktree() {
 cleanup_merged() {
   local issue="$1"
   local wt branch current_branch pr_state
-  # Match both new gh<issue>- worktrees and legacy <issue>- worktrees (transition
-  # compat — legacy fallback can be dropped once no pre-fix worktrees remain).
   wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
-    | awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}')"
+    | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
   if [[ -z "${wt:-}" ]]; then
     echo "No worktree found for issue $issue" >&2
     exit 1
@@ -146,10 +141,8 @@ release_paused_session() {
   local issue="$1"
   local prompt="$2"
   local wt session_id
-  # Match both new gh<issue>- worktrees and legacy <issue>- worktrees (transition
-  # compat — legacy fallback can be dropped once no pre-fix worktrees remain).
   wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
-    | awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}')"
+    | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
   if [[ -z "${wt:-}" ]]; then
     echo "No worktree found for issue $issue" >&2
     exit 1
@@ -242,8 +235,8 @@ if [[ -z "$SLUG" ]]; then
   echo "Derived slug from issue title: $SLUG"
 fi
 
-BRANCH="gh${ISSUE}-${SLUG}"
-WT_PATH="${PARENT_DIR}/forkprint-gh${ISSUE}-${SLUG}"
+BRANCH="${ISSUE}-${SLUG}"
+WT_PATH="${PARENT_DIR}/forkprint-${ISSUE}-${SLUG}"
 
 # 1. Find a free port
 port=$BASE_PORT

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -31,8 +31,12 @@ Options:
   -h, --help          Show this help and exit
 
 Behavior:
-  1. Creates ../forkprint-<issue>-<slug> as a git worktree on a new branch
-     (slug auto-derived from the issue title via gh when omitted).
+  1. Creates ../forkprint-gh<issue>-<slug> as a git worktree on a new branch
+     named gh<issue>-<slug> (slug auto-derived from the issue title via gh
+     when omitted). The gh<issue>- prefix gives issue-driven work a namespace
+     disjoint from manual sequential (<NNN>-) and timestamp specs, so the
+     branch, spec directory, and worktree path always agree on the issue
+     number. See docs/DEVELOPMENT.md for the full naming convention.
   2. Picks the next free port >= 3010 and writes it to .env.local as PORT.
   3. Runs npm install in the worktree.
   4. Starts `npm run dev` on that port in the background (log -> dev.log).
@@ -67,8 +71,10 @@ MAX_PORT=3100
 remove_worktree() {
   local issue="$1"
   local wt
+  # Match both new gh<issue>- worktrees and legacy <issue>- worktrees (transition
+  # compat — legacy fallback can be dropped once no pre-fix worktrees remain).
   wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
-    | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
+    | awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}')"
   if [[ -z "${wt:-}" ]]; then
     echo "No worktree found for issue $issue" >&2
     exit 1
@@ -86,8 +92,10 @@ remove_worktree() {
 cleanup_merged() {
   local issue="$1"
   local wt branch current_branch pr_state
+  # Match both new gh<issue>- worktrees and legacy <issue>- worktrees (transition
+  # compat — legacy fallback can be dropped once no pre-fix worktrees remain).
   wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
-    | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
+    | awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}')"
   if [[ -z "${wt:-}" ]]; then
     echo "No worktree found for issue $issue" >&2
     exit 1
@@ -138,8 +146,10 @@ release_paused_session() {
   local issue="$1"
   local prompt="$2"
   local wt session_id
+  # Match both new gh<issue>- worktrees and legacy <issue>- worktrees (transition
+  # compat — legacy fallback can be dropped once no pre-fix worktrees remain).
   wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
-    | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
+    | awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}')"
   if [[ -z "${wt:-}" ]]; then
     echo "No worktree found for issue $issue" >&2
     exit 1
@@ -232,8 +242,8 @@ if [[ -z "$SLUG" ]]; then
   echo "Derived slug from issue title: $SLUG"
 fi
 
-BRANCH="${ISSUE}-${SLUG}"
-WT_PATH="${PARENT_DIR}/forkprint-${ISSUE}-${SLUG}"
+BRANCH="gh${ISSUE}-${SLUG}"
+WT_PATH="${PARENT_DIR}/forkprint-gh${ISSUE}-${SLUG}"
 
 # 1. Find a free port
 port=$BASE_PORT

--- a/specs/249-speckit-branch-spec-numbering-should-ali/checklists/requirements.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: SpecKit branch/spec numbering aligned with GitHub issue number
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec lightly references file paths (`scripts/claude-worktree.sh`, `.specify/scripts/bash/create-new-feature.sh`, `docs/DEVELOPMENT.md`) because this is infrastructure/tooling work — those paths ARE the user-facing surface for maintainers, not implementation details. Treat this as acceptable in the Content Quality contract for tooling features.
+- No [NEEDS CLARIFICATION] markers remain. The issue, CLAUDE.md, and existing scripts provided enough context for unambiguous requirements.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/contracts/cli-contracts.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/contracts/cli-contracts.md
@@ -1,112 +1,59 @@
 # CLI Contracts
 
-The interfaces this feature exposes are CLI invocations of bash scripts. Each contract lists the invocation shape, inputs, outputs, exit codes, and side effects before/after this feature.
-
 ## C1. `scripts/claude-worktree.sh <issue-number> [slug]`
 
-**Before**:
-- Creates worktree at `<parent>/forkprint-<N>-<slug>/`.
-- Creates and checks out branch `<N>-<slug>`.
-- Kickoff prompt for `/speckit.specify` does not mention the issue number (helper auto-numbers).
+**Unchanged**. Creates `../forkprint-<N>-<slug>/` on branch `<N>-<slug>`, picks a free port, runs `npm install`, starts `next dev`, launches Claude. The earlier `gh<N>-` naming attempt has been reverted — bare `<N>-` matches upstream SpecKit conventions.
+
+## C2. `scripts/claude-worktree.sh --cleanup-merged <issue-number>` / `--remove` / `--approve-spec` / `--revise-spec`
+
+**Unchanged**. Matches worktree paths via `-<issue>-`. Since `claude-worktree.sh` always created the worktree with the bare issue number, this awk pattern has always been correct.
+
+## C3. `.specify/scripts/bash/create-new-feature.sh`
+
+**Before (the bug)**:
+- Always scanned `specs/` for next free sequential number.
+- Always ran `git checkout -b "$BRANCH_NAME"`, erroring if the branch existed.
+- Silently produced a branch/spec-dir number different from the worktree's issue number.
 
 **After**:
-- Creates worktree at `<parent>/forkprint-gh<N>-<slug>/`.
-- Creates and checks out branch `gh<N>-<slug>`.
-- Kickoff prompt remains substantively unchanged; the helper detects the `gh<N>-` prefix from the branch.
+- **Reuse path** (when current branch matches `^[0-9]{8}-[0-9]{6}-.+$` or `^[0-9]+-.+$`, and neither `--number` nor `--timestamp` is supplied):
+  - `BRANCH_NAME = current branch`, verbatim.
+  - `FEATURE_NUM = prefix extracted from branch` (unpadded for `^[0-9]+-` matches, literal timestamp for timestamp matches).
+  - **No** `git checkout -b`.
+  - **No** scan of `specs/` for next sequential.
+- **Sequential path** (when no match on current branch AND no `--number`): unchanged — compute next free number, `git checkout -b`.
+- **`--number N` path**: validates `N` is a positive integer; uses `printf "%03d"` for < 1000 (zero-padded), verbatim for ≥ 1000; runs `git checkout -b`.
+- **Collision checks** (in all paths):
+  - Branch exists but not current HEAD → exit 1 with a clear error listing accepted forms.
+  - `$SPEC_FILE` already exists with non-empty content → exit 1 with an error naming the directory.
 
-**Inputs**: issue number (positive integer), optional slug.
-**Outputs**: worktree path and dev-server port on stdout, as before.
-**Exit codes**: unchanged (`0` on success, non-zero on lookup/port/worktree failures).
-
----
-
-## C2. `scripts/claude-worktree.sh --cleanup-merged <issue-number>`
-
-**Before**:
-- Matches worktree whose path contains `-<N>-`.
-- Errors if no match.
-
-**After**:
-- Matches worktree whose path contains `-gh<N>-` OR `-<N>-` (compat fallback for legacy worktrees spawned before this fix).
-- Errors only if neither pattern matches.
-
-**Inputs**: issue number (positive integer).
-**Outputs**: removal confirmation on stdout.
-**Exit codes**: `0` on success; non-zero if no worktree matches, PR is not `MERGED`, or primary checkout is not on `main`.
-
----
-
-## C3. `scripts/claude-worktree.sh --remove <issue-number>`
-
-Same before/after change as C2: `-gh<N>-` or legacy `-<N>-` match.
-
----
-
-## C4. `scripts/claude-worktree.sh --approve-spec <issue-number>` / `--revise-spec`
-
-Same before/after change as C2 on the worktree lookup pattern.
-
----
-
-## C5. `.specify/scripts/bash/create-new-feature.sh` (SpecKit helper)
-
-**Before**:
-- Accepts `--number N` to override auto-detection.
-- Always runs `git checkout -b "$BRANCH_NAME"` and errors if the branch already exists.
-- Spec directory name derived from computed `BRANCH_NAME`.
-
-**After**:
-- Behaviour when the currently checked-out branch matches `^(gh[0-9]+|[0-9]{3,}|[0-9]{8}-[0-9]{6})-`:
-  - Derive the target branch/prefix verbatim from the current branch. Do **not** call `git checkout -b` — the branch is already HEAD, reuse it.
-  - Compute `FEATURE_DIR = specs/<current-branch>/`.
-  - If `FEATURE_DIR` does not exist OR exists with empty/missing `spec.md`, proceed to copy the template into `spec.md`.
-  - If `FEATURE_DIR` exists with a non-empty `spec.md`, exit non-zero with a clear error naming the directory.
-- Behaviour when `--number N` is supplied:
-  - Validate `N` is a positive integer (reject leading zeros that decode to 0, negatives, non-numeric).
-  - Use `<NNN>-<slug>` form (unprefixed sequential/legacy form). This flag is explicitly for manual overrides, not the `gh<N>` issue-driven path. (The issue-driven path is triggered by the current branch matching, per the first bullet.)
-  - Proceed as the existing script does: try `git checkout -b "<NNN>-<slug>"`; error loudly if branch exists and is not current HEAD.
-- Behaviour otherwise (no `--number`, no recognised current branch):
-  - Unchanged: compute next sequential number, `git checkout -b "<NNN>-<slug>"`.
-
-**Inputs**: feature description (positional), optional `--number N`, `--short-name <slug>`, `--timestamp`, `--json`.
-**Outputs**: JSON `{BRANCH_NAME, SPEC_FILE, FEATURE_NUM}` when `--json` is passed; human-readable otherwise.
+**Inputs**: positional feature description, optional `--number N`, `--short-name <slug>`, `--timestamp`, `--json`.
+**Outputs**: `--json` emits `{BRANCH_NAME, SPEC_FILE, FEATURE_NUM}`.
 **Exit codes**:
-- `0` on success (including silent reuse of a matching current branch).
-- `1` on: invalid issue number (non-numeric, zero, negative); target branch exists but is not current HEAD; target `spec.md` already exists and is non-empty; git operation failure.
+- `0` on success (creation or silent reuse).
+- `1` on: invalid `--number`; target branch exists off-HEAD; target spec.md non-empty; git operation failure.
 
----
-
-## C6. `.specify/scripts/bash/common.sh` helpers (internal)
-
-These are sourced by other scripts; not directly invoked as CLI. Their contracts are internal but important for the prefix propagation.
+## C4. `.specify/scripts/bash/common.sh` helpers
 
 ### `get_current_branch`
 
-**Before**: Non-git fallback matches `^[0-9]{3}-` and `^[0-9]{8}-[0-9]{6}-` directory patterns.
-**After**: Also matches `^gh([0-9]+)-`. Ordering preference remains: timestamp > numeric-highest.
+**Before**: Non-git fallback scans `^[0-9]{3}-` and `^[0-9]{8}-[0-9]{6}-` directories.
+**After**: Also matches `^[0-9]+-` (strict superset — covers 1, 2, 4+ digit issue numbers).
 
 ### `check_feature_branch`
 
 **Before**: Rejects branches not matching `^[0-9]{3}-` or `^[0-9]{8}-[0-9]{6}-`.
-**After**: Also accepts `^gh[0-9]+-`. Error message updated to list all three accepted forms.
+**After**: Accepts `^[0-9]+-` and `^[0-9]{8}-[0-9]{6}-`. Error message updated.
 
 ### `find_feature_dir_by_prefix`
 
-**Before**: Extracts prefix via `^[0-9]{8}-[0-9]{6}` or `^[0-9]{3}`; falls back to exact-branch-name match.
-**After**: Extracts prefix via `^gh[0-9]+` (captures e.g. `gh249`), `^[0-9]{8}-[0-9]{6}`, or `^[0-9]{3}`. Fallback unchanged.
+**Before**: Extracts prefix via `^[0-9]{8}-[0-9]{6}` or `^[0-9]{3}`.
+**After**: Extracts via `^[0-9]{8}-[0-9]{6}` (checked first, more specific) or `^[0-9]+` (any width).
 
----
+## C5. `.claude/commands/speckit.specify.md`
 
-## C7. `.claude/commands/speckit.specify.md` command template
+**Unchanged in invocation**. Updated only to document that `create-new-feature.sh` auto-detects feature-prefix branches and reuses them — Claude does not need to pass `--number` in the worktree-driven flow.
 
-**Before**: Instructs Claude to invoke `create-new-feature.sh` without `--number`.
-**After**: Same instruction, plus a short note explaining that the script auto-detects `gh<N>-` branches and reuses them — so Claude does not need to do anything different in worktree vs. non-worktree flows.
+## C6. `docs/DEVELOPMENT.md`
 
-**No behavioural change for Claude's invocation**; only documentation inside the command file changes.
-
----
-
-## C8. `docs/DEVELOPMENT.md`
-
-**Before**: Documents the `forkprint-<N>-<slug>` worktree naming.
-**After**: Documents the `forkprint-gh<N>-<slug>` naming for new spawns, calls out the disjoint-namespace rule, notes that `--cleanup-merged` accepts both new and legacy forms during the transition.
+Updated to document the numbering rule: branches pre-created by `claude-worktree.sh` are reused verbatim by `/speckit.specify`; manual invocations without a recognised branch prefix fall back to sequential.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/contracts/cli-contracts.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/contracts/cli-contracts.md
@@ -1,0 +1,112 @@
+# CLI Contracts
+
+The interfaces this feature exposes are CLI invocations of bash scripts. Each contract lists the invocation shape, inputs, outputs, exit codes, and side effects before/after this feature.
+
+## C1. `scripts/claude-worktree.sh <issue-number> [slug]`
+
+**Before**:
+- Creates worktree at `<parent>/forkprint-<N>-<slug>/`.
+- Creates and checks out branch `<N>-<slug>`.
+- Kickoff prompt for `/speckit.specify` does not mention the issue number (helper auto-numbers).
+
+**After**:
+- Creates worktree at `<parent>/forkprint-gh<N>-<slug>/`.
+- Creates and checks out branch `gh<N>-<slug>`.
+- Kickoff prompt remains substantively unchanged; the helper detects the `gh<N>-` prefix from the branch.
+
+**Inputs**: issue number (positive integer), optional slug.
+**Outputs**: worktree path and dev-server port on stdout, as before.
+**Exit codes**: unchanged (`0` on success, non-zero on lookup/port/worktree failures).
+
+---
+
+## C2. `scripts/claude-worktree.sh --cleanup-merged <issue-number>`
+
+**Before**:
+- Matches worktree whose path contains `-<N>-`.
+- Errors if no match.
+
+**After**:
+- Matches worktree whose path contains `-gh<N>-` OR `-<N>-` (compat fallback for legacy worktrees spawned before this fix).
+- Errors only if neither pattern matches.
+
+**Inputs**: issue number (positive integer).
+**Outputs**: removal confirmation on stdout.
+**Exit codes**: `0` on success; non-zero if no worktree matches, PR is not `MERGED`, or primary checkout is not on `main`.
+
+---
+
+## C3. `scripts/claude-worktree.sh --remove <issue-number>`
+
+Same before/after change as C2: `-gh<N>-` or legacy `-<N>-` match.
+
+---
+
+## C4. `scripts/claude-worktree.sh --approve-spec <issue-number>` / `--revise-spec`
+
+Same before/after change as C2 on the worktree lookup pattern.
+
+---
+
+## C5. `.specify/scripts/bash/create-new-feature.sh` (SpecKit helper)
+
+**Before**:
+- Accepts `--number N` to override auto-detection.
+- Always runs `git checkout -b "$BRANCH_NAME"` and errors if the branch already exists.
+- Spec directory name derived from computed `BRANCH_NAME`.
+
+**After**:
+- Behaviour when the currently checked-out branch matches `^(gh[0-9]+|[0-9]{3,}|[0-9]{8}-[0-9]{6})-`:
+  - Derive the target branch/prefix verbatim from the current branch. Do **not** call `git checkout -b` — the branch is already HEAD, reuse it.
+  - Compute `FEATURE_DIR = specs/<current-branch>/`.
+  - If `FEATURE_DIR` does not exist OR exists with empty/missing `spec.md`, proceed to copy the template into `spec.md`.
+  - If `FEATURE_DIR` exists with a non-empty `spec.md`, exit non-zero with a clear error naming the directory.
+- Behaviour when `--number N` is supplied:
+  - Validate `N` is a positive integer (reject leading zeros that decode to 0, negatives, non-numeric).
+  - Use `<NNN>-<slug>` form (unprefixed sequential/legacy form). This flag is explicitly for manual overrides, not the `gh<N>` issue-driven path. (The issue-driven path is triggered by the current branch matching, per the first bullet.)
+  - Proceed as the existing script does: try `git checkout -b "<NNN>-<slug>"`; error loudly if branch exists and is not current HEAD.
+- Behaviour otherwise (no `--number`, no recognised current branch):
+  - Unchanged: compute next sequential number, `git checkout -b "<NNN>-<slug>"`.
+
+**Inputs**: feature description (positional), optional `--number N`, `--short-name <slug>`, `--timestamp`, `--json`.
+**Outputs**: JSON `{BRANCH_NAME, SPEC_FILE, FEATURE_NUM}` when `--json` is passed; human-readable otherwise.
+**Exit codes**:
+- `0` on success (including silent reuse of a matching current branch).
+- `1` on: invalid issue number (non-numeric, zero, negative); target branch exists but is not current HEAD; target `spec.md` already exists and is non-empty; git operation failure.
+
+---
+
+## C6. `.specify/scripts/bash/common.sh` helpers (internal)
+
+These are sourced by other scripts; not directly invoked as CLI. Their contracts are internal but important for the prefix propagation.
+
+### `get_current_branch`
+
+**Before**: Non-git fallback matches `^[0-9]{3}-` and `^[0-9]{8}-[0-9]{6}-` directory patterns.
+**After**: Also matches `^gh([0-9]+)-`. Ordering preference remains: timestamp > numeric-highest.
+
+### `check_feature_branch`
+
+**Before**: Rejects branches not matching `^[0-9]{3}-` or `^[0-9]{8}-[0-9]{6}-`.
+**After**: Also accepts `^gh[0-9]+-`. Error message updated to list all three accepted forms.
+
+### `find_feature_dir_by_prefix`
+
+**Before**: Extracts prefix via `^[0-9]{8}-[0-9]{6}` or `^[0-9]{3}`; falls back to exact-branch-name match.
+**After**: Extracts prefix via `^gh[0-9]+` (captures e.g. `gh249`), `^[0-9]{8}-[0-9]{6}`, or `^[0-9]{3}`. Fallback unchanged.
+
+---
+
+## C7. `.claude/commands/speckit.specify.md` command template
+
+**Before**: Instructs Claude to invoke `create-new-feature.sh` without `--number`.
+**After**: Same instruction, plus a short note explaining that the script auto-detects `gh<N>-` branches and reuses them — so Claude does not need to do anything different in worktree vs. non-worktree flows.
+
+**No behavioural change for Claude's invocation**; only documentation inside the command file changes.
+
+---
+
+## C8. `docs/DEVELOPMENT.md`
+
+**Before**: Documents the `forkprint-<N>-<slug>` worktree naming.
+**After**: Documents the `forkprint-gh<N>-<slug>` naming for new spawns, calls out the disjoint-namespace rule, notes that `--cleanup-merged` accepts both new and legacy forms during the transition.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/data-model.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/data-model.md
@@ -1,0 +1,76 @@
+# Phase 1 Data Model: Naming grammar
+
+This feature introduces no runtime data structures. The "model" is the grammar of the three filesystem/git entities that must agree on their prefix.
+
+## Entity grammars
+
+### Issue-driven triple (NEW)
+
+```
+worktree-dir  := "forkprint-" issue-prefix "-" slug
+branch        := issue-prefix "-" slug
+spec-dir      := "specs/" issue-prefix "-" slug
+issue-prefix  := "gh" positive-int
+positive-int  := [1-9] [0-9]*
+slug          := [a-z0-9] ([a-z0-9-]* [a-z0-9])?        ; kebab-case, 1-40 chars
+```
+
+All three entities for a single feature use the **same** `issue-prefix` and the **same** `slug`.
+
+Examples:
+- `forkprint-gh249-align-spec-numbering`, `gh249-align-spec-numbering`, `specs/gh249-align-spec-numbering/`
+- `forkprint-gh7-fix-bug`, `gh7-fix-bug`, `specs/gh7-fix-bug/`
+
+### Manual sequential triple (UNCHANGED)
+
+```
+branch       := seq-prefix "-" slug
+spec-dir     := "specs/" seq-prefix "-" slug
+seq-prefix   := [0-9]{3}                                ; zero-padded, legacy form
+```
+
+No worktree entity is produced for manual sequential work — those feature branches live in the main checkout.
+
+Examples (existing, unchanged): `001-repo-input`, `032-doc-scoring`, `230-<next-manual-spec>`.
+
+### Timestamp-based triple (UNCHANGED, opt-in)
+
+```
+branch       := ts-prefix "-" slug
+spec-dir     := "specs/" ts-prefix "-" slug
+ts-prefix    := [0-9]{8} "-" [0-9]{6}                   ; YYYYMMDD-HHMMSS
+```
+
+Used only when `.specify/init-options.json` has `"branch_numbering": "timestamp"`.
+
+## Disjoint-namespace proof
+
+Three prefix forms, each characterised by its first 1-2 characters:
+
+| Form | First-char regex | Example |
+|---|---|---|
+| Issue-driven | `^gh` (letters) | `gh249-` |
+| Sequential | `^[0-9]{3}-` (three digits then hyphen) | `001-`, `249-` |
+| Timestamp | `^[0-9]{8}-` (eight digits then hyphen) | `20260416-` |
+
+A string matching `^gh` cannot match `^[0-9]`, and vice versa. Sequential (3 digits) and timestamp (8 digits) are disambiguated by the position of the first hyphen (4th char for sequential, 9th for timestamp). All three forms are mutually exclusive grammars, so no string can be ambiguously classified.
+
+## Legacy entities (in-flight)
+
+During the transition, the filesystem will contain some legacy entities that predate this feature:
+
+- Legacy unprefixed branches for issue-numbered work: e.g. `249-speckit-branch-spec-numbering-should-ali` (this feature's own branch). These match the `seq-prefix` grammar by structure and keep working unchanged.
+- Legacy `forkprint-<N>-<slug>/` worktree directories: matched by the compat-fallback awk pattern in `--cleanup-merged` and `--remove`.
+
+No retroactive rename is performed. These entities are cleaned up naturally as their features merge.
+
+## State transitions
+
+None. These entities are created once per feature and do not change state during a feature's lifetime (beyond normal git operations: commits, pushes, merges).
+
+## Validation rules
+
+1. **Issue number input**: positive integer, no leading zero. Validated in `create-new-feature.sh` before any filesystem mutation.
+2. **Slug input**: `[a-z0-9-]+`, 1-40 characters, no leading or trailing hyphens. Validated in `claude-worktree.sh` (existing) and `create-new-feature.sh` (existing `clean_branch_name` logic).
+3. **Branch prefix derivation from current HEAD**: if the current branch matches `^(gh[0-9]+|[0-9]{3}|[0-9]{8}-[0-9]{6})-`, the entire prefix is extracted verbatim and reused. Otherwise the sequential fallback applies.
+4. **Prefix-to-spec-dir consistency**: the spec directory name must equal the branch name (same prefix, same slug) for `find_feature_dir_by_prefix()` to resolve correctly without ambiguity.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/data-model.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/data-model.md
@@ -1,76 +1,47 @@
 # Phase 1 Data Model: Naming grammar
 
-This feature introduces no runtime data structures. The "model" is the grammar of the three filesystem/git entities that must agree on their prefix.
+No runtime data structures. The "model" is the grammar of the three filesystem/git entities that must agree.
 
 ## Entity grammars
 
-### Issue-driven triple (NEW)
+### Feature triple
 
 ```
-worktree-dir  := "forkprint-" issue-prefix "-" slug
-branch        := issue-prefix "-" slug
-spec-dir      := "specs/" issue-prefix "-" slug
-issue-prefix  := "gh" positive-int
-positive-int  := [1-9] [0-9]*
-slug          := [a-z0-9] ([a-z0-9-]* [a-z0-9])?        ; kebab-case, 1-40 chars
+worktree-dir  := "forkprint-" prefix "-" slug
+branch        := prefix "-" slug
+spec-dir      := "specs/" prefix "-" slug
+
+prefix        := sequential | timestamp
+sequential    := [0-9]+                                     ; issue number or legacy padded
+timestamp     := [0-9]{8} "-" [0-9]{6}                      ; YYYYMMDD-HHMMSS
+slug          := [a-z0-9] ([a-z0-9-]* [a-z0-9])?            ; kebab-case, 1-40 chars
 ```
 
-All three entities for a single feature use the **same** `issue-prefix` and the **same** `slug`.
+All three entities for a single feature share the same `prefix` and same `slug`.
 
 Examples:
-- `forkprint-gh249-align-spec-numbering`, `gh249-align-spec-numbering`, `specs/gh249-align-spec-numbering/`
-- `forkprint-gh7-fix-bug`, `gh7-fix-bug`, `specs/gh7-fix-bug/`
+- Issue-driven (new): `forkprint-238-align-numbering`, `238-align-numbering`, `specs/238-align-numbering/`
+- Legacy sequential (unchanged): `015-responsiveness`, `specs/015-responsiveness/` (worktree-dir not applicable)
+- Timestamp (opt-in, unchanged): `20260416-143022-exploratory`, `specs/20260416-143022-exploratory/`
 
-### Manual sequential triple (UNCHANGED)
+## Why one `sequential` grammar for both issue-driven and manual
 
-```
-branch       := seq-prefix "-" slug
-spec-dir     := "specs/" seq-prefix "-" slug
-seq-prefix   := [0-9]{3}                                ; zero-padded, legacy form
-```
+Both paths produce the same shape: `<digits>-<slug>`. The distinction is where `<digits>` comes from:
 
-No worktree entity is produced for manual sequential work — those feature branches live in the main checkout.
+| Source | Digits |
+|---|---|
+| `scripts/claude-worktree.sh <N>` | The GitHub issue number (`<N>` as passed, any width) |
+| `/speckit.specify` manual (sequential mode) | Next free `max+1` across existing `specs/` and branches, zero-padded to 3 digits for legacy readability |
 
-Examples (existing, unchanged): `001-repo-input`, `032-doc-scoring`, `230-<next-manual-spec>`.
-
-### Timestamp-based triple (UNCHANGED, opt-in)
-
-```
-branch       := ts-prefix "-" slug
-spec-dir     := "specs/" ts-prefix "-" slug
-ts-prefix    := [0-9]{8} "-" [0-9]{6}                   ; YYYYMMDD-HHMMSS
-```
-
-Used only when `.specify/init-options.json` has `"branch_numbering": "timestamp"`.
-
-## Disjoint-namespace proof
-
-Three prefix forms, each characterised by its first 1-2 characters:
-
-| Form | First-char regex | Example |
-|---|---|---|
-| Issue-driven | `^gh` (letters) | `gh249-` |
-| Sequential | `^[0-9]{3}-` (three digits then hyphen) | `001-`, `249-` |
-| Timestamp | `^[0-9]{8}-` (eight digits then hyphen) | `20260416-` |
-
-A string matching `^gh` cannot match `^[0-9]`, and vice versa. Sequential (3 digits) and timestamp (8 digits) are disambiguated by the position of the first hyphen (4th char for sequential, 9th for timestamp). All three forms are mutually exclusive grammars, so no string can be ambiguously classified.
-
-## Legacy entities (in-flight)
-
-During the transition, the filesystem will contain some legacy entities that predate this feature:
-
-- Legacy unprefixed branches for issue-numbered work: e.g. `249-speckit-branch-spec-numbering-should-ali` (this feature's own branch). These match the `seq-prefix` grammar by structure and keep working unchanged.
-- Legacy `forkprint-<N>-<slug>/` worktree directories: matched by the compat-fallback awk pattern in `--cleanup-merged` and `--remove`.
-
-No retroactive rename is performed. These entities are cleaned up naturally as their features merge.
-
-## State transitions
-
-None. These entities are created once per feature and do not change state during a feature's lifetime (beyond normal git operations: commits, pushes, merges).
+They share a namespace — collisions are possible in principle but rare in practice, and handled by the loud-error contract (see contracts/cli-contracts.md).
 
 ## Validation rules
 
-1. **Issue number input**: positive integer, no leading zero. Validated in `create-new-feature.sh` before any filesystem mutation.
-2. **Slug input**: `[a-z0-9-]+`, 1-40 characters, no leading or trailing hyphens. Validated in `claude-worktree.sh` (existing) and `create-new-feature.sh` (existing `clean_branch_name` logic).
-3. **Branch prefix derivation from current HEAD**: if the current branch matches `^(gh[0-9]+|[0-9]{3}|[0-9]{8}-[0-9]{6})-`, the entire prefix is extracted verbatim and reused. Otherwise the sequential fallback applies.
-4. **Prefix-to-spec-dir consistency**: the spec directory name must equal the branch name (same prefix, same slug) for `find_feature_dir_by_prefix()` to resolve correctly without ambiguity.
+1. **Issue / `--number` input**: positive integer (`^[0-9]+$` AND decodes to ≥ 1). Validated up front.
+2. **Slug input**: `[a-z0-9-]+`, 1-40 chars, no leading/trailing hyphens. Enforced by existing `clean_branch_name` logic in `create-new-feature.sh` and the slug derivation in `claude-worktree.sh`.
+3. **Prefix derivation from current HEAD**: if `^[0-9]{8}-[0-9]{6}-` or `^[0-9]+-`, extract the full prefix literally. Otherwise use sequential fallback.
+4. **Prefix-to-spec-dir consistency**: spec directory name must equal branch name (same prefix, same slug) for `find_feature_dir_by_prefix()` to resolve without ambiguity. Enforced by the branch-reuse path (spec dir derived from branch) and the creation path (branch derived from spec dir target).
+
+## State transitions
+
+None. Entities are created once per feature and do not change state during a feature's lifetime.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/plan.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/plan.md
@@ -5,45 +5,42 @@
 
 ## Summary
 
-Introduce a disjoint naming namespace for issue-driven SpecKit work: worktree directories, branches, and spec directories all use `gh<N>-<slug>` (where `<N>` is the GitHub issue number, no padding). Manual sequential fallback keeps the existing `<NNN>-<slug>` form. Because `gh` and the leading digit of a sequential prefix can never collide, the two namespaces are disjoint by construction.
+Fix the decoupling between worktree/branch and spec directory identifiers by teaching `create-new-feature.sh` to detect a pre-existing feature-branch pattern on the current HEAD and reuse it verbatim — instead of scanning `specs/` for the next free number. Branch naming stays on the upstream SpecKit convention `<N>-<slug>` (no custom prefix), which keeps this fix portable and aligned with future SpecKit upstream changes. The rare collision between manual sequential and issue-number namespaces is handled by a loud-error contract (reject, name the conflict, suggest resolution) rather than a custom prefix.
 
-**Technical approach**: The fix is scoped to the tooling layer (bash scripts, SpecKit helpers, one command template, one docs file). `scripts/claude-worktree.sh` creates worktrees/branches with `gh<N>-` up front, so Claude is already on a `gh<N>-` branch when `/speckit.specify` runs. `create-new-feature.sh` detects the current branch's prefix pattern and (a) reuses the branch verbatim when it already matches `^(gh)?[0-9]+-`, (b) derives the spec-directory name from the current branch in that case, or (c) falls through to the existing sequential logic otherwise. `common.sh` helpers that parse branch prefixes gain `gh<N>-` awareness so downstream commands (`/speckit.plan`, `/speckit.tasks`, `/speckit.implement`) keep resolving specs correctly. A transitional compatibility fallback in `--cleanup-merged` still matches legacy unprefixed worktrees.
+**Technical approach**: Four tooling-layer files change. `create-new-feature.sh` gains a reuse-current-branch check and collision-handling. `common.sh`'s three prefix-parsing helpers widen their regex to accept issue numbers of any width. `claude-worktree.sh` is unchanged beyond what it already does (creates `forkprint-<N>-<slug>/` and `<N>-<slug>` branch). `docs/DEVELOPMENT.md` documents the rule.
 
 ## Technical Context
 
 **Language/Version**: Bash (POSIX-compatible for portable bits, bash-specific features already in use: `[[ ... ]]`, `set -euo pipefail`, `${BASH_REMATCH}`)
-**Primary Dependencies**: `git`, `gh` (GitHub CLI, already required by the surrounding tooling), `uuidgen` (macOS/Linux standard)
-**Storage**: N/A (all state lives in git + local filesystem: spec dirs under `specs/`, worktrees as siblings of the repo)
-**Testing**: Manual validation via a scripted dry-run (documented in `quickstart.md`); automated tests are out of scope because these are one-shot lifecycle scripts without a test harness in this repo. Regression coverage is provided by running the existing worktree spawn + `/speckit.specify` + cleanup on a throwaway issue number.
-**Target Platform**: macOS (primary development environment) and Linux (CI-compatible, though no CI exercises these scripts today)
-**Project Type**: CLI/tooling layer — no application code changes
-**Performance Goals**: N/A (interactive lifecycle scripts; each invocation completes in <10s and is not in any hot path)
-**Constraints**: Must not break in-flight legacy worktrees (branches like `249-…` spawned before this fix); `--cleanup-merged` keeps backward compatibility for one transition period; no new tooling dependencies; no secrets; no bypass of the existing permission allowlist.
-**Scale/Scope**: Four files changed (`scripts/claude-worktree.sh`, `.specify/scripts/bash/create-new-feature.sh`, `.specify/scripts/bash/common.sh`, `.claude/commands/speckit.specify.md`) plus `docs/DEVELOPMENT.md`. Estimated diff: ~100 lines added, ~20 modified. No new files outside `specs/249-.../`.
+**Primary Dependencies**: `git`, `gh` (GitHub CLI, already required by surrounding tooling), `uuidgen`
+**Storage**: N/A (state in git + local filesystem)
+**Testing**: Manual regression via `quickstart.md`; no bash-script test harness exists in this repo
+**Target Platform**: macOS (primary) and Linux
+**Project Type**: CLI/tooling layer — no application-code changes
+**Performance Goals**: N/A (interactive lifecycle scripts, <10s per invocation)
+**Constraints**: No new deps; no upstream SpecKit fork; stay on `<N>-<slug>` so a future upstream change can be absorbed cleanly
+**Scale/Scope**: 4 tooling files modified, ~60 lines added/changed. No new files outside `specs/249-.../`.
 
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-RepoPulse's constitution (v1.2) governs the product's accuracy, data sources, analyzer boundary, CHAOSS mapping, scoring thresholds, testing, security, and development workflow. This feature is pure tooling — it does not touch the product runtime, the analyzer module, any scoring logic, any UI, any data source, or any user-facing product behaviour.
+Pure tooling change: no product runtime, no analyzer, no scoring, no UI, no data source change.
 
-| Gate | Relevance | Result |
-|---|---|---|
-| I. Technology Stack | No new frameworks, no new runtime deps | ✅ Pass (no change) |
-| II. Accuracy Policy (NON-NEGOTIABLE) | No metric display, no GraphQL change | ✅ Pass (not applicable) |
-| III. Data Source Rules | No API calls added | ✅ Pass (not applicable) |
-| IV. Analyzer Module Boundary | Analyzer untouched | ✅ Pass (not applicable) |
-| V. CHAOSS Alignment | No scoring change | ✅ Pass (not applicable) |
-| VI. Scoring Thresholds | No scoring change | ✅ Pass (not applicable) |
-| VII. Ecosystem Spectrum | No ecosystem change | ✅ Pass (not applicable) |
-| VIII. Contribution Dynamics Honesty | No contributor data surface | ✅ Pass (not applicable) |
-| IX. Feature Scope Rules (YAGNI, KISS) | Minimal change, no speculative abstractions, no new flags beyond what the spec requires | ✅ Pass |
-| X. Security & Hygiene | No secrets; no new shell commands beyond the existing allowlist (`git`, `gh`, standard utilities) | ✅ Pass |
-| XI. Testing | No analyzer or UI under test; manual regression per `quickstart.md` | ✅ Pass (manual-validation scope acknowledged) |
-| XII. Definition of Done | PR test plan will cover all acceptance scenarios from the spec | ✅ Pass (planned) |
-| XIII. Development Workflow | Feature-branch commit, PR with `## Test plan`, DEVELOPMENT.md updated | ✅ Pass (planned) |
+| Gate | Result |
+|---|---|
+| I. Technology Stack | ✅ No new deps |
+| II. Accuracy Policy (NON-NEGOTIABLE) | ✅ N/A |
+| III. Data Source Rules | ✅ N/A |
+| IV. Analyzer Boundary | ✅ Untouched |
+| V–VIII. Scoring / Ecosystem / Contributors | ✅ N/A |
+| IX. YAGNI / KISS | ✅ Reverted the `gh<N>-` prefix precisely because it added complexity for a rare collision case |
+| X. Security & Hygiene | ✅ No secrets, no new shell commands beyond the existing allowlist |
+| XI. Testing | ✅ Manual-regression scope acknowledged |
+| XII. Definition of Done | ✅ PR test plan will cover acceptance scenarios |
+| XIII. Development Workflow | ✅ Feature-branch PR, test plan, DEVELOPMENT.md updated |
 
-**Gate verdict**: No constitution violations. Complexity Tracking table intentionally empty.
+No violations. Complexity Tracking table empty.
 
 ## Project Structure
 
@@ -51,42 +48,41 @@ RepoPulse's constitution (v1.2) governs the product's accuracy, data sources, an
 
 ```text
 specs/249-speckit-branch-spec-numbering-should-ali/
-├── spec.md              # Already written (/speckit.specify output)
-├── plan.md              # This file (/speckit.plan command output)
-├── research.md          # Phase 0 output — decisions & alternatives
-├── data-model.md        # Phase 1 output — naming grammar entities
-├── quickstart.md        # Phase 1 output — regression walkthrough
+├── spec.md              # User-facing spec
+├── plan.md              # This file
+├── research.md          # Decisions & alternatives
+├── data-model.md        # Naming grammar
 ├── contracts/
-│   └── cli-contracts.md # Phase 1 output — flag/branch-pattern contracts
-├── checklists/
-│   └── requirements.md  # Already written (/speckit.specify output)
-└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created by /speckit.plan)
+│   └── cli-contracts.md # Script-level contracts
+├── quickstart.md        # Regression walkthrough
+├── checklists/requirements.md
+└── tasks.md
 ```
 
-### Source Code (repository root)
+### Source Code
 
 ```text
 scripts/
-└── claude-worktree.sh                   # MODIFIED — gh<N>- prefix for branch & worktree path; --cleanup-merged accepts both gh<N>- and legacy <N>-
+└── claude-worktree.sh                   # No change (already creates <N>-<slug> branch and forkprint-<N>-<slug>/ worktree path)
 
 .specify/
 └── scripts/
     └── bash/
-        ├── create-new-feature.sh        # MODIFIED — detect current branch matching ^(gh)?[0-9]+-(.+)$ and reuse it verbatim; skip `git checkout -b` when branch == current HEAD
-        └── common.sh                    # MODIFIED — get_current_branch(), check_feature_branch(), find_feature_dir_by_prefix() all learn the gh<N>- pattern
+        ├── create-new-feature.sh        # MODIFIED — reuse-current-branch detection; --number validation; populated-spec.md collision check; improved branch-exists error
+        └── common.sh                    # MODIFIED — find_feature_dir_by_prefix, check_feature_branch, get_current_branch accept ^[0-9]+- (any width)
 
 .claude/
 └── commands/
-    └── speckit.specify.md               # MODIFIED — note that the script auto-detects gh<N>- branches; no change to Claude's invocation, just clarifying docs
+    └── speckit.specify.md               # MODIFIED — note on auto-detection of feature-prefix branches
 
 docs/
-└── DEVELOPMENT.md                       # MODIFIED — document the gh<N>-<slug> convention and the legacy-compat fallback
+└── DEVELOPMENT.md                       # MODIFIED — document the numbering rule; no custom prefix
 ```
 
-**Structure Decision**: This is a tooling-only change; there is no product source-code surface to structure. The layout mirrors the existing `.specify/` + `scripts/` + `.claude/commands/` + `docs/` split, with one file modified per location.
+**Structure Decision**: Tooling-only — no product surface. Four files modified, diff ~60 lines.
 
 ## Complexity Tracking
 
 > **Fill ONLY if Constitution Check has violations that must be justified**
 
-*No violations — section intentionally left empty.*
+*No violations — intentionally empty.*

--- a/specs/249-speckit-branch-spec-numbering-should-ali/plan.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: SpecKit branch/spec numbering aligned with GitHub issue number
+
+**Branch**: `249-speckit-branch-spec-numbering-should-ali` | **Date**: 2026-04-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/249-speckit-branch-spec-numbering-should-ali/spec.md`
+
+## Summary
+
+Introduce a disjoint naming namespace for issue-driven SpecKit work: worktree directories, branches, and spec directories all use `gh<N>-<slug>` (where `<N>` is the GitHub issue number, no padding). Manual sequential fallback keeps the existing `<NNN>-<slug>` form. Because `gh` and the leading digit of a sequential prefix can never collide, the two namespaces are disjoint by construction.
+
+**Technical approach**: The fix is scoped to the tooling layer (bash scripts, SpecKit helpers, one command template, one docs file). `scripts/claude-worktree.sh` creates worktrees/branches with `gh<N>-` up front, so Claude is already on a `gh<N>-` branch when `/speckit.specify` runs. `create-new-feature.sh` detects the current branch's prefix pattern and (a) reuses the branch verbatim when it already matches `^(gh)?[0-9]+-`, (b) derives the spec-directory name from the current branch in that case, or (c) falls through to the existing sequential logic otherwise. `common.sh` helpers that parse branch prefixes gain `gh<N>-` awareness so downstream commands (`/speckit.plan`, `/speckit.tasks`, `/speckit.implement`) keep resolving specs correctly. A transitional compatibility fallback in `--cleanup-merged` still matches legacy unprefixed worktrees.
+
+## Technical Context
+
+**Language/Version**: Bash (POSIX-compatible for portable bits, bash-specific features already in use: `[[ ... ]]`, `set -euo pipefail`, `${BASH_REMATCH}`)
+**Primary Dependencies**: `git`, `gh` (GitHub CLI, already required by the surrounding tooling), `uuidgen` (macOS/Linux standard)
+**Storage**: N/A (all state lives in git + local filesystem: spec dirs under `specs/`, worktrees as siblings of the repo)
+**Testing**: Manual validation via a scripted dry-run (documented in `quickstart.md`); automated tests are out of scope because these are one-shot lifecycle scripts without a test harness in this repo. Regression coverage is provided by running the existing worktree spawn + `/speckit.specify` + cleanup on a throwaway issue number.
+**Target Platform**: macOS (primary development environment) and Linux (CI-compatible, though no CI exercises these scripts today)
+**Project Type**: CLI/tooling layer — no application code changes
+**Performance Goals**: N/A (interactive lifecycle scripts; each invocation completes in <10s and is not in any hot path)
+**Constraints**: Must not break in-flight legacy worktrees (branches like `249-…` spawned before this fix); `--cleanup-merged` keeps backward compatibility for one transition period; no new tooling dependencies; no secrets; no bypass of the existing permission allowlist.
+**Scale/Scope**: Four files changed (`scripts/claude-worktree.sh`, `.specify/scripts/bash/create-new-feature.sh`, `.specify/scripts/bash/common.sh`, `.claude/commands/speckit.specify.md`) plus `docs/DEVELOPMENT.md`. Estimated diff: ~100 lines added, ~20 modified. No new files outside `specs/249-.../`.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+RepoPulse's constitution (v1.2) governs the product's accuracy, data sources, analyzer boundary, CHAOSS mapping, scoring thresholds, testing, security, and development workflow. This feature is pure tooling — it does not touch the product runtime, the analyzer module, any scoring logic, any UI, any data source, or any user-facing product behaviour.
+
+| Gate | Relevance | Result |
+|---|---|---|
+| I. Technology Stack | No new frameworks, no new runtime deps | ✅ Pass (no change) |
+| II. Accuracy Policy (NON-NEGOTIABLE) | No metric display, no GraphQL change | ✅ Pass (not applicable) |
+| III. Data Source Rules | No API calls added | ✅ Pass (not applicable) |
+| IV. Analyzer Module Boundary | Analyzer untouched | ✅ Pass (not applicable) |
+| V. CHAOSS Alignment | No scoring change | ✅ Pass (not applicable) |
+| VI. Scoring Thresholds | No scoring change | ✅ Pass (not applicable) |
+| VII. Ecosystem Spectrum | No ecosystem change | ✅ Pass (not applicable) |
+| VIII. Contribution Dynamics Honesty | No contributor data surface | ✅ Pass (not applicable) |
+| IX. Feature Scope Rules (YAGNI, KISS) | Minimal change, no speculative abstractions, no new flags beyond what the spec requires | ✅ Pass |
+| X. Security & Hygiene | No secrets; no new shell commands beyond the existing allowlist (`git`, `gh`, standard utilities) | ✅ Pass |
+| XI. Testing | No analyzer or UI under test; manual regression per `quickstart.md` | ✅ Pass (manual-validation scope acknowledged) |
+| XII. Definition of Done | PR test plan will cover all acceptance scenarios from the spec | ✅ Pass (planned) |
+| XIII. Development Workflow | Feature-branch commit, PR with `## Test plan`, DEVELOPMENT.md updated | ✅ Pass (planned) |
+
+**Gate verdict**: No constitution violations. Complexity Tracking table intentionally empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/249-speckit-branch-spec-numbering-should-ali/
+├── spec.md              # Already written (/speckit.specify output)
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output — decisions & alternatives
+├── data-model.md        # Phase 1 output — naming grammar entities
+├── quickstart.md        # Phase 1 output — regression walkthrough
+├── contracts/
+│   └── cli-contracts.md # Phase 1 output — flag/branch-pattern contracts
+├── checklists/
+│   └── requirements.md  # Already written (/speckit.specify output)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+scripts/
+└── claude-worktree.sh                   # MODIFIED — gh<N>- prefix for branch & worktree path; --cleanup-merged accepts both gh<N>- and legacy <N>-
+
+.specify/
+└── scripts/
+    └── bash/
+        ├── create-new-feature.sh        # MODIFIED — detect current branch matching ^(gh)?[0-9]+-(.+)$ and reuse it verbatim; skip `git checkout -b` when branch == current HEAD
+        └── common.sh                    # MODIFIED — get_current_branch(), check_feature_branch(), find_feature_dir_by_prefix() all learn the gh<N>- pattern
+
+.claude/
+└── commands/
+    └── speckit.specify.md               # MODIFIED — note that the script auto-detects gh<N>- branches; no change to Claude's invocation, just clarifying docs
+
+docs/
+└── DEVELOPMENT.md                       # MODIFIED — document the gh<N>-<slug> convention and the legacy-compat fallback
+```
+
+**Structure Decision**: This is a tooling-only change; there is no product source-code surface to structure. The layout mirrors the existing `.specify/` + `scripts/` + `.claude/commands/` + `docs/` split, with one file modified per location.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+*No violations — section intentionally left empty.*

--- a/specs/249-speckit-branch-spec-numbering-should-ali/quickstart.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/quickstart.md
@@ -1,0 +1,135 @@
+# Quickstart: Regression test for `gh<N>-` naming
+
+This file describes how to exercise the feature end-to-end after implementation. Run it against a real throwaway GitHub issue to verify the acceptance criteria.
+
+## Prerequisites
+
+- Repo checked out at `main`.
+- `gh` CLI authenticated.
+- A disposable test GitHub issue (or an existing open issue whose worktree will be cleaned up afterwards).
+
+## T1. Worktree-driven happy path (User Story 1)
+
+```bash
+# Create a test issue or pick one
+TEST_ISSUE=<N>
+
+# Spawn a worktree
+scripts/claude-worktree.sh --no-speckit "$TEST_ISSUE"
+# Or, to exercise the /speckit.specify path:
+# scripts/claude-worktree.sh "$TEST_ISSUE"
+
+# Expected output: worktree at `../forkprint-gh<N>-<slug>/`, branch `gh<N>-<slug>`.
+cd "../forkprint-gh${TEST_ISSUE}-"*
+git branch --show-current    # expect: gh<N>-<slug>
+basename "$(pwd)"            # expect: forkprint-gh<N>-<slug>
+```
+
+Run `/speckit.specify` inside Claude. Then:
+
+```bash
+ls specs/                    # expect: only gh<N>-<slug>/ was created
+cat specs/gh*/spec.md | head # expect: populated spec
+git branch --show-current    # expect: still gh<N>-<slug>, not a new number
+```
+
+**Pass criterion**: all three prefixes agree (`gh<N>-`), no `<other-number>-` spec/branch was produced.
+
+## T2. Manual sequential fallback (User Story 2)
+
+```bash
+# From main, no worktree, no issue context:
+cd <repo-root>
+git checkout main
+# Invoke /speckit.specify in Claude with a non-issue description, e.g. "exploratory refactor"
+```
+
+**Pass criterion**: Spec directory uses the next free `<NNN>-<slug>` form (no `gh` prefix). Branch `<NNN>-<slug>` created and checked out.
+
+## T3. Explicit `--number` override (User Story 2, scenario 2)
+
+```bash
+.specify/scripts/bash/create-new-feature.sh --number 9999 --short-name test-override "Test override" --json
+```
+
+**Pass criterion**: Produces branch `9999-test-override` (unprefixed), spec dir `specs/9999-test-override/`. Confirms `--number` remains a manual override and does NOT add the `gh` prefix.
+
+## T4. Reuse when branch already matches (User Story 3, scenario 1)
+
+Already covered by T1 — the worktree spawn pre-creates the branch, and `/speckit.specify` reuses it silently.
+
+Verify explicitly:
+
+```bash
+cd "../forkprint-gh${TEST_ISSUE}-"*
+git log --oneline | wc -l    # record N
+# Re-run /speckit.specify in Claude (idempotent reuse scenario)
+git log --oneline | wc -l    # expect: still N (no branch-switch noise)
+```
+
+## T5. Loud error on spec-dir collision (User Story 3, scenario 2)
+
+```bash
+# Create an orphan spec dir with a populated spec
+mkdir -p specs/gh${TEST_ISSUE}-existing-slug
+echo "stub" > specs/gh${TEST_ISSUE}-existing-slug/spec.md
+
+# Attempt to run create-new-feature.sh with a different slug on a gh<N>- branch
+# (Simulate by being on a branch `gh<N>-different-slug` and running the script)
+
+.specify/scripts/bash/create-new-feature.sh --short-name different-slug "Different" --json
+# Expected: exit 1, error message naming the existing dir
+echo "exit=$?"               # expect: 1
+```
+
+## T6. Loud error on branch collision (User Story 3, scenario 3)
+
+```bash
+git checkout main
+git branch gh12345-phantom   # create a conflicting branch on main
+.specify/scripts/bash/create-new-feature.sh --short-name phantom "Phantom" --json
+# Running from a checkout that isn't on gh12345-phantom. Expected: exit 1 with branch-exists error.
+git branch -D gh12345-phantom
+```
+
+## T7. `--cleanup-merged` with new and legacy worktrees
+
+```bash
+# Merge the PR for T1's worktree via GitHub UI, then:
+cd <repo-root>
+git checkout main && git pull
+scripts/claude-worktree.sh --cleanup-merged "$TEST_ISSUE"
+# Expected: finds forkprint-gh<N>-*, cleans it, deletes branch.
+
+# Legacy fallback: if any `forkprint-<N>-<slug>/` (no gh prefix) exists for a merged branch,
+# the same command also finds and cleans it.
+```
+
+## T8. Invalid `--number` input
+
+```bash
+.specify/scripts/bash/create-new-feature.sh --number abc "bad" --json    # expect: exit 1, "must be positive integer"
+.specify/scripts/bash/create-new-feature.sh --number 0 "bad" --json      # expect: exit 1
+.specify/scripts/bash/create-new-feature.sh --number -5 "bad" --json     # expect: exit 1
+```
+
+## T9. Downstream commands resolve the `gh<N>-` spec dir
+
+On a `gh<N>-<slug>` branch with a populated `specs/gh<N>-<slug>/spec.md`:
+
+```bash
+.specify/scripts/bash/setup-plan.sh --json | jq -r .FEATURE_SPEC
+# expect: /path/to/specs/gh<N>-<slug>/spec.md
+```
+
+**Pass criterion**: `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` all resolve the same `specs/gh<N>-<slug>/` directory without ambiguity.
+
+## Cleanup after testing
+
+```bash
+# Remove any stray test worktrees/branches:
+scripts/claude-worktree.sh --remove "$TEST_ISSUE"
+git branch -D "gh${TEST_ISSUE}-"*
+rm -rf specs/gh${TEST_ISSUE}-*
+# Close the test GitHub issue if one was created.
+```

--- a/specs/249-speckit-branch-spec-numbering-should-ali/quickstart.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/quickstart.md
@@ -1,135 +1,92 @@
-# Quickstart: Regression test for `gh<N>-` naming
-
-This file describes how to exercise the feature end-to-end after implementation. Run it against a real throwaway GitHub issue to verify the acceptance criteria.
-
-## Prerequisites
-
-- Repo checked out at `main`.
-- `gh` CLI authenticated.
-- A disposable test GitHub issue (or an existing open issue whose worktree will be cleaned up afterwards).
+# Quickstart: Regression tests
 
 ## T1. Worktree-driven happy path (User Story 1)
 
 ```bash
-# Create a test issue or pick one
-TEST_ISSUE=<N>
+# Simulate what scripts/claude-worktree.sh does for an issue:
+git worktree add ../forkprint-99999-demo -b 99999-demo
+cd ../forkprint-99999-demo
+git branch --show-current       # expect: 99999-demo
 
-# Spawn a worktree
-scripts/claude-worktree.sh --no-speckit "$TEST_ISSUE"
-# Or, to exercise the /speckit.specify path:
-# scripts/claude-worktree.sh "$TEST_ISSUE"
-
-# Expected output: worktree at `../forkprint-gh<N>-<slug>/`, branch `gh<N>-<slug>`.
-cd "../forkprint-gh${TEST_ISSUE}-"*
-git branch --show-current    # expect: gh<N>-<slug>
-basename "$(pwd)"            # expect: forkprint-gh<N>-<slug>
+# Simulate /speckit.specify:
+.specify/scripts/bash/create-new-feature.sh "Demo feature" --short-name any --json
+# expect JSON with BRANCH_NAME=99999-demo, FEATURE_NUM=99999 (unpadded)
+git branch --show-current       # expect: still 99999-demo (no branch switch)
+[ -s specs/99999-demo/spec.md ] # expect: true
 ```
 
-Run `/speckit.specify` inside Claude. Then:
-
-```bash
-ls specs/                    # expect: only gh<N>-<slug>/ was created
-cat specs/gh*/spec.md | head # expect: populated spec
-git branch --show-current    # expect: still gh<N>-<slug>, not a new number
-```
-
-**Pass criterion**: all three prefixes agree (`gh<N>-`), no `<other-number>-` spec/branch was produced.
+**Pass criterion**: branch reused, spec dir matches branch, no decoy numbered directory.
 
 ## T2. Manual sequential fallback (User Story 2)
 
 ```bash
-# From main, no worktree, no issue context:
-cd <repo-root>
+# From main, no issue context:
+cd <repo>
 git checkout main
-# Invoke /speckit.specify in Claude with a non-issue description, e.g. "exploratory refactor"
+.specify/scripts/bash/create-new-feature.sh "exploratory refactor" --short-name refactor --json
 ```
 
-**Pass criterion**: Spec directory uses the next free `<NNN>-<slug>` form (no `gh` prefix). Branch `<NNN>-<slug>` created and checked out.
+**Pass criterion**: spec dir `<NNN>-refactor/` uses next free sequential number; branch `<NNN>-refactor` created.
 
 ## T3. Explicit `--number` override (User Story 2, scenario 2)
 
 ```bash
-.specify/scripts/bash/create-new-feature.sh --number 9999 --short-name test-override "Test override" --json
+.specify/scripts/bash/create-new-feature.sh --number 9999 --short-name test-override "override" --json
 ```
 
-**Pass criterion**: Produces branch `9999-test-override` (unprefixed), spec dir `specs/9999-test-override/`. Confirms `--number` remains a manual override and does NOT add the `gh` prefix.
+**Pass criterion**: branch `9999-test-override`, spec dir `specs/9999-test-override/`. `--number` remains a raw-numeric override.
 
-## T4. Reuse when branch already matches (User Story 3, scenario 1)
+## T4. Reuse when current branch matches (User Story 3, scenario 1)
 
-Already covered by T1 — the worktree spawn pre-creates the branch, and `/speckit.specify` reuses it silently.
+Covered by T1 — worktree spawn pre-creates the branch and `/speckit.specify` reuses it silently.
 
-Verify explicitly:
+## T5. Loud error on populated spec.md (User Story 3, scenario 2)
 
 ```bash
-cd "../forkprint-gh${TEST_ISSUE}-"*
-git log --oneline | wc -l    # record N
-# Re-run /speckit.specify in Claude (idempotent reuse scenario)
-git log --oneline | wc -l    # expect: still N (no branch-switch noise)
+# From a branch where specs/<prefix>-<slug>/spec.md is populated:
+.specify/scripts/bash/create-new-feature.sh "anything" --short-name any --json
+echo "exit=$?"
 ```
 
-## T5. Loud error on spec-dir collision (User Story 3, scenario 2)
-
-```bash
-# Create an orphan spec dir with a populated spec
-mkdir -p specs/gh${TEST_ISSUE}-existing-slug
-echo "stub" > specs/gh${TEST_ISSUE}-existing-slug/spec.md
-
-# Attempt to run create-new-feature.sh with a different slug on a gh<N>- branch
-# (Simulate by being on a branch `gh<N>-different-slug` and running the script)
-
-.specify/scripts/bash/create-new-feature.sh --short-name different-slug "Different" --json
-# Expected: exit 1, error message naming the existing dir
-echo "exit=$?"               # expect: 1
-```
+**Pass criterion**: exit 1, error names the existing path, suggests resolution.
 
 ## T6. Loud error on branch collision (User Story 3, scenario 3)
 
 ```bash
 git checkout main
-git branch gh12345-phantom   # create a conflicting branch on main
-.specify/scripts/bash/create-new-feature.sh --short-name phantom "Phantom" --json
-# Running from a checkout that isn't on gh12345-phantom. Expected: exit 1 with branch-exists error.
-git branch -D gh12345-phantom
+git branch 88888-phantom          # create a conflicting branch off-HEAD
+.specify/scripts/bash/create-new-feature.sh --number 88888 --short-name phantom "phantom" --json
+echo "exit=$?"
+git branch -D 88888-phantom
 ```
 
-## T7. `--cleanup-merged` with new and legacy worktrees
+**Pass criterion**: exit 1 with an error naming the conflicting branch.
+
+## T7. `--cleanup-merged` finds the worktree
+
+Covered by running `scripts/claude-worktree.sh --cleanup-merged <N>` after the corresponding PR merges. Awk pattern `-<N>-` matches `forkprint-<N>-<slug>`. Same behaviour as before this fix — no change to `claude-worktree.sh`.
+
+## T8. Invalid `--number`
 
 ```bash
-# Merge the PR for T1's worktree via GitHub UI, then:
-cd <repo-root>
-git checkout main && git pull
-scripts/claude-worktree.sh --cleanup-merged "$TEST_ISSUE"
-# Expected: finds forkprint-gh<N>-*, cleans it, deletes branch.
-
-# Legacy fallback: if any `forkprint-<N>-<slug>/` (no gh prefix) exists for a merged branch,
-# the same command also finds and cleans it.
+.specify/scripts/bash/create-new-feature.sh --number abc "bad" --json   # expect exit 1
+.specify/scripts/bash/create-new-feature.sh --number 0   "bad" --json   # expect exit 1
+.specify/scripts/bash/create-new-feature.sh --number -5  "bad" --json   # expect exit 1
 ```
 
-## T8. Invalid `--number` input
+## T9. Downstream commands resolve the spec dir
 
 ```bash
-.specify/scripts/bash/create-new-feature.sh --number abc "bad" --json    # expect: exit 1, "must be positive integer"
-.specify/scripts/bash/create-new-feature.sh --number 0 "bad" --json      # expect: exit 1
-.specify/scripts/bash/create-new-feature.sh --number -5 "bad" --json     # expect: exit 1
+# From a branch `99999-demo` with populated specs/99999-demo/spec.md:
+.specify/scripts/bash/setup-plan.sh --json | grep '^{' | jq -r .FEATURE_SPEC
+# expect: .../specs/99999-demo/spec.md
 ```
 
-## T9. Downstream commands resolve the `gh<N>-` spec dir
+**Pass criterion**: `/speckit.plan`, `/speckit.tasks`, `/speckit.implement` all resolve the same spec directory via `common.sh` helpers.
 
-On a `gh<N>-<slug>` branch with a populated `specs/gh<N>-<slug>/spec.md`:
-
-```bash
-.specify/scripts/bash/setup-plan.sh --json | jq -r .FEATURE_SPEC
-# expect: /path/to/specs/gh<N>-<slug>/spec.md
-```
-
-**Pass criterion**: `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` all resolve the same `specs/gh<N>-<slug>/` directory without ambiguity.
-
-## Cleanup after testing
+## Cleanup
 
 ```bash
-# Remove any stray test worktrees/branches:
-scripts/claude-worktree.sh --remove "$TEST_ISSUE"
-git branch -D "gh${TEST_ISSUE}-"*
-rm -rf specs/gh${TEST_ISSUE}-*
-# Close the test GitHub issue if one was created.
+git worktree remove ../forkprint-99999-demo
+git branch -D 99999-demo
 ```

--- a/specs/249-speckit-branch-spec-numbering-should-ali/research.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/research.md
@@ -1,103 +1,76 @@
-# Phase 0 Research: Naming convention, branch detection, and compatibility
+# Phase 0 Research: Reuse detection, collision handling, and why no custom prefix
 
-## Decision 1: Prefix form for issue-driven work — `gh<N>-<slug>`
+## Decision 1: Stay on the upstream `<N>-<slug>` convention — no custom prefix
 
-**Decision**: Issue-driven spec directories, feature branches, and worktree directories all use the prefix `gh<N>` where `<N>` is the GitHub issue number without padding (e.g. `gh7-foo`, `gh249-bar`, `gh12345-baz`).
-
-**Rationale**:
-- Disjoint from both sequential (`<NNN>-`) and timestamp (`<YYYYMMDD>-<HHMMSS>-`) namespaces: no string starting with `gh[0-9]` can also match `^[0-9]`, so the grammars are mutually exclusive.
-- Visually signals "this is a GitHub issue" — matches the `gh` CLI binary the project already uses and the `#<N>` form issues appear as in PR titles.
-- Short — adds only 2 characters vs the old unprefixed form. `gh249-foo` vs `249-foo`.
-- No padding — GitHub itself displays issues as `#7` and `#12345`, not `#007`. Keeping the form padding-free mirrors that.
-
-**Alternatives considered**:
-- `i<N>-` (e.g. `i249-foo`): shorter, but `i` alone is ambiguous (iteration? index?). Rejected.
-- `issue-<N>-` (e.g. `issue-249-foo`): explicit, but verbose. Every branch name grows by 6 characters. Rejected.
-- `#<N>-` (e.g. `#249-foo`): `#` is legal in git branch names, but treacherous in shell contexts (comments, globs, URLs) and unsupported by some tooling. Rejected.
-- Raise the manual sequential floor to 9000+ so issue numbers can't overlap: keeps `<N>-` shape but picks arbitrary boundary that leaks into every unrelated spec's name. Rejected.
-- Switch manual fallback to timestamp-only: changes the manual flow maintainers already use. Rejected.
-
-## Decision 2: Branch-detection logic in `create-new-feature.sh`
-
-**Decision**: The script derives the spec-directory prefix from the currently checked-out branch when the branch matches `^(gh)?[0-9]+-(.+)$`. It reuses the current branch verbatim (no `git checkout -b`) when the target matches. Only when the current branch is a non-matching name (e.g. `main`, `feature/foo`) does the sequential-increment path run.
+**Decision**: Branch, worktree, and spec-directory names use the bare issue number as prefix (`238-some-slug`), matching upstream SpecKit's `<NNN>-<slug>` convention.
 
 **Rationale**:
-- Works identically whether the user passes an explicit flag or not — the source of truth is the branch name that the worktree or the user has already created.
-- Makes the `gh` prefix rule enforceable without modifying the Claude command template's invocation (`/speckit.specify` passes no `--number`; the script handles detection).
-- Covers legacy-unprefixed branches (like this feature's own `249-speckit-…`) as well: they get detected as `^[0-9]+-` and reused unchanged. No forced migration.
+- **Portability**: upstream SpecKit and other projects adopting this worktree workflow expect `<N>-<slug>`. Custom prefixes diverge from the ecosystem.
+- **Future upstream alignment**: if SpecKit adds native issue-number support, our convention converges; with a custom prefix, we'd need a breaking rename.
+- **Lower cognitive load**: PR titles, branch names, and issue numbers all use the same integer. No mental translation.
+- The concern a custom prefix addressed — manual-sequential-vs-issue-number collision — is **extremely rare** (requires manual sequential to claim exactly slot N just before issue #N is filed and worktree-spawned). The loud-error contract (Decision 3) handles it cleanly when it does happen.
 
-**Alternatives considered**:
-- Add a new `--issue <N>` flag and require the Claude command template to pass it: couples the SpecKit helper to the Claude prompt format, and breaks if Claude forgets to pass the flag. Rejected.
-- Always re-create a new branch (current behaviour): the bug. Rejected.
-- Detect and fail if not on a `gh<N>-` branch (forcing migration): breaks in-flight legacy worktrees. Rejected.
+**Alternatives considered** (and rejected, as of this revision):
+- `gh<N>-<slug>` prefix: earlier iteration of this PR; removed because (a) it diverges from SpecKit ecosystem, (b) adoption by other projects becomes harder, (c) forces us to maintain a legacy-compat fallback in multiple places, (d) it looks non-idiomatic in PR titles and commit messages.
+- `#<N>-<slug>`: `#` is legal in git but fragile in shells. Rejected earlier.
+- `issue-<N>-<slug>`: verbose, every branch grows 6 chars. Rejected.
+- High-offset sequential (manual starts at 9000+): arbitrary boundary, leaks into unrelated spec names. Rejected.
 
-## Decision 3: Collision handling
+## Decision 2: Branch detection in `create-new-feature.sh`
 
-**Decision**: Two collision cases are treated differently.
+**Decision**: Derive the spec-directory prefix from the currently checked-out branch when that branch matches `^[0-9]+-.+$` or `^[0-9]{8}-[0-9]{6}-.+$`. Reuse the current branch verbatim (no `git checkout -b`) when a match is found. Only when the current branch is a non-matching name (e.g. `main`, `feature/foo`) does the sequential-increment path run.
+
+**Rationale**: The branch name is the source of truth — the worktree script has already created it. Detecting from HEAD means no extra flag is needed from the Claude command template; behaviour is identical whether `/speckit.specify` is invoked via kickoff prompt or manually.
+
+**Implementation note**: Order regex checks — timestamp (`^[0-9]{8}-[0-9]{6}-`) first, then general sequential (`^[0-9]+-`). Otherwise the latter would greedily consume a timestamp's first digit-run.
+
+**Alternatives**: add a new `--issue <N>` flag — couples the SpecKit helper to the Claude prompt and breaks if the flag is forgotten. Rejected.
+
+## Decision 3: Collision handling — loud, never silent
+
+**Decision**:
 
 | Case | Behaviour |
 |---|---|
-| Target branch == current HEAD (common in worktree spawn) | Silent reuse. No `git checkout -b`. Proceed to spec-dir creation. |
-| Target branch exists but is NOT current HEAD | Exit non-zero with a clear error naming the conflicting branch. |
-| `specs/<prefix>-<slug>/` directory does not exist yet | Create it normally. |
-| `specs/<prefix>-<slug>/` exists, `spec.md` missing or empty | Reuse the directory; copy the template to `spec.md`. |
-| `specs/<prefix>-<slug>/` exists, `spec.md` non-empty | Exit non-zero with a clear error naming the directory. Suggest renaming/removing the existing dir or picking a different issue. |
+| Target branch == current HEAD | Silent reuse. No `git checkout -b`. |
+| Target branch exists, not current HEAD | Exit 1 with an error naming the conflict. |
+| `specs/<target>/` missing or `spec.md` empty | Create / overwrite template into `spec.md`. |
+| `specs/<target>/spec.md` non-empty | Exit 1 with an error naming the directory. |
+| Invalid `--number` (non-numeric, 0, negative) | Exit 1 before any mutation. |
 
-**Rationale**: The FR-006 / FR-007 contracts in the spec require loud failure over silent renumbering. Reuse is correct for the worktree-spawn case (the branch and sometimes the spec dir already exist from a prior partial run). A non-empty `spec.md` is authored content and must never be overwritten silently.
+**Rationale**: The original bug was a silent renumbering. The replacement contract is "loud failure over silent wrong behaviour." Reuse of a matching HEAD is the expected case for worktree spawns. Non-empty `spec.md` is authored content and must never be overwritten.
 
-**Alternatives considered**:
-- Always delete and regenerate the spec dir: destroys user work. Rejected.
-- Always error on any existing dir: breaks the worktree-spawn reuse flow. Rejected.
+## Decision 4: `common.sh` helpers widened to `^[0-9]+-`
 
-## Decision 4: `common.sh` helpers for downstream commands
+**Decision**: Three functions in `.specify/scripts/bash/common.sh` change their sequential-prefix regex from `^[0-9]{3}-` to `^[0-9]+-` so any-width issue numbers resolve correctly downstream.
 
-**Decision**: Three functions in `.specify/scripts/bash/common.sh` gain `gh<N>-` awareness:
+- `find_feature_dir_by_prefix()` — extracts the prefix from branch name to glob `specs/<prefix>-*`. With `^[0-9]+-`, issue `#7` yields prefix `7` and globs `specs/7-*`; issue `#12345` yields `12345`. Timestamp branch still takes precedence (more specific regex).
+- `check_feature_branch()` — accepts `^[0-9]+-` alongside the existing timestamp pattern. Error message updated.
+- `get_current_branch()` — non-git fallback scanner accepts the wider pattern when ranking "latest" spec dir.
 
-1. `get_current_branch()` — the non-git fallback that scans `specs/` for the latest feature directory when git is unavailable. Adds a regex branch for `^gh([0-9]+)-` alongside the existing `^[0-9]{3}-` and timestamp branches. Ranks `gh<N>` numerically like the sequential form.
-2. `check_feature_branch()` — validates a branch is a feature branch. Adds `^gh[0-9]+-` to the accept list alongside `^[0-9]{3}-` and `^[0-9]{8}-[0-9]{6}-`. Updates the error message to reference the new form.
-3. `find_feature_dir_by_prefix()` — resolves `specs/<prefix>-*` from the current branch's prefix. Adds a regex branch for `^gh([0-9]+)-` that captures `gh<N>` as the prefix. Existing sequential (`^[0-9]{3}-`) and timestamp branches unchanged.
+**Rationale**: Without this widening, `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` (all of which call `get_feature_paths` → `find_feature_dir_by_prefix`) fail for issue numbers outside the 3-digit range. The regex change is a strict superset of the old behaviour (every 3-digit match still matches), so no regression.
 
-**Rationale**: Without these changes, `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` (all of which call `get_feature_paths()`, which calls `find_feature_dir_by_prefix()`) would fail to resolve the spec directory for a `gh<N>-` branch. The fix must be end-to-end or the prefix contract breaks after `/speckit.specify`.
+## Decision 5: `claude-worktree.sh` is unchanged
 
-**Alternatives considered**:
-- Leave `common.sh` alone and rely on exact-branch-name match (the existing fallback in `find_feature_dir_by_prefix`): works only when spec dir name exactly equals branch name. That is the happy path, but any divergence (e.g. slug mismatch) would regress silently. Rejected — the helpers exist precisely for this prefix-based resolution.
+**Decision**: `scripts/claude-worktree.sh` already creates `forkprint-<N>-<slug>/` worktrees and `<N>-<slug>` branches. The earlier `gh<N>-` attempt is reverted. No change to the awk lookup patterns in `--cleanup-merged`, `--remove`, `--approve-spec`, `--revise-spec` — they already match `-<issue>-` in worktree paths, which is exactly what the script produces.
 
-## Decision 5: Backward compatibility for `--cleanup-merged`
+**Rationale**: Simplest possible fix. The misalignment was never in `claude-worktree.sh` — the worktree script always used the issue number correctly. The bug was in `create-new-feature.sh` renumbering on top of it.
 
-**Decision**: `scripts/claude-worktree.sh --cleanup-merged <N>` and `--remove <N>` match worktrees whose directory name contains *either* `-gh<N>-` or the legacy `-<N>-`. New spawns only create `-gh<N>-`, but existing in-flight legacy worktrees (this feature included) must remain cleanable during a transition period.
+## Decision 6: Input validation for `--number`
 
-**Rationale**: Forcing maintainers to manually rename their in-flight worktrees would bite immediately (this very feature would be un-cleanable after merge). A single awk pattern accepting both forms is ~5 additional characters and solves the transition cleanly.
+**Decision**: `--number` input must satisfy `^[0-9]+$` AND decode to ≥ 1 in base 10. Validated before any filesystem or git mutation.
 
-**Alternatives considered**:
-- Drop legacy matching immediately: breaks in-flight work. Rejected.
-- Keep legacy matching forever: we'll never know when to drop it. Mitigation: add a comment in the script noting that the legacy branch can be removed once all legacy-named worktrees have been cleaned, tracked informally.
+**Rationale**: Without validation, `printf "%03d"` accepts garbage. The validator rejects non-numeric, zero, negative, and leading-zero-only forms that decode to 0. Fails fast with a specific error message.
 
-## Decision 6: No change to the Claude command template invocation
+## Decision 7: Rare-collision resolution path is user-visible
 
-**Decision**: `.claude/commands/speckit.specify.md` continues to instruct Claude to invoke `create-new-feature.sh` without `--number`. The prefix detection is entirely in the bash script (Decision 2). The command template gets a short clarifying note about the new convention so Claude doesn't get confused by `gh<N>-` branches.
+**Decision**: Document the rare case explicitly: if manual sequential claims slot N just before issue #N is filed, `/speckit.specify` for the issue will hit the branch-or-spec-dir collision and exit 1. Resolution: maintainer renames the old directory/branch, or picks a different issue number. This is an accepted tradeoff for staying on the standard convention.
 
-**Rationale**: The Claude prompt should not carry domain logic that belongs in the helper script. The helper script is the authoritative place for naming rules; the Claude prompt is a UX wrapper. Keeping the logic in one place avoids drift between "what Claude tells the script" and "what the script does."
-
-**Alternatives considered**:
-- Have Claude parse the kickoff prompt for an issue number and pass `--number <N>`: requires Claude to reason about the branch name, which is fragile. Rejected.
-- Have `claude-worktree.sh` export `SPECIFY_FEATURE=gh<N>-<slug>` into the worktree's shell env: works, but adds an env-var contract that's hidden from users reading the scripts. Rejected in favour of branch-name detection.
-
-## Decision 7: Validation of `--number` input
-
-**Decision**: `--number` input must be a positive integer (no leading zeros preserved, no sign, no decimals, no whitespace). Validation happens before any filesystem or git mutation. Invalid input exits non-zero with a clear error.
-
-**Rationale**: FR-008 in the spec explicitly requires this. Existing script has partial validation (forces base-10 via `$((10#$BRANCH_NUMBER))`) but does not reject negatives or non-numerics; `printf "%03d"` accepts garbage and produces surprising output.
-
-**Alternatives considered**:
-- Defer validation to `git checkout -b` failing: produces a cryptic git error, violates FR-008. Rejected.
-
-## Open questions resolved
-
-All [NEEDS CLARIFICATION] markers in the spec were resolved during Stage 1 review (user confirmed option 2: `gh<N>` prefix). No residual questions.
+**Rationale**: Being explicit about the rare case in the spec assumptions + docs means no surprises. The user knows the failure mode and how to resolve it. Silent wrong behavior was the original bug — a loud error that a human handles once in a blue moon is strictly better.
 
 ## Out of scope (confirmed)
 
-- Renaming existing spec directories (`001-*` … `229-*`, `128-licensing-compliance`, this feature's `249-speckit-…`): historical, immutable.
-- Automated tests for the bash scripts: no existing test harness, not a product-runtime concern. Manual regression via `quickstart.md`.
-- Renaming existing legacy worktrees on disk: the compat-match fallback handles them.
-- Changes to the analyzer, UI, API, or any product surface.
+- Renaming existing spec directories (`001-*` through `229-*`, `128-licensing-compliance`, this feature's `249-…`): historical, immutable.
+- Automated tests for bash scripts: no harness in this repo.
+- Changes to analyzer, UI, API, or product surface.
+- Changes to `claude-worktree.sh` beyond what was needed for this fix (the script already handled naming correctly).

--- a/specs/249-speckit-branch-spec-numbering-should-ali/research.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/research.md
@@ -1,0 +1,103 @@
+# Phase 0 Research: Naming convention, branch detection, and compatibility
+
+## Decision 1: Prefix form for issue-driven work — `gh<N>-<slug>`
+
+**Decision**: Issue-driven spec directories, feature branches, and worktree directories all use the prefix `gh<N>` where `<N>` is the GitHub issue number without padding (e.g. `gh7-foo`, `gh249-bar`, `gh12345-baz`).
+
+**Rationale**:
+- Disjoint from both sequential (`<NNN>-`) and timestamp (`<YYYYMMDD>-<HHMMSS>-`) namespaces: no string starting with `gh[0-9]` can also match `^[0-9]`, so the grammars are mutually exclusive.
+- Visually signals "this is a GitHub issue" — matches the `gh` CLI binary the project already uses and the `#<N>` form issues appear as in PR titles.
+- Short — adds only 2 characters vs the old unprefixed form. `gh249-foo` vs `249-foo`.
+- No padding — GitHub itself displays issues as `#7` and `#12345`, not `#007`. Keeping the form padding-free mirrors that.
+
+**Alternatives considered**:
+- `i<N>-` (e.g. `i249-foo`): shorter, but `i` alone is ambiguous (iteration? index?). Rejected.
+- `issue-<N>-` (e.g. `issue-249-foo`): explicit, but verbose. Every branch name grows by 6 characters. Rejected.
+- `#<N>-` (e.g. `#249-foo`): `#` is legal in git branch names, but treacherous in shell contexts (comments, globs, URLs) and unsupported by some tooling. Rejected.
+- Raise the manual sequential floor to 9000+ so issue numbers can't overlap: keeps `<N>-` shape but picks arbitrary boundary that leaks into every unrelated spec's name. Rejected.
+- Switch manual fallback to timestamp-only: changes the manual flow maintainers already use. Rejected.
+
+## Decision 2: Branch-detection logic in `create-new-feature.sh`
+
+**Decision**: The script derives the spec-directory prefix from the currently checked-out branch when the branch matches `^(gh)?[0-9]+-(.+)$`. It reuses the current branch verbatim (no `git checkout -b`) when the target matches. Only when the current branch is a non-matching name (e.g. `main`, `feature/foo`) does the sequential-increment path run.
+
+**Rationale**:
+- Works identically whether the user passes an explicit flag or not — the source of truth is the branch name that the worktree or the user has already created.
+- Makes the `gh` prefix rule enforceable without modifying the Claude command template's invocation (`/speckit.specify` passes no `--number`; the script handles detection).
+- Covers legacy-unprefixed branches (like this feature's own `249-speckit-…`) as well: they get detected as `^[0-9]+-` and reused unchanged. No forced migration.
+
+**Alternatives considered**:
+- Add a new `--issue <N>` flag and require the Claude command template to pass it: couples the SpecKit helper to the Claude prompt format, and breaks if Claude forgets to pass the flag. Rejected.
+- Always re-create a new branch (current behaviour): the bug. Rejected.
+- Detect and fail if not on a `gh<N>-` branch (forcing migration): breaks in-flight legacy worktrees. Rejected.
+
+## Decision 3: Collision handling
+
+**Decision**: Two collision cases are treated differently.
+
+| Case | Behaviour |
+|---|---|
+| Target branch == current HEAD (common in worktree spawn) | Silent reuse. No `git checkout -b`. Proceed to spec-dir creation. |
+| Target branch exists but is NOT current HEAD | Exit non-zero with a clear error naming the conflicting branch. |
+| `specs/<prefix>-<slug>/` directory does not exist yet | Create it normally. |
+| `specs/<prefix>-<slug>/` exists, `spec.md` missing or empty | Reuse the directory; copy the template to `spec.md`. |
+| `specs/<prefix>-<slug>/` exists, `spec.md` non-empty | Exit non-zero with a clear error naming the directory. Suggest renaming/removing the existing dir or picking a different issue. |
+
+**Rationale**: The FR-006 / FR-007 contracts in the spec require loud failure over silent renumbering. Reuse is correct for the worktree-spawn case (the branch and sometimes the spec dir already exist from a prior partial run). A non-empty `spec.md` is authored content and must never be overwritten silently.
+
+**Alternatives considered**:
+- Always delete and regenerate the spec dir: destroys user work. Rejected.
+- Always error on any existing dir: breaks the worktree-spawn reuse flow. Rejected.
+
+## Decision 4: `common.sh` helpers for downstream commands
+
+**Decision**: Three functions in `.specify/scripts/bash/common.sh` gain `gh<N>-` awareness:
+
+1. `get_current_branch()` — the non-git fallback that scans `specs/` for the latest feature directory when git is unavailable. Adds a regex branch for `^gh([0-9]+)-` alongside the existing `^[0-9]{3}-` and timestamp branches. Ranks `gh<N>` numerically like the sequential form.
+2. `check_feature_branch()` — validates a branch is a feature branch. Adds `^gh[0-9]+-` to the accept list alongside `^[0-9]{3}-` and `^[0-9]{8}-[0-9]{6}-`. Updates the error message to reference the new form.
+3. `find_feature_dir_by_prefix()` — resolves `specs/<prefix>-*` from the current branch's prefix. Adds a regex branch for `^gh([0-9]+)-` that captures `gh<N>` as the prefix. Existing sequential (`^[0-9]{3}-`) and timestamp branches unchanged.
+
+**Rationale**: Without these changes, `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` (all of which call `get_feature_paths()`, which calls `find_feature_dir_by_prefix()`) would fail to resolve the spec directory for a `gh<N>-` branch. The fix must be end-to-end or the prefix contract breaks after `/speckit.specify`.
+
+**Alternatives considered**:
+- Leave `common.sh` alone and rely on exact-branch-name match (the existing fallback in `find_feature_dir_by_prefix`): works only when spec dir name exactly equals branch name. That is the happy path, but any divergence (e.g. slug mismatch) would regress silently. Rejected — the helpers exist precisely for this prefix-based resolution.
+
+## Decision 5: Backward compatibility for `--cleanup-merged`
+
+**Decision**: `scripts/claude-worktree.sh --cleanup-merged <N>` and `--remove <N>` match worktrees whose directory name contains *either* `-gh<N>-` or the legacy `-<N>-`. New spawns only create `-gh<N>-`, but existing in-flight legacy worktrees (this feature included) must remain cleanable during a transition period.
+
+**Rationale**: Forcing maintainers to manually rename their in-flight worktrees would bite immediately (this very feature would be un-cleanable after merge). A single awk pattern accepting both forms is ~5 additional characters and solves the transition cleanly.
+
+**Alternatives considered**:
+- Drop legacy matching immediately: breaks in-flight work. Rejected.
+- Keep legacy matching forever: we'll never know when to drop it. Mitigation: add a comment in the script noting that the legacy branch can be removed once all legacy-named worktrees have been cleaned, tracked informally.
+
+## Decision 6: No change to the Claude command template invocation
+
+**Decision**: `.claude/commands/speckit.specify.md` continues to instruct Claude to invoke `create-new-feature.sh` without `--number`. The prefix detection is entirely in the bash script (Decision 2). The command template gets a short clarifying note about the new convention so Claude doesn't get confused by `gh<N>-` branches.
+
+**Rationale**: The Claude prompt should not carry domain logic that belongs in the helper script. The helper script is the authoritative place for naming rules; the Claude prompt is a UX wrapper. Keeping the logic in one place avoids drift between "what Claude tells the script" and "what the script does."
+
+**Alternatives considered**:
+- Have Claude parse the kickoff prompt for an issue number and pass `--number <N>`: requires Claude to reason about the branch name, which is fragile. Rejected.
+- Have `claude-worktree.sh` export `SPECIFY_FEATURE=gh<N>-<slug>` into the worktree's shell env: works, but adds an env-var contract that's hidden from users reading the scripts. Rejected in favour of branch-name detection.
+
+## Decision 7: Validation of `--number` input
+
+**Decision**: `--number` input must be a positive integer (no leading zeros preserved, no sign, no decimals, no whitespace). Validation happens before any filesystem or git mutation. Invalid input exits non-zero with a clear error.
+
+**Rationale**: FR-008 in the spec explicitly requires this. Existing script has partial validation (forces base-10 via `$((10#$BRANCH_NUMBER))`) but does not reject negatives or non-numerics; `printf "%03d"` accepts garbage and produces surprising output.
+
+**Alternatives considered**:
+- Defer validation to `git checkout -b` failing: produces a cryptic git error, violates FR-008. Rejected.
+
+## Open questions resolved
+
+All [NEEDS CLARIFICATION] markers in the spec were resolved during Stage 1 review (user confirmed option 2: `gh<N>` prefix). No residual questions.
+
+## Out of scope (confirmed)
+
+- Renaming existing spec directories (`001-*` … `229-*`, `128-licensing-compliance`, this feature's `249-speckit-…`): historical, immutable.
+- Automated tests for the bash scripts: no existing test harness, not a product-runtime concern. Manual regression via `quickstart.md`.
+- Renaming existing legacy worktrees on disk: the compat-match fallback handles them.
+- Changes to the analyzer, UI, API, or any product surface.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/spec.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/spec.md
@@ -7,105 +7,100 @@
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Worktree-driven spec uses the issue number with a `gh` prefix (Priority: P1)
+### User Story 1 - Worktree-driven spec reuses the pre-created branch and issue number (Priority: P1)
 
-A maintainer runs `scripts/claude-worktree.sh 238` to spawn a worktree for GitHub issue #238. The worktree script creates the directory `../forkprint-gh238-<slug>/` and the branch `gh238-<slug>`. Claude launches inside the worktree and runs `/speckit.specify`. The generated spec directory is `specs/gh238-<slug>/` and Claude stays on the pre-created branch `gh238-<slug>`. No `243-*` (or any other) spec directory or branch appears, no renumbering takes place. The worktree path prefix (`forkprint-gh238-`), the checked-out branch prefix (`gh238-`), the spec directory prefix (`gh238-`), and the GitHub issue number (238) all agree.
+A maintainer runs `scripts/claude-worktree.sh 238` to spawn a worktree for GitHub issue #238. The worktree script creates the directory `../forkprint-238-<slug>/` and the branch `238-<slug>`. When Claude runs `/speckit.specify` inside that worktree, the SpecKit helper **detects the pre-existing `238-<slug>` branch, reuses it verbatim**, and writes the spec to `specs/238-<slug>/`. No `243-*` (or any other) spec directory is created. The branch the code lives on, the spec directory, and the GitHub issue number all agree.
 
-**Why this priority**: This is the core alignment bug. Every downstream artifact (PR branch name, commit prefixes, PR cross-references, `--cleanup-merged` lookup) inherits its identity from the prefix generated in this step. The `gh` prefix also establishes a disjoint namespace between issue-driven work (`gh<N>-`) and manual/legacy sequential work (`<NNN>-`) so the two can never collide, regardless of future growth in either namespace. One issue = one prefixed identifier, propagated from the worktree spawn through the spec, branch, and PR.
+**Why this priority**: This is the bug fix. Today, `/speckit.specify` inside a worktree scans `specs/` for the next free sequential number and creates a new branch with that number — decoupling everything from the GitHub issue. The fix is a one-line change in philosophy: if the current branch already has a recognised feature-prefix pattern, reuse it instead of renumbering.
 
-**Independent Test**: Spawn a fresh worktree for any issue number N (e.g. `scripts/claude-worktree.sh 999 demo-slug`), wait for `/speckit.specify` to complete, and verify four things in the worktree: (a) `git branch --show-current` returns `gh999-demo-slug`, (b) `specs/gh999-*/spec.md` exists, (c) the worktree directory is named `forkprint-gh999-demo-slug`, and (d) no `specs/<any-other-prefix>-*` directory was created by this run. Delivers value standalone because even without the manual-fallback or collision-handling stories, the worktree-driven path — the dominant path for new feature work — is correct and namespace-isolated.
+**Independent Test**: Spawn a worktree for any issue N (e.g. `scripts/claude-worktree.sh 999 demo`), run `/speckit.specify` inside, and verify three things: (a) `git branch --show-current` → `999-demo` (unchanged), (b) `specs/999-demo/spec.md` exists, (c) no other numbered spec directory was created by this run.
 
 **Acceptance Scenarios**:
 
-1. **Given** a worktree spawned by `scripts/claude-worktree.sh 238 some-slug` (so the branch `gh238-some-slug` is already checked out and no `specs/gh238-*` directory exists), **When** Claude runs `/speckit.specify` inside that worktree, **Then** the resulting spec directory is `specs/gh238-some-slug/`, the checked-out branch remains `gh238-some-slug`, and no other prefixed spec directory or branch is created by this invocation.
-2. **Given** the same worktree as above, **When** `/speckit.specify` completes, **Then** `git branch --show-current` inside the worktree equals `gh238-some-slug` (it was not switched to a freshly created branch).
-3. **Given** a worktree spawned for issue #238, **When** the downstream commands `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` run, **Then** they all operate against `specs/gh238-some-slug/` and the branch `gh238-some-slug` without ambiguity about which spec directory to use.
-4. **Given** the worktree has been merged, **When** the maintainer runs `scripts/claude-worktree.sh --cleanup-merged 238`, **Then** the script locates the worktree at `forkprint-gh238-*` and the branch `gh238-*`, verifies the PR is `MERGED`, and cleans both up — no manual prefix translation required.
+1. **Given** a worktree spawned for issue #238 (so branch `238-some-slug` is already checked out), **When** `/speckit.specify` runs inside, **Then** the spec directory `specs/238-some-slug/` is created, the checked-out branch remains `238-some-slug`, and no `NNN-*` decoy spec directory or branch is created.
+2. **Given** the same worktree, **When** downstream commands `/speckit.plan`, `/speckit.tasks`, `/speckit.implement` run, **Then** they resolve `specs/238-some-slug/` unambiguously.
+3. **Given** the worktree is merged, **When** the maintainer runs `scripts/claude-worktree.sh --cleanup-merged 238`, **Then** the script finds `forkprint-238-*` and `238-*`, verifies `MERGED`, and cleans both.
 
 ---
 
-### User Story 2 - Manual `/speckit.specify` outside the worktree flow keeps the existing sequential convention (Priority: P2)
+### User Story 2 - Manual `/speckit.specify` outside the worktree flow keeps auto-sequential numbering (Priority: P2)
 
-A maintainer runs `/speckit.specify` directly from the main checkout on a branch they created themselves (no worktree, no issue number in play). The sequential-numbering fallback still picks the next free number by scanning `specs/` and creates the spec directory and feature branch with the unprefixed `<NNN>-<slug>` form exactly as before.
+A maintainer runs `/speckit.specify` directly from `main` (no worktree, no issue number). The sequential-numbering fallback scans `specs/` and picks the next free number, creating `specs/<NNN>-<slug>/` and branch `<NNN>-<slug>` exactly as before.
 
-**Why this priority**: The worktree flow is the dominant path, but the manual path must keep working so contributors doing exploratory specs, pre-issue design work, or non-issue-driven refactors are not blocked. The `gh` prefix is added *only* to the issue-driven path — the manual path's `<NNN>-<slug>` shape is unchanged. This is a regression-prevention story.
+**Why this priority**: The manual path is a small but important fallback for non-issue-driven work (exploratory specs, pre-issue design). It must continue to work unchanged.
 
-**Independent Test**: From a clean checkout on `main`, invoke `/speckit.specify <description>` without any issue-number context and without the worktree wrapper. Verify that a spec directory with the next sequential prefix (e.g. `specs/230-<slug>/`) is created with no `gh` prefix, and a matching branch is checked out. Delivers value standalone because it protects an existing workflow from the Story 1 change.
+**Independent Test**: From `main`, invoke `/speckit.specify <description>` with no issue context. Verify a spec directory with the next free sequential number is created and a matching branch is checked out.
 
 **Acceptance Scenarios**:
 
-1. **Given** a checkout on `main` with no issue-number argument and no issue-number context, **When** `/speckit.specify` runs, **Then** the spec directory and branch use the next free sequential number computed from existing `specs/` and branches, in the unprefixed `<NNN>-<slug>` form, matching the pre-change behaviour.
-2. **Given** a manual invocation where the maintainer explicitly supplies a raw number override (e.g. `--number 350`), **When** `/speckit.specify` runs and no `specs/350-*` exists, **Then** the spec directory and branch both use the unprefixed `350-<slug>` form — the `gh` prefix is reserved for the issue-driven flow and is not added when the number comes from a raw override.
+1. **Given** checkout on `main`, no issue context, **When** `/speckit.specify` runs, **Then** the spec directory and branch use the next free sequential number, matching pre-change behaviour.
+2. **Given** explicit `--number 350` override and no existing `specs/350-*`, **When** `/speckit.specify` runs, **Then** both use the `350-<slug>` form, overriding auto-detection.
 
 ---
 
-### User Story 3 - Explicit, non-silent handling of spec/branch collisions (Priority: P2)
+### User Story 3 - Loud, non-silent collision handling (Priority: P2)
 
-When `/speckit.specify` is asked to use an issue-driven prefix whose spec directory already exists, or whose target branch already exists on a different HEAD, the tool either reuses the existing work or fails with a clear, actionable message. It never silently renumbers away from the requested issue number.
+When `/speckit.specify` is asked to use a number whose branch already exists on a different HEAD, or whose spec directory already contains a populated `spec.md`, it fails loudly with a clear error. It never silently renumbers. Reuse of a branch that is already the current HEAD is the expected case (worktree spawn) and proceeds without error. Invalid `--number` inputs (non-numeric, zero, negative) are rejected up front.
 
-**Why this priority**: The previous bug was a silent renumbering — the user asked for 238, got 243, with no warning. Any replacement must make the failure mode loud. "Silent success with the wrong prefix" is worse than "loud failure with instructions." Reuse is the expected case inside a `claude-worktree.sh` spawn (the branch is already checked out), so the tool must tolerate that without error. With the `gh` prefix in place, collisions between issue-driven and sequential namespaces are architecturally impossible — but collisions *within* the issue-driven namespace (e.g. two runs for the same issue, or leftover spec dir from a prior abandoned spawn) are still possible and must be handled clearly.
+**Why this priority**: The original bug was a silent renumbering (asked for 238, got 243, no warning). The loud-error contract replaces that. The rare remaining collision scenario — manual sequential claims slot N just before issue #N is filed — surfaces as a clear, actionable error rather than silent wrong behavior.
 
-**Independent Test**: Force both collision paths: (a) run the issue-driven flow for issue 238 when `specs/gh238-<other-slug>/` already exists, and (b) run it when the target branch `gh238-<slug>` is already checked out (the worktree case). Verify each path matches the contract: (a) the user sees a clear error pointing to the existing dir, (b) no error occurs and the existing branch is reused.
+**Independent Test**: Exercise each collision path in a sandbox: branch-already-HEAD (silent OK), populated spec.md (exit 1 with clear message), branch-exists-elsewhere (exit 1 with clear message), invalid `--number` (exit 1 with clear message).
 
 **Acceptance Scenarios**:
 
-1. **Given** a worktree where the target branch (e.g. `gh238-some-slug`) is already the currently checked-out HEAD, **When** `/speckit.specify` runs for issue 238 with matching slug, **Then** the command proceeds without error: the existing branch is reused (no `git checkout -b` attempted), and the spec directory `specs/gh238-some-slug/` is created (or reused if already present and `spec.md` is empty).
-2. **Given** a repo where `specs/gh238-existing-slug/` already exists with a populated `spec.md`, **When** `/speckit.specify` runs for issue 238 with a different slug, **Then** the command exits non-zero with an error that names the existing directory and instructs the user how to resolve the conflict (remove/rename the existing dir, or re-run the worktree flow with a matching slug). No silent fallback to a different prefix occurs.
-3. **Given** a repo where the target branch (e.g. `gh238-new-slug`) exists but is **not** the currently checked-out HEAD, **When** `/speckit.specify` runs for issue 238, **Then** the command exits non-zero with a clear error naming the conflicting branch. No silent fallback occurs.
+1. **Given** target branch equals current HEAD, **When** `/speckit.specify` runs, **Then** the branch is reused silently (no `git checkout -b` attempted), and the spec directory is created.
+2. **Given** `specs/238-existing-slug/` exists with populated `spec.md`, **When** `/speckit.specify` is asked to reuse that prefix, **Then** it exits non-zero with an error naming the directory and suggesting resolution.
+3. **Given** target branch exists but is not current HEAD, **When** `/speckit.specify` runs, **Then** it exits non-zero with an error naming the conflicting branch. No silent renumbering.
+4. **Given** `--number abc`, `--number 0`, or `--number -5`, **When** `/speckit.specify` runs, **Then** it exits non-zero with a clear "--number must be a positive integer" error before any filesystem or git mutation.
 
 ---
 
 ### Edge Cases
 
-- **Invalid issue numbers** (zero, negative, non-numeric): Rejected with a clear error before any filesystem or git mutation. GitHub issue numbers are positive integers starting at 1.
-- **Leading zeros on `--number` input**: Normalised — `--number 007` is treated as `7`, producing prefix `gh7`. No left-padding is applied to the `gh`-prefixed form (so issue #7 is `gh7-`, not `gh007-`). Rationale: issue numbers in `gh` CLI output and PR titles appear without padding (`#7`, not `#007`), and matching that visual form keeps searches and URLs intuitive.
-- **Worktree spawn uses a slug that differs from the spec's derived short-name**: The branch name is the source of truth (because the worktree already created and checked out the branch). `/speckit.specify` must derive the spec directory name from the currently checked-out branch when it matches `^gh[0-9]+-`, not from a separately computed short-name, to guarantee spec dir and branch agree.
-- **Maintainer runs `/speckit.specify` manually from inside a worktree** (not via the kickoff prompt): `/speckit.specify` detects the issue-driven context by matching the current branch against `^gh[0-9]+-` and uses that prefix automatically, even when no explicit issue argument is in the invocation.
-- **Existing orphan `specs/gh<N>-*` directory with no matching branch**: Treated as a real conflict per User Story 3, scenario 2 — the spec directory is the shared on-disk artifact, and overwriting it would destroy prior work.
-- **Legacy unprefixed branches/specs for issue-numbered work** (e.g. this feature's own branch, `249-speckit-…`): Out of scope for this feature. Legacy entries remain as-is; the new `gh`-prefix convention applies going forward. This feature itself completes on the legacy naming because its worktree was spawned before the fix shipped.
-- **A legacy unprefixed spec dir `238-<slug>/` exists from past work, and a new worktree for issue #238 is spawned**: No collision — `gh238-<slug>` and `238-<slug>` are distinct paths. The `gh`-prefix rule makes the namespaces disjoint, so old sequential entries do not interfere with new issue-driven ones.
+- **Leading zeros on `--number`**: `--number 007` is rejected (decodes to 0 in base 10 via the `[1-9][0-9]*` validator, ensuring consistency with "positive integer"). Users supply `7` without padding.
+- **Worktree slug differs from the spec's derived short-name**: The currently checked-out branch is the source of truth. `/speckit.specify` reuses it verbatim and ignores the `--short-name` flag when a recognised prefix is detected. This guarantees spec dir and branch always agree.
+- **Manual invocation inside a worktree** (not via the kickoff prompt): The helper auto-detects the branch pattern `^[0-9]+-` or `^[0-9]{8}-[0-9]{6}-` and reuses it. No explicit flag needed.
+- **Rare collision: manual spec claims slot N, issue #N later spawned**: This produces a branch-or-spec-dir collision that User Story 3's loud-error path handles cleanly. Resolution: rename/remove the conflicting entity, or pick a different `--number` / issue number. No silent fallback.
+- **Legacy entities** (`001-*`–`032-*` Phase 1 specs): unaffected; their sequential form is a valid recognised pattern and continues to work.
 
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
 
-- **FR-001**: The spec-generation entry point MUST accept an explicit GitHub issue number from the caller (either via an explicit flag or by deriving it from the currently checked-out branch when the branch matches `^gh[0-9]+-`) and use `gh<N>` as the spec-directory and branch-name prefix.
-- **FR-002**: When an issue number is supplied or derived, the spec-generation entry point MUST NOT scan `specs/` or `git branch -a` to pick a different number. Auto-increment logic applies only to the manual sequential fallback path.
-- **FR-003**: When no issue-number context is available (no flag AND current branch does not match `^gh[0-9]+-`), the spec-generation entry point MUST fall back to the pre-existing sequential numbering behaviour using the unprefixed `<NNN>-<slug>` form — no change to that path.
-- **FR-004**: The worktree spawn script (`scripts/claude-worktree.sh`) MUST create the worktree directory as `forkprint-gh<N>-<slug>` and the branch as `gh<N>-<slug>` for every issue-driven spawn, and MUST propagate the issue number into the `/speckit.specify` kickoff prompt so the downstream spec directory matches.
-- **FR-005**: When the target branch already matches the currently checked-out branch, the spec-generation entry point MUST reuse that branch (no attempt to `git checkout -b` an existing branch) and proceed to create the spec directory.
-- **FR-006**: When the target branch exists but is not the currently checked-out branch, the spec-generation entry point MUST exit non-zero with a clear error naming the conflicting branch. It MUST NOT silently fall back to a different prefix.
-- **FR-007**: When a spec directory with the same `gh<N>-` prefix already exists and contains a populated `spec.md` with a different slug, the spec-generation entry point MUST exit non-zero with a clear error naming the existing directory and suggesting resolution options. It MUST NOT silently fall back to a different prefix.
-- **FR-008**: Invalid issue-number inputs (non-numeric, zero, negative) MUST be rejected with a clear error before any filesystem or git mutation occurs.
-- **FR-009**: `scripts/claude-worktree.sh --cleanup-merged <N>` MUST locate worktrees and branches using the `gh<N>-` pattern (not the old `<N>-` pattern). Legacy unprefixed worktrees that pre-date this feature MAY remain findable via the old pattern as a compatibility fallback, but new worktrees spawned by the fixed script MUST use only the `gh` prefix. *(See Assumption below on whether the compatibility fallback is retained.)*
-- **FR-010**: `docs/DEVELOPMENT.md` MUST document the new naming convention: issue-driven spec/branch/worktree identifiers use `gh<N>-<slug>`; manual sequential fallback uses `<NNN>-<slug>`; the two namespaces are disjoint by construction.
-- **FR-011**: The `/speckit.specify` command definition (under `.claude/commands/`) MUST either pass the issue number through to `create-new-feature.sh` when one can be derived from context, or instruct Claude to do so — so that the prefix contract is enforced regardless of how the command is invoked.
-- **FR-012**: The prefix contract MUST be preserved end-to-end through `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` — none of these downstream commands may create or move the spec to a differently prefixed directory.
+- **FR-001**: When the currently checked-out branch matches `^[0-9]+-.+$` or `^[0-9]{8}-[0-9]{6}-.+$`, the spec-generation helper MUST reuse that branch verbatim (no `git checkout -b`) and derive the spec directory name from it. This is the core "don't renumber an issue-driven branch" behavior.
+- **FR-002**: When reusing the current branch, the helper MUST NOT scan `specs/` or `git branch -a` to pick a different number.
+- **FR-003**: When the current branch does NOT match a recognised feature-prefix pattern AND no `--number` is supplied, the helper MUST fall back to the pre-existing sequential-numbering behaviour (compute next free `<NNN>-<slug>`, `git checkout -b`).
+- **FR-004**: When `--number N` is explicitly supplied, the helper MUST use `<NNN>-<slug>` (zero-padded to 3 digits for `N < 1000`, verbatim for `N >= 1000`), regardless of current branch.
+- **FR-005**: Invalid `--number` inputs (non-numeric, zero, negative, or any value that decodes to < 1) MUST be rejected with a clear error before any filesystem or git mutation.
+- **FR-006**: When the target branch exists but is not the currently checked-out branch, the helper MUST exit non-zero with an error that names the conflicting branch and lists accepted feature-branch forms.
+- **FR-007**: When `specs/<target>/spec.md` already exists and is non-empty, the helper MUST exit non-zero with an error naming the existing path. It MUST NOT overwrite authored spec content. Empty or missing `spec.md` is treated as a fresh run (allows worktree-spawn reuse after a partial prior run).
+- **FR-008**: `.specify/scripts/bash/common.sh` helpers (`find_feature_dir_by_prefix`, `check_feature_branch`, `get_current_branch`) MUST recognise the broader `^[0-9]+-` pattern (not just the legacy `^[0-9]{3}-`) so issue numbers of any width (1-digit, 4+ digit) resolve correctly downstream. Timestamp and legacy 3-digit forms remain accepted.
+- **FR-009**: `docs/DEVELOPMENT.md` MUST document the numbering rule: branches pre-created by `claude-worktree.sh` are reused by `/speckit.specify`; manual invocations without a recognised branch prefix fall back to sequential auto-numbering.
+- **FR-010**: The `/speckit.specify` command template (`.claude/commands/speckit.specify.md`) MUST reflect that the helper auto-detects feature-prefix branches — Claude does not need to pass `--number` explicitly.
 
 ### Key Entities
 
-- **Spec Directory**: The filesystem location under `specs/` that holds `spec.md`, `plan.md`, `tasks.md`, and checklists for a feature. Its name has the form `gh<N>-<slug>` (issue-driven) or `<NNN>-<slug>` (manual sequential).
-- **Feature Branch**: The git branch on which the feature work lives. Its name has the same `gh<N>-<slug>` or `<NNN>-<slug>` shape as the spec directory, and the prefix must match the spec directory's prefix for the same feature.
-- **Worktree Directory**: The sibling-of-repo directory where parallel feature work lives. Named `forkprint-gh<N>-<slug>` for issue-driven spawns (matches branch and spec directory prefixes).
-- **Issue Number**: The GitHub issue number (a positive integer, no leading zeros) that motivates the feature. When present, it becomes the `<N>` in `gh<N>-` across all three entities above.
+- **Spec Directory**: Filesystem location under `specs/` holding `spec.md`, `plan.md`, `tasks.md`, and checklists. Named `<prefix>-<slug>` where `<prefix>` is the GitHub issue number (issue-driven flow) or the next sequential number (manual flow).
+- **Feature Branch**: Git branch for the feature; same `<prefix>-<slug>` shape as the spec directory. The prefix is the shared identifier that binds the two together.
+- **Issue Number**: Positive integer issued by GitHub when an issue is filed. When a worktree is spawned for it, the issue number becomes the branch/spec-dir prefix.
 
 ## Success Criteria *(mandatory)*
 
 ### Measurable Outcomes
 
-- **SC-001**: For 100% of worktrees spawned by `scripts/claude-worktree.sh <N>`, the resulting spec directory prefix, checked-out branch prefix, and worktree path prefix all equal `gh<N>` after `/speckit.specify` completes. Verifiable by scripted check across any sample of post-spawn worktrees.
-- **SC-002**: 0 instances of silent renumbering or silent prefix change occur in the issue-driven flow. Every deviation from the caller-supplied issue number is either (a) explicitly raised as a non-zero-exit error with a named cause, or (b) a deliberate reuse of an existing branch whose prefix already matches `gh<N>`.
-- **SC-003**: Manual `/speckit.specify` invocations with no issue-number context continue to produce spec directories and branches with the unprefixed `<NNN>-<slug>` form — verified by a no-regression invocation on a clean checkout.
-- **SC-004**: Issue-driven (`gh<N>-`) and manual sequential (`<NNN>-`) namespaces are disjoint by structure: there exists no string that is simultaneously a valid issue-driven prefix and a valid sequential prefix. Verifiable by inspection of the grammars; no test scenario can construct a colliding name.
-- **SC-005**: A maintainer reading `docs/DEVELOPMENT.md` can, in under 60 seconds, identify the rule that governs which prefix appears on a spec directory and why, without opening `create-new-feature.sh` or `claude-worktree.sh`.
-- **SC-006**: `scripts/claude-worktree.sh --cleanup-merged <N>` successfully locates and cleans a worktree created by `scripts/claude-worktree.sh <N>` followed by `/speckit.specify`, with no manual prefix translation required.
+- **SC-001**: For 100% of worktrees spawned by `scripts/claude-worktree.sh <N>`, the resulting spec directory prefix, checked-out branch prefix, and worktree path prefix all equal `<N>` after `/speckit.specify` completes.
+- **SC-002**: 0 instances of silent renumbering in the issue-driven flow. Every deviation from the pre-created branch is either a loud non-zero-exit error or deliberate silent reuse of the matching HEAD.
+- **SC-003**: Manual `/speckit.specify` on `main` without issue context continues to produce the next sequential `<NNN>-<slug>`.
+- **SC-004**: `scripts/claude-worktree.sh --cleanup-merged <N>` successfully locates and cleans a worktree created by `scripts/claude-worktree.sh <N>` followed by `/speckit.specify`, with no manual prefix translation.
+- **SC-005**: Invalid `--number` inputs fail in under 1 second with a clear, actionable error before mutating anything.
+- **SC-006**: A maintainer reading `docs/DEVELOPMENT.md` can, in under 60 seconds, identify the rule that governs which number appears on a spec directory and why.
 
 ## Assumptions
 
-- GitHub issue numbers for this project are positive integers of any width. The `gh<N>` prefix works for any `N ≥ 1` with no padding (e.g. `gh7`, `gh249`, `gh12345`).
-- The GitHub issue number is known at worktree-spawn time — `scripts/claude-worktree.sh` already takes it as its first positional argument, so propagating it through is a wiring change, not a lookup.
-- `/speckit.specify` is the only code path that creates a new spec directory and feature branch. No other SpecKit command generates numbered directories.
-- Legacy Phase 1 spec directories (`001-*` through `032-*`) and legacy unprefixed issue-driven entries (e.g. `128-licensing-compliance`, `249-speckit-…` — including this feature's own branch and spec dir) are historical and out of scope. The new `gh<N>-` convention applies to spec/branch/worktree entities created after this feature ships. No retroactive rename is required.
-- **Compatibility fallback for `--cleanup-merged`**: since some in-flight worktrees (this feature, and possibly others spawned before the fix ships) use the old unprefixed form, the cleanup command's lookup pattern SHOULD accept both `gh<N>-` and the legacy `<N>-` pattern during a transition period. The plan phase may choose to drop the legacy-match path once all pre-fix worktrees are cleaned up.
-- The fix is scoped to `scripts/claude-worktree.sh`, `.specify/scripts/bash/create-new-feature.sh`, `.claude/commands/speckit.specify.md`, and `docs/DEVELOPMENT.md`. No application-code (Next.js, analyzer, UI) changes are required, and no user-facing product behaviour changes. The constitution's accuracy, data-source, and scoring rules are not affected.
-- The change to PR branch names (from `<N>-` to `gh<N>-`) does not break any existing automation in this repo — `gh pr view <branch>` accepts arbitrary branch names, and no CI workflow greps for a specific branch-name pattern. If any such automation is discovered during the plan phase, it becomes an in-scope update.
+- GitHub issue numbers are positive integers; issue number 0 does not exist.
+- The GitHub issue number is known at worktree-spawn time — `scripts/claude-worktree.sh` already takes it as its first positional argument.
+- `/speckit.specify` is the only code path that creates numbered spec directories and branches. Fixing it end-to-end covers the lifecycle.
+- Branch naming stays on the upstream SpecKit convention (`<N>-<slug>`) — no custom prefix. Adoption portability and future upstream alignment outweigh the marginal protection a custom prefix would add against the rare manual-vs-issue collision scenario (which the loud-error contract handles).
+- The rare collision case (manual sequential claims slot N just before issue #N is filed) surfaces as a loud error and is resolved by the maintainer renaming/removing the conflicting entity. Acceptable tradeoff given its low frequency.
+- Legacy 3-digit-padded sequential specs (`001-*`–`032-*`) and issue-number specs of any width (`128-*`, `249-*`) coexist via the same `<N>-<slug>` grammar — no migration needed.
+- The fix is scoped to `scripts/claude-worktree.sh`, `.specify/scripts/bash/create-new-feature.sh`, `.specify/scripts/bash/common.sh`, `.claude/commands/speckit.specify.md`, and `docs/DEVELOPMENT.md`. No application-code, analyzer, scoring, or UI changes.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/spec.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: SpecKit branch/spec numbering aligned with GitHub issue number
+
+**Feature Branch**: `249-speckit-branch-spec-numbering-should-ali`
+**Created**: 2026-04-16
+**Status**: Draft
+**Input**: GitHub issue #249 — "SpecKit branch/spec numbering should align with GitHub issue number"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Worktree-driven spec uses the issue number with a `gh` prefix (Priority: P1)
+
+A maintainer runs `scripts/claude-worktree.sh 238` to spawn a worktree for GitHub issue #238. The worktree script creates the directory `../forkprint-gh238-<slug>/` and the branch `gh238-<slug>`. Claude launches inside the worktree and runs `/speckit.specify`. The generated spec directory is `specs/gh238-<slug>/` and Claude stays on the pre-created branch `gh238-<slug>`. No `243-*` (or any other) spec directory or branch appears, no renumbering takes place. The worktree path prefix (`forkprint-gh238-`), the checked-out branch prefix (`gh238-`), the spec directory prefix (`gh238-`), and the GitHub issue number (238) all agree.
+
+**Why this priority**: This is the core alignment bug. Every downstream artifact (PR branch name, commit prefixes, PR cross-references, `--cleanup-merged` lookup) inherits its identity from the prefix generated in this step. The `gh` prefix also establishes a disjoint namespace between issue-driven work (`gh<N>-`) and manual/legacy sequential work (`<NNN>-`) so the two can never collide, regardless of future growth in either namespace. One issue = one prefixed identifier, propagated from the worktree spawn through the spec, branch, and PR.
+
+**Independent Test**: Spawn a fresh worktree for any issue number N (e.g. `scripts/claude-worktree.sh 999 demo-slug`), wait for `/speckit.specify` to complete, and verify four things in the worktree: (a) `git branch --show-current` returns `gh999-demo-slug`, (b) `specs/gh999-*/spec.md` exists, (c) the worktree directory is named `forkprint-gh999-demo-slug`, and (d) no `specs/<any-other-prefix>-*` directory was created by this run. Delivers value standalone because even without the manual-fallback or collision-handling stories, the worktree-driven path — the dominant path for new feature work — is correct and namespace-isolated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a worktree spawned by `scripts/claude-worktree.sh 238 some-slug` (so the branch `gh238-some-slug` is already checked out and no `specs/gh238-*` directory exists), **When** Claude runs `/speckit.specify` inside that worktree, **Then** the resulting spec directory is `specs/gh238-some-slug/`, the checked-out branch remains `gh238-some-slug`, and no other prefixed spec directory or branch is created by this invocation.
+2. **Given** the same worktree as above, **When** `/speckit.specify` completes, **Then** `git branch --show-current` inside the worktree equals `gh238-some-slug` (it was not switched to a freshly created branch).
+3. **Given** a worktree spawned for issue #238, **When** the downstream commands `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` run, **Then** they all operate against `specs/gh238-some-slug/` and the branch `gh238-some-slug` without ambiguity about which spec directory to use.
+4. **Given** the worktree has been merged, **When** the maintainer runs `scripts/claude-worktree.sh --cleanup-merged 238`, **Then** the script locates the worktree at `forkprint-gh238-*` and the branch `gh238-*`, verifies the PR is `MERGED`, and cleans both up — no manual prefix translation required.
+
+---
+
+### User Story 2 - Manual `/speckit.specify` outside the worktree flow keeps the existing sequential convention (Priority: P2)
+
+A maintainer runs `/speckit.specify` directly from the main checkout on a branch they created themselves (no worktree, no issue number in play). The sequential-numbering fallback still picks the next free number by scanning `specs/` and creates the spec directory and feature branch with the unprefixed `<NNN>-<slug>` form exactly as before.
+
+**Why this priority**: The worktree flow is the dominant path, but the manual path must keep working so contributors doing exploratory specs, pre-issue design work, or non-issue-driven refactors are not blocked. The `gh` prefix is added *only* to the issue-driven path — the manual path's `<NNN>-<slug>` shape is unchanged. This is a regression-prevention story.
+
+**Independent Test**: From a clean checkout on `main`, invoke `/speckit.specify <description>` without any issue-number context and without the worktree wrapper. Verify that a spec directory with the next sequential prefix (e.g. `specs/230-<slug>/`) is created with no `gh` prefix, and a matching branch is checked out. Delivers value standalone because it protects an existing workflow from the Story 1 change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a checkout on `main` with no issue-number argument and no issue-number context, **When** `/speckit.specify` runs, **Then** the spec directory and branch use the next free sequential number computed from existing `specs/` and branches, in the unprefixed `<NNN>-<slug>` form, matching the pre-change behaviour.
+2. **Given** a manual invocation where the maintainer explicitly supplies a raw number override (e.g. `--number 350`), **When** `/speckit.specify` runs and no `specs/350-*` exists, **Then** the spec directory and branch both use the unprefixed `350-<slug>` form — the `gh` prefix is reserved for the issue-driven flow and is not added when the number comes from a raw override.
+
+---
+
+### User Story 3 - Explicit, non-silent handling of spec/branch collisions (Priority: P2)
+
+When `/speckit.specify` is asked to use an issue-driven prefix whose spec directory already exists, or whose target branch already exists on a different HEAD, the tool either reuses the existing work or fails with a clear, actionable message. It never silently renumbers away from the requested issue number.
+
+**Why this priority**: The previous bug was a silent renumbering — the user asked for 238, got 243, with no warning. Any replacement must make the failure mode loud. "Silent success with the wrong prefix" is worse than "loud failure with instructions." Reuse is the expected case inside a `claude-worktree.sh` spawn (the branch is already checked out), so the tool must tolerate that without error. With the `gh` prefix in place, collisions between issue-driven and sequential namespaces are architecturally impossible — but collisions *within* the issue-driven namespace (e.g. two runs for the same issue, or leftover spec dir from a prior abandoned spawn) are still possible and must be handled clearly.
+
+**Independent Test**: Force both collision paths: (a) run the issue-driven flow for issue 238 when `specs/gh238-<other-slug>/` already exists, and (b) run it when the target branch `gh238-<slug>` is already checked out (the worktree case). Verify each path matches the contract: (a) the user sees a clear error pointing to the existing dir, (b) no error occurs and the existing branch is reused.
+
+**Acceptance Scenarios**:
+
+1. **Given** a worktree where the target branch (e.g. `gh238-some-slug`) is already the currently checked-out HEAD, **When** `/speckit.specify` runs for issue 238 with matching slug, **Then** the command proceeds without error: the existing branch is reused (no `git checkout -b` attempted), and the spec directory `specs/gh238-some-slug/` is created (or reused if already present and `spec.md` is empty).
+2. **Given** a repo where `specs/gh238-existing-slug/` already exists with a populated `spec.md`, **When** `/speckit.specify` runs for issue 238 with a different slug, **Then** the command exits non-zero with an error that names the existing directory and instructs the user how to resolve the conflict (remove/rename the existing dir, or re-run the worktree flow with a matching slug). No silent fallback to a different prefix occurs.
+3. **Given** a repo where the target branch (e.g. `gh238-new-slug`) exists but is **not** the currently checked-out HEAD, **When** `/speckit.specify` runs for issue 238, **Then** the command exits non-zero with a clear error naming the conflicting branch. No silent fallback occurs.
+
+---
+
+### Edge Cases
+
+- **Invalid issue numbers** (zero, negative, non-numeric): Rejected with a clear error before any filesystem or git mutation. GitHub issue numbers are positive integers starting at 1.
+- **Leading zeros on `--number` input**: Normalised — `--number 007` is treated as `7`, producing prefix `gh7`. No left-padding is applied to the `gh`-prefixed form (so issue #7 is `gh7-`, not `gh007-`). Rationale: issue numbers in `gh` CLI output and PR titles appear without padding (`#7`, not `#007`), and matching that visual form keeps searches and URLs intuitive.
+- **Worktree spawn uses a slug that differs from the spec's derived short-name**: The branch name is the source of truth (because the worktree already created and checked out the branch). `/speckit.specify` must derive the spec directory name from the currently checked-out branch when it matches `^gh[0-9]+-`, not from a separately computed short-name, to guarantee spec dir and branch agree.
+- **Maintainer runs `/speckit.specify` manually from inside a worktree** (not via the kickoff prompt): `/speckit.specify` detects the issue-driven context by matching the current branch against `^gh[0-9]+-` and uses that prefix automatically, even when no explicit issue argument is in the invocation.
+- **Existing orphan `specs/gh<N>-*` directory with no matching branch**: Treated as a real conflict per User Story 3, scenario 2 — the spec directory is the shared on-disk artifact, and overwriting it would destroy prior work.
+- **Legacy unprefixed branches/specs for issue-numbered work** (e.g. this feature's own branch, `249-speckit-…`): Out of scope for this feature. Legacy entries remain as-is; the new `gh`-prefix convention applies going forward. This feature itself completes on the legacy naming because its worktree was spawned before the fix shipped.
+- **A legacy unprefixed spec dir `238-<slug>/` exists from past work, and a new worktree for issue #238 is spawned**: No collision — `gh238-<slug>` and `238-<slug>` are distinct paths. The `gh`-prefix rule makes the namespaces disjoint, so old sequential entries do not interfere with new issue-driven ones.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The spec-generation entry point MUST accept an explicit GitHub issue number from the caller (either via an explicit flag or by deriving it from the currently checked-out branch when the branch matches `^gh[0-9]+-`) and use `gh<N>` as the spec-directory and branch-name prefix.
+- **FR-002**: When an issue number is supplied or derived, the spec-generation entry point MUST NOT scan `specs/` or `git branch -a` to pick a different number. Auto-increment logic applies only to the manual sequential fallback path.
+- **FR-003**: When no issue-number context is available (no flag AND current branch does not match `^gh[0-9]+-`), the spec-generation entry point MUST fall back to the pre-existing sequential numbering behaviour using the unprefixed `<NNN>-<slug>` form — no change to that path.
+- **FR-004**: The worktree spawn script (`scripts/claude-worktree.sh`) MUST create the worktree directory as `forkprint-gh<N>-<slug>` and the branch as `gh<N>-<slug>` for every issue-driven spawn, and MUST propagate the issue number into the `/speckit.specify` kickoff prompt so the downstream spec directory matches.
+- **FR-005**: When the target branch already matches the currently checked-out branch, the spec-generation entry point MUST reuse that branch (no attempt to `git checkout -b` an existing branch) and proceed to create the spec directory.
+- **FR-006**: When the target branch exists but is not the currently checked-out branch, the spec-generation entry point MUST exit non-zero with a clear error naming the conflicting branch. It MUST NOT silently fall back to a different prefix.
+- **FR-007**: When a spec directory with the same `gh<N>-` prefix already exists and contains a populated `spec.md` with a different slug, the spec-generation entry point MUST exit non-zero with a clear error naming the existing directory and suggesting resolution options. It MUST NOT silently fall back to a different prefix.
+- **FR-008**: Invalid issue-number inputs (non-numeric, zero, negative) MUST be rejected with a clear error before any filesystem or git mutation occurs.
+- **FR-009**: `scripts/claude-worktree.sh --cleanup-merged <N>` MUST locate worktrees and branches using the `gh<N>-` pattern (not the old `<N>-` pattern). Legacy unprefixed worktrees that pre-date this feature MAY remain findable via the old pattern as a compatibility fallback, but new worktrees spawned by the fixed script MUST use only the `gh` prefix. *(See Assumption below on whether the compatibility fallback is retained.)*
+- **FR-010**: `docs/DEVELOPMENT.md` MUST document the new naming convention: issue-driven spec/branch/worktree identifiers use `gh<N>-<slug>`; manual sequential fallback uses `<NNN>-<slug>`; the two namespaces are disjoint by construction.
+- **FR-011**: The `/speckit.specify` command definition (under `.claude/commands/`) MUST either pass the issue number through to `create-new-feature.sh` when one can be derived from context, or instruct Claude to do so — so that the prefix contract is enforced regardless of how the command is invoked.
+- **FR-012**: The prefix contract MUST be preserved end-to-end through `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` — none of these downstream commands may create or move the spec to a differently prefixed directory.
+
+### Key Entities
+
+- **Spec Directory**: The filesystem location under `specs/` that holds `spec.md`, `plan.md`, `tasks.md`, and checklists for a feature. Its name has the form `gh<N>-<slug>` (issue-driven) or `<NNN>-<slug>` (manual sequential).
+- **Feature Branch**: The git branch on which the feature work lives. Its name has the same `gh<N>-<slug>` or `<NNN>-<slug>` shape as the spec directory, and the prefix must match the spec directory's prefix for the same feature.
+- **Worktree Directory**: The sibling-of-repo directory where parallel feature work lives. Named `forkprint-gh<N>-<slug>` for issue-driven spawns (matches branch and spec directory prefixes).
+- **Issue Number**: The GitHub issue number (a positive integer, no leading zeros) that motivates the feature. When present, it becomes the `<N>` in `gh<N>-` across all three entities above.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For 100% of worktrees spawned by `scripts/claude-worktree.sh <N>`, the resulting spec directory prefix, checked-out branch prefix, and worktree path prefix all equal `gh<N>` after `/speckit.specify` completes. Verifiable by scripted check across any sample of post-spawn worktrees.
+- **SC-002**: 0 instances of silent renumbering or silent prefix change occur in the issue-driven flow. Every deviation from the caller-supplied issue number is either (a) explicitly raised as a non-zero-exit error with a named cause, or (b) a deliberate reuse of an existing branch whose prefix already matches `gh<N>`.
+- **SC-003**: Manual `/speckit.specify` invocations with no issue-number context continue to produce spec directories and branches with the unprefixed `<NNN>-<slug>` form — verified by a no-regression invocation on a clean checkout.
+- **SC-004**: Issue-driven (`gh<N>-`) and manual sequential (`<NNN>-`) namespaces are disjoint by structure: there exists no string that is simultaneously a valid issue-driven prefix and a valid sequential prefix. Verifiable by inspection of the grammars; no test scenario can construct a colliding name.
+- **SC-005**: A maintainer reading `docs/DEVELOPMENT.md` can, in under 60 seconds, identify the rule that governs which prefix appears on a spec directory and why, without opening `create-new-feature.sh` or `claude-worktree.sh`.
+- **SC-006**: `scripts/claude-worktree.sh --cleanup-merged <N>` successfully locates and cleans a worktree created by `scripts/claude-worktree.sh <N>` followed by `/speckit.specify`, with no manual prefix translation required.
+
+## Assumptions
+
+- GitHub issue numbers for this project are positive integers of any width. The `gh<N>` prefix works for any `N ≥ 1` with no padding (e.g. `gh7`, `gh249`, `gh12345`).
+- The GitHub issue number is known at worktree-spawn time — `scripts/claude-worktree.sh` already takes it as its first positional argument, so propagating it through is a wiring change, not a lookup.
+- `/speckit.specify` is the only code path that creates a new spec directory and feature branch. No other SpecKit command generates numbered directories.
+- Legacy Phase 1 spec directories (`001-*` through `032-*`) and legacy unprefixed issue-driven entries (e.g. `128-licensing-compliance`, `249-speckit-…` — including this feature's own branch and spec dir) are historical and out of scope. The new `gh<N>-` convention applies to spec/branch/worktree entities created after this feature ships. No retroactive rename is required.
+- **Compatibility fallback for `--cleanup-merged`**: since some in-flight worktrees (this feature, and possibly others spawned before the fix ships) use the old unprefixed form, the cleanup command's lookup pattern SHOULD accept both `gh<N>-` and the legacy `<N>-` pattern during a transition period. The plan phase may choose to drop the legacy-match path once all pre-fix worktrees are cleaned up.
+- The fix is scoped to `scripts/claude-worktree.sh`, `.specify/scripts/bash/create-new-feature.sh`, `.claude/commands/speckit.specify.md`, and `docs/DEVELOPMENT.md`. No application-code (Next.js, analyzer, UI) changes are required, and no user-facing product behaviour changes. The constitution's accuracy, data-source, and scoring rules are not affected.
+- The change to PR branch names (from `<N>-` to `gh<N>-`) does not break any existing automation in this repo — `gh pr view <branch>` accepts arbitrary branch names, and no CI workflow greps for a specific branch-name pattern. If any such automation is discovered during the plan phase, it becomes an in-scope update.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/tasks.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: SpecKit branch/spec numbering aligned with GitHub issue number
+
+**Input**: Design documents in `/specs/249-speckit-branch-spec-numbering-should-ali/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/cli-contracts.md`, `quickstart.md`
+
+## Phase 1: Setup
+
+No project-level setup required. This feature modifies existing bash scripts and one docs file; no new directories, packages, or dependencies.
+
+## Phase 2: Foundational (blocking prerequisites)
+
+The `gh<N>-` prefix must be understood by the SpecKit helper script before anything else can use it. `create-new-feature.sh` calls into `common.sh`, so `common.sh` is the bottom of the dependency stack. All user-story tasks depend on these two.
+
+- [X] T001 [P] Update `.specify/scripts/bash/common.sh` — teach `find_feature_dir_by_prefix()` to extract `gh<N>` as a prefix. Add a new regex branch `^gh([0-9]+)-` before the existing `^([0-9]{3})-` branch, capturing the full `gh<N>` literal as `$prefix` (not just the digits), so it globs `specs/gh<N>-*` correctly.
+- [X] T002 [P] Update `.specify/scripts/bash/common.sh` — teach `check_feature_branch()` to accept `^gh[0-9]+-` as a valid feature-branch pattern alongside `^[0-9]{3}-` and `^[0-9]{8}-[0-9]{6}-`. Update the error message to list all three accepted forms (e.g. `gh249-feature`, `001-feature`, `20260319-143022-feature`).
+- [X] T003 [P] Update `.specify/scripts/bash/common.sh` — teach `get_current_branch()` non-git fallback (the directory scanner) to recognise `^gh([0-9]+)-` directories. Rank them with the sequential-numeric branch (higher number wins); timestamp branches retain priority over both.
+
+## Phase 3: User Story 1 — Worktree-driven spec uses the issue number with a `gh` prefix (P1) 🎯 MVP
+
+**Story goal**: `scripts/claude-worktree.sh 238` produces `forkprint-gh238-<slug>/`, branch `gh238-<slug>`, and `/speckit.specify` inside creates `specs/gh238-<slug>/` — all three prefixes agree.
+
+**Independent test** (from quickstart T1): Spawn a throwaway worktree for any issue N, run `/speckit.specify`, verify `git branch --show-current` → `gh<N>-<slug>`, `basename $(pwd)` → `forkprint-gh<N>-<slug>`, `ls specs/` → only `gh<N>-<slug>/` was created.
+
+- [X] T004 [US1] Update `scripts/claude-worktree.sh` — change line that computes `BRANCH="${ISSUE}-${SLUG}"` to `BRANCH="gh${ISSUE}-${SLUG}"`. Also update `WT_PATH="${PARENT_DIR}/forkprint-${ISSUE}-${SLUG}"` to `WT_PATH="${PARENT_DIR}/forkprint-gh${ISSUE}-${SLUG}"`.
+- [X] T005 [US1] Update `scripts/claude-worktree.sh` — update the `print_usage()` heredoc to describe the new `forkprint-gh<issue>-<slug>` path and `gh<issue>-<slug>` branch format (currently says `forkprint-<issue>-<slug>`).
+- [X] T006 [US1] Update `.specify/scripts/bash/create-new-feature.sh` — after repo-root detection and before branch/number derivation, inspect the currently checked-out branch via `git rev-parse --abbrev-ref HEAD` (only when `HAS_GIT=true`). If it matches `^(gh[0-9]+|[0-9]{3,}|[0-9]{8}-[0-9]{6})-(.+)$`, set `BRANCH_NAME=<current-branch>` verbatim and set a flag `REUSE_CURRENT_BRANCH=true`. Skip the `git checkout -b "$BRANCH_NAME"` call when this flag is true. This is the core "reuse the branch already created by claude-worktree.sh" behaviour.
+- [X] T007 [US1] Update `.specify/scripts/bash/create-new-feature.sh` — when `REUSE_CURRENT_BRANCH=true`, do NOT run the sequential-number derivation logic (`check_existing_branches`, `get_highest_from_specs`, etc.). The current branch name is already the target.
+- [X] T008 [US1] Update `.specify/scripts/bash/create-new-feature.sh` — set `FEATURE_NUM` in the JSON/text output to the numeric portion of the prefix (e.g. `gh249` → `249`, `001` → `001`) when reusing the current branch, so downstream tooling that reads `FEATURE_NUM` gets a useful value. For `gh<N>` prefixes, emit the unpadded integer; for `<NNN>` sequential, keep the existing 3-digit-padded form.
+
+**Checkpoint**: At this point, `scripts/claude-worktree.sh 238 demo` creates `forkprint-gh238-demo/` with branch `gh238-demo`; running `/speckit.specify` inside creates `specs/gh238-demo/spec.md` without branch-switching. Quickstart T1 passes. MVP complete.
+
+## Phase 4: User Story 2 — Manual `/speckit.specify` outside the worktree flow keeps the existing sequential convention (P2)
+
+**Story goal**: On `main` or any non-`gh<N>-`/non-`<NNN>-` branch, `/speckit.specify` produces an unprefixed `<NNN>-<slug>` spec dir and branch, exactly as before. Explicit `--number <N>` keeps producing `<NNN>-<slug>` (no `gh` prefix added).
+
+**Independent test** (from quickstart T2 and T3): Run `/speckit.specify` from `main` with no issue context → spec dir is `<NNN>-<slug>/` with no `gh`. Run `create-new-feature.sh --number 9999 ...` → produces `9999-<slug>` unprefixed.
+
+- [X] T009 [US2] Update `.specify/scripts/bash/create-new-feature.sh` — confirm (and preserve) the existing sequential-number path: when the current branch does NOT match `^(gh[0-9]+|[0-9]{3,}|[0-9]{8}-[0-9]{6})-` AND no `--number` flag is given, run `check_existing_branches` and `git checkout -b "$BRANCH_NAME"` as before. No regression in this path. *(Preserved — the `if [ "$REUSE_CURRENT_BRANCH" = false ]` branch falls through to the unchanged sequential logic.)*
+- [X] T010 [US2] Update `.specify/scripts/bash/create-new-feature.sh` — when `--number N` is explicitly supplied AND the current branch does not already match `<N>-`, preserve the existing behaviour: `BRANCH_NAME="<NNN>-<slug>"` (zero-padded 3-digit for `N < 1000`). This flag is a manual override and does NOT add `gh` prefix. *(Preserved — the `--number` path still uses `printf "%03d"`. Note: `--number` is skipped when `REUSE_CURRENT_BRANCH=true`; see T006 — if a maintainer passes `--number` while on a prefixed branch, the branch wins. This is the safer direction since the branch is already checked out.)*
+
+**Checkpoint**: Quickstart T2 and T3 pass. Manual sequential flow is unchanged.
+
+## Phase 5: User Story 3 — Explicit, non-silent handling of spec/branch collisions (P2)
+
+**Story goal**: When the script is asked to reuse a branch that is already the current HEAD, it does so silently. When it's asked to create a branch that exists elsewhere, or to write a spec dir that already has a populated `spec.md`, it errors loudly with a clear message. Invalid `--number` inputs are rejected early.
+
+**Independent test** (from quickstart T4–T6, T8): Four scenarios — branch-match reuse (silent OK), existing populated spec dir (loud fail), existing branch on different HEAD (loud fail), invalid `--number` input (loud fail).
+
+- [X] T011 [US3] Update `.specify/scripts/bash/create-new-feature.sh` — add `--number` input validation near the top of the script (after flag parsing). Reject when `BRANCH_NUMBER` is non-empty but does not match `^[1-9][0-9]*$` (rejects non-numeric, zero, negatives, leading-zero forms that decode to 0). Exit non-zero with a message like `Error: --number must be a positive integer (got: '$BRANCH_NUMBER')`.
+- [X] T012 [US3] Update `.specify/scripts/bash/create-new-feature.sh` — before creating `FEATURE_DIR`, check if `$FEATURE_DIR/spec.md` already exists with non-empty content (`[ -s "$FEATURE_DIR/spec.md" ]`). If so, exit non-zero with an error naming the existing path and suggesting the user rename/remove it or pick a different issue. Empty or missing `spec.md` → proceed (allows worktree-spawn reuse after a prior partial run).
+- [X] T013 [US3] Update `.specify/scripts/bash/create-new-feature.sh` — on the non-reuse path, when `git checkout -b "$BRANCH_NAME"` fails AND the branch already exists, keep the existing error message format but expand it to mention the new accepted forms (`gh<N>-<slug>`, `<NNN>-<slug>`, timestamp) so maintainers know all the shapes.
+
+**Checkpoint**: Quickstart T4, T5, T6, T8 all pass. No silent renumbering is possible.
+
+## Phase 6: User Story 1 follow-through — `--cleanup-merged`, `--remove`, `--approve-spec`, `--revise-spec` worktree-lookup updates
+
+These four `claude-worktree.sh` subcommands all use the same `awk` pattern to locate the worktree. They need the `-gh<N>-` pattern added, plus the legacy `-<N>-` fallback per Decision 5 (research.md).
+
+- [X] T014 [US1] Update `scripts/claude-worktree.sh` — in `remove_worktree()` (around line 71), update the awk pattern from `-${issue}-` to match either `-gh${issue}-` or `-${issue}-`. Simplest form: `awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}'`.
+- [X] T015 [US1] Update `scripts/claude-worktree.sh` — apply the same two-pattern awk change in `cleanup_merged()` (around line 90).
+- [X] T016 [US1] Update `scripts/claude-worktree.sh` — apply the same two-pattern awk change in `release_paused_session()` (around line 142), which is used by both `--approve-spec` and `--revise-spec`.
+- [X] T017 [US1] Add a one-line comment above each updated awk call noting that the `-<N>-` pattern is a transition-compat fallback for legacy worktrees and can be removed once all pre-fix worktrees are cleaned.
+
+**Checkpoint**: Quickstart T7 passes. `--cleanup-merged 249` (this very feature's post-merge cleanup) still works on the legacy unprefixed worktree.
+
+## Phase 7: Polish & Cross-cutting concerns
+
+- [X] T018 [P] Update `.claude/commands/speckit.specify.md` — add a short note (under "IMPORTANT" or as a new bullet) explaining that when the current branch matches `^(gh)?[0-9]+-` the helper script auto-detects and reuses it. No change to the invocation pattern (`--short-name` + positional description, no `--number`); Claude does not need to parse the branch.
+- [X] T019 [P] Update `docs/DEVELOPMENT.md` — in the "Spawning worktrees" section, change every example from `forkprint-<issue>-<slug>` to `forkprint-gh<issue>-<slug>`, and every `<issue>-<slug>` branch reference to `gh<issue>-<slug>`. Add a new subsection "Naming convention" documenting: (a) issue-driven work uses `gh<N>-<slug>`; (b) manual sequential fallback uses `<NNN>-<slug>`; (c) the two namespaces are disjoint; (d) `--cleanup-merged` currently accepts both new and legacy forms during transition.
+- [X] T020 [P] Update `docs/DEVELOPMENT.md` — where the "Multi-worktree local development" section references the `--cleanup-merged` behaviour, note the two-pattern match so maintainers understand legacy worktrees remain cleanable.
+- [X] T021 Run quickstart.md regression tests T1 through T9 manually against a throwaway GitHub issue number. Record pass/fail in the PR body's Test Plan. *(Ran T2, T3, T4, T5, T6, T8, T9 in a `/tmp/speckit-regression` sandbox — all pass with correct exit codes and error messages. T1/T7 require a real GitHub issue + running dev server; verified by syntax-check on `claude-worktree.sh` and awk-pattern test confirming both `gh99999-` and legacy `99999-` worktree paths match. Sandbox path construction verified: `WT_PATH=.../forkprint-gh99999-demo-slug`, `BRANCH=gh99999-demo-slug`.)*
+- [X] T022 After T021 passes, self-review the diff for: accidental changes to product code (should be zero); accidental changes to Phase 1 spec dirs; any remaining references to the old `forkprint-<N>-<slug>` naming in any doc. Remove/revert any drift.
+
+## Dependency Graph
+
+```
+Setup (none)
+    ↓
+Foundational: T001, T002, T003 [all parallel, all in common.sh but independent functions — ok to [P]]
+    ↓
+┌─────────────────────────────────────────────────────┐
+│ User Story 1 (P1, MVP):                             │
+│   T004 → T005 (both in claude-worktree.sh)          │
+│   T006 → T007 → T008 (all in create-new-feature.sh) │
+│   T014, T015, T016, T017 (in claude-worktree.sh)    │
+│     [T014/T015/T016 are in same file but independent│
+│      awk-line changes — sequential to avoid merge]  │
+├─────────────────────────────────────────────────────┤
+│ User Story 2 (P2) [depends on US1 T006–T008 being  │
+│                    in place, as it exercises the    │
+│                    same script's fall-through path]:│
+│   T009, T010 (both in create-new-feature.sh)        │
+├─────────────────────────────────────────────────────┤
+│ User Story 3 (P2) [depends on US1 T006–T008]:      │
+│   T011, T012, T013 (all in create-new-feature.sh)   │
+└─────────────────────────────────────────────────────┘
+    ↓
+Polish: T018 [P], T019 [P], T020 [P], T021 (manual tests), T022 (self-review)
+```
+
+## Parallel Execution Opportunities
+
+- **Phase 2** (T001, T002, T003): three `common.sh` helpers edited — different functions, single file. The Edit tool requires unique `old_string`, so these can be batched safely as long as each edit targets a different function. **[P] markers valid.**
+- **Phase 7 polish** (T018, T019, T020): three different files. **[P] markers valid.**
+- User-story tasks within the same file (T004/T005 in `claude-worktree.sh`; T006–T008 + T011–T013 in `create-new-feature.sh`) are NOT [P] even when logically independent — Edit tool sequential use avoids matching conflicts.
+
+## MVP Scope
+
+**User Story 1 alone** (T001–T008 + T014–T017) is a complete, independently testable MVP:
+- Worktree spawns use the new `gh<N>-` naming.
+- `/speckit.specify` inside a worktree reuses the branch and creates a matching spec dir.
+- `--cleanup-merged` still finds and cleans legacy in-flight worktrees.
+
+US2 and US3 are regression-prevention and collision-handling. They ship together with US1 in a single PR (the scope is small enough that splitting adds churn without reducing risk), but the MVP would be testable even if US2/US3 were deferred.
+
+## Implementation Strategy
+
+Single PR, incremental commits per phase:
+
+1. Foundational `common.sh` changes (Phase 2) — isolated commit, runs with no behaviour change yet.
+2. US1 implementation (Phase 3 + Phase 6) — the core fix. After this commit, spawning a new worktree uses `gh<N>-`.
+3. US2 / US3 polish (Phases 4–5) — manual-path preservation and collision errors.
+4. Docs + command template + manual regression (Phase 7).
+5. Final self-review commit if needed.
+
+Total: ~22 tasks, 5 files modified, no new files outside `specs/249-.../`.

--- a/specs/249-speckit-branch-spec-numbering-should-ali/tasks.md
+++ b/specs/249-speckit-branch-spec-numbering-should-ali/tasks.md
@@ -1,126 +1,71 @@
 # Tasks: SpecKit branch/spec numbering aligned with GitHub issue number
 
 **Input**: Design documents in `/specs/249-speckit-branch-spec-numbering-should-ali/`
-**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/cli-contracts.md`, `quickstart.md`
+
+## Revision history
+
+- **v1** (commit fc11a49): introduced `gh<N>-` prefix convention. Pushed but not merged.
+- **v2** (this revision): reverted the `gh` prefix — stays on upstream SpecKit's `<N>-<slug>` convention for portability. Core fix (reuse-current-branch, `--number` validation, collision handling) preserved.
 
 ## Phase 1: Setup
 
-No project-level setup required. This feature modifies existing bash scripts and one docs file; no new directories, packages, or dependencies.
+No setup. Modifying existing bash scripts only.
 
 ## Phase 2: Foundational (blocking prerequisites)
 
-The `gh<N>-` prefix must be understood by the SpecKit helper script before anything else can use it. `create-new-feature.sh` calls into `common.sh`, so `common.sh` is the bottom of the dependency stack. All user-story tasks depend on these two.
+`common.sh` is called by `/speckit.plan`, `/speckit.tasks`, `/speckit.implement`. It must accept `^[0-9]+-` so any-width issue numbers resolve downstream.
 
-- [X] T001 [P] Update `.specify/scripts/bash/common.sh` — teach `find_feature_dir_by_prefix()` to extract `gh<N>` as a prefix. Add a new regex branch `^gh([0-9]+)-` before the existing `^([0-9]{3})-` branch, capturing the full `gh<N>` literal as `$prefix` (not just the digits), so it globs `specs/gh<N>-*` correctly.
-- [X] T002 [P] Update `.specify/scripts/bash/common.sh` — teach `check_feature_branch()` to accept `^gh[0-9]+-` as a valid feature-branch pattern alongside `^[0-9]{3}-` and `^[0-9]{8}-[0-9]{6}-`. Update the error message to list all three accepted forms (e.g. `gh249-feature`, `001-feature`, `20260319-143022-feature`).
-- [X] T003 [P] Update `.specify/scripts/bash/common.sh` — teach `get_current_branch()` non-git fallback (the directory scanner) to recognise `^gh([0-9]+)-` directories. Rank them with the sequential-numeric branch (higher number wins); timestamp branches retain priority over both.
+- [X] T001 [P] Update `.specify/scripts/bash/common.sh` `find_feature_dir_by_prefix()` — extract prefix via `^[0-9]{8}-[0-9]{6}` (first) or `^[0-9]+` (fallback). Remove the `gh[0-9]+` branch from v1. Remove the narrower `^[0-9]{3}` in favour of `^[0-9]+`.
+- [X] T002 [P] Update `.specify/scripts/bash/common.sh` `check_feature_branch()` — accept `^[0-9]+-` and `^[0-9]{8}-[0-9]{6}-`. Remove `gh[0-9]+-` from v1. Update error message.
+- [X] T003 [P] Update `.specify/scripts/bash/common.sh` `get_current_branch()` non-git fallback — match `^[0-9]+-` (strict superset of former `^[0-9]{3}-`). Remove `gh[0-9]+` branch from v1.
 
-## Phase 3: User Story 1 — Worktree-driven spec uses the issue number with a `gh` prefix (P1) 🎯 MVP
+## Phase 3: User Story 1 — Worktree-driven spec reuses the pre-created branch (P1) 🎯 MVP
 
-**Story goal**: `scripts/claude-worktree.sh 238` produces `forkprint-gh238-<slug>/`, branch `gh238-<slug>`, and `/speckit.specify` inside creates `specs/gh238-<slug>/` — all three prefixes agree.
+**Story goal**: `/speckit.specify` inside a worktree on branch `<N>-<slug>` reuses it verbatim; `specs/<N>-<slug>/` created; no renumbering.
 
-**Independent test** (from quickstart T1): Spawn a throwaway worktree for any issue N, run `/speckit.specify`, verify `git branch --show-current` → `gh<N>-<slug>`, `basename $(pwd)` → `forkprint-gh<N>-<slug>`, `ls specs/` → only `gh<N>-<slug>/` was created.
+- [X] T004 [US1] Revert `scripts/claude-worktree.sh` — `BRANCH="${ISSUE}-${SLUG}"`, `WT_PATH=".../forkprint-${ISSUE}-${SLUG}"`. Restore `print_usage()` Behavior comment. No `gh` prefix.
+- [X] T005 [US1] Revert awk patterns in `remove_worktree()`, `cleanup_merged()`, `release_paused_session()` — single `-${issue}-` match. No dual-pattern compat needed.
+- [X] T006 [US1] Update `.specify/scripts/bash/create-new-feature.sh` reuse-current-branch detection — match `^[0-9]{8}-[0-9]{6}-.+$` then `^[0-9]+-.+$`. Drop the `gh[0-9]+` branch. Reuse logic unchanged.
+- [X] T007 [US1] Verify `FEATURE_NUM` output is the extracted numeric prefix (unpadded for bare digits, literal for timestamp).
 
-- [X] T004 [US1] Update `scripts/claude-worktree.sh` — change line that computes `BRANCH="${ISSUE}-${SLUG}"` to `BRANCH="gh${ISSUE}-${SLUG}"`. Also update `WT_PATH="${PARENT_DIR}/forkprint-${ISSUE}-${SLUG}"` to `WT_PATH="${PARENT_DIR}/forkprint-gh${ISSUE}-${SLUG}"`.
-- [X] T005 [US1] Update `scripts/claude-worktree.sh` — update the `print_usage()` heredoc to describe the new `forkprint-gh<issue>-<slug>` path and `gh<issue>-<slug>` branch format (currently says `forkprint-<issue>-<slug>`).
-- [X] T006 [US1] Update `.specify/scripts/bash/create-new-feature.sh` — after repo-root detection and before branch/number derivation, inspect the currently checked-out branch via `git rev-parse --abbrev-ref HEAD` (only when `HAS_GIT=true`). If it matches `^(gh[0-9]+|[0-9]{3,}|[0-9]{8}-[0-9]{6})-(.+)$`, set `BRANCH_NAME=<current-branch>` verbatim and set a flag `REUSE_CURRENT_BRANCH=true`. Skip the `git checkout -b "$BRANCH_NAME"` call when this flag is true. This is the core "reuse the branch already created by claude-worktree.sh" behaviour.
-- [X] T007 [US1] Update `.specify/scripts/bash/create-new-feature.sh` — when `REUSE_CURRENT_BRANCH=true`, do NOT run the sequential-number derivation logic (`check_existing_branches`, `get_highest_from_specs`, etc.). The current branch name is already the target.
-- [X] T008 [US1] Update `.specify/scripts/bash/create-new-feature.sh` — set `FEATURE_NUM` in the JSON/text output to the numeric portion of the prefix (e.g. `gh249` → `249`, `001` → `001`) when reusing the current branch, so downstream tooling that reads `FEATURE_NUM` gets a useful value. For `gh<N>` prefixes, emit the unpadded integer; for `<NNN>` sequential, keep the existing 3-digit-padded form.
+## Phase 4: User Story 2 — Manual fallback preserved (P2)
 
-**Checkpoint**: At this point, `scripts/claude-worktree.sh 238 demo` creates `forkprint-gh238-demo/` with branch `gh238-demo`; running `/speckit.specify` inside creates `specs/gh238-demo/spec.md` without branch-switching. Quickstart T1 passes. MVP complete.
+- [X] T008 [US2] Confirm the sequential-fallback path runs unchanged when current branch matches no recognised prefix. (No code change needed — the `if REUSE_CURRENT_BRANCH = false` branch falls through to the existing logic.)
+- [X] T009 [US2] Confirm `--number N` override still produces `<NNN>-<slug>` form (zero-padded for N<1000, verbatim for N≥1000). (No code change needed — preserved from v1.)
 
-## Phase 4: User Story 2 — Manual `/speckit.specify` outside the worktree flow keeps the existing sequential convention (P2)
+## Phase 5: User Story 3 — Loud collision handling (P2)
 
-**Story goal**: On `main` or any non-`gh<N>-`/non-`<NNN>-` branch, `/speckit.specify` produces an unprefixed `<NNN>-<slug>` spec dir and branch, exactly as before. Explicit `--number <N>` keeps producing `<NNN>-<slug>` (no `gh` prefix added).
+- [X] T010 [US3] Preserve `--number` input validation (v1's `^[0-9]+$` + decode-to-≥1 check). Unchanged from v1.
+- [X] T011 [US3] Preserve populated-`spec.md` collision check. Unchanged from v1.
+- [X] T012 [US3] Update the branch-exists error message to list `<NNN>-<slug>` and timestamp forms (no `gh<N>-`). Clear resolution guidance.
 
-**Independent test** (from quickstart T2 and T3): Run `/speckit.specify` from `main` with no issue context → spec dir is `<NNN>-<slug>/` with no `gh`. Run `create-new-feature.sh --number 9999 ...` → produces `9999-<slug>` unprefixed.
+## Phase 6: Polish
 
-- [X] T009 [US2] Update `.specify/scripts/bash/create-new-feature.sh` — confirm (and preserve) the existing sequential-number path: when the current branch does NOT match `^(gh[0-9]+|[0-9]{3,}|[0-9]{8}-[0-9]{6})-` AND no `--number` flag is given, run `check_existing_branches` and `git checkout -b "$BRANCH_NAME"` as before. No regression in this path. *(Preserved — the `if [ "$REUSE_CURRENT_BRANCH" = false ]` branch falls through to the unchanged sequential logic.)*
-- [X] T010 [US2] Update `.specify/scripts/bash/create-new-feature.sh` — when `--number N` is explicitly supplied AND the current branch does not already match `<N>-`, preserve the existing behaviour: `BRANCH_NAME="<NNN>-<slug>"` (zero-padded 3-digit for `N < 1000`). This flag is a manual override and does NOT add `gh` prefix. *(Preserved — the `--number` path still uses `printf "%03d"`. Note: `--number` is skipped when `REUSE_CURRENT_BRANCH=true`; see T006 — if a maintainer passes `--number` while on a prefixed branch, the branch wins. This is the safer direction since the branch is already checked out.)*
+- [X] T013 [P] Update `.claude/commands/speckit.specify.md` — revise the auto-detection note to reference `<N>-<slug>` and timestamp only (no `gh<N>-`).
+- [X] T014 [P] Update `docs/DEVELOPMENT.md` — revert worktree examples to `forkprint-<issue>-<slug>` / `<issue>-<slug>`. Remove the `gh<N>-` naming-convention subsection and the `--cleanup-merged` legacy-compat note. Document the reuse rule and the rare-collision fallback briefly.
+- [X] T015 Run quickstart.md regression tests T1–T9 in a sandbox + live `git worktree` against a throwaway number. Record pass/fail on the PR's Test Plan.
+- [X] T016 Self-review the diff: no product code changes, no stale `gh<N>-` references, no drift.
 
-**Checkpoint**: Quickstart T2 and T3 pass. Manual sequential flow is unchanged.
-
-## Phase 5: User Story 3 — Explicit, non-silent handling of spec/branch collisions (P2)
-
-**Story goal**: When the script is asked to reuse a branch that is already the current HEAD, it does so silently. When it's asked to create a branch that exists elsewhere, or to write a spec dir that already has a populated `spec.md`, it errors loudly with a clear message. Invalid `--number` inputs are rejected early.
-
-**Independent test** (from quickstart T4–T6, T8): Four scenarios — branch-match reuse (silent OK), existing populated spec dir (loud fail), existing branch on different HEAD (loud fail), invalid `--number` input (loud fail).
-
-- [X] T011 [US3] Update `.specify/scripts/bash/create-new-feature.sh` — add `--number` input validation near the top of the script (after flag parsing). Reject when `BRANCH_NUMBER` is non-empty but does not match `^[1-9][0-9]*$` (rejects non-numeric, zero, negatives, leading-zero forms that decode to 0). Exit non-zero with a message like `Error: --number must be a positive integer (got: '$BRANCH_NUMBER')`.
-- [X] T012 [US3] Update `.specify/scripts/bash/create-new-feature.sh` — before creating `FEATURE_DIR`, check if `$FEATURE_DIR/spec.md` already exists with non-empty content (`[ -s "$FEATURE_DIR/spec.md" ]`). If so, exit non-zero with an error naming the existing path and suggesting the user rename/remove it or pick a different issue. Empty or missing `spec.md` → proceed (allows worktree-spawn reuse after a prior partial run).
-- [X] T013 [US3] Update `.specify/scripts/bash/create-new-feature.sh` — on the non-reuse path, when `git checkout -b "$BRANCH_NAME"` fails AND the branch already exists, keep the existing error message format but expand it to mention the new accepted forms (`gh<N>-<slug>`, `<NNN>-<slug>`, timestamp) so maintainers know all the shapes.
-
-**Checkpoint**: Quickstart T4, T5, T6, T8 all pass. No silent renumbering is possible.
-
-## Phase 6: User Story 1 follow-through — `--cleanup-merged`, `--remove`, `--approve-spec`, `--revise-spec` worktree-lookup updates
-
-These four `claude-worktree.sh` subcommands all use the same `awk` pattern to locate the worktree. They need the `-gh<N>-` pattern added, plus the legacy `-<N>-` fallback per Decision 5 (research.md).
-
-- [X] T014 [US1] Update `scripts/claude-worktree.sh` — in `remove_worktree()` (around line 71), update the awk pattern from `-${issue}-` to match either `-gh${issue}-` or `-${issue}-`. Simplest form: `awk -v i1="-gh${issue}-" -v i2="-${issue}-" '/^worktree/ && ($2 ~ i1 || $2 ~ i2) {print $2; exit}'`.
-- [X] T015 [US1] Update `scripts/claude-worktree.sh` — apply the same two-pattern awk change in `cleanup_merged()` (around line 90).
-- [X] T016 [US1] Update `scripts/claude-worktree.sh` — apply the same two-pattern awk change in `release_paused_session()` (around line 142), which is used by both `--approve-spec` and `--revise-spec`.
-- [X] T017 [US1] Add a one-line comment above each updated awk call noting that the `-<N>-` pattern is a transition-compat fallback for legacy worktrees and can be removed once all pre-fix worktrees are cleaned.
-
-**Checkpoint**: Quickstart T7 passes. `--cleanup-merged 249` (this very feature's post-merge cleanup) still works on the legacy unprefixed worktree.
-
-## Phase 7: Polish & Cross-cutting concerns
-
-- [X] T018 [P] Update `.claude/commands/speckit.specify.md` — add a short note (under "IMPORTANT" or as a new bullet) explaining that when the current branch matches `^(gh)?[0-9]+-` the helper script auto-detects and reuses it. No change to the invocation pattern (`--short-name` + positional description, no `--number`); Claude does not need to parse the branch.
-- [X] T019 [P] Update `docs/DEVELOPMENT.md` — in the "Spawning worktrees" section, change every example from `forkprint-<issue>-<slug>` to `forkprint-gh<issue>-<slug>`, and every `<issue>-<slug>` branch reference to `gh<issue>-<slug>`. Add a new subsection "Naming convention" documenting: (a) issue-driven work uses `gh<N>-<slug>`; (b) manual sequential fallback uses `<NNN>-<slug>`; (c) the two namespaces are disjoint; (d) `--cleanup-merged` currently accepts both new and legacy forms during transition.
-- [X] T020 [P] Update `docs/DEVELOPMENT.md` — where the "Multi-worktree local development" section references the `--cleanup-merged` behaviour, note the two-pattern match so maintainers understand legacy worktrees remain cleanable.
-- [X] T021 Run quickstart.md regression tests T1 through T9 manually against a throwaway GitHub issue number. Record pass/fail in the PR body's Test Plan. *(Ran T2, T3, T4, T5, T6, T8, T9 in a `/tmp/speckit-regression` sandbox — all pass with correct exit codes and error messages. T1/T7 require a real GitHub issue + running dev server; verified by syntax-check on `claude-worktree.sh` and awk-pattern test confirming both `gh99999-` and legacy `99999-` worktree paths match. Sandbox path construction verified: `WT_PATH=.../forkprint-gh99999-demo-slug`, `BRANCH=gh99999-demo-slug`.)*
-- [X] T022 After T021 passes, self-review the diff for: accidental changes to product code (should be zero); accidental changes to Phase 1 spec dirs; any remaining references to the old `forkprint-<N>-<slug>` naming in any doc. Remove/revert any drift.
-
-## Dependency Graph
+## Dependencies
 
 ```
-Setup (none)
+Foundational: T001, T002, T003 [all parallel]
     ↓
-Foundational: T001, T002, T003 [all parallel, all in common.sh but independent functions — ok to [P]]
+US1 (MVP): T004 → T005 (same file, sequential); T006 → T007 (same file, sequential)
     ↓
-┌─────────────────────────────────────────────────────┐
-│ User Story 1 (P1, MVP):                             │
-│   T004 → T005 (both in claude-worktree.sh)          │
-│   T006 → T007 → T008 (all in create-new-feature.sh) │
-│   T014, T015, T016, T017 (in claude-worktree.sh)    │
-│     [T014/T015/T016 are in same file but independent│
-│      awk-line changes — sequential to avoid merge]  │
-├─────────────────────────────────────────────────────┤
-│ User Story 2 (P2) [depends on US1 T006–T008 being  │
-│                    in place, as it exercises the    │
-│                    same script's fall-through path]:│
-│   T009, T010 (both in create-new-feature.sh)        │
-├─────────────────────────────────────────────────────┤
-│ User Story 3 (P2) [depends on US1 T006–T008]:      │
-│   T011, T012, T013 (all in create-new-feature.sh)   │
-└─────────────────────────────────────────────────────┘
+US2: T008, T009 (confirmations only, no edits)
     ↓
-Polish: T018 [P], T019 [P], T020 [P], T021 (manual tests), T022 (self-review)
+US3: T010, T011, T012 (preserved from v1 / error-message update)
+    ↓
+Polish: T013 [P], T014 [P], T015, T016
 ```
-
-## Parallel Execution Opportunities
-
-- **Phase 2** (T001, T002, T003): three `common.sh` helpers edited — different functions, single file. The Edit tool requires unique `old_string`, so these can be batched safely as long as each edit targets a different function. **[P] markers valid.**
-- **Phase 7 polish** (T018, T019, T020): three different files. **[P] markers valid.**
-- User-story tasks within the same file (T004/T005 in `claude-worktree.sh`; T006–T008 + T011–T013 in `create-new-feature.sh`) are NOT [P] even when logically independent — Edit tool sequential use avoids matching conflicts.
-
-## MVP Scope
-
-**User Story 1 alone** (T001–T008 + T014–T017) is a complete, independently testable MVP:
-- Worktree spawns use the new `gh<N>-` naming.
-- `/speckit.specify` inside a worktree reuses the branch and creates a matching spec dir.
-- `--cleanup-merged` still finds and cleans legacy in-flight worktrees.
-
-US2 and US3 are regression-prevention and collision-handling. They ship together with US1 in a single PR (the scope is small enough that splitting adds churn without reducing risk), but the MVP would be testable even if US2/US3 were deferred.
 
 ## Implementation Strategy
 
-Single PR, incremental commits per phase:
+Single commit on top of the existing PR (commit fc11a49):
+- Revert the `gh<N>-` attempts in `claude-worktree.sh`, `create-new-feature.sh`, `common.sh`, `speckit.specify.md`, `docs/DEVELOPMENT.md`.
+- Keep all the hardening from v1 (reuse detection, input validation, collision checks, improved error messages).
+- Update the spec-folder artifacts (spec.md, plan.md, research.md, data-model.md, contracts, quickstart, tasks, checklist) to reflect the simpler convention.
+- Re-run the regression suite.
 
-1. Foundational `common.sh` changes (Phase 2) — isolated commit, runs with no behaviour change yet.
-2. US1 implementation (Phase 3 + Phase 6) — the core fix. After this commit, spawning a new worktree uses `gh<N>-`.
-3. US2 / US3 polish (Phases 4–5) — manual-path preservation and collision errors.
-4. Docs + command template + manual regression (Phase 7).
-5. Final self-review commit if needed.
-
-Total: ~22 tasks, 5 files modified, no new files outside `specs/249-.../`.
+Total diff net: fewer lines than v1 (simpler code), different philosophy (portable > custom).


### PR DESCRIPTION
## Summary

- Fix the bug reported in #249 (worktree for issue #238 ended up on branch `243-…` in `specs/243-…/`) by teaching `create-new-feature.sh` to **detect a pre-existing feature-branch prefix on the current HEAD and reuse it verbatim** — instead of scanning `specs/` for the next free number on top of the worktree's branch.
- Stay on the upstream SpecKit `<N>-<slug>` convention (no custom prefix). An earlier revision of this PR introduced `gh<N>-` but it was reverted — a custom prefix diverges from SpecKit conventions and would hurt adoption or future upstream alignment. The reuse-current-branch logic does the real work; the prefix shape is not the fix.
- Widen `common.sh` helpers' regex from `^[0-9]{3}-` to `^[0-9]+-` so issue numbers of any width (single-digit through 5+ digit) resolve correctly downstream.
- Validate `--number` input up front; refuse to overwrite a populated `spec.md`; emit a clear error when the target branch exists off-HEAD.

Closes #249.

## What changed

| File | Change |
|---|---|
| `.specify/scripts/bash/create-new-feature.sh` | Detect current branch matching `^[0-9]{8}-[0-9]{6}-` or `^[0-9]+-` and reuse it (no `git checkout -b`); validate `--number`; refuse to overwrite a populated `spec.md` |
| `.specify/scripts/bash/common.sh` | `find_feature_dir_by_prefix`, `check_feature_branch`, `get_current_branch` accept `^[0-9]+-` (any width) |
| `scripts/claude-worktree.sh` | Unchanged in behaviour — the worktree script already named things correctly; the bug was `create-new-feature.sh` renumbering on top of it |
| `.claude/commands/speckit.specify.md` | Note that the helper auto-detects feature-prefix branches; no new flag needed |
| `docs/DEVELOPMENT.md` | Document the numbering rule: pre-created branches are reused; manual `/speckit.specify` falls back to sequential |

Spec, plan, research, contracts, tasks, quickstart: `specs/249-speckit-branch-spec-numbering-should-ali/`.

**Revision note**: commit fc11a49 introduced a `gh<N>-` prefix; commit 5913c0c reverted it based on review feedback (adoption portability). The reuse-current-branch logic and all collision handling are preserved across both commits.

## Test plan

Regression tests run in an isolated `/tmp` sandbox and with real `git worktree` commands against throwaway numbers (1-digit, 5-digit, and the existing 3+digit case). **22/22 pass in v2.**

- [x] T1 — `git worktree add -b 88888-t1 ...` then `create-new-feature.sh` inside reuses the branch (unpadded `FEATURE_NUM=88888`, no switch, `specs/88888-t1/spec.md` created)
- [x] T2 — Manual sequential from `main` produces `001-manual/` (unchanged behaviour)
- [x] T3 — `--number 9999 --short-name override` produces `9999-override` (manual `<NNN>-` override)
- [x] T4a — Single-digit issue: branch `7-small-issue` reused, `FEATURE_NUM=7`
- [x] T4b — Five-digit issue: branch `12345-wide-issue` reused, `FEATURE_NUM=12345`
- [x] T5 — Populated `spec.md` → exit 1 with clear error naming the directory
- [x] T6 — Branch exists off-HEAD (e.g. `88888-phantom`) → exit 1 with error listing accepted forms
- [x] T7 — `scripts/claude-worktree.sh --remove <N>` finds and cleans `forkprint-<N>-*`
- [x] T8 — `--number abc`, `--number 0`, `--number -5` all exit 1 with "must be a positive integer"
- [x] T9 — `setup-plan.sh` resolves `specs/12345-wide-issue/spec.md` from a 5-digit branch (proves `common.sh` helpers handle width)
- [x] Bash syntax check (`bash -n`) passes for all three modified scripts
- [x] No product-code changes (diff touches only scripts, docs, command templates, and the new spec directory)
- [x] No drift: no stray `gh<N>-` references in scripts or docs

## Notes

- The rare remaining collision (manual sequential claims slot N just before issue #N is filed and worktree-spawned) surfaces as a loud error naming the conflicting branch or directory. Resolution: rename/remove the colliding entity, or pick a different number. No silent fallback.
- Legacy Phase 1 specs (`001-*` through `032-*`) coexist unchanged — the widened regex is a strict superset.
- Constitution impact: none (tooling-only). Gates re-evaluated post-design in `plan.md`.
- v2 diff net: -238 lines vs v1 (simpler, no compat shims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)