### PR TITLE
Broaden SECURITY.md detection for DOC-5/SEC-14 (#309)

### DIFF
--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -64,7 +64,13 @@ interface RepoOverviewResponse {
     docCodeOfConductTxt?: DocBlob | null
     docLicenseRst?: DocBlob | null
     docSecurity?: DocBlob | null
+    docSecurityLower?: DocBlob | null
     docSecurityRst?: DocBlob | null
+    docSecurityGithub?: DocBlob | null
+    docSecurityGithubLower?: DocBlob | null
+    docSecurityDocs?: DocBlob | null
+    docSecurityDocsLower?: DocBlob | null
+    docSecurityContacts?: DocBlob | null
     docChangelog?: DocBlob | null
     docChangelogPlain?: DocBlob | null
     docChanges?: DocBlob | null
@@ -760,7 +766,7 @@ function buildAnalysisResult(
   }
 }
 
-function extractDocumentationResult(repo: RepoOverviewResponse['repository']): DocumentationResult | Unavailable {
+export function extractDocumentationResult(repo: RepoOverviewResponse['repository']): DocumentationResult | Unavailable {
   if (!repo) return 'unavailable'
 
   const findFirst = (...aliases: (DocBlob | null | undefined)[]): DocBlob | null =>
@@ -770,7 +776,12 @@ function extractDocumentationResult(repo: RepoOverviewResponse['repository']): D
   const licenseBlob = findFirst(repo.docLicense, repo.docLicenseMd, repo.docLicenseTxt, repo.docLicenseRst, repo.docCopying, repo.docLicenseMit, repo.docLicenseApache, repo.docLicenseBsd)
   const contributingBlob = findFirst(repo.docContributing, repo.docContributingRst, repo.docContributingTxt)
   const codeOfConductBlob = findFirst(repo.docCodeOfConduct, repo.docCodeOfConductRst, repo.docCodeOfConductTxt)
-  const securityBlob = findFirst(repo.docSecurity, repo.docSecurityRst)
+  const securityBlob = findFirst(
+    repo.docSecurity, repo.docSecurityLower, repo.docSecurityRst,
+    repo.docSecurityGithub, repo.docSecurityGithubLower,
+    repo.docSecurityDocs, repo.docSecurityDocsLower,
+    repo.docSecurityContacts,
+  )
   const changelogBlob = findFirst(repo.docChangelog, repo.docChangelogPlain, repo.docChanges, repo.docChangesRst, repo.docHistory, repo.docNews)
 
   const readmePathMap: [string, DocBlob | null | undefined][] = [
@@ -837,7 +848,12 @@ function extractDocumentationResult(repo: RepoOverviewResponse['repository']): D
     { name: 'license', found: licenseBlob !== null, path: foundPath(licensePathMap) },
     { name: 'contributing', found: contributingBlob !== null, path: foundPath(contributingPathMap) },
     { name: 'code_of_conduct', found: codeOfConductBlob !== null, path: foundPath([['CODE_OF_CONDUCT.md', repo.docCodeOfConduct], ['CODE_OF_CONDUCT.rst', repo.docCodeOfConductRst], ['CODE_OF_CONDUCT.txt', repo.docCodeOfConductTxt]]) },
-    { name: 'security', found: securityBlob !== null, path: foundPath([['SECURITY.md', repo.docSecurity], ['SECURITY.rst', repo.docSecurityRst]]) },
+    { name: 'security', found: securityBlob !== null, path: foundPath([
+      ['SECURITY.md', repo.docSecurity], ['security.md', repo.docSecurityLower], ['SECURITY.rst', repo.docSecurityRst],
+      ['.github/SECURITY.md', repo.docSecurityGithub], ['.github/security.md', repo.docSecurityGithubLower],
+      ['docs/SECURITY.md', repo.docSecurityDocs], ['docs/security.md', repo.docSecurityDocsLower],
+      ['SECURITY_CONTACTS', repo.docSecurityContacts],
+    ]) },
     { name: 'changelog', found: changelogBlob !== null, path: foundPath(changelogPathMap) },
     { name: 'issue_templates', found: hasIssueTemplates, path: issueTemplatePath },
     { name: 'pull_request_template', found: hasPullRequestTemplate, path: prTemplatePath },
@@ -952,20 +968,37 @@ export function extractCommunitySignals(
   }
 }
 
-function extractSecurityResult(repo: RepoOverviewResponse['repository']): SecurityResult | 'unavailable' {
+export function extractSecurityResult(repo: RepoOverviewResponse['repository']): SecurityResult | 'unavailable' {
   if (!repo) return 'unavailable'
 
   const hasDependabot = (repo.secDependabot != null) || (repo.secDependabotYaml != null)
   const hasRenovate = (repo.secRenovateRoot != null) || (repo.secRenovateGithub != null) ||
     (repo.secRenovateConfig != null) || (repo.secRenovateRc != null)
-  const hasSecurity = (repo.docSecurity != null) || (repo.docSecurityRst != null)
+  const securityPathMap: Array<[string, DocBlob | null | undefined]> = [
+    ['SECURITY.md', repo.docSecurity],
+    ['security.md', repo.docSecurityLower],
+    ['SECURITY.rst', repo.docSecurityRst],
+    ['.github/SECURITY.md', repo.docSecurityGithub],
+    ['.github/security.md', repo.docSecurityGithubLower],
+    ['docs/SECURITY.md', repo.docSecurityDocs],
+    ['docs/security.md', repo.docSecurityDocsLower],
+    ['SECURITY_CONTACTS', repo.docSecurityContacts],
+  ]
+  const securityPath = securityPathMap.find(([, blob]) => blob != null)?.[0] ?? null
+  const hasSecurity = securityPath !== null
   const hasWorkflows = repo.workflowDir?.entries != null && repo.workflowDir.entries.length > 0
+
+  const securityDetails = !hasSecurity
+    ? null
+    : securityPath === 'SECURITY_CONTACTS'
+      ? 'SECURITY_CONTACTS detected (Kubernetes/CNCF convention — consider promoting to SECURITY.md for GitHub-standard recognition)'
+      : `${securityPath} detected`
 
   const directChecks: DirectSecurityCheck[] = [
     {
       name: 'security_policy',
       detected: hasSecurity,
-      details: hasSecurity ? 'SECURITY.md detected' : null,
+      details: securityDetails,
     },
     {
       name: 'dependabot',

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -52,7 +52,13 @@ export const REPO_OVERVIEW_QUERY = `
       docCodeOfConductTxt: object(expression: "HEAD:CODE_OF_CONDUCT.txt") { ... on Blob { oid } }
       docLicenseRst: object(expression: "HEAD:LICENSE.rst") { ... on Blob { oid text } }
       docSecurity: object(expression: "HEAD:SECURITY.md") { ... on Blob { oid } }
+      docSecurityLower: object(expression: "HEAD:security.md") { ... on Blob { oid } }
       docSecurityRst: object(expression: "HEAD:SECURITY.rst") { ... on Blob { oid } }
+      docSecurityGithub: object(expression: "HEAD:.github/SECURITY.md") { ... on Blob { oid } }
+      docSecurityGithubLower: object(expression: "HEAD:.github/security.md") { ... on Blob { oid } }
+      docSecurityDocs: object(expression: "HEAD:docs/SECURITY.md") { ... on Blob { oid } }
+      docSecurityDocsLower: object(expression: "HEAD:docs/security.md") { ... on Blob { oid } }
+      docSecurityContacts: object(expression: "HEAD:SECURITY_CONTACTS") { ... on Blob { oid } }
       docChangelog: object(expression: "HEAD:CHANGELOG.md") { ... on Blob { oid } }
       docChangelogPlain: object(expression: "HEAD:CHANGELOG") { ... on Blob { oid } }
       docChanges: object(expression: "HEAD:CHANGES.md") { ... on Blob { oid } }

--- a/lib/analyzer/security-path-coverage.test.ts
+++ b/lib/analyzer/security-path-coverage.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { extractDocumentationResult, extractSecurityResult } from './analyze'
+
+// Minimal shape for testing — matches RepoOverviewResponse['repository'] structurally.
+// We only populate the fields under test; other required fields are cast via `as any`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function repoFixture(overrides: Record<string, unknown>): any {
+  return {
+    name: 'test', description: '', createdAt: '', primaryLanguage: null,
+    stargazerCount: 0, forkCount: 0, watchers: { totalCount: 0 },
+    issues: { totalCount: 0 },
+    ...overrides,
+  }
+}
+
+describe('SECURITY.md path coverage (issue #309)', () => {
+  describe('extractDocumentationResult — file:security signal', () => {
+    it.each([
+      ['docSecurity', 'SECURITY.md'],
+      ['docSecurityLower', 'security.md'],
+      ['docSecurityRst', 'SECURITY.rst'],
+      ['docSecurityGithub', '.github/SECURITY.md'],
+      ['docSecurityGithubLower', '.github/security.md'],
+      ['docSecurityDocs', 'docs/SECURITY.md'],
+      ['docSecurityDocsLower', 'docs/security.md'],
+      ['docSecurityContacts', 'SECURITY_CONTACTS'],
+    ])('marks security as found when %s exists (path: %s)', (field, expectedPath) => {
+      const result = extractDocumentationResult(repoFixture({ [field]: { oid: 'abc' } }))
+      if (result === 'unavailable') throw new Error('expected non-unavailable result')
+      const securityCheck = result.fileChecks.find((c) => c.name === 'security')
+      expect(securityCheck?.found).toBe(true)
+      expect(securityCheck?.path).toBe(expectedPath)
+    })
+
+    it('marks security as not found when no security file exists at any path', () => {
+      const result = extractDocumentationResult(repoFixture({}))
+      if (result === 'unavailable') throw new Error('expected non-unavailable result')
+      const securityCheck = result.fileChecks.find((c) => c.name === 'security')
+      expect(securityCheck?.found).toBe(false)
+      expect(securityCheck?.path).toBeNull()
+    })
+
+    it('prefers root SECURITY.md over other locations when multiple exist', () => {
+      const result = extractDocumentationResult(repoFixture({
+        docSecurity: { oid: 'a' },
+        docSecurityGithub: { oid: 'b' },
+        docSecurityContacts: { oid: 'c' },
+      }))
+      if (result === 'unavailable') throw new Error('expected non-unavailable result')
+      const securityCheck = result.fileChecks.find((c) => c.name === 'security')
+      expect(securityCheck?.path).toBe('SECURITY.md')
+    })
+  })
+
+  describe('extractSecurityResult — security_policy direct check', () => {
+    it.each([
+      ['docSecurity', 'SECURITY.md detected'],
+      ['docSecurityLower', 'security.md detected'],
+      ['docSecurityRst', 'SECURITY.rst detected'],
+      ['docSecurityGithub', '.github/SECURITY.md detected'],
+      ['docSecurityGithubLower', '.github/security.md detected'],
+      ['docSecurityDocs', 'docs/SECURITY.md detected'],
+      ['docSecurityDocsLower', 'docs/security.md detected'],
+    ])('detects security_policy when %s exists', (field, expectedDetails) => {
+      const result = extractSecurityResult(repoFixture({ [field]: { oid: 'abc' } }))
+      if (result === 'unavailable') throw new Error('expected non-unavailable result')
+      const sec = result.directChecks.find((c) => c.name === 'security_policy')
+      expect(sec?.detected).toBe(true)
+      expect(sec?.details).toBe(expectedDetails)
+    })
+
+    it('detects security_policy when SECURITY_CONTACTS exists and notes the convention', () => {
+      const result = extractSecurityResult(repoFixture({ docSecurityContacts: { oid: 'abc' } }))
+      if (result === 'unavailable') throw new Error('expected non-unavailable result')
+      const sec = result.directChecks.find((c) => c.name === 'security_policy')
+      expect(sec?.detected).toBe(true)
+      expect(sec?.details).toMatch(/SECURITY_CONTACTS/)
+      expect(sec?.details).toMatch(/promoting to SECURITY\.md/)
+    })
+
+    it('does not detect security_policy when no security file exists', () => {
+      const result = extractSecurityResult(repoFixture({}))
+      if (result === 'unavailable') throw new Error('expected non-unavailable result')
+      const sec = result.directChecks.find((c) => c.name === 'security_policy')
+      expect(sec?.detected).toBe(false)
+      expect(sec?.details).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Closes #309. GraphQL path lookups are case-sensitive and the old query only probed `HEAD:SECURITY.md` / `HEAD:SECURITY.rst`, missing `.github/SECURITY.md`, `docs/SECURITY.md`, lowercase variants, and the Kubernetes/CNCF `SECURITY_CONTACTS` convention.
- Added seven new probes (`.github/SECURITY.md`, `.github/security.md`, `docs/SECURITY.md`, `docs/security.md`, `security.md`, `SECURITY_CONTACTS`) and wired them into both `extractDocumentationResult` (DOC-5) and `extractSecurityResult` (SEC-14), so the fix resolves both symptoms from the same signal.
- `SECURITY_CONTACTS` is recognized as satisfying the policy, with evidence text noting the Kubernetes/CNCF convention and suggesting promotion to `SECURITY.md` for GitHub-standard recognition — matching the second acceptance option in the issue ("flags it with a note").

## Changes

- `lib/analyzer/queries.ts` — adds 6 new GraphQL aliases for SECURITY.md path/casing variants plus `SECURITY_CONTACTS`.
- `lib/analyzer/analyze.ts` — broadens `securityBlob` resolution, `foundPath` map, and `extractSecurityResult` detection; surfaces the `SECURITY_CONTACTS` convention note in `details`. Exports `extractDocumentationResult` and `extractSecurityResult` for direct unit testing (following the `extractCommunitySignals` pattern).
- `lib/analyzer/security-path-coverage.test.ts` — new file, 19 tests covering all 8 detection paths and the preference ordering.

## Decision log

- **SECURITY_CONTACTS recognition** — yes, it satisfies DOC-5/SEC-14 signal. Rationale: it is the canonical disclosure channel for Kubernetes and several CNCF projects, and suppressing the recommendation entirely is wrong for such projects. The recommendation still surfaces a gentle nudge via the evidence string.
- **De-duplication of DOC-5 and SEC-14** — left for a separate issue. They share a signal but live in different buckets; unifying them is a UX/catalog change, not a detector change.

## Test plan

- [x] `npx vitest run lib/analyzer/security-path-coverage.test.ts` passes (19 tests)
- [x] Full test suite still passes: `npx vitest run` (967 tests)
- [x] Lint clean on changed files: `npm run lint -- lib/analyzer/analyze.ts lib/analyzer/queries.ts lib/analyzer/security-path-coverage.test.ts`
- [x] Manual: analyze `kubernetes/kubernetes` via the web app — DOC-5 and SEC-14 no longer surface as open recommendations; Security view's `security_policy` check shows "SECURITY_CONTACTS detected (Kubernetes/CNCF convention — consider promoting to SECURITY.md ...)".
- [x] Manual: analyze a repo with `.github/SECURITY.md` (e.g. `facebook/react`) — DOC-5/SEC-14 no longer flagged; path shown as `.github/SECURITY.md`.
- [x] Manual: analyze a repo with no security file — DOC-5/SEC-14 still surface as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
