### PR TITLE
Fix low-quality DOC-106 'Add governance' recommendation (#310)

### DIFF
--- a/lib/documentation/score-config.test.ts
+++ b/lib/documentation/score-config.test.ts
@@ -102,6 +102,43 @@ describe('documentation/score-config', () => {
       expect(items).not.toContain('license')
     })
 
+    it('emits a concrete governance recommendation with non-zero weight when GOVERNANCE.md is missing', () => {
+      const score = getDocumentationScore(buildDocResult({
+        fileChecks: [
+          { name: 'readme', found: true, path: 'README.md' },
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: true, path: 'CONTRIBUTING.md' },
+          { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+          { name: 'security', found: true, path: 'SECURITY.md' },
+          { name: 'changelog', found: true, path: 'CHANGELOG.md' },
+          { name: 'governance', found: false, path: null },
+        ],
+      }), fullLicensing, 1000)
+
+      const governanceRec = score.recommendations.find((r) => r.category === 'file' && r.item === 'governance')
+      expect(governanceRec).toBeDefined()
+      expect(governanceRec!.text).toContain('GOVERNANCE.md')
+      expect(governanceRec!.text).not.toBe('Add governance')
+      expect(governanceRec!.weight).toBeGreaterThan(0)
+    })
+
+    it('suppresses the governance recommendation when GOVERNANCE.md is present', () => {
+      const score = getDocumentationScore(buildDocResult({
+        fileChecks: [
+          { name: 'readme', found: true, path: 'README.md' },
+          { name: 'license', found: true, path: 'LICENSE' },
+          { name: 'contributing', found: true, path: 'CONTRIBUTING.md' },
+          { name: 'code_of_conduct', found: true, path: 'CODE_OF_CONDUCT.md' },
+          { name: 'security', found: true, path: 'SECURITY.md' },
+          { name: 'changelog', found: true, path: 'CHANGELOG.md' },
+          { name: 'governance', found: true, path: 'GOVERNANCE.md' },
+        ],
+      }), fullLicensing, 1000)
+
+      const governanceRec = score.recommendations.find((r) => r.category === 'file' && r.item === 'governance')
+      expect(governanceRec).toBeUndefined()
+    })
+
     it('generates recommendations for each missing README section', () => {
       const score = getDocumentationScore(buildDocResult({
         readmeSections: [

--- a/lib/documentation/score-config.ts
+++ b/lib/documentation/score-config.ts
@@ -38,6 +38,7 @@ const FILE_WEIGHTS: Record<string, number> = {
   // for fully-documented repos.
   issue_templates: 0.05,
   pull_request_template: 0.05,
+  governance: 0.05,
 }
 
 const FILE_RECOMMENDATIONS: Record<string, string> = {
@@ -49,6 +50,7 @@ const FILE_RECOMMENDATIONS: Record<string, string> = {
   changelog: 'Add a changelog (e.g. CHANGELOG.md) to help users understand what changed between releases',
   issue_templates: 'Add an issue template in .github/ISSUE_TEMPLATE/ to structure bug reports and feature requests',
   pull_request_template: 'Add a PULL_REQUEST_TEMPLATE.md to guide contributors through your PR checklist',
+  governance: 'Add a governance document (e.g. GOVERNANCE.md) to describe project decision-making, maintainer roles, and escalation paths',
 }
 
 const SECTION_WEIGHTS: Record<string, number> = {

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -50,12 +50,12 @@ describe('RECOMMENDATION_CATALOG', () => {
     expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Contributors')).toHaveLength(7)
   })
 
-  it('has 16 documentation entries', () => {
-    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Documentation')).toHaveLength(16)
+  it('has 17 documentation entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Documentation')).toHaveLength(17)
   })
 
-  it('has 4 community-tagged entries', () => {
-    expect(RECOMMENDATION_CATALOG.filter((e) => (e.tags ?? []).includes('community'))).toHaveLength(4)
+  it('has 5 community-tagged entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => (e.tags ?? []).includes('community'))).toHaveLength(5)
   })
 })
 
@@ -107,7 +107,7 @@ describe('getCatalogEntriesByTag', () => {
     const ids = governance.map((e) => e.id).sort()
     expect(ids).toEqual([
       'CTR-2', 'CTR-3', 'CTR-4',
-      'DOC-12', 'DOC-13', 'DOC-14',
+      'DOC-12', 'DOC-13', 'DOC-14', 'DOC-17',
       'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
       'SEC-14', 'SEC-17', 'SEC-3', 'SEC-5',
     ])
@@ -125,7 +125,7 @@ describe('getCatalogEntriesByTag', () => {
     const entries = getCatalogEntriesByTag('quick-win')
     const ids = entries.map((e) => e.id).sort()
     expect(ids).toEqual([
-      'DOC-1', 'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
+      'DOC-1', 'DOC-17', 'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
       'SEC-14', 'SEC-16', 'SEC-6',
     ])
   })
@@ -154,7 +154,7 @@ describe('getCatalogEntriesByTag', () => {
   it('returns community-tagged entries', () => {
     const entries = getCatalogEntriesByTag('community')
     const ids = entries.map((e) => e.id).sort()
-    expect(ids).toEqual(['ACT-5', 'CTR-3', 'DOC-15', 'DOC-16'])
+    expect(ids).toEqual(['ACT-5', 'CTR-3', 'DOC-15', 'DOC-16', 'DOC-17'])
   })
 
   it('entries with multiple tags return for each tag', () => {

--- a/lib/recommendations/__tests__/reference-id.test.ts
+++ b/lib/recommendations/__tests__/reference-id.test.ts
@@ -49,6 +49,7 @@ describe('resolveReferenceId', () => {
     expect(resolveReferenceId('file:readme', 'Documentation', 1)).toBe('DOC-1')
     expect(resolveReferenceId('section:usage', 'Documentation', 1)).toBe('DOC-9')
     expect(resolveReferenceId('licensing:dco_cla', 'Documentation', 1)).toBe('DOC-14')
+    expect(resolveReferenceId('file:governance', 'Documentation', 99)).toBe('DOC-17')
   })
 
   it('falls back to sequential ID for unknown keys', () => {

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -112,6 +112,7 @@ const DOC: CatalogEntry[] = [
   // Community templates
   { id: 'DOC-15', bucket: 'Documentation', key: 'file:issue_templates', title: 'Add an issue template in .github/ISSUE_TEMPLATE/', tags: ['community', 'contrib-ex'] },
   { id: 'DOC-16', bucket: 'Documentation', key: 'file:pull_request_template', title: 'Add a PULL_REQUEST_TEMPLATE.md', tags: ['community', 'contrib-ex'] },
+  { id: 'DOC-17', bucket: 'Documentation', key: 'file:governance', title: 'Add GOVERNANCE.md', tags: ['governance', 'community', 'quick-win'] },
 ]
 
 // ── Combined catalog ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix #310: the `governance` file-check produced a bare `Add governance` recommendation with zero weight and an unstable `DOC-106` sequential reference ID.
- Wire `governance` into the same path as the other community-template files: concrete remediation text, weight `0.05` (matching `issue_templates`/`pull_request_template`), and a stable catalog entry `DOC-17` for `file:governance`.
- Covered by new unit tests that assert the rec fires with actionable text on repos without `GOVERNANCE.md` and is suppressed when present.

## Changes
- `lib/documentation/score-config.ts` — add `governance` to `FILE_RECOMMENDATIONS` and `FILE_WEIGHTS` (0.05).
- `lib/recommendations/catalog.ts` — add `DOC-17` for `file:governance` (tags: `governance`, `community`, `quick-win`).
- Catalog count and tag-filter tests updated; new reference-id test pins `file:governance` → `DOC-17`.
- New `score-config.test.ts` cases: missing-governance emits a governance rec with non-zero weight and non-fallback text; governance-present suppresses it.

## Test plan
- [x] `npx vitest run lib/documentation lib/recommendations` passes
- [x] `npx vitest run lib/scoring lib/tags` passes (health-score + tag-counts tests still green)
- [x] Manual: analyze a repo without `GOVERNANCE.md` (e.g. `kubernetes/kubernetes`) and verify the recommendation now reads "Add a governance document (e.g. GOVERNANCE.md) …" and carries the stable reference ID `DOC-17`
- [x] Manual: analyze a repo with `GOVERNANCE.md` and verify the recommendation does not appear
- [x] Verify the governance recommendation sorts alongside other community-template items (non-zero weight) rather than at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)