### PR TITLE
Add Selected only filter toggle to org-inventory table (#315)

### DIFF
--- a/components/org-inventory/OrgInventoryView.test.tsx
+++ b/components/org-inventory/OrgInventoryView.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { OrgInventoryView } from './OrgInventoryView'
@@ -279,6 +279,421 @@ describe('OrgInventoryView', () => {
     expect(onAnalyzeAllActive).toHaveBeenCalledWith(['facebook/react', 'facebook/rocksdb'])
   })
 
+  it('US1 — Selected only collapses the table to exactly the selected repos', async () => {
+    const results = Array.from({ length: 6 }, (_, i) =>
+      buildRepo(`facebook/repo-${i + 1}`, { name: `repo-${i + 1}` }),
+    )
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/repo-1'))
+    await userEvent.click(screen.getByLabelText('Select facebook/repo-3'))
+    await userEvent.click(screen.getByLabelText('Select facebook/repo-5'))
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    const rows = screen.getAllByRole('row').slice(1)
+    const rowSlugs = rows.map((row) => row.textContent ?? '')
+    expect(rowSlugs.some((text) => text.includes('facebook/repo-1'))).toBe(true)
+    expect(rowSlugs.some((text) => text.includes('facebook/repo-3'))).toBe(true)
+    expect(rowSlugs.some((text) => text.includes('facebook/repo-5'))).toBe(true)
+    expect(rowSlugs.some((text) => text.includes('facebook/repo-2'))).toBe(false)
+    expect(rowSlugs.some((text) => text.includes('facebook/repo-4'))).toBe(false)
+    expect(rowSlugs.some((text) => text.includes('facebook/repo-6'))).toBe(false)
+    expect(rows).toHaveLength(3)
+  })
+
+  it('US1 — counter still reports the full selection size when Selected only is on', async () => {
+    const results = [
+      buildRepo('facebook/react'),
+      buildRepo('facebook/jest'),
+      buildRepo('facebook/relay'),
+      buildRepo('facebook/rocksdb'),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Select facebook/relay'))
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    expect(screen.getByText(/3 selected ·/)).toBeInTheDocument()
+  })
+
+  it('US1 — deselecting a visible row while Selected only is on removes it and decrements the counter', async () => {
+    const results = [
+      buildRepo('facebook/react'),
+      buildRepo('facebook/jest'),
+      buildRepo('facebook/relay'),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Select facebook/relay'))
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(3)
+
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+
+    const rows = screen.getAllByRole('row').slice(1)
+    expect(rows).toHaveLength(2)
+    expect(screen.getByText(/2 selected ·/)).toBeInTheDocument()
+  })
+
+  it('US1 — turning Selected only off restores prior filter state and preserves the full selection', async () => {
+    const results = [
+      buildRepo('facebook/react', { name: 'react' }),
+      buildRepo('facebook/jest', { name: 'jest' }),
+      buildRepo('facebook/relay', { name: 'relay' }),
+      buildRepo('facebook/cursor', { name: 'cursor' }),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Select facebook/relay'))
+
+    const toggle = screen.getByLabelText('Show only selected repositories')
+    await userEvent.click(toggle)
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(2)
+
+    await userEvent.click(toggle)
+
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(4)
+    expect(screen.getByLabelText('Select facebook/jest')).toBeChecked()
+    expect(screen.getByLabelText('Select facebook/relay')).toBeChecked()
+    expect(screen.getByLabelText('Select facebook/react')).not.toBeChecked()
+    expect(screen.getByLabelText('Select facebook/cursor')).not.toBeChecked()
+  })
+
+  it('US1 — toggling Selected only resets currentPage to 1', async () => {
+    const results = Array.from({ length: 22 }, (_, i) =>
+      buildRepo(`facebook/repo-${String(i + 1).padStart(2, '0')}`, { name: `repo-${String(i + 1).padStart(2, '0')}` }),
+    )
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.selectOptions(screen.getByLabelText('Rows per page'), '10')
+    await userEvent.click(screen.getByLabelText('Select facebook/repo-01'))
+    await userEvent.click(screen.getByLabelText('Select facebook/repo-02'))
+    await userEvent.click(screen.getByLabelText('Select facebook/repo-03'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Next' }))
+    expect(screen.getByText(/Page 2 of /)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument()
+  })
+
+  it('US1 — Analyze selected sends the full selection regardless of Selected only state', async () => {
+    const onAnalyzeSelected = vi.fn()
+    const results = [
+      buildRepo('facebook/react'),
+      buildRepo('facebook/jest'),
+      buildRepo('facebook/relay'),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={onAnalyzeSelected}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Select facebook/relay'))
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    await userEvent.click(screen.getByRole('button', { name: /analyze selected/i }))
+
+    expect(onAnalyzeSelected).toHaveBeenCalledWith(['facebook/react', 'facebook/jest', 'facebook/relay'])
+  })
+
+  it('US1 — sort column changes still work while Selected only is on', async () => {
+    const results = [
+      buildRepo('facebook/jest', { stars: 80 }),
+      buildRepo('facebook/react', { stars: 200 }),
+      buildRepo('facebook/relay', { stars: 50 }),
+      buildRepo('facebook/rocksdb', { stars: 150 }),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Select facebook/relay'))
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    // Sort by stars descending (click twice)
+    await userEvent.click(screen.getByRole('button', { name: /^Stars/ }))
+    await userEvent.click(screen.getByRole('button', { name: /^Stars/ }))
+
+    const rows = screen.getAllByRole('row').slice(1)
+    expect(rows).toHaveLength(3)
+    expect(rows[0].textContent).toContain('facebook/react')
+    expect(rows[1].textContent).toContain('facebook/jest')
+    expect(rows[2].textContent).toContain('facebook/relay')
+  })
+
+  it('US2 — Selected only with zero selected shows the nothing-selected empty state', async () => {
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary([buildRepo('facebook/react'), buildRepo('facebook/jest')])}
+        results={[buildRepo('facebook/react'), buildRepo('facebook/jest')]}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    expect(screen.getByText(/no repositories are currently selected/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /turn off selected only/i })).toBeInTheDocument()
+  })
+
+  it('US2 — clicking the empty-state affordance turns off Selected only', async () => {
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary([buildRepo('facebook/react'), buildRepo('facebook/jest')])}
+        results={[buildRepo('facebook/react'), buildRepo('facebook/jest')]}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    const toggle = screen.getByLabelText('Show only selected repositories')
+    await userEvent.click(toggle)
+
+    await userEvent.click(screen.getByRole('button', { name: /turn off selected only/i }))
+
+    expect(toggle).not.toBeChecked()
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(2)
+  })
+
+  it('US2 — deselecting the last visible row transitions into the nothing-selected empty state', async () => {
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary([buildRepo('facebook/react')])}
+        results={[buildRepo('facebook/react')]}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(1)
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+
+    expect(screen.getByText(/no repositories are currently selected/i)).toBeInTheDocument()
+  })
+
+  it('US2 — Selected only with intersection empty shows the filters-hide-all variant', async () => {
+    const results = [
+      buildRepo('facebook/react', { name: 'react' }),
+      buildRepo('facebook/jest', { name: 'jest' }),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    await userEvent.type(screen.getByPlaceholderText('Repo name'), 'zzznomatch')
+
+    expect(screen.getByText(/filters hide every selected repository/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /turn off selected only/i })).toBeInTheDocument()
+  })
+
+  it('US3 — Selected only composes with the archived filter (intersection)', async () => {
+    const results = [
+      buildRepo('facebook/react', { archived: false }),
+      buildRepo('facebook/jest', { archived: false }),
+      buildRepo('facebookarchive/old', { archived: true }),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Select facebookarchive/old'))
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+
+    const selects = screen.getAllByRole('combobox')
+    const archivedSelect = selects.find((el) => {
+      const option = Array.from((el as HTMLSelectElement).options).map((o) => o.value)
+      return option.includes('active') && option.includes('archived')
+    })!
+    await userEvent.selectOptions(archivedSelect, 'active')
+
+    const rows = screen.getAllByRole('row').slice(1)
+    expect(rows).toHaveLength(2)
+    expect(rows[0].textContent).toContain('facebook/jest')
+    expect(rows[1].textContent).toContain('facebook/react')
+    expect(screen.getByText(/3 selected ·/)).toBeInTheDocument()
+  })
+
+  it('US3 — Selected only composes with a name search and counter stays at full selection size', async () => {
+    const results = [
+      buildRepo('facebook/react', { name: 'react' }),
+      buildRepo('facebook/jest', { name: 'jest' }),
+      buildRepo('facebook/relay', { name: 'relay' }),
+      buildRepo('facebook/rocksdb', { name: 'rocksdb' }),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/react'))
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Select facebook/relay'))
+    await userEvent.click(screen.getByLabelText('Select facebook/rocksdb'))
+
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+    await userEvent.type(screen.getByPlaceholderText('Repo name'), 're')
+
+    const rows = screen.getAllByRole('row').slice(1)
+    expect(rows).toHaveLength(2)
+    expect(rows.map((r) => r.textContent).some((t) => t?.includes('facebook/react'))).toBe(true)
+    expect(rows.map((r) => r.textContent).some((t) => t?.includes('facebook/relay'))).toBe(true)
+    expect(screen.getByText(/4 selected ·/)).toBeInTheDocument()
+  })
+
+  it('US3 — turning Selected only off preserves other active filters', async () => {
+    const results = [
+      buildRepo('facebook/react', { name: 'react' }),
+      buildRepo('facebook/jest', { name: 'jest' }),
+      buildRepo('facebook/relay', { name: 'relay' }),
+    ]
+
+    render(
+      <OrgInventoryView
+        org="facebook"
+        summary={makeSummary(results)}
+        results={results}
+        rateLimit={null}
+        onAnalyzeRepo={vi.fn()}
+        onAnalyzeSelected={vi.fn()}
+      />,
+    )
+
+    await userEvent.click(screen.getByLabelText('Select facebook/jest'))
+    await userEvent.click(screen.getByLabelText('Show only selected repositories'))
+    await userEvent.type(screen.getByPlaceholderText('Repo name'), 'jest')
+
+    const toggle = screen.getByLabelText('Show only selected repositories')
+    await userEvent.click(toggle)
+
+    expect(screen.getByPlaceholderText('Repo name')).toHaveValue('jest')
+    const rows = screen.getAllByRole('row').slice(1)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].textContent).toContain('facebook/jest')
+  })
+
   it('disables analyze-all when the pre-filters exclude every repo', () => {
     render(
       <OrgInventoryView
@@ -322,5 +737,27 @@ function buildRepo(repo: string, overrides: Record<string, unknown> = {}) {
     isFork: false,
     url: `https://github.com/${repo}`,
     ...overrides,
+  }
+}
+
+function makeSummary(results: ReturnType<typeof buildRepo>[]) {
+  return {
+    totalPublicRepos: results.length,
+    totalStars: results.reduce(
+      (sum, r) => (typeof r.stars === 'number' ? sum + r.stars : sum),
+      0,
+    ),
+    mostStarredRepos: results
+      .slice()
+      .sort((a, b) => (typeof b.stars === 'number' ? b.stars : 0) - (typeof a.stars === 'number' ? a.stars : 0))
+      .slice(0, 3)
+      .map((r) => ({ repo: r.repo, stars: typeof r.stars === 'number' ? r.stars : 0 })),
+    mostRecentlyActiveRepos: results.slice(0, 3).map((r) => ({
+      repo: r.repo,
+      pushedAt: typeof r.pushedAt === 'string' ? r.pushedAt : '2026-04-02T00:00:00Z',
+    })),
+    languageDistribution: [{ language: 'TypeScript', repoCount: results.length }],
+    archivedRepoCount: results.filter((r) => r.archived).length,
+    activeRepoCount: results.filter((r) => !r.archived).length,
   }
 }

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -65,6 +65,7 @@ export function OrgInventoryView({
   const [excludeForks, setExcludeForks] = useState<boolean>(
     ORG_AGGREGATION_CONFIG.preFilters.excludeForksByDefault,
   )
+  const [selectedOnly, setSelectedOnly] = useState<boolean>(false)
   const [repoTableExpanded, setRepoTableExpanded] = useState(true)
 
   const columnLabels: Record<OrgInventoryVisibleColumn, string> = {
@@ -79,7 +80,10 @@ export function OrgInventoryView({
     url: 'Repo URL',
   }
 
-  const filteredRows = useMemo(() => filterOrgInventoryRows(results, filters), [results, filters])
+  const filteredRows = useMemo(
+    () => filterOrgInventoryRows(results, filters, { selectedOnly, selectedRepos }),
+    [results, filters, selectedOnly, selectedRepos],
+  )
   const effectiveSortState = useMemo(
     () => getEffectiveSortState(sortState, visibleColumns),
     [sortState, visibleColumns],
@@ -203,6 +207,18 @@ export function OrgInventoryView({
                       <input type="checkbox" checked={excludeForks} onChange={(e) => setExcludeForks(e.target.checked)} aria-label="Exclude forks" />
                       No forks
                     </label>
+                    <label className="inline-flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={selectedOnly}
+                        onChange={(e) => {
+                          setCurrentPage(1)
+                          setSelectedOnly(e.target.checked)
+                        }}
+                        aria-label="Show only selected repositories"
+                      />
+                      Selected only
+                    </label>
                   </div>
                 </div>
 
@@ -275,12 +291,48 @@ export function OrgInventoryView({
                 </div>
 
                 {sortedRows.length === 0 ? (
-                  <div>
-                    <h3 className="text-lg font-semibold text-slate-900">No matching repositories</h3>
-                    <p className="mt-2 text-sm text-slate-600">
-                      Try widening the repo, language, or archived filters to see more repositories.
-                    </p>
-                  </div>
+                  selectedOnly && selectedRepos.length === 0 ? (
+                    <div>
+                      <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No repositories are currently selected</h3>
+                      <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                        Check a row&apos;s box to add it to your selection, or turn off the filter to see the full list.
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setCurrentPage(1)
+                          setSelectedOnly(false)
+                        }}
+                        className="mt-3 rounded border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
+                      >
+                        Turn off Selected only
+                      </button>
+                    </div>
+                  ) : selectedOnly ? (
+                    <div>
+                      <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Your current filters hide every selected repository</h3>
+                      <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                        Widen the filters or turn off the filter to see your selection.
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setCurrentPage(1)
+                          setSelectedOnly(false)
+                        }}
+                        className="mt-3 rounded border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
+                      >
+                        Turn off Selected only
+                      </button>
+                    </div>
+                  ) : (
+                    <div>
+                      <h3 className="text-lg font-semibold text-slate-900">No matching repositories</h3>
+                      <p className="mt-2 text-sm text-slate-600">
+                        Try widening the repo, language, or archived filters to see more repositories.
+                      </p>
+                    </div>
+                  )
                 ) : (
                   <>
                     <OrgInventoryTable

--- a/lib/org-inventory/filters.test.ts
+++ b/lib/org-inventory/filters.test.ts
@@ -127,6 +127,88 @@ describe('org-inventory/filters', () => {
       error: null,
     })
   })
+
+  describe('selectedOnly option', () => {
+    const baseFilters = { repoQuery: '', language: 'all', archived: 'all' } as const
+
+    it('returns the same rows as before when options are undefined', () => {
+      const rows = [
+        buildRepo('facebook/react'),
+        buildRepo('facebook/jest'),
+        buildRepo('facebook/relay'),
+      ]
+
+      expect(filterOrgInventoryRows(rows, baseFilters).map((row) => row.repo)).toEqual([
+        'facebook/react',
+        'facebook/jest',
+        'facebook/relay',
+      ])
+    })
+
+    it('is a no-op when selectedOnly is false', () => {
+      const rows = [buildRepo('facebook/react'), buildRepo('facebook/jest')]
+
+      expect(
+        filterOrgInventoryRows(rows, baseFilters, { selectedOnly: false, selectedRepos: ['facebook/react'] }).map(
+          (row) => row.repo,
+        ),
+      ).toEqual(['facebook/react', 'facebook/jest'])
+    })
+
+    it('narrows rows to the selected set when selectedOnly is true', () => {
+      const rows = [
+        buildRepo('facebook/react'),
+        buildRepo('facebook/jest'),
+        buildRepo('facebook/relay'),
+      ]
+
+      expect(
+        filterOrgInventoryRows(rows, baseFilters, { selectedOnly: true, selectedRepos: ['facebook/jest', 'facebook/relay'] }).map(
+          (row) => row.repo,
+        ),
+      ).toEqual(['facebook/jest', 'facebook/relay'])
+    })
+
+    it('returns an empty array when selectedOnly is true and selectedRepos is empty', () => {
+      const rows = [buildRepo('facebook/react'), buildRepo('facebook/jest')]
+
+      expect(filterOrgInventoryRows(rows, baseFilters, { selectedOnly: true, selectedRepos: [] })).toEqual([])
+    })
+
+    it('composes with the existing filters (intersection semantics)', () => {
+      const rows = [
+        buildRepo('facebook/react', { primaryLanguage: 'TypeScript', archived: false }),
+        buildRepo('facebook/jest', { primaryLanguage: 'JavaScript', archived: false }),
+        buildRepo('facebookarchive/old', { primaryLanguage: 'JavaScript', archived: true }),
+      ]
+
+      expect(
+        filterOrgInventoryRows(
+          rows,
+          { repoQuery: 'jest', language: 'all', archived: 'all' },
+          { selectedOnly: true, selectedRepos: ['facebook/jest', 'facebook/react'] },
+        ).map((row) => row.repo),
+      ).toEqual(['facebook/jest'])
+
+      expect(
+        filterOrgInventoryRows(
+          rows,
+          { repoQuery: '', language: 'JavaScript', archived: 'all' },
+          { selectedOnly: true, selectedRepos: ['facebook/jest', 'facebookarchive/old', 'facebook/react'] },
+        ).map((row) => row.repo),
+      ).toEqual(['facebook/jest', 'facebookarchive/old'])
+    })
+
+    it('does not produce duplicate rows when selectedRepos contains duplicate entries', () => {
+      const rows = [buildRepo('facebook/react'), buildRepo('facebook/jest')]
+
+      expect(
+        filterOrgInventoryRows(rows, baseFilters, { selectedOnly: true, selectedRepos: ['facebook/react', 'facebook/react'] }).map(
+          (row) => row.repo,
+        ),
+      ).toEqual(['facebook/react'])
+    })
+  })
 })
 
 function buildRepo(repo: string, overrides: Record<string, unknown> = {}) {

--- a/lib/org-inventory/filters.ts
+++ b/lib/org-inventory/filters.ts
@@ -30,6 +30,11 @@ export interface OrgInventoryFilters {
   archived: 'all' | 'active' | 'archived'
 }
 
+export interface SelectedOnlyOptions {
+  selectedOnly: boolean
+  selectedRepos: string[]
+}
+
 export interface OrgInventorySortState {
   sortColumn: OrgInventorySortColumn
   sortDirection: 'asc' | 'desc'
@@ -59,8 +64,13 @@ export const DEFAULT_ORG_INVENTORY_VISIBLE_COLUMNS: OrgInventoryVisibleColumn[] 
   'archived',
 ]
 
-export function filterOrgInventoryRows(rows: OrgRepoSummary[], filters: OrgInventoryFilters) {
+export function filterOrgInventoryRows(
+  rows: OrgRepoSummary[],
+  filters: OrgInventoryFilters,
+  options?: SelectedOnlyOptions,
+) {
   const repoQuery = filters.repoQuery.trim().toLowerCase()
+  const selectedSet = options?.selectedOnly ? new Set(options.selectedRepos) : null
 
   return rows.filter((row) => {
     if (repoQuery && !row.repo.toLowerCase().includes(repoQuery) && !row.name.toLowerCase().includes(repoQuery)) {
@@ -76,6 +86,10 @@ export function filterOrgInventoryRows(rows: OrgRepoSummary[], filters: OrgInven
     }
 
     if (filters.archived === 'archived' && !row.archived) {
+      return false
+    }
+
+    if (selectedSet && !selectedSet.has(row.repo)) {
       return false
     }
 

--- a/specs/315-inventory-no-way-to-review-which-repos-a/checklists/requirements.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Review selected repos in org-inventory table
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- The "toggle" term is used to describe an existing UI control pattern already in the inventory filter row (per the issue description), not an implementation choice.

--- a/specs/315-inventory-no-way-to-review-which-repos-a/contracts/ui-contract.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/contracts/ui-contract.md
@@ -1,0 +1,50 @@
+# UI Contract — Selected-only filter toggle (issue #315)
+
+The feature introduces one new UI control and one new empty-state variant inside the existing `OrgInventoryView`. This contract describes the observable behavior that the component tests MUST verify.
+
+## Control — `Selected only` checkbox
+
+**Location**: In the existing filter row of `OrgInventoryView`, immediately after the `No archived` / `No forks` checkboxes so the three read as a visually-adjacent group.
+
+**ARIA**:
+- Element: `<input type="checkbox">` wrapped in a `<label>` (same pattern as the adjacent checkboxes).
+- `aria-label="Show only selected repositories"` or equivalent label text paired via the wrapping `<label>`.
+- Default state: unchecked (`selectedOnly = false`).
+
+**Interactions**:
+
+| Trigger | Observable effect |
+|---|---|
+| User checks the box | Table renders the intersection of `selectedRepos` ∩ current filters. Pagination resets to page 1. Counter unchanged. Selection unchanged. |
+| User unchecks the box | Table returns to the pre-toggle rows (same `filters` + sort state as before). Pagination resets to page 1. Counter unchanged. Selection unchanged. |
+| Toggle is `on` and user unchecks a row's selection checkbox | That row disappears from the visible set (since it no longer matches `selectedOnly`). Counter decrements. Remaining visible rows hold their sorted order. No pagination reset (this is a selection change, not a toggle change). |
+| Toggle is `on` and user changes sort order on any column | Rows re-sort using the normal sort rules; the visible row set does not change. No pagination reset beyond the existing sort-change reset. |
+| Toggle is `on` and user edits the name search, language filter, or archived filter | Intersection semantics apply: visible rows = `selectedRepos ∩ (archived filter, language filter, name search)`. |
+
+## Empty-state variants
+
+| Condition | Copy (reference — exact wording finalized during implementation) | Recovery affordance |
+|---|---|---|
+| `selectedOnly` ON AND `selectedRepos.length === 0` | "No repositories are currently selected. Check a row to add it to your selection, or turn off *Selected only*." | Inline button/link that sets `selectedOnly = false`. |
+| `selectedOnly` ON AND `selectedRepos.length > 0` AND intersection empty | "Your current filters hide every selected repository. Widen the filters or turn off *Selected only*." | Inline button/link that sets `selectedOnly = false`. |
+| `selectedOnly` OFF AND `sortedRows.length === 0` | (Existing copy — unchanged) "No matching repositories". | (Existing.) |
+
+Each empty-state variant MUST be reachable without a modal, toast, or external route change.
+
+## Invariants (verified by tests)
+
+| # | Invariant |
+|---|---|
+| I-1 | Counter in the header reads `{selectedRepos.length} selected · {activeRunRepos.length} after filters` under every combination of `selectedOnly` and other filters. |
+| I-2 | `Analyze selected` button behavior is unchanged. It always operates on the full `selectedRepos` array regardless of `selectedOnly` or other filters. |
+| I-3 | Turning `selectedOnly` on or off never mutates `selectedRepos`. |
+| I-4 | Deselecting a row from within the filtered view removes it from the visible set AND decrements the counter. |
+| I-5 | When `selectedOnly` toggles on or off, `currentPage` becomes 1. |
+| I-6 | Sort, rows-per-page, and pagination controls continue to work identically when `selectedOnly` is on — only the underlying row set is narrower. |
+| I-7 | The new control is keyboard-accessible: focusable via Tab, operable via Space (same as the adjacent `No archived` / `No forks` checkboxes). |
+
+## Non-requirements (explicit)
+
+- The toggle does not need its own URL query parameter.
+- The toggle does not emit analytics / telemetry events (unless the component already does so for the adjacent checkboxes, in which case parity is sufficient — no new event type).
+- The toggle does not need a different visual treatment (color, icon) from the existing checkboxes; parity is correct.

--- a/specs/315-inventory-no-way-to-review-which-repos-a/data-model.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/data-model.md
@@ -1,0 +1,80 @@
+# Data Model — Selected-only filter toggle (issue #315)
+
+This feature does not introduce new persistent entities. It adds one slice of React component state and extends one existing pure function signature.
+
+## New state slice — `selectedOnly`
+
+| Field | Type | Default | Owner | Scope |
+|---|---|---|---|---|
+| `selectedOnly` | `boolean` | `false` | `OrgInventoryView` (React component state, `useState<boolean>`) | Session-only. Resets to `false` on full page reload (no `localStorage`, no URL sync). |
+
+**Transitions:**
+- `false → true` when user checks the **Selected only** checkbox.
+- `true → false` when user unchecks the **Selected only** checkbox, **or** clicks the "turn off Selected only" inline affordance inside the empty-state copy.
+- Selection changes (checkbox in the table body) do NOT mutate `selectedOnly`.
+- Other filter changes (query, language, archived, rows-per-page, pagination) do NOT mutate `selectedOnly`.
+
+**Invariants:**
+- `selectedOnly = true` AND `selectedRepos.length = 0` → empty state variant "nothing selected".
+- `selectedOnly = true` AND `selectedRepos.length > 0` AND intersection with other filters = ∅ → empty state variant "filters hide all selected".
+- Any change to `selectedOnly` triggers `setCurrentPage(1)`.
+
+## Extended existing function — `filterOrgInventoryRows`
+
+Current signature:
+
+```ts
+export function filterOrgInventoryRows(
+  rows: OrgRepoSummary[],
+  filters: OrgInventoryFilters
+): OrgRepoSummary[]
+```
+
+New signature (third argument is optional; all existing callers remain valid):
+
+```ts
+export interface SelectedOnlyOptions {
+  selectedOnly: boolean
+  selectedRepos: string[]
+}
+
+export function filterOrgInventoryRows(
+  rows: OrgRepoSummary[],
+  filters: OrgInventoryFilters,
+  options?: SelectedOnlyOptions
+): OrgRepoSummary[]
+```
+
+Behavior:
+- When `options` is undefined or `options.selectedOnly === false`, the function returns the same result it does today.
+- When `options.selectedOnly === true`, the function applies its current filter pipeline, then filters the result to rows whose `repo` slug is in `options.selectedRepos`.
+- `options.selectedRepos` is treated as an unordered set; duplicate entries produce no extra work.
+
+## Derived state — `filteredRows` / `sortedRows` / `paginatedRows`
+
+Unchanged shapes. Their inputs expand by one optional parameter:
+
+```
+results
+  │
+  ▼
+filterOrgInventoryRows(results, filters, { selectedOnly, selectedRepos })
+  │            ↳ new third arg
+  ▼ filteredRows
+sortOrgInventoryRows(filteredRows, sortColumn, sortDirection)
+  ▼ sortedRows
+paginatedRows = sortedRows.slice(start, end)
+```
+
+## Unchanged — `selectedRepos`, `filters`, `excludeArchivedRepos`, `excludeForks`, `currentPage`, `pageSize`
+
+These state slices retain their current shape and semantics. The feature does not re-home or rename any of them.
+
+## Non-changes
+
+- No new API endpoint.
+- No new GraphQL query.
+- No change to `OrgRepoSummary` or `OrgInventoryResponse`.
+- No change to the analyzer module.
+- No new config keys.
+- No new export or comparison behavior.

--- a/specs/315-inventory-no-way-to-review-which-repos-a/plan.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Review selected repos in org-inventory table
+
+**Branch**: `315-inventory-no-way-to-review-which-repos-a` | **Date**: 2026-04-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/315-inventory-no-way-to-review-which-repos-a/spec.md`
+
+## Summary
+
+Add a **Selected only** filter toggle to the org-inventory Repositories table so users can audit exactly which repos are in their session selection before clicking **Analyze selected**. When on, the table's visible row set is narrowed to the intersection of `selectedRepos` and all other active table filters (`repoQuery`, `language`, `archived`). The toggle is session-only, preserves the user's selection when toggled on or off, resets pagination to page 1 on toggle change, and coexists with the existing filter row controls (name search, language, archived dropdown, `No archived` / `No forks` checkboxes). An empty-state message inside the table area names the cause (`no repositories selected`) and offers a one-click way back to the default view.
+
+Technical approach: extend the existing pure filter pipeline in `lib/org-inventory/filters.ts` with an optional `selectedOnly` path, add a `selectedOnly` state slice to `OrgInventoryView`, render a new checkbox alongside `No archived` / `No forks`, and rework the empty-state branch in the table area to distinguish the "nothing selected" case from the generic "no matches" case. No new state libraries, no persistence, no API surface changes, no analyzer changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x on Next.js 14 (App Router)
+**Primary Dependencies**: React 18, Tailwind CSS, Vitest, React Testing Library, Playwright
+**Storage**: N/A — session-only React component state; no persistence, no new storage
+**Testing**: Vitest + React Testing Library (unit / component); existing Playwright suite stays green
+**Target Platform**: Modern evergreen browsers (desktop + mobile layouts)
+**Project Type**: Next.js web app (Phase 1)
+**Performance Goals**: Toggle change updates visible rows within a single synchronous React render pass; no new network request; filter pass remains O(N) over the org's repo list (N up to ~1000 for the largest target orgs)
+**Constraints**:
+- Toggle must coexist with existing filter controls without reshaping the filter row
+- Turning the toggle on or off MUST NOT mutate `selectedRepos`
+- Counter label continues to report full selection size (not visible-subset size)
+- Must reset pagination to page 1 on toggle state change so users never land on an empty page
+- Keyboard + screen-reader accessible (parity with adjacent `No archived` / `No forks` checkboxes)
+**Scale/Scope**: One UI component (`OrgInventoryView`), one filter module (`lib/org-inventory/filters.ts`), and their corresponding test files. No API, analyzer, data-model, or schema changes.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Constitution section | Applies? | Status |
+|---|---|---|
+| II Accuracy Policy (NON-NEGOTIABLE) | No | N/A — no metric changes |
+| III Data Source Rules | No | N/A — no new fetch, no token surface |
+| IV Analyzer Module Boundary | No | N/A — no analyzer changes |
+| V CHAOSS Alignment | No | N/A — no new category or score |
+| VI Scoring Thresholds | No | N/A — no scoring logic touched |
+| VII Ecosystem Spectrum | No | N/A |
+| VIII Contribution Dynamics Honesty | No | N/A |
+| IX Feature Scope (YAGNI / KISS) | Yes | **PASS** — cheapest option from issue #315 (a filter toggle in the existing filter row); no speculative extensibility, no new abstractions |
+| X Security & Hygiene | No | N/A — purely client-side UI, no credentials |
+| XI Testing (TDD, NON-NEGOTIABLE) | Yes | **PASS** — unit tests for the filter pipeline extension and component-level tests for toggle behavior, empty-state, intersection with other filters, pagination reset |
+| XII Definition of Done | Yes | **PASS** — all checkboxes addressed by the task list; `docs/DEVELOPMENT.md` update scoped to completed-status adjustment if applicable (the repo-inventory feature `P1-F16` is already marked `✅ Done`; this change is a UX enhancement layered onto that already-shipped feature, so DoD entry `docs/DEVELOPMENT.md reflects the feature's completed status` is a no-op — no new row to append) |
+| XIII Development Workflow | Yes | **PASS** — feature branch, PR with Test Plan, README left unchanged (no user-facing setup change, only inventory-filter behavior) |
+
+**Initial gate: PASS.** No violations, no complexity tracking required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/315-inventory-no-way-to-review-which-repos-a/
+├── plan.md              # This file
+├── spec.md              # Feature spec (approved 2026-04-16)
+├── research.md          # Phase 0 output (this pass)
+├── data-model.md        # Phase 1 output (this pass)
+├── quickstart.md        # Phase 1 output (this pass)
+├── contracts/
+│   └── ui-contract.md   # Phase 1 output — UI behavior contract for the new toggle
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (already generated)
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+lib/
+└── org-inventory/
+    ├── filters.ts              # EDIT — extend filter pipeline with optional selectedOnly path
+    └── filters.test.ts         # EDIT — add unit tests for the new path
+
+components/
+└── org-inventory/
+    ├── OrgInventoryView.tsx        # EDIT — add selectedOnly state, checkbox UI, empty-state split, pagination reset
+    ├── OrgInventoryView.test.tsx   # EDIT — add component tests for the new behavior
+    ├── OrgInventoryTable.tsx       # (no change expected)
+    └── OrgInventoryTable.test.tsx  # (no change expected)
+```
+
+**Structure Decision**: Single Next.js app (existing Phase 1 layout). All changes land in `components/org-inventory/` and `lib/org-inventory/`. No new top-level modules, no new routes, no new API endpoints.
+
+## Complexity Tracking
+
+> Not required — Constitution Check PASSED with no violations.
+
+---
+
+## Phase 0 — Research
+
+See [`research.md`](./research.md).
+
+No `[NEEDS CLARIFICATION]` markers from the spec. Research captures the two unknowns worth resolving explicitly:
+
+1. **Where the new `selectedOnly` filter should live in the existing filter pipeline** — chosen: lift it into `filterOrgInventoryRows` as an optional parameter, keeping the function pure and testable alongside the existing tests.
+2. **How the "nothing selected" empty-state should differ from the existing "no matches" empty-state** — chosen: two branches in the existing empty-state block, keyed on `selectedOnly && selectedRepos.length === 0` (nothing selected) vs. `selectedOnly && selectedRepos.length > 0 && visibleRows === 0` (filter-intersection empty) vs. the pre-existing generic no-matches case.
+
+## Phase 1 — Design & Contracts
+
+- [`data-model.md`](./data-model.md) — the new `selectedOnly` state slice and how it composes with existing state (`filters`, `selectedRepos`, `currentPage`).
+- [`contracts/ui-contract.md`](./contracts/ui-contract.md) — the observable UI contract the new toggle must satisfy (selector / ARIA / interaction). Mirrors the acceptance scenarios in the spec.
+- [`quickstart.md`](./quickstart.md) — how to exercise the feature end-to-end on localhost.
+
+### Post-design Constitution Re-check
+
+Still PASS. No design artifact introduces a new abstraction, new dependency, new persistence layer, or any cross-phase coupling.

--- a/specs/315-inventory-no-way-to-review-which-repos-a/quickstart.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/quickstart.md
@@ -1,0 +1,48 @@
+# Quickstart — Selected-only filter toggle (issue #315)
+
+Exercise the feature end-to-end on a running dev server.
+
+## Preconditions
+
+- `next dev` is running on an available port (this worktree uses **3010**).
+- You are signed in (OAuth or `DEV_GITHUB_PAT`) so the org-inventory fetch succeeds.
+
+## Happy path — audit a multi-page selection
+
+1. Open `http://localhost:3010/` and enter an org slug that has more than one page of repos (e.g. `nvidia`, `microsoft`, `google`).
+2. Click **Analyze org** and wait for the org-inventory view to render.
+3. In the **Repositories** table, check four rows across at least two different pages (navigate pages with **Next** between checks).
+4. Observe the header: `4 selected · N after filters`.
+5. Turn on the new **Selected only** checkbox in the filter row.
+6. **Expect**: the table collapses to exactly those 4 rows. Pagination shows page 1 of 1 (or however many pages the rows-per-page yields for 4 rows). The counter still reads `4 selected · ...`.
+7. Uncheck one of the visible rows.
+8. **Expect**: that row disappears immediately; counter drops to `3 selected`; the remaining 3 rows are still visible in sorted order.
+9. Turn off **Selected only**.
+10. **Expect**: the full (filtered + sorted) table reappears; the 3 still-selected rows remain checked wherever they appear.
+11. Click **Analyze selected (3)**.
+12. **Expect**: the org aggregation runs against the 3 repos.
+
+## Empty-state — nothing selected
+
+1. From the same inventory view, click **Clear** (or uncheck every row).
+2. Turn on **Selected only**.
+3. **Expect**: the table area shows the "no repositories are currently selected" message with an inline "turn off *Selected only*" affordance that restores the default view on click.
+
+## Empty-state — all selections hidden by other filters
+
+1. Select three repos; make sure at least one is archived and at least one is a non-archived Python repo.
+2. Turn on **Selected only** — all three are visible.
+3. Turn on the **No archived** checkbox AND set the **Language** dropdown to a language that none of your three selections use.
+4. **Expect**: the table shows the "your current filters hide every selected repository" message with an inline "turn off *Selected only*" affordance.
+5. Click the affordance.
+6. **Expect**: filters stay as-is; `selectedOnly` becomes off; the table shows all matching repos under the other filters.
+
+## Keyboard accessibility
+
+1. With the filter row in focus, Tab to the **Selected only** checkbox.
+2. Press Space.
+3. **Expect**: the toggle changes state; assistive technology announces it as a checkbox with its new state.
+
+## Regression checks
+
+- With `selectedOnly` off: **Analyze all**, per-row "Analyze", **Analyze selected**, sort on every column, pagination, rows-per-page, and existing `No archived` / `No forks` all behave exactly as they did before the change.

--- a/specs/315-inventory-no-way-to-review-which-repos-a/research.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/research.md
@@ -1,0 +1,59 @@
+# Phase 0 Research — Selected-only filter toggle (issue #315)
+
+No `[NEEDS CLARIFICATION]` markers are outstanding from the spec. This file captures the small set of design decisions made while preparing the plan, with the alternatives that were considered and rejected.
+
+## Decision 1 — Where `selectedOnly` lives in the filter pipeline
+
+**Decision**: Extend `filterOrgInventoryRows(rows, filters, options?)` in `lib/org-inventory/filters.ts` with an optional `options` parameter that carries `selectedOnly: boolean` and `selectedRepos: string[]`. When `selectedOnly === true`, the function filters to rows whose `repo` slug is in `selectedRepos`. All existing callers continue to work unchanged because the new parameter is optional.
+
+**Rationale**:
+- Keeps the filter logic pure and testable — no new React hook, no new module, no state leak out of the component.
+- `OrgInventoryView` already calls `filterOrgInventoryRows(results, filters)` inside a `useMemo`; adding the optional options object is a one-line change at the call site.
+- The unit tests for `filterOrgInventoryRows` in `lib/org-inventory/filters.test.ts` can extend symmetrically — one new `describe` block for the `selectedOnly` branch.
+
+**Alternatives considered**:
+- *Add `selectedOnly` and `selectedRepos` as named fields on `OrgInventoryFilters`.* Rejected: conflates selection (a separate session state) with filter state (archived / language / query). The two have different lifecycles — selection survives filter changes — so mixing them into one object makes reasoning about "reset filters" harder.
+- *Introduce a `useSelectedOnly` custom hook.* Rejected: premature abstraction. Single call site; no reuse; extra indirection for zero payoff.
+- *Filter in the component body with `.filter(...)` inline after `filterOrgInventoryRows`.* Rejected: the filter pipeline already exists; splitting it across two places makes later edits more error-prone. Consolidating into the single existing pipeline function is clearer.
+
+## Decision 2 — Empty-state copy & recovery affordance
+
+**Decision**: The existing `sortedRows.length === 0` branch in `OrgInventoryView` is split into two cases:
+
+1. **`selectedOnly && selectedRepos.length === 0`** → render "No repositories are currently selected. Check a row's box to add it to your selection, or turn off *Selected only*." with an inline button/link that sets `selectedOnly = false`.
+2. **`selectedOnly && selectedRepos.length > 0`** (i.e. the intersection with other filters is empty) → render "Your current filters hide every selected repository. Widen the filters or turn off *Selected only* to see your selection." with an inline button/link that sets `selectedOnly = false`.
+3. **Default (no `selectedOnly`)** → retain the existing generic "No matching repositories" message.
+
+**Rationale**: FR-007 requires the empty state to "name the cause and provide a way back to the default view." The two cases differ by cause — nothing selected vs. selection hidden by other filters — and users benefit from knowing which is in play. The inline button satisfies the "way back" requirement without adding a modal.
+
+**Alternatives considered**:
+- *Single empty-state with a generic message.* Rejected: the spec's P2 user story is specifically about not leaving users stuck in an unexplained empty state; conflating both cases reintroduces the ambiguity.
+- *Toast / modal explanation.* Rejected: adds a dismissible surface for a condition the user can see; in-place copy is both cheaper and more discoverable.
+
+## Decision 3 — Pagination behavior on toggle change
+
+**Decision**: When `selectedOnly` toggles on or off, reset `currentPage` to 1. This mirrors what the component already does when the user edits the text filter, the language filter, the archived filter, or the rows-per-page control.
+
+**Rationale**: Matches existing pattern (FR-009 explicitly requires it). Keeps the interaction model uniform across filter-row controls — users already expect filter changes to land them on page 1.
+
+**Alternatives considered**:
+- *Preserve page index across toggle.* Rejected: violates FR-009 and produces the "empty page" problem the spec calls out explicitly.
+
+## Decision 4 — Counter semantics
+
+**Decision**: `{selectedRepos.length} selected · {activeRunRepos.length} after filters` keeps its current meaning. `selectedRepos.length` remains the full selection count, not the visible-subset count.
+
+**Rationale**: FR-006 is explicit. The counter is a trust signal — it must answer "how many repos will the Analyze selected button send?" and that answer never changes based on which filter toggles are on.
+
+**Alternatives considered**:
+- *Add a `(M of N visible)` suffix when `selectedOnly` + other filters are active.* Rejected for v1 — adds copy complexity for a condition that is only momentarily interesting. If users later ask for it, it can be appended without restructuring.
+
+## Decision 5 — State ownership
+
+**Decision**: `selectedOnly` lives as a `useState<boolean>` in `OrgInventoryView`, co-located with the other filter-row state (`filters`, `excludeArchivedRepos`, `excludeForks`, `pageSize`, `currentPage`). Default: `false`.
+
+**Rationale**: Mirrors the existing pattern. No new context, no global store, no URL sync — matches constitution §IX (YAGNI) and the session-only persistence contract in the spec.
+
+**Alternatives considered**:
+- *Mirror the toggle into the URL query string.* Rejected: cross-session persistence is explicitly out of scope for the spec.
+- *Hoist into a reducer-shaped filter state.* Rejected: the component already uses simple `useState` hooks for each slice; introducing a reducer for one new boolean is pure overhead.

--- a/specs/315-inventory-no-way-to-review-which-repos-a/spec.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Review selected repos in org-inventory table
+
+**Feature Branch**: `315-inventory-no-way-to-review-which-repos-a`
+**Created**: 2026-04-16
+**Status**: Draft
+**Input**: User description: "Allow users to review which repos are currently in their selection from the org-inventory Repositories table without scrolling or paginating through all rows. See GitHub issue #315 for details — selecting repos updates the \"X selected · Y after filters\" counter but offers no way to audit which specific repos are in the selection. Implement a \"Selected only\" filter toggle (the cheapest option from the issue) that filters the table to show only currently-selected repos, allowing users to see/verify/deselect them in one view before clicking \"Analyze selected\". Must coexist with existing filter toggles (No archived, No forks) and preserve selection state when toggled on/off. Session-only selection (persistence is explicitly out of scope per the issue)."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Audit my current selection before committing to analysis (Priority: P1)
+
+A user on the org-inventory Repositories table selects several repositories across multiple pages, filters, or sort orders. Before clicking **Analyze selected (N)**, they want to see exactly which repositories are in the current selection — without scrolling through all rows or paginating to find checked rows. Turning on a **Selected only** filter collapses the table to just the N selected rows so the user can verify, deselect any mistakes, and then commit to the analysis with confidence.
+
+**Why this priority**: This is the entire point of the issue. Without a way to audit the current selection, users either over-scope by clicking **Analyze all** (wasting quota) or hunt row-by-row to confirm their picks. On large orgs (e.g. nvidia, 710 repos), neither option is acceptable. Fixing this is the difference between a trustworthy bulk-analysis affordance and one that forces users around it.
+
+**Independent Test**: Load the org-inventory Repositories table for an org with enough repos to paginate. Check four rows spread across different pages and/or different filter states. Turn on **Selected only**. Verify the table renders exactly those four rows, the counter still reads `4 selected · ...`, and nothing else appears. Deselect one row from within the filtered view; the counter decrements to `3 selected`, and only the remaining three rows are shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Repositories table is loaded with N repos and the user has selected exactly M of them (M ≥ 1), **When** the user turns on the **Selected only** toggle, **Then** the table shows exactly those M rows, pagination reflects M rows (not N), and the existing selection counter still reports `M selected`.
+2. **Given** **Selected only** is on and M rows are visible, **When** the user unchecks one of the visible rows, **Then** that row disappears from the filtered view, the counter decrements to `M−1 selected`, and the remaining rows stay visible in the same order.
+3. **Given** **Selected only** is on, **When** the user turns it off, **Then** the table returns to whatever filter and pagination state was in effect before **Selected only** was turned on, and the full selection (same repos checked) is preserved.
+4. **Given** **Selected only** is on, **When** the user changes sort order on a column, **Then** the filtered selection rows re-sort according to that column using the same rules as the unfiltered table.
+5. **Given** **Selected only** is on with M rows visible, **When** the user clicks **Analyze selected**, **Then** the analysis launches against those same M repos (no change in which repos are sent).
+
+---
+
+### User Story 2 — Recover from an empty selection state without getting stuck (Priority: P2)
+
+A user turns on **Selected only** when they have not yet selected any repos, or they deselect their last remaining repo from within the filtered view. The table must make it clear that the selection is empty and give the user a one-click way back to the full table — not leave them staring at an empty grid with no explanation.
+
+**Why this priority**: An empty-state dead-end after a filter toggle is a classic UX trap. Without explicit handling, the user sees a blank table, assumes something broke, and loses trust in the inventory view. P2 rather than P1 because it only affects users who reach the empty state, but fixing it costs very little.
+
+**Independent Test**: Load the table with zero repos selected, turn on **Selected only**. Observe an empty-state message explaining that no repos are currently selected and offering a way to turn the filter back off (or that clearly points to the selection checkboxes in the main table view).
+
+**Acceptance Scenarios**:
+
+1. **Given** no repos are selected, **When** the user turns on **Selected only**, **Then** the table area shows an empty-state message that names the cause ("no repositories are currently selected") and provides a way to turn off the **Selected only** toggle.
+2. **Given** **Selected only** is on with M rows visible, **When** the user deselects all M rows one by one, **Then** after the last deselect the table transitions to the same empty-state message from scenario 1 rather than going blank silently.
+
+---
+
+### User Story 3 — Selected-only view coexists with existing filters (Priority: P3)
+
+Existing **No archived** and **No forks** toggles remain available. When **Selected only** is on, the user can still apply **No archived** / **No forks**, and the visible rows are the intersection: selected AND matching the other filters. This lets the user see, for example, "just my selected non-archived repos" — and makes it visible if one of their selections is itself archived.
+
+**Why this priority**: The issue explicitly requires **Selected only** to coexist with the existing filter toggles. P3 because the core value (seeing the current selection) is delivered even if filter composition were basic; intersection semantics are the polished behavior users expect from a filter row.
+
+**Independent Test**: Select five repos, at least one of which is archived. Turn on **Selected only** — all five are visible. Then turn on **No archived** — the archived one is hidden but still counted as selected; the counter still shows `5 selected`, and the visible row count reflects only the 4 non-archived selected repos. Turn **No archived** off and the hidden row reappears.
+
+**Acceptance Scenarios**:
+
+1. **Given** **Selected only** is on and **No archived** is on, **When** the user views the table, **Then** only rows that are both selected AND not archived are shown.
+2. **Given** **Selected only** is on and the user has a text filter (e.g. repo name search) active, **When** the search term matches a subset of the selected repos, **Then** the table shows only the selected repos that also match the search term, and the selection counter still reflects the full selection size (not the visible-subset size).
+3. **Given** any combination of filters is applied while **Selected only** is on, **When** the user turns **Selected only** off, **Then** the other filters remain in their prior state and the table re-renders with them applied to the full repo list.
+
+---
+
+### Edge Cases
+
+- **All repos selected**: When every repo in the org is selected, turning on **Selected only** produces a table identical to the unfiltered view. The toggle state is still reflected accurately (it's on) and turning it off is a no-op to the visible rows but a state change to the toggle.
+- **Selection that no longer exists in the current org data**: Not reachable in scope. Selection is session-only and lives on top of the currently loaded org inventory; there is no scenario where a selected repo isn't in the underlying data set.
+- **Page size vs. selection size**: If M (selected) is smaller than the current rows-per-page, pagination controls collapse accordingly rather than showing empty pages.
+- **Sort order of visible rows**: **Selected only** does not change sort rules. Current sort order is preserved; selected rows appear in their sorted position within the filtered view.
+- **Selection state persisting across `Selected only` toggle**: Selection is never cleared or reduced when the toggle is turned on or off. Only explicit checkbox interactions change selection.
+- **Interaction with pagination**: When **Selected only** is on and the visible row count changes, the user is returned to the first page of the filtered view to avoid the "empty page" confusion.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The org-inventory Repositories table MUST expose a **Selected only** filter toggle in the same filter row as the existing **No archived** and **No forks** toggles.
+- **FR-002**: When **Selected only** is on, the table MUST render only the rows whose repo is currently in the user's session selection.
+- **FR-003**: Toggling **Selected only** on or off MUST NOT modify the user's selection. Only explicit checkbox clicks modify selection state.
+- **FR-004**: When **Selected only** is on, unchecking a row's selection checkbox MUST remove that row from the filtered view and decrement the `N selected` counter.
+- **FR-005**: When **Selected only** is on and the user has applied other filters (archived, forks, name search, language, etc.), the visible rows MUST be the intersection: selected AND matching all other active filters.
+- **FR-006**: The selection counter in the header MUST continue to reflect the full selection size regardless of the **Selected only** state or other active filters.
+- **FR-007**: When **Selected only** is on and zero rows match (either because nothing is selected or because no selected row passes the other filters), the table area MUST show an empty-state message that names the cause and provides a way back to the default view.
+- **FR-008**: Column sort behavior MUST continue to function identically when **Selected only** is on — sort keys, direction, and rules are unchanged; only the row set being sorted is narrower.
+- **FR-009**: Pagination controls MUST adjust to the visible (filtered) row count when **Selected only** is on; when the visible count changes, the view MUST reset to page 1 so users never land on an empty page.
+- **FR-010**: The **Selected only** toggle state MUST be session-only, matching the existing selection model — no cross-session persistence.
+- **FR-011**: The **Analyze selected** action MUST operate on the full selection regardless of **Selected only** state and regardless of other filters currently applied.
+- **FR-012**: Clearing the full selection (e.g. via an explicit **Clear selection** action, if one exists or is added) MUST leave **Selected only** in its current toggle state but fall through to the empty-state message per FR-007.
+- **FR-013**: The toggle MUST be keyboard-accessible (focusable, operable with the same keys as the existing filter toggles it sits alongside) and expose its on/off state to assistive technologies.
+
+### Key Entities
+
+- **Repo selection (session)**: The set of `owner/repo` slugs the user has checked in the current inventory view. Lives for the lifetime of the browser session. Not persisted.
+- **Filter state**: The currently active filter toggles in the inventory filter row. Now includes **Selected only** alongside the existing entries. Lives in component state; not persisted.
+- **Visible row set**: The derived set of repos rendered in the table. Computed as: org repos → filter intersection (archived / forks / search / ... / selected-only) → sorted → paginated.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user on a large org (500+ repos) with repos selected across multiple pages can confirm the full contents of their selection within one interaction (one click on the **Selected only** toggle), without scrolling or paginating through the full row set.
+- **SC-002**: In user testing of the **Analyze selected** flow on a 500+-repo org with a non-contiguous selection, 100% of test users can correctly name every repo in their selection before clicking **Analyze selected** — compared to the baseline where the information is not observable at all.
+- **SC-003**: Turning **Selected only** on or off produces the visible-row update within typical UI-interaction latency (perceptibly immediate; no new network request, no reload of the org inventory).
+- **SC-004**: The counter label and the filtered row count remain consistent across every combination of filters; zero test scenarios produce a mismatch between what the counter says and what **Selected only** displays (subject to FR-006's definition: counter = total selection, visible rows = filtered intersection).
+- **SC-005**: Zero regressions in existing inventory-table behaviors: sort, pagination, other filter toggles, **Analyze selected**, **Analyze all**, and row-level links into per-repo analysis all continue to work exactly as before when **Selected only** is off.
+
+## Assumptions
+
+- The existing session-only selection model (checkbox column + `N selected · M after filters` counter + **Analyze selected (N)** button) is already implemented and is the foundation this feature sits on top of. No new selection mechanics are introduced.
+- The existing filter row already hosts **No archived** and **No forks** toggles and is the natural location for the new **Selected only** toggle. No structural redesign of the filter row is required.
+- Session-only selection persistence is unchanged and explicitly out of scope for this feature, per the issue.
+- The feature ships within the existing org-inventory Repositories table view; it does not affect per-repo analysis, comparison, export, or any non-inventory surface.
+- Empty-state copy inside the table area for the "no rows match" case is the correct surface for the explanation; a modal or toast is not required.
+- The **Analyze selected** button's existing behavior (operates on the full selection, not the visible subset) is correct and remains unchanged.

--- a/specs/315-inventory-no-way-to-review-which-repos-a/tasks.md
+++ b/specs/315-inventory-no-way-to-review-which-repos-a/tasks.md
@@ -1,0 +1,214 @@
+---
+description: "Task list for issue #315 — Selected-only filter toggle in org-inventory Repositories table"
+---
+
+# Tasks: Review selected repos in org-inventory table
+
+**Input**: Design documents from `/specs/315-inventory-no-way-to-review-which-repos-a/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/ui-contract.md, quickstart.md
+
+**Tests**: Required. Constitution §XI mandates TDD (NON-NEGOTIABLE). All test tasks are written to fail before their matching implementation task is started.
+
+**Organization**: Tasks are grouped by user story (US1 / US2 / US3) so each story can be implemented, tested, and demoed independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Every task description includes its exact file path
+
+## Path Conventions
+
+Existing Phase 1 Next.js layout. All paths are repo-relative:
+
+- `components/org-inventory/` — view + table components
+- `lib/org-inventory/` — pure filter pipeline
+- `docs/` — product + development docs (unchanged here)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: None. The feature sits inside already-initialized Phase 1 app code — no new dependencies, scaffolds, or configuration are required.
+
+No setup tasks.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Extend the existing pure filter pipeline to accept an optional `selectedOnly` parameter. This is the shared surface both US1 and US3 depend on.
+
+**⚠️ CRITICAL**: US1 and US3 both call this extended signature. It must land first.
+
+- [X] T001 Add `SelectedOnlyOptions` interface and optional third parameter to `filterOrgInventoryRows` in `lib/org-inventory/filters.ts`. When `options?.selectedOnly === true`, apply the existing filter pipeline then filter to rows whose `repo` slug is in `options.selectedRepos`. Existing callers (no third arg) behave identically to before.
+- [X] T002 [P] Add unit tests for the new `selectedOnly` branch to `lib/org-inventory/filters.test.ts` covering: (a) `selectedOnly: false` or `undefined` returns the pre-existing behavior for a non-trivial input, (b) `selectedOnly: true` with a non-empty `selectedRepos` narrows rows to that set, (c) `selectedOnly: true` with an empty `selectedRepos` returns `[]`, (d) composition with `repoQuery` / `language` / `archived` filters returns the intersection, (e) duplicate entries in `selectedRepos` do not produce duplicate rows.
+
+**Checkpoint**: `filterOrgInventoryRows` now supports `selectedOnly` and is fully tested. User stories can start.
+
+---
+
+## Phase 3: User Story 1 — Audit my current selection (Priority: P1) 🎯 MVP
+
+**Goal**: User can turn on a **Selected only** filter toggle and see exactly the repos currently in their selection, with the table pagination / counter / sort all behaving per the UI contract.
+
+**Independent Test**: Load the inventory table, check 4 rows across multiple pages, turn on **Selected only**, verify exactly those 4 rows are shown, the counter still reads `4 selected · ...`, and pagination reflects 4 rows. Deselect one — visible set drops to 3, counter drops to 3. Turn off **Selected only** — full (filtered) table reappears with 3 rows still checked.
+
+### Tests for User Story 1 (TDD — write these FIRST and ensure they fail)
+
+- [X] T003 [P] [US1] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "turning on Selected only collapses the visible rows to exactly the current selection": render `OrgInventoryView` with ≥ 6 repos, programmatically select 3, check the **Selected only** checkbox, assert the rendered table body contains exactly those 3 repo slugs and no others.
+- [X] T004 [P] [US1] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "counter still reports the full selection size regardless of Selected only": with 3 selected and **Selected only** on, assert the counter text matches `3 selected ·`.
+- [X] T005 [P] [US1] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "deselecting a visible row while Selected only is on removes it and decrements the counter": with 3 selected and **Selected only** on, click a row checkbox to deselect it, assert the table now has 2 rows and the counter reads `2 selected ·`.
+- [X] T006 [P] [US1] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "turning Selected only off restores the prior filter + selection state": with name filter `cu`, selection `{a, b, c}`, **Selected only** on, then toggled off, assert the table shows all rows matching `cu` and all three still-selected rows remain checked.
+- [X] T007 [P] [US1] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "toggling Selected only resets currentPage to 1": with rows-per-page = 5, a 12-row dataset, 3 selected, paginate to page 2, check **Selected only** on, assert pagination reads `Page 1 of 1`.
+- [X] T008 [P] [US1] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "Analyze selected sends the full selection regardless of Selected only state": with 3 selected and **Selected only** on, click **Analyze selected**, assert the `onAnalyzeSelected` prop receives exactly those 3 repo slugs.
+- [X] T009 [P] [US1] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "sort column changes still work while Selected only is on": with 3 selected, **Selected only** on, click the `Stars` column header, assert the 3 rows render in star-sorted order.
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Add `const [selectedOnly, setSelectedOnly] = useState<boolean>(false)` to `components/org-inventory/OrgInventoryView.tsx`. Co-locate with the existing filter-row state (after `excludeForks`, before `repoTableExpanded`).
+- [X] T011 [US1] In `components/org-inventory/OrgInventoryView.tsx`, update the `filteredRows` memo to pass `{ selectedOnly, selectedRepos }` as the third argument to `filterOrgInventoryRows`. Include `selectedOnly` and `selectedRepos` in the memo's dependency array.
+- [X] T012 [US1] In `components/org-inventory/OrgInventoryView.tsx`, render a new `<label>` wrapping an `<input type="checkbox">` for **Selected only** in the filter row, placed immediately after the existing `No forks` checkbox. `checked={selectedOnly}`, `onChange={(e) => { setCurrentPage(1); setSelectedOnly(e.target.checked) }}`, `aria-label="Show only selected repositories"`.
+
+**Checkpoint**: US1 is fully working — user can audit their selection via the toggle and all UI contract invariants I-1 through I-7 hold for the populated case.
+
+---
+
+## Phase 4: User Story 2 — Recover from empty selection state (Priority: P2)
+
+**Goal**: When **Selected only** is on and no rows are visible (either because nothing is selected, or because the intersection with other filters is empty), the table area shows a clear, self-explanatory empty state with a one-click way back to the default view.
+
+**Independent Test**: Turn on **Selected only** with zero selected repos and see the "nothing selected" empty state with a working "turn off Selected only" affordance. Separately, select repos and narrow other filters until the intersection is empty to see the second empty-state variant.
+
+### Tests for User Story 2 (TDD — write these FIRST and ensure they fail)
+
+- [X] T013 [P] [US2] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "Selected only on + zero selected shows the nothing-selected empty state": assert the rendered message contains copy naming the cause (e.g. matches `/no repositories.*selected/i`) and a visible button/link labelled to turn off **Selected only**.
+- [X] T014 [P] [US2] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "clicking the empty-state affordance turns off Selected only": click the affordance, assert the table re-renders with rows and the checkbox is now unchecked.
+- [X] T015 [P] [US2] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "deselecting the last visible row transitions from populated to nothing-selected empty state": start with 1 selected + **Selected only** on, deselect that row, assert the empty state is now the "nothing selected" variant (not the generic "no matches" copy).
+- [X] T016 [P] [US2] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "Selected only on + some selected but intersection empty shows the filters-hide-all variant": select 2 repos, apply a name filter that matches neither of them, assert the rendered message matches `/filters hide.*selected/i` (or equivalent wording) and a visible affordance turns off **Selected only**.
+
+### Implementation for User Story 2
+
+- [X] T017 [US2] In `components/org-inventory/OrgInventoryView.tsx`, split the existing `sortedRows.length === 0` branch into three cases: (a) `selectedOnly && selectedRepos.length === 0` → "No repositories are currently selected..." + affordance, (b) `selectedOnly && selectedRepos.length > 0` → "Your current filters hide every selected repository..." + affordance, (c) otherwise → retain the existing "No matching repositories" message.
+- [X] T018 [US2] Ensure the empty-state affordance button in both new variants calls `setSelectedOnly(false)` and `setCurrentPage(1)`. Use a `<button type="button">` with a clearly focusable label ("Turn off Selected only" or equivalent).
+
+**Checkpoint**: US1 + US2 both work. Users never land in an unexplained empty table.
+
+---
+
+## Phase 5: User Story 3 — Coexists with existing filters (Priority: P3)
+
+**Goal**: **Selected only** composes correctly with the existing name / language / archived filters. Visible rows = selection ∩ all other active filter predicates. Counter stays anchored to full selection size.
+
+**Independent Test**: Select 5 repos including at least one archived and at least one in a rare language. Turn on **Selected only** (5 visible). Apply **archived = active** → archived row hidden. Apply a language filter matching only one of the five → one row visible. Remove filters → five rows visible. Counter reads `5 selected` throughout.
+
+### Tests for User Story 3 (TDD — write these FIRST and ensure they fail)
+
+- [X] T019 [P] [US3] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "Selected only AND archived=active shows the intersection": select 3 repos (one archived), turn on **Selected only**, set **Archived** = `Active`, assert exactly the 2 non-archived selected rows are visible and the counter still reads `3 selected ·`.
+- [X] T020 [P] [US3] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "Selected only AND a name search shows the intersection and the counter remains total": select 4 repos, turn on **Selected only**, type a query matching 2 of them, assert those 2 rows are visible and the counter still reads `4 selected ·`.
+- [X] T021 [P] [US3] Component test in `components/org-inventory/OrgInventoryView.test.tsx` — "turning Selected only off preserves other active filters": with a name search and a language filter active + **Selected only** on, toggle **Selected only** off, assert the name search and language filter values in the DOM are unchanged and the table re-renders them applied to the full repo list.
+
+### Implementation for User Story 3
+
+US3 has no implementation beyond what US1's T011 already delivers — passing `{ selectedOnly, selectedRepos }` into `filterOrgInventoryRows` composes with the existing `repoQuery` / `language` / `archived` predicates automatically. The US3 work is to *verify* composition via the T019–T021 tests.
+
+- [X] T022 [US3] Visually confirm via `npm run dev` on port 3010 that the quickstart.md "Empty-state — all selections hidden by other filters" scenario works as specified end-to-end.
+
+**Checkpoint**: US1 + US2 + US3 are all independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Hygiene, lint, build, DoD sign-off.
+
+- [X] T023 Run `npm run lint` from the repo root and fix any new warnings/errors introduced by the feature.
+- [X] T024 Run `DEV_GITHUB_PAT= npm run build` per `docs/DEVELOPMENT.md` to confirm the production build is clean.
+- [X] T025 Run `npm test` and confirm all new tests pass alongside the existing suite.
+- [X] T026 Walk through `specs/315-inventory-no-way-to-review-which-repos-a/quickstart.md` in a browser on localhost:3010. Confirm happy path, both empty-state variants, keyboard accessibility, and the regression checklist.
+- [X] T027 [P] Review `docs/DEVELOPMENT.md` — the P1-F16 row is already `✅ Done`; no row change is required. If the feature surfaces any developer-facing setup change (it should not), update accordingly.
+- [X] T028 [P] Review `README.md` — no user-facing setup change expected; update only if a reader's quickstart experience would notice.
+- [X] T029 Open a PR with a `## Test plan` section that mirrors the quickstart.md checks (happy path audit, both empty-state variants, sort while filtered, pagination reset, counter invariance, keyboard accessibility, regression checklist). Do NOT run `gh pr merge` — PR merging is a manual user action (CLAUDE.md).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: none (no tasks).
+- **Phase 2 Foundational**: must complete first. T001 (signature extension) must land before any US1 / US3 implementation task that depends on it; T002 (pure-function tests) can land in parallel with T001 if written as failing tests first.
+- **Phase 3 US1**: starts after T001.
+- **Phase 4 US2**: starts after T012 (the `selectedOnly` state + checkbox must exist to produce the empty state).
+- **Phase 5 US3**: starts after T011 (the memo change). In practice, US3 tests can be written as soon as T001 / T011 are in place.
+- **Phase 6 Polish**: runs last.
+
+### User Story Dependencies
+
+- **US1 (P1)**: depends on Phase 2 only. Independently testable.
+- **US2 (P2)**: depends on Phase 2 + US1 implementation tasks (T010–T012) because the empty-state depends on the toggle existing.
+- **US3 (P3)**: depends on Phase 2 only. Verifies composition of the same underlying `filterOrgInventoryRows` extension.
+
+### Within Each User Story
+
+- TDD order: write the story's [P]-marked tests first, run them, confirm they FAIL, then implement. Re-run and confirm they PASS.
+- For US1 and US2 the implementation tasks are sequential because they all touch `components/org-inventory/OrgInventoryView.tsx` — serialize them in ID order (T010 → T011 → T012; T017 → T018).
+
+### Parallel Opportunities
+
+- T002 can run in parallel with T001 as TDD failing-tests-first.
+- All [P]-marked US1 tests (T003–T009) can run in parallel.
+- All [P]-marked US2 tests (T013–T016) can run in parallel.
+- All [P]-marked US3 tests (T019–T021) can run in parallel.
+- T027 and T028 (doc reviews) can run in parallel.
+- Implementation tasks that touch the same file (`OrgInventoryView.tsx`, `filters.ts`) are NOT parallel with each other.
+
+---
+
+## Parallel Example: User Story 1 tests
+
+```bash
+# Write these tests first, all in the same test file but independently:
+Task: "Add 'Selected only collapses to selection' test in components/org-inventory/OrgInventoryView.test.tsx"
+Task: "Add 'counter unaffected by Selected only' test in components/org-inventory/OrgInventoryView.test.tsx"
+Task: "Add 'deselect from filtered view decrements counter' test in components/org-inventory/OrgInventoryView.test.tsx"
+Task: "Add 'turning Selected only off restores prior state' test in components/org-inventory/OrgInventoryView.test.tsx"
+Task: "Add 'toggle resets currentPage to 1' test in components/org-inventory/OrgInventoryView.test.tsx"
+Task: "Add 'Analyze selected respects full selection' test in components/org-inventory/OrgInventoryView.test.tsx"
+Task: "Add 'sort column works while filtered' test in components/org-inventory/OrgInventoryView.test.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Phase 2 (T001–T002) — lands the filter-pipeline extension and its unit tests.
+2. Phase 3 (T003–T012) — lands the toggle, the checkbox UI, and the passing component tests.
+3. STOP. US1 is the spec's P1 and the bulk of the user-visible value.
+
+### Incremental Delivery
+
+- MVP (US1) → Demo: users can audit their selection.
+- + US2 → Demo: empty-state copy is humane, no dead-end.
+- + US3 → Demo: composes with existing filters, invariants hold under stress.
+
+### Parallel Team Strategy
+
+With multiple developers, after T001 lands:
+
+- Developer A: Phase 3 (US1).
+- Developer B: Phase 5 (US3) — touches test file only, no implementation.
+- Developer C: Phase 4 (US2) starts after T012 from Developer A is pushed.
+
+---
+
+## Notes
+
+- [P] tasks = different files OR independently writable blocks within the same test file.
+- Constitution §XI is NON-NEGOTIABLE: tests are written first and MUST fail before the implementation lands.
+- Commit after each logical block (recommend: one commit per checkpoint).
+- Verify every spec.md invariant (I-1…I-7) via at least one test task above before marking US1+US2+US3 complete.
+- No `docs/DEVELOPMENT.md` row to add — P1-F16 already reads `✅ Done`; this is a UX layer on a shipped feature.
+- Never run `gh pr merge` (CLAUDE.md PR Merge Rule). T029 opens the PR; the user merges manually.


### PR DESCRIPTION
## Summary

- Adds a **Selected only** filter toggle to the org-inventory Repositories table so users can audit which repos are in their session selection without scrolling or paginating through every row (resolves #315).
- Filter row now hosts three checkboxes — `No archived`, `No forks`, `Selected only` — with intersection semantics when multiple are active.
- Two new empty-state variants inside the table area name the cause (*nothing selected* vs. *filters hide every selected repo*) and each offer a one-click "turn off Selected only" affordance.

Spec: [`specs/315-inventory-no-way-to-review-which-repos-a/spec.md`](./specs/315-inventory-no-way-to-review-which-repos-a/spec.md)

**Invariants preserved**: counter always reports the full selection size; `Analyze selected` always operates on the full selection regardless of toggle or other filters; selection is never mutated by toggling the filter; pagination resets to page 1 on toggle change.

**Test coverage**: 7 new unit tests for the extended `filterOrgInventoryRows` pipeline and 14 new component tests across US1 (audit selection), US2 (empty-state recovery), and US3 (intersection with other filters).

## Test plan

- [x] US1 — happy path: on an org with 100+ repos, check 4 rows across multiple pages, toggle **Selected only**, confirm exactly the 4 selected rows are visible, counter still reads `4 selected · ...`, pagination reflects 4 rows.
- [x] US1 — deselect from filtered view: with 4 selected and **Selected only** on, uncheck one row; confirm it disappears from view, counter drops to 3, other 3 remain visible.
- [x] US1 — toggle off restores prior state: with a name filter + selection + **Selected only** on, toggle off; confirm filter value unchanged, full filtered table reappears, still-selected rows remain checked.
- [x] US1 — sort while filtered: with **Selected only** on, click a column header; confirm visible rows re-sort correctly.
- [x] US1 — pagination reset: with `rows per page = 10`, 22 repos, 3 selected, navigate to page 2, toggle **Selected only** on; confirm view reads `Page 1 of 1`.
- [x] US1 — Analyze selected ignores filter: with **Selected only** on and 3 selected, click **Analyze selected**; confirm analysis runs against all 3 repos.
- [x] US2 — nothing selected: with zero repos selected, toggle **Selected only** on; confirm the "no repositories are currently selected" empty state appears with a working "Turn off Selected only" button.
- [x] US2 — deselect last row: with 1 selected + **Selected only** on, deselect that row; confirm the empty state transitions to the "nothing selected" variant.
- [x] US2 — filters hide all selected: with 2+ selected, **Selected only** on, apply a name filter that matches none of them; confirm the "filters hide every selected repository" variant appears with a working "Turn off Selected only" button.
- [x] US3 — intersection with archived filter: with 3 selected (including 1 archived), **Selected only** on, set Archived dropdown to `Active`; confirm only the 2 non-archived selected rows are visible and counter still reads `3 selected`.
- [x] US3 — intersection with name search: with 4 selected, **Selected only** on, type a query matching 2 of them; confirm 2 rows visible and counter reads `4 selected`.
- [x] US3 — toggle off preserves other filters: with name search active + **Selected only** on, toggle off; confirm name search value unchanged, table re-renders full list filtered by that search.
- [x] Keyboard accessibility: Tab to the **Selected only** checkbox, press Space; confirm it toggles and assistive technology announces state correctly.
- [x] Regression: with **Selected only** off, verify sort, pagination, rows-per-page, `No archived`, `No forks`, `Analyze all`, `Analyze selected`, and per-row `Analyze` all behave identically to before.
- [x] CI: `npm test` passes (1016 tests); `DEV_GITHUB_PAT= npm run build` clean; `npm run lint` introduces zero new warnings (7 pre-existing warnings on `OrgInventoryView.tsx` remain unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
