### PR TITLE
Detect CoC/CONTRIBUTING/CHANGELOG in case/location variants (#308)

### DIFF
--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -59,9 +59,16 @@ interface RepoOverviewResponse {
     docContributing?: DocBlob | null
     docContributingRst?: DocBlob | null
     docContributingTxt?: DocBlob | null
+    docContributingLower?: DocBlob | null
+    docContributingDocs?: DocBlob | null
+    docContributingGithub?: DocBlob | null
     docCodeOfConduct?: DocBlob | null
     docCodeOfConductRst?: DocBlob | null
     docCodeOfConductTxt?: DocBlob | null
+    docCodeOfConductHyphenLower?: DocBlob | null
+    docCodeOfConductUnderscoreLower?: DocBlob | null
+    docCodeOfConductDocs?: DocBlob | null
+    docCodeOfConductGithub?: DocBlob | null
     docLicenseRst?: DocBlob | null
     docSecurity?: DocBlob | null
     docSecurityLower?: DocBlob | null
@@ -73,6 +80,7 @@ interface RepoOverviewResponse {
     docSecurityContacts?: DocBlob | null
     docChangelog?: DocBlob | null
     docChangelogPlain?: DocBlob | null
+    docChangelogDocs?: DocBlob | null
     docChanges?: DocBlob | null
     docChangesRst?: DocBlob | null
     docHistory?: DocBlob | null
@@ -774,15 +782,15 @@ export function extractDocumentationResult(repo: RepoOverviewResponse['repositor
 
   const readmeBlob = findFirst(repo.docReadmeMd, repo.docReadmeLower, repo.docReadmeRst, repo.docReadmeTxt, repo.docReadmePlain)
   const licenseBlob = findFirst(repo.docLicense, repo.docLicenseMd, repo.docLicenseTxt, repo.docLicenseRst, repo.docCopying, repo.docLicenseMit, repo.docLicenseApache, repo.docLicenseBsd)
-  const contributingBlob = findFirst(repo.docContributing, repo.docContributingRst, repo.docContributingTxt)
-  const codeOfConductBlob = findFirst(repo.docCodeOfConduct, repo.docCodeOfConductRst, repo.docCodeOfConductTxt)
+  const contributingBlob = findFirst(repo.docContributing, repo.docContributingRst, repo.docContributingTxt, repo.docContributingLower, repo.docContributingDocs, repo.docContributingGithub)
+  const codeOfConductBlob = findFirst(repo.docCodeOfConduct, repo.docCodeOfConductRst, repo.docCodeOfConductTxt, repo.docCodeOfConductHyphenLower, repo.docCodeOfConductUnderscoreLower, repo.docCodeOfConductDocs, repo.docCodeOfConductGithub)
   const securityBlob = findFirst(
     repo.docSecurity, repo.docSecurityLower, repo.docSecurityRst,
     repo.docSecurityGithub, repo.docSecurityGithubLower,
     repo.docSecurityDocs, repo.docSecurityDocsLower,
     repo.docSecurityContacts,
   )
-  const changelogBlob = findFirst(repo.docChangelog, repo.docChangelogPlain, repo.docChanges, repo.docChangesRst, repo.docHistory, repo.docNews)
+  const changelogBlob = findFirst(repo.docChangelog, repo.docChangelogPlain, repo.docChangelogDocs, repo.docChanges, repo.docChangesRst, repo.docHistory, repo.docNews)
 
   const readmePathMap: [string, DocBlob | null | undefined][] = [
     ['README.md', repo.docReadmeMd], ['readme.md', repo.docReadmeLower], ['README.rst', repo.docReadmeRst],
@@ -794,10 +802,16 @@ export function extractDocumentationResult(repo: RepoOverviewResponse['repositor
   ]
   const contributingPathMap: [string, DocBlob | null | undefined][] = [
     ['CONTRIBUTING.md', repo.docContributing], ['CONTRIBUTING.rst', repo.docContributingRst], ['CONTRIBUTING.txt', repo.docContributingTxt],
+    ['contributing.md', repo.docContributingLower], ['docs/CONTRIBUTING.md', repo.docContributingDocs], ['.github/CONTRIBUTING.md', repo.docContributingGithub],
+  ]
+  const codeOfConductPathMap: [string, DocBlob | null | undefined][] = [
+    ['CODE_OF_CONDUCT.md', repo.docCodeOfConduct], ['CODE_OF_CONDUCT.rst', repo.docCodeOfConductRst], ['CODE_OF_CONDUCT.txt', repo.docCodeOfConductTxt],
+    ['code-of-conduct.md', repo.docCodeOfConductHyphenLower], ['code_of_conduct.md', repo.docCodeOfConductUnderscoreLower],
+    ['docs/CODE_OF_CONDUCT.md', repo.docCodeOfConductDocs], ['.github/CODE_OF_CONDUCT.md', repo.docCodeOfConductGithub],
   ]
   const changelogPathMap: [string, DocBlob | null | undefined][] = [
-    ['CHANGELOG.md', repo.docChangelog], ['CHANGELOG', repo.docChangelogPlain], ['CHANGES.md', repo.docChanges],
-    ['CHANGES.rst', repo.docChangesRst], ['HISTORY.md', repo.docHistory], ['NEWS.md', repo.docNews],
+    ['CHANGELOG.md', repo.docChangelog], ['CHANGELOG', repo.docChangelogPlain], ['docs/CHANGELOG.md', repo.docChangelogDocs],
+    ['CHANGES.md', repo.docChanges], ['CHANGES.rst', repo.docChangesRst], ['HISTORY.md', repo.docHistory], ['NEWS.md', repo.docNews],
   ]
 
   function foundPath(pathMap: [string, DocBlob | null | undefined][]): string | null {
@@ -847,7 +861,7 @@ export function extractDocumentationResult(repo: RepoOverviewResponse['repositor
     { name: 'readme', found: readmeBlob !== null, path: foundPath(readmePathMap) },
     { name: 'license', found: licenseBlob !== null, path: foundPath(licensePathMap) },
     { name: 'contributing', found: contributingBlob !== null, path: foundPath(contributingPathMap) },
-    { name: 'code_of_conduct', found: codeOfConductBlob !== null, path: foundPath([['CODE_OF_CONDUCT.md', repo.docCodeOfConduct], ['CODE_OF_CONDUCT.rst', repo.docCodeOfConductRst], ['CODE_OF_CONDUCT.txt', repo.docCodeOfConductTxt]]) },
+    { name: 'code_of_conduct', found: codeOfConductBlob !== null, path: foundPath(codeOfConductPathMap) },
     { name: 'security', found: securityBlob !== null, path: foundPath([
       ['SECURITY.md', repo.docSecurity], ['security.md', repo.docSecurityLower], ['SECURITY.rst', repo.docSecurityRst],
       ['.github/SECURITY.md', repo.docSecurityGithub], ['.github/security.md', repo.docSecurityGithubLower],

--- a/lib/analyzer/documentation-extraction.test.ts
+++ b/lib/analyzer/documentation-extraction.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { extractDocumentationResult } from './analyze'
+import type { DocumentationFileCheck } from './analysis-result'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function repoFixture(overrides: Record<string, unknown>): any {
+  return {
+    name: 'test', description: '', createdAt: '', primaryLanguage: null,
+    stargazerCount: 0, forkCount: 0, watchers: { totalCount: 0 },
+    issues: { totalCount: 0 },
+    ...overrides,
+  }
+}
+
+function check(
+  result: ReturnType<typeof extractDocumentationResult>,
+  name: DocumentationFileCheck['name'],
+): DocumentationFileCheck {
+  if (result === 'unavailable') throw new Error('expected DocumentationResult, got unavailable')
+  const found = result.fileChecks.find((c) => c.name === name)
+  if (!found) throw new Error(`no ${name} check in result`)
+  return found
+}
+
+describe('extractDocumentationResult — non-security governance variants', () => {
+  describe('code_of_conduct', () => {
+    it.each([
+      ['CODE_OF_CONDUCT.md', 'docCodeOfConduct'],
+      ['CODE_OF_CONDUCT.rst', 'docCodeOfConductRst'],
+      ['CODE_OF_CONDUCT.txt', 'docCodeOfConductTxt'],
+      // Regression: kubernetes/kubernetes uses lowercase hyphenated form (issue #308).
+      ['code-of-conduct.md', 'docCodeOfConductHyphenLower'],
+      ['code_of_conduct.md', 'docCodeOfConductUnderscoreLower'],
+      ['docs/CODE_OF_CONDUCT.md', 'docCodeOfConductDocs'],
+      ['.github/CODE_OF_CONDUCT.md', 'docCodeOfConductGithub'],
+    ])('resolves as present when %s exists', (path, field) => {
+      const result = extractDocumentationResult(repoFixture({ [field]: { oid: 'abc' } }))
+      const coc = check(result, 'code_of_conduct')
+      expect(coc.found).toBe(true)
+      expect(coc.path).toBe(path)
+    })
+
+    it('resolves as absent when no CoC variant exists', () => {
+      const result = extractDocumentationResult(repoFixture({}))
+      const coc = check(result, 'code_of_conduct')
+      expect(coc.found).toBe(false)
+      expect(coc.path).toBeNull()
+    })
+  })
+
+  describe('contributing', () => {
+    it.each([
+      ['CONTRIBUTING.md', 'docContributing'],
+      ['contributing.md', 'docContributingLower'],
+      ['docs/CONTRIBUTING.md', 'docContributingDocs'],
+      ['.github/CONTRIBUTING.md', 'docContributingGithub'],
+    ])('resolves as present when %s exists', (path, field) => {
+      const result = extractDocumentationResult(repoFixture({ [field]: { oid: 'abc' } }))
+      const contrib = check(result, 'contributing')
+      expect(contrib.found).toBe(true)
+      expect(contrib.path).toBe(path)
+    })
+  })
+
+  describe('changelog', () => {
+    it('resolves as present when docs/CHANGELOG.md exists', () => {
+      const result = extractDocumentationResult(repoFixture({ docChangelogDocs: { oid: 'abc' } }))
+      const changelog = check(result, 'changelog')
+      expect(changelog.found).toBe(true)
+      expect(changelog.path).toBe('docs/CHANGELOG.md')
+    })
+  })
+
+  it('returns unavailable when repo is null', () => {
+    expect(extractDocumentationResult(null)).toBe('unavailable')
+  })
+})

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -47,9 +47,16 @@ export const REPO_OVERVIEW_QUERY = `
       docContributing: object(expression: "HEAD:CONTRIBUTING.md") { ... on Blob { oid } }
       docContributingRst: object(expression: "HEAD:CONTRIBUTING.rst") { ... on Blob { oid } }
       docContributingTxt: object(expression: "HEAD:CONTRIBUTING.txt") { ... on Blob { oid } }
+      docContributingLower: object(expression: "HEAD:contributing.md") { ... on Blob { oid } }
+      docContributingDocs: object(expression: "HEAD:docs/CONTRIBUTING.md") { ... on Blob { oid } }
+      docContributingGithub: object(expression: "HEAD:.github/CONTRIBUTING.md") { ... on Blob { oid } }
       docCodeOfConduct: object(expression: "HEAD:CODE_OF_CONDUCT.md") { ... on Blob { oid } }
       docCodeOfConductRst: object(expression: "HEAD:CODE_OF_CONDUCT.rst") { ... on Blob { oid } }
       docCodeOfConductTxt: object(expression: "HEAD:CODE_OF_CONDUCT.txt") { ... on Blob { oid } }
+      docCodeOfConductHyphenLower: object(expression: "HEAD:code-of-conduct.md") { ... on Blob { oid } }
+      docCodeOfConductUnderscoreLower: object(expression: "HEAD:code_of_conduct.md") { ... on Blob { oid } }
+      docCodeOfConductDocs: object(expression: "HEAD:docs/CODE_OF_CONDUCT.md") { ... on Blob { oid } }
+      docCodeOfConductGithub: object(expression: "HEAD:.github/CODE_OF_CONDUCT.md") { ... on Blob { oid } }
       docLicenseRst: object(expression: "HEAD:LICENSE.rst") { ... on Blob { oid text } }
       docSecurity: object(expression: "HEAD:SECURITY.md") { ... on Blob { oid } }
       docSecurityLower: object(expression: "HEAD:security.md") { ... on Blob { oid } }
@@ -61,6 +68,7 @@ export const REPO_OVERVIEW_QUERY = `
       docSecurityContacts: object(expression: "HEAD:SECURITY_CONTACTS") { ... on Blob { oid } }
       docChangelog: object(expression: "HEAD:CHANGELOG.md") { ... on Blob { oid } }
       docChangelogPlain: object(expression: "HEAD:CHANGELOG") { ... on Blob { oid } }
+      docChangelogDocs: object(expression: "HEAD:docs/CHANGELOG.md") { ... on Blob { oid } }
       docChanges: object(expression: "HEAD:CHANGES.md") { ... on Blob { oid } }
       docChangesRst: object(expression: "HEAD:CHANGES.rst") { ... on Blob { oid } }
       docHistory: object(expression: "HEAD:HISTORY.md") { ... on Blob { oid } }


### PR DESCRIPTION
## Summary

Fix DOC-4 false positive for repos like `kubernetes/kubernetes` that ship their code of conduct as `code-of-conduct.md` (lowercase, hyphenated). GraphQL path lookups are case-sensitive, so the existing probes only matched `CODE_OF_CONDUCT.md` / `.rst` / `.txt`.

Scoped to non-security governance — SECURITY-policy variants were shipped separately in #312. This PR audits the remaining community-health files called out in the issue:

- **CoC**: adds `code-of-conduct.md`, `code_of_conduct.md`, `docs/CODE_OF_CONDUCT.md`, `.github/CODE_OF_CONDUCT.md`
- **CONTRIBUTING**: adds `contributing.md`, `docs/CONTRIBUTING.md`, `.github/CONTRIBUTING.md`
- **CHANGELOG**: adds `docs/CHANGELOG.md`

Went with option 1 from the issue (extend GraphQL probes) rather than option 2 (REST community endpoint) — contained change, reuses the existing `findFirst` + `foundPath` plumbing, no extra REST round-trip per analysis.

Closes #308.

## Test plan

- [x] `npx vitest run lib/analyzer` — 6 suites / 90 tests pass (includes 14 new tests in `documentation-extraction.test.ts`)
- [x] `npx tsc --noEmit` — no new errors in changed files
- [x] Analyze `kubernetes/kubernetes` in the running app and confirm DOC-4 no longer appears as an open recommendation
- [x] Analyze a repo with `docs/CONTRIBUTING.md` and confirm CONTRIBUTING detection resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)