### PR TITLE
Add collapse/expand chevron + condensed Org admin activity panel (#318)

### DIFF
--- a/components/org-summary/panels/LicenseConsistencyPanel.tsx
+++ b/components/org-summary/panels/LicenseConsistencyPanel.tsx
@@ -122,25 +122,44 @@ function GroupSection({
   return (
     <details
       open={defaultOpen}
-      className={`rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName}`}
+      className={`group rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName}`}
       data-testid={`license-consistency-group-${classification}`}
     >
       <summary
-        className="flex cursor-pointer select-none items-center gap-2 px-3 py-2 text-sm font-medium text-slate-800 dark:text-slate-100"
+        className="flex cursor-pointer select-none items-center gap-2 px-3 py-1.5 text-sm font-medium text-slate-800 list-none dark:text-slate-100 [&::-webkit-details-marker]:hidden"
         aria-label={config.groupAriaLabel}
       >
+        <GroupChevron />
         <span aria-hidden="true">{config.icon}</span>
         <span>{config.label}</span>
         <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${config.pillClassName}`}>
           {count}
         </span>
       </summary>
-      <ul role="list" className="divide-y divide-slate-200 px-3 pb-2 dark:divide-slate-700">
+      <ul role="list" className="divide-y divide-slate-200 px-3 pb-1.5 dark:divide-slate-700">
         {repos.map((r) => (
           <RepoRow key={r.repo} repo={r.repo} spdxId={r.spdxId} classification={classification} />
         ))}
       </ul>
     </details>
+  )
+}
+
+function GroupChevron() {
+  return (
+    <svg
+      aria-hidden="true"
+      data-testid="group-chevron"
+      className="h-4 w-4 shrink-0 -rotate-90 text-slate-400 transition-transform group-open:rotate-0"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        fillRule="evenodd"
+        d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z"
+        clipRule="evenodd"
+      />
+    </svg>
   )
 }
 
@@ -155,7 +174,7 @@ function RepoRow({
 }) {
   return (
     <li
-      className="flex flex-wrap items-baseline justify-between gap-2 py-1.5"
+      className="flex flex-wrap items-baseline justify-between gap-2 py-1"
       data-testid={`license-consistency-row-${classification}`}
     >
       <a

--- a/components/org-summary/panels/LicenseConsistencyPanel.tsx
+++ b/components/org-summary/panels/LicenseConsistencyPanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { LicenseConsistencyValue } from '@/lib/org-aggregation/aggregators/types'
 import { EmptyState } from '../EmptyState'
@@ -36,28 +37,61 @@ const GROUP_CONFIG: Record<
 }
 
 export function LicenseConsistencyPanel({ panel }: Props) {
+  const [expanded, setExpanded] = useState(true)
   return (
     <section
       aria-label="License consistency"
       className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
       data-testid="license-consistency-panel"
     >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">License consistency</h3>
+      <header className={`flex flex-wrap items-center justify-between gap-2 ${expanded ? 'mb-3' : ''}`}>
+        <div className="flex min-w-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            aria-label={expanded ? 'Collapse License consistency' : 'Expand License consistency'}
+            aria-expanded={expanded}
+            title={expanded ? 'Collapse' : 'Expand'}
+            data-testid="license-consistency-panel-toggle"
+            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <PanelChevron expanded={expanded} />
+          </button>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">License consistency</h3>
+        </div>
         {panel.lastUpdatedAt ? (
           <span className="text-xs text-slate-400 dark:text-slate-500">
             updated {panel.lastUpdatedAt.toLocaleTimeString()}
           </span>
         ) : null}
       </header>
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No licensing data available.</p>
-      ) : (
-        <PanelBody value={panel.value} contributingReposCount={panel.contributingReposCount} totalReposInRun={panel.totalReposInRun} />
-      )}
+      {expanded ? (
+        panel.status === 'in-progress' && !panel.value ? (
+          <EmptyState />
+        ) : panel.status === 'unavailable' || !panel.value ? (
+          <p className="text-sm text-slate-500 dark:text-slate-400">No licensing data available.</p>
+        ) : (
+          <PanelBody value={panel.value} contributingReposCount={panel.contributingReposCount} totalReposInRun={panel.totalReposInRun} />
+        )
+      ) : null}
     </section>
+  )
+}
+
+function PanelChevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`h-4 w-4 transition-transform ${expanded ? '' : '-rotate-90'}`}
+    >
+      <path d="M4 6l4 4 4-4" />
+    </svg>
   )
 }
 

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -74,7 +74,7 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     expect(badge.textContent).toMatch(/public admins only/i)
   })
 
-  it('renders a risk-first count strip summarizing every classification', () => {
+  it('shows per-group count pills matching the number of admins in each group', () => {
     const section = makeSection({
       admins: [
         mkAdmin('a1', 'active'),
@@ -86,13 +86,34 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     })
     renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
 
-    const strip = screen.getByTestId('stale-admins-count-strip')
-    expect(strip).toBeInTheDocument()
-    expect(within(strip).getByTestId('stale-admins-count-stale').textContent).toMatch(/\b1\b/)
-    expect(within(strip).getByTestId('stale-admins-count-active').textContent).toMatch(/\b2\b/)
-    expect(within(strip).getByTestId('stale-admins-count-no-public-activity').textContent).toMatch(/\b1\b/)
-    expect(within(strip).getByTestId('stale-admins-count-unavailable').textContent).toMatch(/\b1\b/)
-    expect(strip.textContent).toMatch(/5 admins/i)
+    // Standalone count strip is removed; per-group pills carry the counts.
+    expect(screen.queryByTestId('stale-admins-count-strip')).not.toBeInTheDocument()
+
+    const staleSummary = screen.getByTestId('stale-admins-group-stale').querySelector('summary')!
+    const activeSummary = screen.getByTestId('stale-admins-group-active').querySelector('summary')!
+    const noActivitySummary = screen
+      .getByTestId('stale-admins-group-no-public-activity')
+      .querySelector('summary')!
+    const unavailableSummary = screen
+      .getByTestId('stale-admins-group-unavailable')
+      .querySelector('summary')!
+
+    expect(within(staleSummary).getByText('1')).toBeInTheDocument()
+    expect(within(activeSummary).getByText('2')).toBeInTheDocument()
+    expect(within(noActivitySummary).getByText('1')).toBeInTheDocument()
+    expect(within(unavailableSummary).getByText('1')).toBeInTheDocument()
+  })
+
+  it('renders a chevron inside each group header summary', () => {
+    const section = makeSection({
+      admins: [mkAdmin('s1', 'stale'), mkAdmin('a1', 'active')],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+
+    const staleSummary = screen.getByTestId('stale-admins-group-stale').querySelector('summary')!
+    const activeSummary = screen.getByTestId('stale-admins-group-active').querySelector('summary')!
+    expect(staleSummary.querySelector('[data-testid="group-chevron"]')).not.toBeNull()
+    expect(activeSummary.querySelector('[data-testid="group-chevron"]')).not.toBeNull()
   })
 
   it('renders Stale and Unavailable groups open by default, No-public-activity and Active closed', () => {

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -104,6 +104,40 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     expect(within(unavailableSummary).getByText('1')).toBeInTheDocument()
   })
 
+  it('renders a commit-search badge with an explanatory tooltip on admins whose activity was inferred from org commit search', () => {
+    const section = makeSection({
+      admins: [
+        {
+          username: 'alice',
+          classification: 'active',
+          lastActivityAt: '2026-04-10T00:00:00Z',
+          lastActivitySource: 'public-events',
+          unavailableReason: null,
+        },
+        {
+          username: 'bob',
+          classification: 'stale',
+          lastActivityAt: '2025-09-01T00:00:00Z',
+          lastActivitySource: 'org-commit-search',
+          unavailableReason: null,
+        },
+      ],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+
+    // The stale group (bob) has a commit-search badge; the active group (alice) does not.
+    const staleGroup = screen.getByTestId('stale-admins-group-stale')
+    const activeGroup = screen.getByTestId('stale-admins-group-active')
+
+    const badge = within(staleGroup).getByTestId('stale-admin-commit-search-badge')
+    expect(badge.getAttribute('title')).toBe('Activity inferred from org commit search')
+    expect(badge.getAttribute('aria-label')).toBe('Activity inferred from org commit search')
+
+    expect(
+      within(activeGroup).queryByTestId('stale-admin-commit-search-badge'),
+    ).not.toBeInTheDocument()
+  })
+
   it('renders a chevron inside each group header summary', () => {
     const section = makeSection({
       admins: [mkAdmin('s1', 'stale'), mkAdmin('a1', 'active')],

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useAuth } from '@/components/auth/AuthContext'
 import { STALE_ADMIN_THRESHOLD_DAYS } from '@/lib/config/governance'
 import { useStaleAdmins, type OwnerType } from '@/components/shared/hooks/useStaleAdmins'
@@ -83,6 +84,7 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
 
   const section = hasOverride ? sectionOverride : hookState.section
   const loading = loadingOverride ?? (hasOverride ? false : hookState.loading)
+  const [expanded, setExpanded] = useState(true)
 
   return (
     <section
@@ -90,25 +92,58 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
       className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
       data-testid="stale-admins-panel"
     >
-      <header className="mb-3 flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="flex items-center gap-1.5">
-            <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-              Org admin activity
-            </h3>
-            <ScoringHelp section={section} />
+      <header className={`flex flex-wrap items-start justify-between gap-2 ${expanded ? 'mb-3' : ''}`}>
+        <div className="flex min-w-0 items-start gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            aria-label={expanded ? 'Collapse Org admin activity' : 'Expand Org admin activity'}
+            aria-expanded={expanded}
+            title={expanded ? 'Collapse' : 'Expand'}
+            data-testid="stale-admins-panel-toggle"
+            className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <PanelChevron expanded={expanded} />
+          </button>
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                Org admin activity
+              </h3>
+              <ScoringHelp section={section} />
+            </div>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Stale admin detection — an inactive admin is a privilege-escalation risk.
+            </p>
           </div>
-          <p className="text-xs text-slate-500 dark:text-slate-400">
-            Stale admin detection — an inactive admin is a privilege-escalation risk.
-          </p>
         </div>
         {section ? <ModeBadge mode={section.mode} /> : null}
       </header>
 
-      {loading ? <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p> : null}
-
-      {!loading && section ? <SectionBody section={section} /> : null}
+      {expanded ? (
+        <>
+          {loading ? <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p> : null}
+          {!loading && section ? <SectionBody section={section} /> : null}
+        </>
+      ) : null}
     </section>
+  )
+}
+
+function PanelChevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`h-4 w-4 transition-transform ${expanded ? '' : '-rotate-90'}`}
+    >
+      <path d="M4 6l4 4 4-4" />
+    </svg>
   )
 }
 

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -90,11 +90,14 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
       className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
       data-testid="stale-admins-panel"
     >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <div>
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-            Org admin activity
-          </h3>
+      <header className="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+              Org admin activity
+            </h3>
+            <ScoringHelp section={section} />
+          </div>
           <p className="text-xs text-slate-500 dark:text-slate-400">
             Stale admin detection — an inactive admin is a privilege-escalation risk.
           </p>
@@ -105,12 +108,24 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
       {loading ? <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p> : null}
 
       {!loading && section ? <SectionBody section={section} /> : null}
-
-      <details className="mt-4 text-xs text-slate-500 dark:text-slate-400">
-        <summary className="cursor-pointer select-none">How is this scored?</summary>
-        <ThresholdDisclosure section={section} />
-      </details>
     </section>
+  )
+}
+
+function ScoringHelp({ section }: { section: StaleAdminsSection | null }) {
+  return (
+    <details className="relative" data-testid="stale-admins-scoring-help">
+      <summary
+        aria-label="How is this scored?"
+        className="inline-flex h-4 w-4 cursor-pointer select-none items-center justify-center rounded-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-500 list-none hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200 [&::-webkit-details-marker]:hidden"
+      >
+        ?
+      </summary>
+      <div className="absolute left-0 top-6 z-10 w-72 rounded-md border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <p className="mb-1 font-medium text-slate-700 dark:text-slate-200">How is this scored?</p>
+        <ThresholdDisclosure section={section} />
+      </div>
+    </details>
   )
 }
 
@@ -141,12 +156,10 @@ function SectionBody({ section }: { section: StaleAdminsSection }) {
     )
   }
 
-  const counts = countByClassification(section.admins)
   const grouped = groupByClassification(section.admins)
 
   return (
-    <div className="space-y-3">
-      <CountStrip counts={counts} total={section.admins.length} />
+    <div className="space-y-2">
       {GROUP_ORDER.filter((c) => grouped[c].length > 0).map((classification) => (
         <GroupSection
           key={classification}
@@ -156,48 +169,6 @@ function SectionBody({ section }: { section: StaleAdminsSection }) {
         />
       ))}
     </div>
-  )
-}
-
-function CountStrip({
-  counts,
-  total,
-}: {
-  counts: Record<StaleAdminClassification, number>
-  total: number
-}) {
-  return (
-    <div
-      className="flex flex-wrap items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs dark:border-slate-700 dark:bg-slate-800"
-      data-testid="stale-admins-count-strip"
-      aria-label={`Admin summary — ${total} admins`}
-    >
-      <span className="font-medium text-slate-700 dark:text-slate-200">{total} admin{total === 1 ? '' : 's'}</span>
-      <span className="text-slate-300 dark:text-slate-600">·</span>
-      {GROUP_ORDER.map((c) => (
-        <CountPill key={c} classification={c} count={counts[c]} />
-      ))}
-    </div>
-  )
-}
-
-function CountPill({
-  classification,
-  count,
-}: {
-  classification: StaleAdminClassification
-  count: number
-}) {
-  const config = GROUP_CONFIG[classification]
-  const dim = count === 0
-  return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium ${config.pillClassName} ${dim ? 'opacity-40' : ''}`}
-      data-testid={`stale-admins-count-${classification}`}
-    >
-      <span aria-hidden="true">{config.icon}</span>
-      {count} {config.label.toLowerCase()}
-    </span>
   )
 }
 
@@ -214,20 +185,21 @@ function GroupSection({
   return (
     <details
       open={defaultOpen}
-      className={`rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName}`}
+      className={`group rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName}`}
       data-testid={`stale-admins-group-${classification}`}
     >
       <summary
-        className="flex cursor-pointer select-none items-center gap-2 px-3 py-2 text-sm font-medium text-slate-800 dark:text-slate-100"
+        className="flex cursor-pointer select-none items-center gap-2 px-3 py-1.5 text-sm font-medium text-slate-800 list-none dark:text-slate-100 [&::-webkit-details-marker]:hidden"
         aria-label={config.groupAriaLabel}
       >
+        <GroupChevron />
         <span aria-hidden="true">{config.icon}</span>
         <span>{config.label}</span>
         <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${config.pillClassName}`}>
           {admins.length}
         </span>
       </summary>
-      <ul role="list" className="divide-y divide-slate-200 px-3 pb-2 dark:divide-slate-700">
+      <ul role="list" className="divide-y divide-slate-200 px-3 pb-1.5 dark:divide-slate-700">
         {admins.map((admin) => (
           <AdminRow key={admin.username} admin={admin} />
         ))}
@@ -236,10 +208,28 @@ function GroupSection({
   )
 }
 
+function GroupChevron() {
+  return (
+    <svg
+      aria-hidden="true"
+      data-testid="group-chevron"
+      className="h-4 w-4 shrink-0 -rotate-90 text-slate-400 transition-transform group-open:rotate-0"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        fillRule="evenodd"
+        d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
+
 function AdminRow({ admin }: { admin: StaleAdminRecord }) {
   return (
     <li
-      className="flex flex-wrap items-baseline justify-between gap-2 py-1.5"
+      className="flex flex-wrap items-baseline justify-between gap-2 py-1"
       data-testid={`stale-admin-row-${admin.classification}`}
     >
       <a
@@ -258,10 +248,19 @@ function AdminRow({ admin }: { admin: StaleAdminRecord }) {
 function RowDetail({ admin }: { admin: StaleAdminRecord }) {
   if (admin.lastActivityAt) {
     return (
-      <span className="text-xs text-slate-500 dark:text-slate-400">
-        Last public activity: {admin.lastActivityAt.slice(0, 10)} ({formatRelative(admin.lastActivityAt)})
+      <span className="inline-flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
+        <span>
+          Last public activity: {admin.lastActivityAt.slice(0, 10)} ({formatRelative(admin.lastActivityAt)})
+        </span>
         {admin.lastActivitySource === 'org-commit-search' ? (
-          <span className="ml-1 text-slate-400">(commit search)</span>
+          <span
+            aria-label="Activity inferred from org commit search"
+            title="Activity inferred from org commit search"
+            className="inline-flex h-3.5 w-3.5 shrink-0 cursor-help items-center justify-center rounded-full border border-slate-300 text-[9px] text-slate-400 dark:border-slate-600 dark:text-slate-500"
+            data-testid="stale-admin-commit-search-badge"
+          >
+            c
+          </span>
         ) : null}
       </span>
     )
@@ -344,17 +343,6 @@ function formatRelative(iso: string | null): string {
   if (days < 30) return `${days} days ago`
   if (days < 365) return `${Math.floor(days / 30)} months ago`
   return `${Math.floor(days / 365)} years ago`
-}
-
-function countByClassification(admins: StaleAdminRecord[]): Record<StaleAdminClassification, number> {
-  const counts: Record<StaleAdminClassification, number> = {
-    active: 0,
-    stale: 0,
-    'no-public-activity': 0,
-    unavailable: 0,
-  }
-  for (const a of admins) counts[a.classification]++
-  return counts
 }
 
 function groupByClassification(


### PR DESCRIPTION
## Summary

Closes #318.

- Adds a panel-level collapse/expand chevron to the left of the title in both `StaleAdminsPanel` (Org admin activity) and `LicenseConsistencyPanel`, matching the `RunStatusHeader` pattern (aria-expanded + rotated chevron SVG). Panel defaults to expanded; when collapsed, only the header row is visible.
- Adds a group-level chevron (▶ collapsed, ▼ expanded) to every group header in both panels so the collapse/expand affordance is discoverable without hovering.
- Condenses the Org admin activity panel:
  - drops the standalone count strip (per-group count pills were already carrying the same information)
  - tightens summary padding (`py-2` → `py-1.5`) and row padding (`py-1.5` → `py-1`)
  - collapses the inline `(commit search)` annotation into a small `c` badge with a tooltip
  - moves `How is this scored?` from a footer disclosure to a `(?)` icon next to the panel title (content unchanged)
- Same chevron + padding tightening applied to `LicenseConsistencyPanel` — both panels share the same GroupSection skeleton.

## Test plan

- [x] `Org admin activity` panel shows a panel-level chevron next to its title; clicking it collapses and re-expands the panel body (groups + mode badge area stays visible in header).
- [x] `License consistency` panel shows the same panel-level chevron toggle.
- [x] Each group header inside both panels still shows a `▶ / ▼` chevron that toggles the group body independently of the panel-level toggle.
- [x] Stale and Unavailable groups still open by default; No public activity and Active still start collapsed.
- [x] Per-group count pill matches the number of admins inside the group; the old stand-alone count strip is gone.
- [x] For an admin whose activity was derived from `org-commit-search`, the row shows a small `c` badge next to the date and its tooltip reads "Activity inferred from org commit search". — covered by `components/org-summary/panels/StaleAdminsPanel.test.tsx` → *"renders a commit-search badge with an explanatory tooltip on admins whose activity was inferred from org commit search"* (asserts `title` and `aria-label` equal `"Activity inferred from org commit search"`, and that the badge is absent for `public-events` admins).
- [x] Clicking the `(?)` icon next to the "Org admin activity" title reveals the threshold / public-only / eventually-consistent disclosure with the same text as before.
- [x] `npx vitest run` — all 1017 tests pass.
- [x] `npm run lint` — no new warnings introduced.
- [x] `npx tsc --noEmit` — no new type errors (pre-existing failures on `main` are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)