### PR TITLE
Fix rateLimit test expectation: add missing limit field (#277)

### DIFF
--- a/lib/analyzer/analyzer.test.ts
+++ b/lib/analyzer/analyzer.test.ts
@@ -534,6 +534,7 @@ describe('analyze', () => {
       },
     ])
     expect(result.rateLimit).toEqual({
+      limit: 'unavailable',
       remaining: 'unavailable',
       resetAt: 'unavailable',
       retryAfter: 60,


### PR DESCRIPTION
## Summary
- Adds `limit: 'unavailable'` to the rate-limit expectation at `lib/analyzer/analyzer.test.ts:536` so it matches the analyzer's actual output shape.
- Restores a green test suite on `main` (now 863 passed / 0 failed — was 862 / 1).
- Fixes #277.

## Test plan
- [x] `npm test` reports 863 passed / 0 failed locally
- [x] The previously failing case `analyze > surfaces rate-limit failures with retry metadata when GitHub rejects the request` now passes
- [x] Sibling rate-limit assertions (lines 34, 46, 50, 68, 103, 117, 133) still pass unchanged
- [x] No production code under `lib/analyzer/` was modified — fix is test-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)