### PR TITLE
Group license-consistency repos by OSI status (#316)

### DIFF
--- a/components/org-summary/panels/LicenseConsistencyPanel.tsx
+++ b/components/org-summary/panels/LicenseConsistencyPanel.tsx
@@ -6,28 +6,180 @@ import { EmptyState } from '../EmptyState'
 
 interface Props { panel: AggregatePanel<LicenseConsistencyValue> }
 
+type OsiClassification = 'non-osi' | 'osi'
+
+const GROUP_ORDER: OsiClassification[] = ['non-osi', 'osi']
+
+const DEFAULT_OPEN: Record<OsiClassification, boolean> = {
+  'non-osi': true,
+  osi: false,
+}
+
+const GROUP_CONFIG: Record<
+  OsiClassification,
+  { label: string; icon: string; pillClassName: string; groupAriaLabel: string; headerBorderClassName: string }
+> = {
+  'non-osi': {
+    label: 'Non-OSI-approved',
+    icon: '⚠',
+    pillClassName: 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400',
+    groupAriaLabel: 'Repos using non-OSI-approved licenses',
+    headerBorderClassName: 'border-l-4 border-amber-500',
+  },
+  osi: {
+    label: 'OSI-approved',
+    icon: '✓',
+    pillClassName: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400',
+    groupAriaLabel: 'Repos using OSI-approved licenses',
+    headerBorderClassName: 'border-l-4 border-emerald-500',
+  },
+}
+
 export function LicenseConsistencyPanel({ panel }: Props) {
   return (
-    <section aria-label="License consistency" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+    <section
+      aria-label="License consistency"
+      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+      data-testid="license-consistency-panel"
+    >
       <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">License consistency</h3>
-        {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
+        {panel.lastUpdatedAt ? (
+          <span className="text-xs text-slate-400 dark:text-slate-500">
+            updated {panel.lastUpdatedAt.toLocaleTimeString()}
+          </span>
+        ) : null}
       </header>
-      {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
+      {panel.status === 'in-progress' && !panel.value ? (
+        <EmptyState />
+      ) : panel.status === 'unavailable' || !panel.value ? (
         <p className="text-sm text-slate-500 dark:text-slate-400">No licensing data available.</p>
       ) : (
-        <>
-          <p className="mb-3 text-sm text-slate-700 dark:text-slate-300">{panel.value.nonOsiCount > 0 ? <span className="text-amber-700 dark:text-amber-400">{panel.value.nonOsiCount} repo(s) use non-OSI-approved licenses</span> : <span className="text-emerald-700 dark:text-emerald-400">All repos use OSI-approved licenses</span>}</p>
-          <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
-            {panel.value.perLicense.map((l) => (
-              <li key={l.spdxId} className="flex items-center justify-between gap-3 py-2">
-                <span className="text-sm text-slate-800 dark:text-slate-200">{l.spdxId}{!l.osiApproved ? <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">non-OSI</span> : null}</span>
-                <span className="text-xs text-slate-500 dark:text-slate-400">{l.count} {l.count === 1 ? 'repo' : 'repos'}</span>
-              </li>
-            ))}
-          </ul>
-        </>
+        <PanelBody value={panel.value} contributingReposCount={panel.contributingReposCount} totalReposInRun={panel.totalReposInRun} />
       )}
     </section>
   )
+}
+
+function PanelBody({
+  value,
+  contributingReposCount,
+  totalReposInRun,
+}: {
+  value: LicenseConsistencyValue
+  contributingReposCount: number
+  totalReposInRun: number
+}) {
+  const grouped = groupByOsi(value.perRepo)
+  const counts: Record<OsiClassification, number> = {
+    'non-osi': grouped['non-osi'].length,
+    osi: grouped.osi.length,
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-slate-700 dark:text-slate-300">
+        {contributingReposCount} of {totalReposInRun} repos contributed
+        {value.nonOsiCount > 0 ? (
+          <>
+            {' · '}
+            <span className="text-amber-700 dark:text-amber-400">
+              {value.nonOsiCount} use non-OSI-approved licenses
+            </span>
+          </>
+        ) : (
+          <>
+            {' · '}
+            <span className="text-emerald-700 dark:text-emerald-400">All use OSI-approved licenses</span>
+          </>
+        )}
+      </p>
+      {GROUP_ORDER.filter((c) => grouped[c].length > 0).map((classification) => (
+        <GroupSection
+          key={classification}
+          classification={classification}
+          repos={grouped[classification]}
+          defaultOpen={DEFAULT_OPEN[classification]}
+          count={counts[classification]}
+        />
+      ))}
+    </div>
+  )
+}
+
+function GroupSection({
+  classification,
+  repos,
+  defaultOpen,
+  count,
+}: {
+  classification: OsiClassification
+  repos: { repo: string; spdxId: string; osiApproved: boolean }[]
+  defaultOpen: boolean
+  count: number
+}) {
+  const config = GROUP_CONFIG[classification]
+  return (
+    <details
+      open={defaultOpen}
+      className={`rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName}`}
+      data-testid={`license-consistency-group-${classification}`}
+    >
+      <summary
+        className="flex cursor-pointer select-none items-center gap-2 px-3 py-2 text-sm font-medium text-slate-800 dark:text-slate-100"
+        aria-label={config.groupAriaLabel}
+      >
+        <span aria-hidden="true">{config.icon}</span>
+        <span>{config.label}</span>
+        <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${config.pillClassName}`}>
+          {count}
+        </span>
+      </summary>
+      <ul role="list" className="divide-y divide-slate-200 px-3 pb-2 dark:divide-slate-700">
+        {repos.map((r) => (
+          <RepoRow key={r.repo} repo={r.repo} spdxId={r.spdxId} classification={classification} />
+        ))}
+      </ul>
+    </details>
+  )
+}
+
+function RepoRow({
+  repo,
+  spdxId,
+  classification,
+}: {
+  repo: string
+  spdxId: string
+  classification: OsiClassification
+}) {
+  return (
+    <li
+      className="flex flex-wrap items-baseline justify-between gap-2 py-1.5"
+      data-testid={`license-consistency-row-${classification}`}
+    >
+      <a
+        href={`https://github.com/${repo}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm font-medium text-slate-900 hover:underline dark:text-slate-100"
+      >
+        {repo}
+      </a>
+      <span className="text-xs text-slate-500 dark:text-slate-400">{spdxId}</span>
+    </li>
+  )
+}
+
+function groupByOsi(
+  perRepo: { repo: string; spdxId: string; osiApproved: boolean }[],
+): Record<OsiClassification, { repo: string; spdxId: string; osiApproved: boolean }[]> {
+  const groups: Record<OsiClassification, { repo: string; spdxId: string; osiApproved: boolean }[]> = {
+    'non-osi': [],
+    osi: [],
+  }
+  for (const r of perRepo) {
+    groups[r.osiApproved ? 'osi' : 'non-osi'].push(r)
+  }
+  return groups
 }

--- a/lib/org-aggregation/aggregators/license-consistency.test.ts
+++ b/lib/org-aggregation/aggregators/license-consistency.test.ts
@@ -77,6 +77,11 @@ describe('licenseConsistencyAggregator — FR-022', () => {
       { spdxId: 'Apache-2.0', count: 2, osiApproved: true },
       { spdxId: 'MIT', count: 1, osiApproved: true },
     ])
+    expect(panel.value!.perRepo).toEqual([
+      { repo: 'o/alpha', spdxId: 'Apache-2.0', osiApproved: true },
+      { repo: 'o/bravo', spdxId: 'MIT', osiApproved: true },
+      { repo: 'o/charlie', spdxId: 'Apache-2.0', osiApproved: true },
+    ])
     expect(panel.value!.nonOsiCount).toBe(0)
   })
 
@@ -115,6 +120,10 @@ describe('licenseConsistencyAggregator — FR-022', () => {
     expect(panel.value!.perLicense).toEqual([
       { spdxId: 'MIT', count: 1, osiApproved: true },
       { spdxId: 'Unknown', count: 1, osiApproved: false },
+    ])
+    expect(panel.value!.perRepo).toEqual([
+      { repo: 'o/alpha', spdxId: 'MIT', osiApproved: true },
+      { repo: 'o/charlie', spdxId: 'Unknown', osiApproved: false },
     ])
     expect(panel.value!.nonOsiCount).toBe(1)
   })

--- a/lib/org-aggregation/aggregators/license-consistency.ts
+++ b/lib/org-aggregation/aggregators/license-consistency.ts
@@ -27,6 +27,7 @@ export const licenseConsistencyAggregator: Aggregator<LicenseConsistencyValue> =
   }
 
   const counts = new Map<string, { count: number; osiApproved: boolean }>()
+  const perRepo: { repo: string; spdxId: string; osiApproved: boolean }[] = []
   let contributingReposCount = 0
   let nonOsiCount = 0
 
@@ -38,6 +39,8 @@ export const licenseConsistencyAggregator: Aggregator<LicenseConsistencyValue> =
 
     const spdxId = lr.license.spdxId ?? 'Unknown'
     const osiApproved = lr.license.osiApproved
+
+    perRepo.push({ repo: r.repo, spdxId, osiApproved })
 
     const existing = counts.get(spdxId)
     if (existing) {
@@ -65,11 +68,13 @@ export const licenseConsistencyAggregator: Aggregator<LicenseConsistencyValue> =
     .map(([spdxId, { count, osiApproved }]) => ({ spdxId, count, osiApproved }))
     .sort((a, b) => b.count - a.count || a.spdxId.localeCompare(b.spdxId))
 
+  perRepo.sort((a, b) => a.repo.localeCompare(b.repo))
+
   return {
     panelId: 'license-consistency',
     contributingReposCount,
     totalReposInRun: context.totalReposInRun,
     status: 'final',
-    value: { perLicense, nonOsiCount },
+    value: { perLicense, perRepo, nonOsiCount },
   }
 }

--- a/lib/org-aggregation/aggregators/types.ts
+++ b/lib/org-aggregation/aggregators/types.ts
@@ -107,6 +107,7 @@ export type ResponsivenessRollupValue = {
 
 export type LicenseConsistencyValue = {
   perLicense: { spdxId: string; count: number; osiApproved: boolean }[]
+  perRepo: { repo: string; spdxId: string; osiApproved: boolean }[]
   nonOsiCount: number
 }
 

--- a/specs/231-org-aggregation/contracts/aggregator-contracts.ts
+++ b/specs/231-org-aggregation/contracts/aggregator-contracts.ts
@@ -82,6 +82,7 @@ export type ResponsivenessRollupValue = {
 
 export type LicenseConsistencyValue = {
   perLicense: { spdxId: string; count: number; osiApproved: boolean }[]
+  perRepo: { repo: string; spdxId: string; osiApproved: boolean }[]
   nonOsiCount: number
 }
 


### PR DESCRIPTION
## Summary

Closes #316.

- The license-consistency aggregator now carries `perRepo: { repo, spdxId, osiApproved }[]` through aggregation (in addition to the existing `perLicense` summary). Pure data-shape change — no new GraphQL fields, no new REST calls, no scoring change.
- `LicenseConsistencyPanel` renders two collapsible groups (Non-OSI-approved / OSI-approved), with one row per repo showing slug + license. Non-OSI is open by default (it's the actionable bucket); OSI collapses. Mirrors the `StaleAdminsPanel` GroupSection / pill pattern.
- Header line now reads `N of M repos contributed · K use non-OSI-approved licenses` so the count contextualizes against the org's total repos.

## Test plan

- [x] On an org with mixed licenses, the panel shows two groups (Non-OSI / OSI) with the actionable bucket open by default.
- [x] Each row shows `owner/repo` (linked to GitHub) on the left and the SPDX license on the right.
- [x] Group count pills match the number of repos inside each group.
- [x] Non-OSI group hides when zero repos are non-OSI; OSI group hides when zero repos are OSI.
- [x] All-unavailable case still renders the existing "No licensing data available." message.
- [x] `npx vitest run` — all 996 tests pass.
- [x] `npm run lint` — no new warnings or errors.
- [x] `npx tsc --noEmit` — no new type errors introduced (180 pre-existing lines unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)