### PR TITLE
Fix pre-existing lint errors on main (#301)

### DIFF
--- a/app/baseline/page.tsx
+++ b/app/baseline/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { BaselineView } from '@/components/baseline/BaselineView'
 import { BackToAnalyzerLink } from '@/components/baseline/BackToAnalyzerLink'
 import { ThemeToggle } from '@/components/theme/ThemeToggle'
@@ -13,10 +14,10 @@ export default function BaselinePage() {
       <header className="w-full bg-sky-900 text-white dark:bg-slate-900">
         <div className="mx-auto flex max-w-5xl items-start justify-between gap-4 px-4 py-5">
           <div>
-            <a href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+            <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
               <img src="/repo-pulse-banner.png" alt="" className="h-8 w-8 rounded object-cover" aria-hidden="true" />
               <h1 className="text-2xl font-semibold tracking-tight text-white">RepoPulse</h1>
-            </a>
+            </Link>
             <p className="mt-1 text-sm text-sky-100 md:text-base">Scoring Methodology</p>
           </div>
           <div className="flex items-center gap-2">

--- a/components/app-shell/ResultsTabs.tsx
+++ b/components/app-shell/ResultsTabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import type { ResultTabDefinition, ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import type { TabMatchCounts } from '@/lib/search/types'
 
@@ -14,17 +14,28 @@ interface ResultsTabsProps {
 const COLLAPSED_COUNT_MOBILE = 3
 const COLLAPSED_COUNT_DESKTOP = 6
 
+const MOBILE_QUERY = '(max-width: 639px)'
+
+function subscribeMobile(callback: () => void) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+  const mql = window.matchMedia(MOBILE_QUERY)
+  mql.addEventListener('change', callback)
+  return () => mql.removeEventListener('change', callback)
+}
+
+function getMobileSnapshot() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(MOBILE_QUERY).matches
+}
+
+function getMobileServerSnapshot() {
+  return false
+}
+
 function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(false)
-  useEffect(() => {
-    if (typeof window.matchMedia !== 'function') return
-    const mql = window.matchMedia('(max-width: 639px)')
-    setIsMobile(mql.matches)
-    function onChange(e: MediaQueryListEvent) { setIsMobile(e.matches) }
-    mql.addEventListener('change', onChange)
-    return () => mql.removeEventListener('change', onChange)
-  }, [])
-  return isMobile
+  return useSyncExternalStore(subscribeMobile, getMobileSnapshot, getMobileServerSnapshot)
 }
 
 export function ResultsTabs({ tabs, activeTab, onChange, matchCounts }: ResultsTabsProps) {

--- a/components/baseline/BackToAnalyzerLink.tsx
+++ b/components/baseline/BackToAnalyzerLink.tsx
@@ -1,10 +1,12 @@
+import Link from 'next/link'
+
 export function BackToAnalyzerLink() {
   return (
-    <a
+    <Link
       href="/"
       className="rounded-full border border-sky-700 bg-sky-950/25 px-4 py-2 text-sm font-medium text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
     >
       Back to analyzer
-    </a>
+    </Link>
   )
 }

--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -331,7 +331,7 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
                 ) : null}
 
                 {filteredTotal === 0 && activeTag ? (
-                  <p className="mt-4 text-center text-sm text-slate-400">No recommendations match the "{activeTag}" tag.</p>
+                  <p className="mt-4 text-center text-sm text-slate-400">No recommendations match the &ldquo;{activeTag}&rdquo; tag.</p>
                 ) : null}
 
                 <div className="mt-4 space-y-4">

--- a/components/shared/hooks/useOrgAggregation.ts
+++ b/components/shared/hooks/useOrgAggregation.ts
@@ -123,14 +123,35 @@ export function useOrgAggregation(options: UseOrgAggregationOptions = {}): UseOr
   const completedCountRef = useRef(0)
   const totalReposRef = useRef(0)
   const lastTickBucketRef = useRef(-1)
-  const [tick, setTick] = useState(0)
+  const [now, setNow] = useState<number>(() => Date.now())
 
   // Wall-clock tick so elapsed/remaining keep updating between completions (FR-017d).
   useEffect(() => {
     if (!run || run.status !== 'in-progress') return
-    const id = setInterval(() => setTick((n) => n + 1), ORG_AGGREGATION_CONFIG.wallClockTickIntervalMs)
+    const id = setInterval(() => setNow(Date.now()), ORG_AGGREGATION_CONFIG.wallClockTickIntervalMs)
     return () => clearInterval(id)
   }, [run?.status, run])
