### PR TITLE
Delete remote branch in --cleanup-merged (closes #294)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -198,8 +198,8 @@ The pause is per-worktree: in a batch spawn (`for i in 210 211 212; do scripts/c
 **Cleanup:**
 
 ```bash
-# Post-merge, from the main repo: pull main, kill processes,
-# remove the worktree, delete the branch (refuses if unmerged).
+# Post-merge, from the main repo: pull main, kill processes, remove the
+# worktree, delete the local+remote branch (refuses if unmerged).
 scripts/claude-worktree.sh --cleanup-merged 207
 
 # Discard unmerged work (kills processes + force-removes worktree, keeps branch).
@@ -215,7 +215,7 @@ scripts/claude-worktree.sh --cleanup-merged    # no arg needed
 
 When invoked with no argument from a linked worktree, the script chdirs to the main repo, auto-checks out `main` if the primary worktree is on another branch (refuses on dirty state — never force-discards), then runs the standard cleanup flow. On success, if the caller's current working directory was the removed worktree, the script prints a final-line notice of the form `note: your shell's previous CWD (...) no longer exists — run \`cd <main-repo-path>\` to continue` so the stranded shell knows where to go. Inference only fires from inside a linked worktree — the no-argument form from the main repo clone still prints the existing usage error and takes no destructive action.
 
-`--cleanup-merged` verifies merge status by querying the associated PR's state via `gh pr view <branch> --json state` — **not** by local ancestry. This matters because squash-merges and rebase-merges on GitHub produce a merge commit that is not an ancestor of the local feature branch, so the older ancestry check (`git branch -d`) would silently refuse even after a real merge. When the PR state is `MERGED`, the local branch is force-deleted. When the PR is `OPEN`, `CLOSED` without merge, missing, or `gh` cannot reach GitHub, the command refuses and points to `--remove`. Use `--remove` as the escape hatch for unmerged branches.
+`--cleanup-merged` verifies merge status by querying the associated PR's state via `gh pr view <branch> --json state` — **not** by local ancestry. This matters because squash-merges and rebase-merges on GitHub produce a merge commit that is not an ancestor of the local feature branch, so the older ancestry check (`git branch -d`) would silently refuse even after a real merge. When the PR state is `MERGED`, the local branch is force-deleted, then `git push origin --delete <branch>` removes the remote ref. If the remote was already removed (e.g. GitHub's "Automatically delete head branches" setting fired at merge time), the step prints `Remote branch <branch> already removed` and exits 0. Any other remote-delete failure (network, auth, protected branch) surfaces a warning and exits non-zero — the worktree and local branch are already gone, so only a manual `git push origin --delete <branch>` remains. When the PR is `OPEN`, `CLOSED` without merge, missing, or `gh` cannot reach GitHub, the command refuses and points to `--remove`. Use `--remove` as the escape hatch for unmerged branches; it does not touch the remote.
 
 If something gets stuck:
 

--- a/scripts/claude-worktree.sh
+++ b/scripts/claude-worktree.sh
@@ -21,7 +21,7 @@ Options:
   --approve-spec    Release the spec-review pause for a paused headless spawn
   --revise-spec     Send non-empty revision feedback to a paused spawn
   --remove          Discard worktree (works on unmerged work)
-  --cleanup-merged  Post-merge: pull main, remove worktree, delete branch
+  --cleanup-merged  Post-merge: pull main, remove worktree, delete local+remote branch
   -h, --help        Show this help and exit
 
 For --remove and --cleanup-merged, the issue number is inferred from the branch
@@ -117,7 +117,7 @@ cleanup_merged() {
   local issue="$1"
   local caller_cwd
   caller_cwd="$(pwd -P)"  # physical path so we match git's canonical worktree paths (macOS /tmp -> /private/tmp)
-  local wt branch current_branch pr_state
+  local wt branch current_branch pr_state push_err
   wt="$(git -C "$REPO_ROOT" worktree list --porcelain \
     | awk -v i="-${issue}-" '/^worktree/ && $2 ~ i {print $2; exit}')"
   if [[ -z "${wt:-}" ]]; then
@@ -169,6 +169,25 @@ cleanup_merged() {
   echo "Removed $wt"
 
   git -C "$REPO_ROOT" branch -D "$branch"
+
+  # Treat "remote ref does not exist" as success — GitHub's "Automatically
+  # delete head branches" setting removes the remote at merge time in most
+  # repos, so an explicit delete becomes a documented no-op. Any other failure
+  # (network, auth, protected branch) warns and exits non-zero; local state
+  # is already clean, so only a manual remote delete remains.
+  if push_err="$(git -C "$REPO_ROOT" push origin --delete "$branch" 2>&1)"; then
+    echo "Deleted remote branch origin/$branch"
+  elif grep -q "remote ref does not exist" <<<"$push_err"; then
+    echo "Remote branch $branch already removed"
+  else
+    echo "WARNING: could not delete remote branch $branch" >&2
+    echo "$push_err" >&2
+    echo "Worktree and local branch were removed; delete the remote manually with:" >&2
+    echo "  git push origin --delete $branch" >&2
+    print_stranded_shell_notice_if_needed "$wt" "$caller_cwd" "$REPO_ROOT"
+    exit 1
+  fi
+
   print_stranded_shell_notice_if_needed "$wt" "$caller_cwd" "$REPO_ROOT"
 }
 


### PR DESCRIPTION
## Summary

- `scripts/claude-worktree.sh --cleanup-merged` now runs `git push origin --delete <branch>` after removing the worktree and force-deleting the local branch, so the flag's promise of "cleanup of a merged branch" also clears the remote ref that's visible in GitHub's branch list.
- Treats "remote ref does not exist" as success so the step is a documented no-op when GitHub's repo-level *Automatically delete head branches* setting already fired at merge time. Other failures (network, auth, protected branch) surface a warning with a manual recovery command and exit non-zero — worktree and local branch removal already happened, so only the remote delete is left.
- `--remove` is unchanged (intentionally local-only for unmerged work).

## Test plan

- [x] `scripts/claude-worktree.sh --help` shows `Post-merge: pull main, remove worktree, delete local+remote branch` under `--cleanup-merged`.
- [x] On a merged PR where the remote branch still exists: `scripts/claude-worktree.sh --cleanup-merged <N>` removes the worktree, deletes the local branch, and `git ls-remote --heads origin <branch>` returns no ref afterward.
- [x] On a merged PR where GitHub already auto-deleted the head branch: `--cleanup-merged` prints `Remote branch <branch> already removed` and exits 0.
- [x] Simulated remote-delete failure (e.g. offline / revoke auth): worktree and local branch are still removed, script prints a WARNING with the manual `git push origin --delete <branch>` command, and exits non-zero.
- [x] `--remove` still only touches local state — `git ls-remote --heads origin <branch>` still returns the ref after `--remove`.

Tests 2–5 verified in a sandboxed harness (bare-origin + clone + stub `gh` returning `MERGED`; test 4 uses an origin pre-receive hook to reject deletions, simulating branch protection). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)