### PR TITLE
Stop /speckit.plan from auto-populating CLAUDE.md (fixes #284)

### DIFF
--- a/.claude/commands/speckit.plan.md
+++ b/.claude/commands/speckit.plan.md
@@ -64,7 +64,6 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Evaluate gates (ERROR if violations unjustified)
    - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
    - Phase 1: Generate data-model.md, contracts/, quickstart.md
-   - Phase 1: Update agent context by running the agent script
    - Re-evaluate Constitution Check post-design
 
 4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
@@ -138,14 +137,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
    - Skip if project is purely internal (build scripts, one-off tools, etc.)
 
-3. **Agent context update**:
-   - Run `.specify/scripts/bash/update-agent-context.sh claude`
-   - These scripts detect which AI agent is in use
-   - Update the appropriate agent-specific context file
-   - Add only new technology from current plan
-   - Preserve manual additions between markers
-
-**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+**Output**: data-model.md, /contracts/*, quickstart.md
 
 ## Key rules
 


### PR DESCRIPTION
## Summary

- Removes the "Agent context update" step from `.claude/commands/speckit.plan.md`. That step invoked `.specify/scripts/bash/update-agent-context.sh claude`, which appended per-feature `## Active Technologies` and `## Recent Changes` sections to `CLAUDE.md`.
- This is option 1 from issue #284 — the smaller diff. The upstream SpecKit script is untouched and remains available for anyone who wants to run it manually.
- `CLAUDE.md` itself is not modified by this PR; the cleanup from PR #282 / commit `a057ce3` stays as-is, and the next `/speckit.plan` run will no longer revert it.

Related upstream: [github/spec-kit#2246](https://github.com/github/spec-kit/issues/2246) tracks the same verbosity concern against SpecKit itself.

Fixes #284.

## Test plan

- [x] Verify diff is limited to `.claude/commands/speckit.plan.md` (no `CLAUDE.md` changes, no script changes): `git diff --stat main`. → `1 file changed, 1 insertion(+), 9 deletions(-)`
- [x] On this branch, confirm `CLAUDE.md` line count is unchanged vs. `main`: `diff <(git show main:CLAUDE.md) CLAUDE.md` is empty. → diff produced no output; files are byte-for-byte identical.
- [x] After merge, on the next feature branch that runs `/speckit.plan`, confirm `CLAUDE.md` is not listed among changed files and no `## Active Technologies` / `## Recent Changes` sections have been appended. → Verified post-merge on branch `284-stop-update-agent-context-sh-from-popula` with PR #292 merged to `main`. Ran `/speckit.plan` end-to-end. `md5 CLAUDE.md` returned `b57b062df85435c34823bb85f86941ad` both before and after; `git status` showed only the scratch `specs/` directory, with `CLAUDE.md` unchanged.
- [x] Confirm `/speckit.plan` still produces `plan.md`, `research.md`, `data-model.md`, `contracts/` (when applicable), and `quickstart.md`. → Verified in the same run: `plan.md`, `research.md`, `data-model.md`, and `quickstart.md` were all generated under `specs/284-.../`. `contracts/` was correctly skipped (the change is purely internal per the template's skip rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)