+
+  const maybeFireCompletionNotification = useCallback(() => {
+    dispatchReducer({
+      type: 'apply',
+      mutate: (r) => {
+        if (!r.notificationOptIn) return r
+        if (typeof window === 'undefined' || !('Notification' in window)) return r
+        if (Notification.permission !== 'granted') return r
+        const done = Array.from(r.perRepo.values()).filter((s) => s.status === 'done').length
+        const total = r.repos.length
+        try {
+          new Notification('RepoPulse — org analysis complete', {
+            body: `${done} of ${total} repos succeeded for ${r.org}`,
+          })
+        } catch {
+          // Notifications can throw in service-worker-only contexts; ignore.
+        }
+        return r
+      },
+    })
+  }, [])
 
   const applyEvent = useCallback(
     (event: QueueEvent) => {
@@ -178,24 +199,24 @@ export function useOrgAggregation(options: UseOrgAggregationOptions = {}): UseOr
         completedSinceRerenderRef.current++
         completedCountRef.current++
         if (cadence.kind === 'per-completion') {
-          setTick((n) => n + 1)
+          setNow(Date.now())
         } else if (cadence.kind === 'every-n-completions') {
           if (completedSinceRerenderRef.current >= cadence.n) {
             completedSinceRerenderRef.current = 0
-            setTick((n) => n + 1)
+            setNow(Date.now())
           }
         } else if (cadence.kind === 'every-n-percent' && totalReposRef.current > 0) {
           const percentComplete = (completedCountRef.current / totalReposRef.current) * 100
           const bucket = Math.floor(percentComplete / cadence.percentStep)
           if (bucket > lastTickBucketRef.current) {
             lastTickBucketRef.current = bucket
-            setTick((n) => n + 1)
+            setNow(Date.now())
           }
         }
         // 'on-completion-only' deliberately omits mid-run ticks.
       }
       if (event.type === 'complete' || event.type === 'cancelled') {
-        setTick((n) => n + 1)
+        setNow(Date.now())
       }
 
       // Completion notification (FR-018) — fire exactly once on terminal.
@@ -203,32 +224,8 @@ export function useOrgAggregation(options: UseOrgAggregationOptions = {}): UseOr
         maybeFireCompletionNotification()
       }
     },
-    [cadence],
+    [cadence, maybeFireCompletionNotification],
   )
-
-  const fireTick = useCallback(() => setTick((n) => n + 1), [])
-  void fireTick
-
-  function maybeFireCompletionNotification() {
-    dispatchReducer({
-      type: 'apply',
-      mutate: (r) => {
-        if (!r.notificationOptIn) return r
-        if (typeof window === 'undefined' || !('Notification' in window)) return r
-        if (Notification.permission !== 'granted') return r
-        const done = Array.from(r.perRepo.values()).filter((s) => s.status === 'done').length
-        const total = r.repos.length
-        try {
-          new Notification('RepoPulse — org analysis complete', {
-            body: `${done} of ${total} repos succeeded for ${r.org}`,
-          })
-        } catch {
-          // Notifications can throw in service-worker-only contexts; ignore.
-        }
-        return r
-      },
-    })
-  }
 
   const start = useCallback(
     async (input: StartRunInput) => {
@@ -300,9 +297,8 @@ export function useOrgAggregation(options: UseOrgAggregationOptions = {}): UseOr
 
   const view = useMemo(() => {
     if (!run) return null
-    void tick // read tick so this memo refreshes on wall-clock ticks too
-    return buildOrgSummaryViewModel(run, Date.now())
-  }, [run, tick])
+    return buildOrgSummaryViewModel(run, now)
+  }, [run, now])
 
   const reset = useCallback(() => {
     queueRef.current?.cancel()


### PR DESCRIPTION
## Summary
- Resolves all 7 pre-existing lint errors on `main` so `npm run lint` exits 0 and `dod-verifier` can report Check 3 (Lint clean) as SATISFIED going forward.
- Warnings (24) are deferred — the issue explicitly scoped fixes to the 7 errors.

## What changed
- `app/baseline/page.tsx`, `components/baseline/BackToAnalyzerLink.tsx` — replace `<a href="/">` with Next.js `<Link>` (`@next/next/no-html-link-for-pages`).
- `components/app-shell/ResultsTabs.tsx` — replace the `useState`+effect matchMedia hook with `useSyncExternalStore` so we no longer call `setIsMobile` synchronously inside an effect (`react-hooks/set-state-in-effect`).
- `components/recommendations/RecommendationsView.tsx` — escape the literal quotes around the active tag label with `&ldquo;`/`&rdquo;` (`react/no-unescaped-entities`).
- `components/shared/hooks/useOrgAggregation.ts` — hoist `maybeFireCompletionNotification` into a `useCallback` declared before `applyEvent` (`react-hooks/immutability` — no access-before-declaration), and replace the in-render `Date.now()` with a `now` state driven off the existing tick sources (`react-hooks/purity` — no impure call during render).

## Verification
- `npm run lint` → `exit 0` (0 errors, 24 warnings — pre-existing).
- `npx tsc --noEmit` → 176 errors both before and after this branch (all pre-existing test-type drift; none in files this PR touches).
- `vitest run components/app-shell components/shared/hooks components/recommendations` → 26/26 passed.
- Dev server @ `:3011`: `/` and `/baseline` return 200, "Back to analyzer" and the header logo both navigate to `/`.

## Test plan
- [x] `npm run lint` exits 0 locally (acceptance criterion 1) — confirmed via direct run, exit code 0
- [x] On a clean branch off this merged main, `dod-verifier` reports Check 3 (Lint clean) as SATISFIED (acceptance criterion 2) — confirmed via dod-verifier agent run against this branch; Check 3 reported SATISFIED (0 errors)
- [x] Visit `/baseline` — header logo and "Back to analyzer" pill both navigate back to `/`
- [x] Resize browser across the 639px breakpoint on a results page — `ResultsTabs` still shows/hides the overflow menu correctly
- [ ] Trigger a recommendation tag filter that returns zero matches — the "No recommendations match the &ldquo;…&rdquo; tag." copy renders with curly quotes
- [x] Run an org aggregation — per-repo status, elapsed time, and completion notification still update as expected (useOrgAggregation regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)