### PR TITLE
Clarify inactive-repos panel copy to name default-branch signal (#300)

### DIFF
--- a/components/org-summary/panels/InactiveReposPanel.test.tsx
+++ b/components/org-summary/panels/InactiveReposPanel.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { InactiveReposPanel } from './InactiveReposPanel'
+import type { AggregatePanel } from '@/lib/org-aggregation/types'
+import type { InactiveReposValue } from '@/lib/org-aggregation/aggregators/types'
+
+function makePanel(override: Partial<AggregatePanel<InactiveReposValue>> = {}): AggregatePanel<InactiveReposValue> {
+  return {
+    panelId: 'inactive-repos',
+    contributingReposCount: 3,
+    totalReposInRun: 3,
+    status: 'final',
+    value: { windowMonths: 12, repos: [] },
+    ...override,
+  }
+}
+
+describe('InactiveReposPanel — honest labeling (issue #300)', () => {
+  it('header subtitle clarifies default-branch scope and flags the pushed_at gap', () => {
+    render(<InactiveReposPanel panel={makePanel()} />)
+    // Subtitle names the signal precisely.
+    expect(
+      screen.getByText(/no commits on the default branch in the last 90 days/i),
+    ).toBeInTheDocument()
+    // Subtitle explains why the inventory's "Last pushed" can disagree.
+    expect(screen.getByText(/Last pushed/i)).toBeInTheDocument()
+  })
+
+  it('inactive count sentence says "default branch", not a bare "no commits"', () => {
+    const panel = makePanel({
+      value: {
+        windowMonths: 12,
+        repos: [{ repo: 'vercel/hyper', lastCommitAt: null }],
+      },
+    })
+    render(<InactiveReposPanel panel={panel} />)
+    expect(
+      screen.getByText(
+        /1 repo\(s\) with no commits on the default branch in the last 90 days/i,
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByText('vercel/hyper')).toBeInTheDocument()
+  })
+
+  it('empty-state sentence also scopes to default-branch activity', () => {
+    render(<InactiveReposPanel panel={makePanel()} />)
+    expect(
+      screen.getByText(/all repos have recent default-branch commit activity/i),
+    ).toBeInTheDocument()
+  })
+
+  it('unavailable status renders the neutral fallback', () => {
+    render(
+      <InactiveReposPanel
+        panel={makePanel({ status: 'unavailable', value: null })}
+      />,
+    )
+    expect(screen.getByText(/no activity data available/i)).toBeInTheDocument()
+  })
+})

--- a/components/org-summary/panels/InactiveReposPanel.tsx
+++ b/components/org-summary/panels/InactiveReposPanel.tsx
@@ -9,17 +9,24 @@ interface Props { panel: AggregatePanel<InactiveReposValue> }
 export function InactiveReposPanel({ panel }: Props) {
   return (
     <section aria-label="Inactive repos" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Inactive repos</h3>
+      <header className="mb-3 flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Inactive repos</h3>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Repos with no commits on the default branch in the last 90 days. Pushes to other branches (release tags, maintenance branches, dependabot PRs) are not counted, so a repo flagged here may still show a recent <code className="rounded bg-slate-100 px-1 py-0.5 text-[11px] dark:bg-slate-800">Last pushed</code> date in the inventory.
+          </p>
+        </div>
         {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
       </header>
       {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
         <p className="text-sm text-slate-500 dark:text-slate-400">No activity data available.</p>
       ) : panel.value.repos.length === 0 ? (
-        <p className="text-sm text-emerald-700 dark:text-emerald-400">All repos have recent commit activity.</p>
+        <p className="text-sm text-emerald-700 dark:text-emerald-400">All repos have recent default-branch commit activity.</p>
       ) : (
         <>
-          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400">{panel.value.repos.length} repo(s) with no commits in 90 days</p>
+          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400">
+            {panel.value.repos.length} repo(s) with no commits on the default branch in the last 90 days
+          </p>
           <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
             {panel.value.repos.map((r) => (
               <li key={r.repo} className="py-2 text-sm text-slate-800 dark:text-slate-200">{r.repo}</li>


### PR DESCRIPTION
## Summary
- Issue #300: The Inactive repos panel flagged `vercel/hyper` as "1 repo(s) with no commits in 90 days" while the inventory on the same page showed `Last pushed: 3 days ago`. Both were technically correct — `commits90d` counts default-branch commits only, while GitHub's `pushed_at` reflects pushes to any ref (release tags, maintenance branches, dependabot PRs). The contradiction was a copy bug.
- Panel now says **"no commits on the default branch in the last 90 days"** and carries a header subtitle explaining why a flagged repo can still show a recent `Last pushed` date in the inventory. Same fix applied to the "all repos fresh" empty state.
- Underlying `inactiveReposAggregator` signal is unchanged (out-of-scope per the issue). Locked the copy in with a small component test.

## Test plan
- [x] Unit test `components/org-summary/panels/InactiveReposPanel.test.tsx` passes (`npx vitest run components/org-summary/panels/InactiveReposPanel.test.tsx`)
- [x] Existing aggregator tests still green (`npx vitest run lib/org-aggregation/aggregators/inactive-repos`)
- [x] Manual: open an org summary with a repo that has zero default-branch commits in 90 days — verify the panel now reads "no commits on the default branch in the last 90 days" and the subtitle explains the `Last pushed` divergence
- [x] Manual: open an org summary where all repos have recent commits — verify the empty state reads "All repos have recent default-branch commit activity."
- [x] Lint clean for the two touched files (`npm run lint` — pre-existing warnings elsewhere, 0 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)