### PR TITLE
chore: trim trailing whitespace in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Never run `gh pr merge` automatically. PR merging is always a manual user action
 Do not infer confirmation from phrases like "manual check confirmed" if any checkbox remains unchecked — ask explicitly before merging.
 
 ## On Ambiguity
-If a spec is missing, incomplete, or conflicts with the constitution — 
+If a spec is missing, incomplete, or conflicts with the constitution —
 stop and ask. Do not infer. Do not proceed.
 
 ## Signoff Metadata


### PR DESCRIPTION
## Summary

Throwaway test PR used to exercise the T1 end-to-end path of `scripts/claude-worktree.sh --cleanup-merged` self-healing introduced in #307 (fixes #304). Kept intentionally minimal — a one-byte real fix (trailing whitespace on one line) so the commit is a legitimate no-op rather than invented content.

## Why a real PR rather than a forged state

`--cleanup-merged` consults `gh pr view <branch> --json state` against the actual GitHub API. No local forging of `MERGED` is possible — a real PR needs to be merged to test the happy path. Once this merges, I will run `--cleanup-merged 9999` against the live MERGED state to check off T1 on #307.

## Test plan
- [ ] This PR merges cleanly.
- [ ] After merge, `scripts/claude-worktree.sh --cleanup-merged 9999` (from PR #307) completes end-to-end, removing the worktree, the local branch, and the remote branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)