### PR TITLE
Clarify inclusive naming panel tier labels and counts (#323)

### DIFF
--- a/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
+++ b/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
@@ -2,6 +2,7 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { InclusiveNamingRollupValue } from '@/lib/org-aggregation/aggregators/types'
+import { HelpLabel } from '@/components/shared/HelpLabel'
 import { EmptyState } from '../EmptyState'
 
 interface Props { panel: AggregatePanel<InclusiveNamingRollupValue> }
@@ -75,13 +76,8 @@ function Stat({
   const toneClass = tone === 'good' ? 'text-emerald-700 dark:text-emerald-400' : tone === 'bad' ? 'text-rose-700 dark:text-rose-400' : tone === 'warn' ? 'text-amber-700 dark:text-amber-400' : 'text-slate-900 dark:text-slate-100'
   return (
     <div>
-      <dt
-        className="flex items-center gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
-        title={tooltip}
-      >
-        <span>{label}</span>
-        <span aria-hidden="true" className="cursor-help text-slate-400 dark:text-slate-500">(?)</span>
-        <span className="sr-only">{tooltip}</span>
+      <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <HelpLabel label={label} helpText={tooltip} />
       </dt>
       <dd className={`text-lg font-semibold ${toneClass}`}>
         {value}

--- a/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
+++ b/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
@@ -6,6 +6,12 @@ import { EmptyState } from '../EmptyState'
 
 interface Props { panel: AggregatePanel<InclusiveNamingRollupValue> }
 
+const TIER_TOOLTIPS = {
+  tier1: 'Tier 1 — "Replace immediately". Exclusionary terminology (e.g. master, whitelist, blacklist). Counted per occurrence across default branches, descriptions, and topics.',
+  tier2: 'Tier 2 — "Recommended to replace". Terminology with non-inclusive connotations (e.g. sanity-check). Counted per occurrence across default branches, descriptions, and topics.',
+  tier3: 'Tier 3 — "Consider replacing". Context-dependent terminology (e.g. man-in-the-middle, segregate). Counted per occurrence across default branches, descriptions, and topics.',
+} as const
+
 export function InclusiveNamingRollupPanel({ panel }: Props) {
   return (
     <section aria-label="Inclusive naming" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
@@ -17,24 +23,74 @@ export function InclusiveNamingRollupPanel({ panel }: Props) {
         <p className="text-sm text-slate-500 dark:text-slate-400">No inclusive naming data available.</p>
       ) : (
         <>
-          <dl className="mb-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <Stat label="Tier 1" value={panel.value.tier1} tone={panel.value.tier1 > 0 ? 'bad' : 'good'} />
-            <Stat label="Tier 2" value={panel.value.tier2} tone={panel.value.tier2 > 0 ? 'warn' : 'good'} />
-            <Stat label="Tier 3" value={panel.value.tier3} tone="neutral" />
-            <Stat label="Repos with violations" value={panel.value.reposWithAnyViolation} tone={panel.value.reposWithAnyViolation > 0 ? 'warn' : 'good'} />
+          <dl className="mb-2 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat
+              label="Tier 1 violations"
+              tooltip={TIER_TOOLTIPS.tier1}
+              value={panel.value.tier1}
+              tone={panel.value.tier1 > 0 ? 'bad' : 'good'}
+            />
+            <Stat
+              label="Tier 2 violations"
+              tooltip={TIER_TOOLTIPS.tier2}
+              value={panel.value.tier2}
+              tone={panel.value.tier2 > 0 ? 'warn' : 'good'}
+            />
+            <Stat
+              label="Tier 3 violations"
+              tooltip={TIER_TOOLTIPS.tier3}
+              value={panel.value.tier3}
+              tone="neutral"
+            />
+            <Stat
+              label="Repos with violations"
+              tooltip={`${panel.value.reposWithAnyViolation} of ${panel.contributingReposCount} scanned ${panel.contributingReposCount === 1 ? 'repo' : 'repos'} have at least one Tier 1–3 violation.`}
+              value={panel.value.reposWithAnyViolation}
+              denominator={panel.contributingReposCount}
+              tone={panel.value.reposWithAnyViolation > 0 ? 'warn' : 'good'}
+            />
           </dl>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Tier counts are violation occurrences (one repo can contribute multiple). Hover each label for the tier definition.
+          </p>
         </>
       )}
     </section>
   )
 }
 
-function Stat({ label, value, tone }: { label: string; value: number; tone: 'good' | 'warn' | 'bad' | 'neutral' }) {
+function Stat({
+  label,
+  tooltip,
+  value,
+  denominator,
+  tone,
+}: {
+  label: string
+  tooltip: string
+  value: number
+  denominator?: number
+  tone: 'good' | 'warn' | 'bad' | 'neutral'
+}) {
   const toneClass = tone === 'good' ? 'text-emerald-700 dark:text-emerald-400' : tone === 'bad' ? 'text-rose-700 dark:text-rose-400' : tone === 'warn' ? 'text-amber-700 dark:text-amber-400' : 'text-slate-900 dark:text-slate-100'
   return (
     <div>
-      <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
-      <dd className={`text-lg font-semibold ${toneClass}`}>{value}</dd>
+      <dt
+        className="flex items-center gap-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400"
+        title={tooltip}
+      >
+        <span>{label}</span>
+        <span aria-hidden="true" className="cursor-help text-slate-400 dark:text-slate-500">(?)</span>
+        <span className="sr-only">{tooltip}</span>
+      </dt>
+      <dd className={`text-lg font-semibold ${toneClass}`}>
+        {value}
+        {denominator !== undefined ? (
+          <span className="ml-1 text-sm font-normal text-slate-500 dark:text-slate-400">
+            / {denominator}
+          </span>
+        ) : null}
+      </dd>
     </div>
   )
 }

--- a/components/shared/HelpLabel.tsx
+++ b/components/shared/HelpLabel.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useRef, useState } from 'react'
+
 interface HelpLabelProps {
   label: string
   helpText?: string
@@ -7,27 +9,74 @@ interface HelpLabelProps {
 }
 
 export function HelpLabel({ label, helpText, className }: HelpLabelProps) {
+  const [open, setOpen] = useState(false)
+  const wrapperRef = useRef<HTMLSpanElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onDocClick(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
   return (
     <span className={className ? className : 'inline-flex items-center gap-1'}>
       <span>{label}</span>
       {helpText ? (
-        <span
-          tabIndex={0}
-          title={helpText}
-          aria-label={`${label}. ${helpText}`}
-          className="inline-flex h-4.5 w-4.5 shrink-0 cursor-help items-center justify-center rounded-full border border-slate-300 bg-white text-slate-500 align-middle"
-        >
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 16 16"
-            className="h-3 w-3"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
+        <span ref={wrapperRef} className="relative inline-flex">
+          <span
+            role="button"
+            tabIndex={0}
+            title={helpText}
+            aria-label={`${label}. ${helpText}`}
+            aria-expanded={open}
+            onMouseEnter={() => setOpen(true)}
+            onMouseLeave={() => setOpen(false)}
+            onFocus={() => setOpen(true)}
+            onBlur={() => setOpen(false)}
+            onClick={(e) => {
+              e.preventDefault()
+              setOpen((v) => !v)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                setOpen((v) => !v)
+              }
+            }}
+            className="inline-flex h-4 w-4 shrink-0 cursor-help items-center justify-center rounded-full border border-slate-300 bg-white text-slate-500 align-middle hover:border-slate-400 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200"
           >
-            <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.5" />
-            <circle cx="8" cy="4.75" r="0.75" fill="currentColor" />
-            <path d="M8 7V11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          </svg>
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 16 16"
+              className="h-3 w-3"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.5" />
+              <circle cx="8" cy="4.75" r="0.75" fill="currentColor" />
+              <path d="M8 7V11" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </span>
+          {open ? (
+            <span
+              role="tooltip"
+              className="pointer-events-none absolute left-1/2 top-full z-20 mt-1 w-64 -translate-x-1/2 rounded-md border border-slate-200 bg-white p-2 text-xs font-normal normal-case tracking-normal text-slate-700 shadow-lg dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+            >
+              {helpText}
+            </span>
+          ) : null}
         </span>
       ) : null}
     </span>


### PR DESCRIPTION
## Summary
- Rename Tier 1/2/3 stats to "Tier N **violations**" so the unit is explicit (per issue #323, counts are violation occurrences, not repos).
- Add a `(?)` tooltip on each tier label with the Inclusive Naming Initiative definition pulled from the spec (Tier 1 = "Replace immediately", Tier 2 = "Recommended to replace", Tier 3 = "Consider replacing").
- Show "Repos with violations" as `N / total` against the contributing-repo count so the reader can reconcile it with the scan.
- Add a short footnote clarifying that tier counts are occurrence-based and can exceed the repo count.
- Upgrade `HelpLabel` so its tooltip renders as a real visible popup on hover/focus/click (native `title` was unreliable) — fixes tooltip behavior across every panel that uses it.

Closes #323.

## Scope
Presentation-only: touches `components/org-summary/panels/InclusiveNamingRollupPanel.tsx` and `components/shared/HelpLabel.tsx`. No changes to tier classification, the word list, or what passes vs. fails — explicit non-goals in the issue.

## Test plan
- [x] Type-check: `npx tsc --noEmit` shows no new errors from the panel or HelpLabel file.
- [x] Lint: `npx eslint` passes on both changed files.
- [x] Aggregator tests: `npx vitest run lib/org-aggregation/aggregators/inclusive-naming-rollup.test.ts` passes (4/4).
- [x] HelpLabel tests: `npx vitest run components/shared/HelpLabel.test.tsx` passes (2/2).
- [x] Manual: tier stats read "Tier N violations" with a (?) icon whose tooltip popup shows the definition.
- [x] Manual: "Repos with violations" renders as `N / total` and matches `contributingReposCount`.
- [x] Manual: footnote renders below the stat grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)