### PR TITLE
Dark mode: fix light-theme panels, score cards, controls across all tabs (#326)

### DIFF
--- a/components/activity/ActivityScoreHelp.tsx
+++ b/components/activity/ActivityScoreHelp.tsx
@@ -12,16 +12,16 @@ export function ActivityScoreHelp({ score }: ActivityScoreHelpProps) {
   const [showDetails, setShowDetails] = useState(false)
 
   return (
-    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
+    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:bg-slate-800/60 dark:border-slate-700">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is Activity scored?</p>
-          <p className="mt-1 text-sm text-slate-700">{score.summary}</p>
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">How is Activity scored?</p>
+          <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">{score.summary}</p>
         </div>
         <button
           type="button"
           onClick={() => setShowDetails((current) => !current)}
-          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200"
           aria-pressed={showDetails}
         >
           {showDetails ? 'Hide details' : 'Show details'}
@@ -29,10 +29,10 @@ export function ActivityScoreHelp({ score }: ActivityScoreHelpProps) {
       </div>
       <div className="mt-3 flex flex-wrap gap-2">
         {score.weightedFactors.map((factor) => (
-          <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700">
-            <span className="font-semibold text-slate-900">{factor.label}</span> <span>{factor.weightLabel}</span>
+          <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-200">
+            <span className="font-semibold text-slate-900 dark:text-slate-100">{factor.label}</span> <span>{factor.weightLabel}</span>
             {factor.percentile !== undefined ? (
-              <span className="ml-1 text-slate-500">({formatPercentileLabel(factor.percentile)})</span>
+              <span className="ml-1 text-slate-500 dark:text-slate-400">({formatPercentileLabel(factor.percentile)})</span>
             ) : null}
           </div>
         ))}
@@ -40,20 +40,20 @@ export function ActivityScoreHelp({ score }: ActivityScoreHelpProps) {
       {showDetails ? (
         <div className="mt-3 grid gap-2 md:grid-cols-1">
           {score.weightedFactors.map((factor) => (
-            <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3">
+            <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
               <div className="flex items-center justify-between">
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{factor.label} ({factor.weightLabel})</p>
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{factor.label} ({factor.weightLabel})</p>
                 {factor.percentile !== undefined ? (
-                  <p className="text-sm font-semibold text-slate-900">{formatPercentileLabel(factor.percentile)}</p>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{formatPercentileLabel(factor.percentile)}</p>
                 ) : null}
               </div>
-              <p className="mt-1 text-xs leading-relaxed text-slate-600">{factor.description}</p>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-300">{factor.description}</p>
             </div>
           ))}
         </div>
       ) : null}
       {score.missingInputs.length > 0 ? (
-        <p className="mt-3 text-xs text-amber-800">Missing inputs: {score.missingInputs.join(', ')}</p>
+        <p className="mt-3 text-xs text-amber-800 dark:text-amber-200">Missing inputs: {score.missingInputs.join(', ')}</p>
       ) : null}
     </div>
   )

--- a/components/activity/ActivityView.tsx
+++ b/components/activity/ActivityView.tsx
@@ -44,11 +44,11 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
 
   return (
     <section aria-label="Activity view" className="space-y-6">
-      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Recent activity window</p>
-            <p className="mt-1 text-sm text-slate-600">Change the local activity window without rerunning repository analysis.</p>
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Recent activity window</p>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">Change the local activity window without rerunning repository analysis.</p>
           </div>
           <div className="flex flex-wrap gap-2">
             {windowOptions.map((option) => (
@@ -56,11 +56,7 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
                 key={option.days}
                 type="button"
                 onClick={() => setWindowDays(option.days)}
-                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
-                  windowDays === option.days
-                    ? 'border-slate-900 bg-slate-900 text-white'
-                    : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900'
-                }`}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${ windowDays === option.days ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white' }`}
                 aria-pressed={windowDays === option.days}
               >
                 {option.label}
@@ -76,7 +72,7 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
         const score = getActivityScore(result, windowDays)
 
         return (
-          <article key={section.repo} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <article key={section.repo} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
             <button
               type="button"
               onClick={() => setCollapsed((prev) => { const next = new Set(prev); if (next.has(section.repo)) next.delete(section.repo); else next.add(section.repo); return next })}
@@ -84,16 +80,16 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
               aria-expanded={!isCollapsed}
             >
               <CollapseChevron expanded={!isCollapsed} />
-              <h2 className="text-lg font-semibold text-slate-900">{section.repo}</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{section.repo}</h2>
             </button>
             {!isCollapsed ? (
               <div className="mt-4 space-y-4">
                 <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                   <div>
-                    <p className="text-sm text-slate-600">
+                    <p className="text-sm text-slate-600 dark:text-slate-300">
                       Recent repository activity and delivery flow derived from verified public GitHub data.
                     </p>
-                    <p className="mt-2 text-sm text-slate-700">{score.description}</p>
+                    <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">{score.description}</p>
                   </div>
                   <div className="w-full md:max-w-xs">
                     <ScoreBadge category="Activity" value={score.value} tone={score.tone} />
@@ -110,9 +106,9 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
                     .map((card) => {
                       const tags = getActivityCardTags(card.title)
                       return (
-                    <div key={card.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                    <div key={card.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
                       <div className="flex items-center justify-between">
-                        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{card.title}</p>
+                        <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{card.title}</p>
                         {tags.map((tag) => <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={handleTagClick} />)}
                       </div>
                       {card.value ? <p className="mt-1 text-lg"><MetricValue value={card.value} /></p> : null}
@@ -120,33 +116,33 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
                         <dl className="mt-3 space-y-2">
                           {card.lines.map((line) => (
                             <div key={line.label} className="flex items-baseline justify-between gap-4">
-                              <dt className="text-sm text-slate-600">{line.label}</dt>
+                              <dt className="text-sm text-slate-600 dark:text-slate-300">{line.label}</dt>
                               <dd className="text-base"><MetricValue value={line.value} /></dd>
                             </div>
                           ))}
                           {card.title === 'Pull requests' ? (
-                            <div className="flex items-baseline justify-between gap-4 border-t border-slate-200 pt-2">
-                              <dt className="text-sm text-slate-600">Median time to merge</dt>
+                            <div className="flex items-baseline justify-between gap-4 border-t border-slate-200 pt-2 dark:border-slate-700">
+                              <dt className="text-sm text-slate-600 dark:text-slate-300">Median time to merge</dt>
                               <dd className="text-base"><MetricValue value={formatHours(section.metrics.medianTimeToMergeHours)} /></dd>
                             </div>
                           ) : null}
                           {card.title === 'Issues' ? (
                             <>
-                              <div className="flex items-baseline justify-between gap-4 border-t border-slate-200 pt-2">
-                                <dt className="text-sm text-slate-600">
+                              <div className="flex items-baseline justify-between gap-4 border-t border-slate-200 pt-2 dark:border-slate-700">
+                                <dt className="text-sm text-slate-600 dark:text-slate-300">
                                   <HelpLabel label="Stale issue ratio" helpText={staleIssueTooltip} />
                                 </dt>
                                 <dd className="text-base"><MetricValue value={formatPercentage(section.metrics.staleIssueRatio)} /></dd>
                               </div>
                               <div className="flex items-baseline justify-between gap-4">
-                                <dt className="text-sm text-slate-600">Median time to close</dt>
+                                <dt className="text-sm text-slate-600 dark:text-slate-300">Median time to close</dt>
                                 <dd className="text-base"><MetricValue value={formatHours(section.metrics.medianTimeToCloseHours)} /></dd>
                               </div>
                             </>
                           ) : null}
                         </dl>
                       ) : null}
-                      {card.detail ? <p className="mt-3 text-sm text-slate-600">{card.detail}</p> : null}
+                      {card.detail ? <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{card.detail}</p> : null}
                     </div>
                       )
                     })}

--- a/components/activity/DiscussionsCard.tsx
+++ b/components/activity/DiscussionsCard.tsx
@@ -54,13 +54,13 @@ export function DiscussionsCard({ result, activeTag, onTagClick, windowDays = 90
   }
 
   return (
-    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:bg-slate-800/60 dark:border-slate-700">
       <div className="flex items-center justify-between">
-        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Discussions</p>
+        <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Discussions</p>
         <TagPill tag="community" active={activeTag === 'community'} onClick={onTagClick} />
       </div>
-      <p className="mt-1 text-sm text-slate-700">{statusLine}</p>
-      <p className="mt-2 text-xs text-slate-500">
+      <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">{statusLine}</p>
+      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
         GitHub Discussions is a forum for long-form community conversation. Presence and recent activity here signal an engaged community.
       </p>
     </div>

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -92,7 +92,7 @@ export function ResultsShell({
   }, [domMatchCounts, domTotalMatches, domMatchedTabCount, onDomMatchCounts])
 
   return (
-    <main className="min-h-screen bg-slate-50 dark:bg-slate-950">
+    <main className="min-h-screen bg-slate-50 dark:bg-slate-950 dark:bg-slate-800/60">
       <header className="w-full bg-sky-900 text-white dark:bg-slate-900">
         <div className="mx-auto flex max-w-5xl items-start justify-between gap-4 px-4 py-5">
           <div className="min-w-0">
@@ -197,7 +197,7 @@ export function ResultsShell({
 
       <div className="mx-auto max-w-5xl px-4 py-6">
         {isStale ? (
-          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200" role="alert">
+          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200 dark:border-amber-800/60" role="alert">
             Scores calibrated against GitHub data from {calibrationMeta.generated}. A more recent calibration is recommended.
           </div>
         ) : null}

--- a/components/app-shell/ResultsTabs.tsx
+++ b/components/app-shell/ResultsTabs.tsx
@@ -121,7 +121,7 @@ export function ResultsTabs({ tabs, activeTab, onChange, matchCounts }: ResultsT
                     }}
                   >
                     {tab.label}
-                    {count ? <span className="ml-1.5 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-sky-100 px-1 text-xs font-medium text-sky-700">{count}</span> : null}
+                    {count ? <span className="ml-1.5 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-sky-100 px-1 text-xs font-medium text-sky-700 dark:bg-sky-900/40 dark:text-sky-200">{count}</span> : null}
                   </button>
                 )
               })}
@@ -160,7 +160,7 @@ function TabButton({ tab, active, onClick, badgeCount }: { tab: ResultTabDefinit
       onClick={onClick}
     >
       {tab.label}
-      {badgeCount ? <span className="ml-1.5 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-sky-100 px-1 text-xs font-medium text-sky-700">{badgeCount}</span> : null}
+      {badgeCount ? <span className="ml-1.5 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-sky-100 px-1 text-xs font-medium text-sky-700 dark:bg-sky-900/40 dark:text-sky-200">{badgeCount}</span> : null}
     </button>
   )
 }

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -44,7 +44,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   if (authError) {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-6">
-        <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:bg-red-900/20 dark:border-red-800/60 dark:text-red-200">
           Sign-in failed: {authError.replace(/_/g, ' ')}. Please try again.
         </p>
         <SignInButton />
@@ -54,48 +54,48 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (!session) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-slate-50 px-4 py-6 sm:gap-5">
+      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-slate-50 px-4 py-6 sm:gap-5 dark:bg-slate-800/60">
         <div className="text-center">
           <img src="/repo-pulse-banner.png" alt="RepoPulse" className="mx-auto h-16 rounded-xl shadow-lg sm:h-24" />
-          <h1 className="mt-2 text-2xl font-bold text-slate-900 sm:mt-3 sm:text-3xl">RepoPulse</h1>
-          <p className="mt-1 text-sm text-slate-600 sm:text-base">Know the real health of any open source project — in seconds</p>
+          <h1 className="mt-2 text-2xl font-bold text-slate-900 sm:mt-3 sm:text-3xl dark:text-slate-100">RepoPulse</h1>
+          <p className="mt-1 text-sm text-slate-600 sm:text-base dark:text-slate-300">Know the real health of any open source project — in seconds</p>
         </div>
 
         <div className="max-w-lg space-y-3">
-          <p className="text-center text-sm text-slate-600">
-            A single <span className="font-semibold text-slate-800">OSS Health Score</span> from
+          <p className="text-center text-sm text-slate-600 dark:text-slate-300">
+            A single <span className="font-semibold text-slate-800 dark:text-slate-100">OSS Health Score</span> from
             five dimensions — percentile-ranked against 2,400+ real GitHub repos.
           </p>
 
           <div className="flex flex-wrap justify-center gap-1.5">
-            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">👥 Contributors</span>
-            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">⚡ Activity</span>
-            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">💬 Responsiveness</span>
-            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">📄 Documentation</span>
-            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500">🔒 Security</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-400">👥 Contributors</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-400">⚡ Activity</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-400">💬 Responsiveness</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-400">📄 Documentation</span>
+            <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-400">🔒 Security</span>
           </div>
 
-          <p className="text-center text-xs font-medium text-slate-600">
+          <p className="text-center text-xs font-medium text-slate-600 dark:text-slate-300">
             ✨ Plus tailored recommendations to improve each dimension
           </p>
 
-          <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-slate-500">
+          <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
             <span>Compare up to 4 repos</span>
-            <span className="text-slate-300">|</span>
+            <span className="text-slate-300 dark:text-slate-600">|</span>
             <span>Browse by org</span>
-            <span className="text-slate-300">|</span>
+            <span className="text-slate-300 dark:text-slate-600">|</span>
             <span>Export JSON / Markdown</span>
           </div>
         </div>
 
         <SignInButton elevated={elevatedOptIn} />
 
-        <label className="flex max-w-md cursor-pointer items-start gap-2 px-4 text-left text-xs text-slate-600">
+        <label className="flex max-w-md cursor-pointer items-start gap-2 px-4 text-left text-xs text-slate-600 dark:text-slate-300">
           <input
             type="checkbox"
             checked={elevatedOptIn}
             onChange={(e) => setElevatedOptIn(e.target.checked)}
-            className="mt-0.5 h-3.5 w-3.5 rounded border-slate-300"
+            className="mt-0.5 h-3.5 w-3.5 rounded border-slate-300 dark:border-slate-600"
           />
           <span>
             Request a <span className="font-semibold">deeper GitHub permission</span> (<code>read:org</code>)
@@ -105,11 +105,11 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
         </label>
 
         <div className="max-w-md space-y-2 text-center">
-          <p className="text-xs italic text-slate-400">
+          <p className="text-xs italic text-slate-400 dark:text-slate-500">
             Built for community-oriented projects. Solo-maintainer repos are auto-detected and
             scored on Activity, Security, and Documentation instead.
           </p>
-          <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 transition">View scoring methodology</a>
+          <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 transition dark:text-slate-500">View scoring methodology</a>
         </div>
       </div>
     )

--- a/components/baseline/BaselineView.tsx
+++ b/components/baseline/BaselineView.tsx
@@ -160,74 +160,74 @@ export function BaselineView() {
 
   return (
     <div className="space-y-6">
-      <section className="rounded-2xl border border-sky-200 bg-sky-50 p-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-sky-900">OSS Health Score</h3>
-        <p className="mt-2 text-sm text-sky-800">
+      <section className="rounded-2xl border border-sky-200 bg-sky-50 p-4 dark:bg-sky-900/20 dark:border-sky-800/60">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-sky-900 dark:text-sky-200">OSS Health Score</h3>
+        <p className="mt-2 text-sm text-sky-800 dark:text-sky-200">
           The composite health score is computed from five weighted buckets:
         </p>
         <div className="mt-2 flex flex-wrap gap-2">
-          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800">Activity 25%</span>
-          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800">Responsiveness 25%</span>
-          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800">Contributors 23%</span>
-          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800">Security 15%</span>
-          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800">Documentation 12%</span>
+          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-200">Activity 25%</span>
+          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-200">Responsiveness 25%</span>
+          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-200">Contributors 23%</span>
+          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-200">Security 15%</span>
+          <span className="rounded-full bg-sky-100 px-2.5 py-1 text-xs font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-200">Documentation 12%</span>
         </div>
-        <p className="mt-2 text-xs text-sky-700">
+        <p className="mt-2 text-xs text-sky-700 dark:text-sky-300">
           Each bucket produces a percentile score relative to repos in the same star bracket. The weighted average becomes the overall health score.
         </p>
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">How Buckets Are Scored</h3>
-        <p className="mt-1 text-sm text-slate-600">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:bg-slate-900 dark:border-slate-700">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900 dark:text-slate-100">How Buckets Are Scored</h3>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
           Every metric is derived from verified GitHub API data — nothing is estimated or inferred. Scores are percentile-based: a repo is ranked against others in the same star bracket, so an emerging project is compared to peers of similar visibility, not to the top 100 repos on GitHub.
         </p>
-        <dl className="mt-3 space-y-3 text-sm text-slate-700">
+        <dl className="mt-3 space-y-3 text-sm text-slate-700 dark:text-slate-200">
           <div>
-            <dt className="font-medium text-slate-900">Activity</dt>
+            <dt className="font-medium text-slate-900 dark:text-slate-100">Activity</dt>
             <dd>PR throughput, issue flow, commit cadence, release frequency, and completion speed over recent time windows.</dd>
           </div>
           <div>
-            <dt className="font-medium text-slate-900">Responsiveness</dt>
+            <dt className="font-medium text-slate-900 dark:text-slate-100">Responsiveness</dt>
             <dd>How quickly maintainers engage — issue and PR response times, resolution speed, backlog health, and engagement quality signals.</dd>
           </div>
           <div>
-            <dt className="font-medium text-slate-900">Contributors</dt>
+            <dt className="font-medium text-slate-900 dark:text-slate-100">Contributors</dt>
             <dd>Contributor concentration and distribution — whether the project depends on a single maintainer or has a healthy base of repeat contributors.</dd>
           </div>
           <div>
-            <dt className="font-medium text-slate-900">Security</dt>
+            <dt className="font-medium text-slate-900 dark:text-slate-100">Security</dt>
             <dd>
               {'Combines '}
-              <a href="https://github.com/ossf/scorecard" className="text-sky-700 underline hover:text-sky-900" target="_blank" rel="noopener noreferrer">OpenSSF Scorecard</a>
+              <a href="https://github.com/ossf/scorecard" className="text-sky-700 underline hover:text-sky-900 dark:text-sky-300" target="_blank" rel="noopener noreferrer">OpenSSF Scorecard</a>
               {' results with direct checks for security policy, dependency automation, CI/CD, and branch protection.'}
             </dd>
           </div>
           <div>
-            <dt className="font-medium text-slate-900">Documentation</dt>
+            <dt className="font-medium text-slate-900 dark:text-slate-100">Documentation</dt>
             <dd>Presence and quality of key project files (README, LICENSE, CONTRIBUTING, CHANGELOG, CODE_OF_CONDUCT), README section coverage, licensing compliance, and inclusive naming.</dd>
           </div>
         </dl>
-        <p className="mt-3 text-xs text-slate-500">
+        <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
           For full details on calibration data, metrics collected, and percentile thresholds, see{' '}
-          <a href="https://github.com/arun-gupta/repo-pulse/blob/main/docs/scoring-and-calibration.md" className="text-sky-700 underline hover:text-sky-900" target="_blank" rel="noopener noreferrer">Scoring and Calibration</a>.
+          <a href="https://github.com/arun-gupta/repo-pulse/blob/main/docs/scoring-and-calibration.md" className="text-sky-700 underline hover:text-sky-900 dark:text-sky-300" target="_blank" rel="noopener noreferrer">Scoring and Calibration</a>.
         </p>
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">Cross-Cutting Lenses</h3>
-        <p className="mt-1 text-sm text-slate-600">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:bg-slate-900 dark:border-slate-700">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900 dark:text-slate-100">Cross-Cutting Lenses</h3>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
           <strong>Community</strong> and <strong>Governance</strong> are cross-cutting lenses, not weighted composite buckets. They do not feed the OSS Health Score. Their signals live inside the existing buckets and surface as small pills on individual rows, so you can see how a repo stacks up on each lens without reshaping the composite.
         </p>
 
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <div>
-            <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-700">
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">
               Community
-              <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600">{COMMUNITY_SIGNAL_COUNT} signals</span>
+              <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">{COMMUNITY_SIGNAL_COUNT} signals</span>
             </h4>
-            <p className="mt-1 text-xs text-slate-600">Hosted across Documentation, Contributors, and Activity:</p>
-            <ul className="mt-2 space-y-0.5 text-xs text-slate-700">
+            <p className="mt-1 text-xs text-slate-600 dark:text-slate-300">Hosted across Documentation, Contributors, and Activity:</p>
+            <ul className="mt-2 space-y-0.5 text-xs text-slate-700 dark:text-slate-200">
               <li><span className="font-mono">CODE_OF_CONDUCT.md</span> &rarr; Documentation</li>
               <li>Issue templates &rarr; Documentation</li>
               <li>PR template &rarr; Documentation</li>
@@ -236,33 +236,33 @@ export function BaselineView() {
               <li><span className="font-mono">FUNDING.yml</span> &rarr; Contributors</li>
               <li>Discussions &rarr; Activity</li>
             </ul>
-            <p className="mt-2 text-xs text-slate-500">
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
               Completeness is <strong>count-based</strong> (signals present / signals known), not a weighted percentile.
             </p>
           </div>
 
           <div>
-            <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-700">
+            <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-700 dark:text-slate-200">
               Governance
-              <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600">{GOVERNANCE_SIGNAL_COUNT} signals</span>
+              <span className="ml-2 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">{GOVERNANCE_SIGNAL_COUNT} signals</span>
             </h4>
-            <p className="mt-1 text-xs text-slate-600">Signals that indicate project stewardship, hosted across Documentation, Security, and Contributors:</p>
-            <ul className="mt-2 space-y-0.5 text-xs text-slate-700">
+            <p className="mt-1 text-xs text-slate-600 dark:text-slate-300">Signals that indicate project stewardship, hosted across Documentation, Security, and Contributors:</p>
+            <ul className="mt-2 space-y-0.5 text-xs text-slate-700 dark:text-slate-200">
               <li>LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CHANGELOG, GOVERNANCE &rarr; Documentation</li>
               <li>Branch protection, Code review, Security policy, License checks &rarr; Security</li>
               <li>Maintainer count &rarr; Contributors</li>
               <li>Licensing compliance pane &rarr; Documentation</li>
             </ul>
-            <p className="mt-2 text-xs text-slate-500">
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
               Individual rows tagged as governance show a small pill; there is no separate completeness score.
             </p>
           </div>
         </div>
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">Scoring Methodology</h3>
-        <p className="mt-1 text-sm text-slate-600">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 dark:bg-slate-900 dark:border-slate-700">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900 dark:text-slate-100">Scoring Methodology</h3>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
           Percentile thresholds derived from sampling real GitHub repositories. All RepoPulse scores are computed relative to these distributions.
         </p>
 
@@ -272,11 +272,7 @@ export function BaselineView() {
               key={b}
               type="button"
               onClick={() => setSelectedBracket(b)}
-              className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${
-                selectedBracket === b
-                  ? 'bg-sky-900 text-white'
-                  : 'border border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900'
-              }`}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition ${ selectedBracket === b ? 'bg-sky-900 text-white' : 'border border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900' } dark:border-slate-600 dark:text-slate-100 dark:text-slate-200 `}
             >
               {BRACKET_LABELS[b]}
             </button>
@@ -285,27 +281,27 @@ export function BaselineView() {
 
         <dl className="mt-3 flex flex-wrap gap-4">
           <div>
-            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Calibration date</dt>
-            <dd className="mt-0.5 text-sm font-semibold text-slate-900">{meta.generated}</dd>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Calibration date</dt>
+            <dd className="mt-0.5 text-sm font-semibold text-slate-900 dark:text-slate-100">{meta.generated}</dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Source</dt>
-            <dd className="mt-0.5 text-sm font-semibold text-slate-900">{meta.source}</dd>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Source</dt>
+            <dd className="mt-0.5 text-sm font-semibold text-slate-900 dark:text-slate-100">{meta.source}</dd>
           </div>
           <div>
-            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Sample size</dt>
-            <dd className="mt-0.5 text-sm font-semibold text-slate-900">{meta.sampleSizes[selectedBracket]} repos</dd>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Sample size</dt>
+            <dd className="mt-0.5 text-sm font-semibold text-slate-900 dark:text-slate-100">{meta.sampleSizes[selectedBracket]} repos</dd>
           </div>
         </dl>
       </section>
 
       {METRIC_SECTIONS.map((section) => (
-        <section key={section.title} className="rounded-2xl border border-slate-200 bg-white p-4">
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">{section.title}</h3>
+        <section key={section.title} className="rounded-2xl border border-slate-200 bg-white p-4 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900 dark:text-slate-100">{section.title}</h3>
           <div className="mt-3 overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-slate-200 text-xs font-medium uppercase tracking-wide text-slate-500">
+                <tr className="border-b border-slate-200 text-xs font-medium uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400">
                   <th className="pb-2 pr-4 text-left">Metric</th>
                   <th className="pb-2 px-3 text-right">p25</th>
                   <th className="pb-2 px-3 text-right">p50</th>
@@ -318,23 +314,23 @@ export function BaselineView() {
                   const ps = cal[metric.key] as PercentileSet | undefined
                   if (!ps) {
                     return (
-                      <tr key={metric.key} className="border-b border-slate-100">
-                        <td className="py-2 pr-4 text-slate-700">{metric.label}</td>
-                        <td className="py-2 px-3 text-right font-mono text-slate-400" colSpan={4}>Calibration data pending</td>
+                      <tr key={metric.key} className="border-b border-slate-100 dark:border-slate-700">
+                        <td className="py-2 pr-4 text-slate-700 dark:text-slate-200">{metric.label}</td>
+                        <td className="py-2 px-3 text-right font-mono text-slate-400 dark:text-slate-500" colSpan={4}>Calibration data pending</td>
                       </tr>
                     )
                   }
                   const row = buildMetricRow(metric.key, metric.label, ps)
                   return (
-                    <tr key={metric.key} className="border-b border-slate-100">
-                      <td className="py-2 pr-4 text-slate-700">
+                    <tr key={metric.key} className="border-b border-slate-100 dark:border-slate-700">
+                      <td className="py-2 pr-4 text-slate-700 dark:text-slate-200">
                         {row.label}
-                        {row.inverted ? <span className="ml-1 text-xs text-slate-400" title="Lower is better">&darr;</span> : null}
+                        {row.inverted ? <span className="ml-1 text-xs text-slate-400 dark:text-slate-500" title="Lower is better">&darr;</span> : null}
                       </td>
-                      <td className="py-2 px-3 text-right font-mono text-slate-600">{row.p25}</td>
-                      <td className="py-2 px-3 text-right font-mono text-slate-600">{row.p50}</td>
-                      <td className="py-2 px-3 text-right font-mono text-slate-600">{row.p75}</td>
-                      <td className="py-2 px-3 text-right font-mono text-slate-600">{row.p90}</td>
+                      <td className="py-2 px-3 text-right font-mono text-slate-600 dark:text-slate-300">{row.p25}</td>
+                      <td className="py-2 px-3 text-right font-mono text-slate-600 dark:text-slate-300">{row.p50}</td>
+                      <td className="py-2 px-3 text-right font-mono text-slate-600 dark:text-slate-300">{row.p75}</td>
+                      <td className="py-2 px-3 text-right font-mono text-slate-600 dark:text-slate-300">{row.p90}</td>
                     </tr>
                   )
                 })}
@@ -344,7 +340,7 @@ export function BaselineView() {
         </section>
       ))}
 
-      <p className="text-xs text-slate-400">
+      <p className="text-xs text-slate-400 dark:text-slate-500">
         Metrics marked with &darr; are scored inversely (lower is better).{' '}
         <a
           href="https://github.com/arun-gupta/repo-pulse/blob/main/docs/scoring-and-calibration.md"

--- a/components/comparison/ComparisonControls.tsx
+++ b/components/comparison/ComparisonControls.tsx
@@ -36,15 +36,15 @@ export function ComparisonControls({
   const nonAnchorRepos = repos.filter((repo) => repo !== anchorRepo)
 
   return (
-    <section className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+    <section className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:bg-slate-800/60 dark:border-slate-700">
       <div className="flex flex-wrap items-end gap-4">
         <label className="space-y-1">
-          <span className="block text-xs font-medium uppercase tracking-wide text-slate-500">Anchor repo</span>
+          <span className="block text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Anchor repo</span>
           <select
             aria-label="Anchor repo"
             value={anchorRepo}
             onChange={(event) => onAnchorChange(event.target.value)}
-            className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900"
+            className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 dark:bg-slate-900 dark:border-slate-600 dark:text-slate-100"
           >
             {repos.map((repo) => (
               <option key={repo} value={repo}>
@@ -55,10 +55,10 @@ export function ComparisonControls({
         </label>
         {nonAnchorRepos.length > 0 ? (
           <div className="space-y-1">
-            <span className="block text-xs font-medium uppercase tracking-wide text-slate-500">Compare with</span>
+            <span className="block text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Compare with</span>
             <div className="flex flex-wrap gap-2">
               {nonAnchorRepos.map((repo) => (
-                <label key={repo} className="inline-flex items-center gap-1.5 text-sm text-slate-700">
+                <label key={repo} className="inline-flex items-center gap-1.5 text-sm text-slate-700 dark:text-slate-200">
                   <input
                     aria-label={repo}
                     type="checkbox"
@@ -71,26 +71,26 @@ export function ComparisonControls({
             </div>
           </div>
         ) : null}
-        <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+        <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
           <input aria-label="Show median column" type="checkbox" checked={showMedianColumn} onChange={onToggleMedianColumn} />
           Show median column
         </label>
         <button
           type="button"
           onClick={() => setShowAdvanced((v) => !v)}
-          className="ml-auto text-xs text-slate-500 underline-offset-2 hover:text-slate-700 hover:underline"
+          className="ml-auto text-xs text-slate-500 underline-offset-2 hover:text-slate-700 hover:underline dark:text-slate-400"
         >
           {showAdvanced ? 'Hide options' : 'Sections & attributes'}
         </button>
       </div>
 
       {showAdvanced ? (
-        <div className="grid gap-4 border-t border-slate-200 pt-3 md:grid-cols-2">
+        <div className="grid gap-4 border-t border-slate-200 pt-3 md:grid-cols-2 dark:border-slate-700">
           <div className="space-y-2">
-            <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Sections</h3>
+            <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Sections</h3>
             <div className="space-y-2">
               {COMPARISON_SECTIONS.map((section) => (
-                <label key={section.id} className="flex items-start gap-2 text-sm text-slate-700">
+                <label key={section.id} className="flex items-start gap-2 text-sm text-slate-700 dark:text-slate-200">
                   <input
                     aria-label={section.label}
                     type="checkbox"
@@ -98,8 +98,8 @@ export function ComparisonControls({
                     onChange={() => onToggleSection(section.id)}
                   />
                   <span>
-                    <span className="font-medium text-slate-900">{section.label}</span>
-                    <span className="block text-xs text-slate-500">{section.description}</span>
+                    <span className="font-medium text-slate-900 dark:text-slate-100">{section.label}</span>
+                    <span className="block text-xs text-slate-500 dark:text-slate-400">{section.description}</span>
                   </span>
                 </label>
               ))}
@@ -107,25 +107,25 @@ export function ComparisonControls({
           </div>
 
           <div className="space-y-2">
-            <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Attributes</h3>
+            <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Attributes</h3>
             <div className="space-y-3">
               {COMPARISON_SECTIONS.filter((section) => enabledSections.includes(section.id)).map((section) => {
                 const allSelected = section.attributes.every((a) => enabledAttributes.includes(a.id))
                 return (
                 <div key={section.id} className="space-y-1">
                   <div className="flex items-center gap-2">
-                    <p className="text-xs font-medium text-slate-600">{section.label}</p>
+                    <p className="text-xs font-medium text-slate-600 dark:text-slate-300">{section.label}</p>
                     <button
                       type="button"
                       onClick={() => onToggleAllSectionAttributes(section.id, !allSelected)}
-                      className="text-[10px] text-slate-400 underline-offset-1 hover:text-slate-600 hover:underline"
+                      className="text-[10px] text-slate-400 underline-offset-1 hover:text-slate-600 hover:underline dark:text-slate-500"
                     >
                       {allSelected ? 'None' : 'All'}
                     </button>
                   </div>
                   <div className="flex flex-wrap gap-x-4 gap-y-2">
                     {section.attributes.map((attribute) => (
-                      <label key={attribute.id} className="inline-flex items-center gap-2 text-sm text-slate-700">
+                      <label key={attribute.id} className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
                         <input
                           aria-label={attribute.label}
                           type="checkbox"

--- a/components/comparison/ComparisonTable.tsx
+++ b/components/comparison/ComparisonTable.tsx
@@ -27,45 +27,45 @@ export function ComparisonTable({
   return (
     <div className="space-y-6">
       {sections.map((section) => (
-        <section key={section.id} className="space-y-3 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+        <section key={section.id} className="space-y-3 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 dark:bg-slate-900 dark:border-slate-700">
           <div>
-            <h2 className="text-lg font-semibold text-slate-900">{section.label}</h2>
-            <p className="mt-1 text-sm text-slate-600">{section.description}</p>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{section.label}</h2>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{section.description}</p>
           </div>
           <div className="overflow-x-auto">
             <table className="min-w-full border-separate border-spacing-y-2">
               <thead>
                 <tr>
-                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500">Metric</th>
+                  <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Metric</th>
                   {repos.map((repo) => (
-                    <th key={repo} className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                    <th key={repo} className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                       <button
                         type="button"
-                        className="inline-flex items-center gap-2 text-left text-slate-600 transition hover:text-slate-800"
+                        className="inline-flex items-center gap-2 text-left text-slate-600 transition hover:text-slate-800 dark:text-slate-300"
                         onClick={() => onSortRepo(repo)}
                       >
                         <span>{repo}</span>
                         {repo === anchorRepo ? (
-                          <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-sky-700">
+                          <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
                             Anchor
                           </span>
                         ) : null}
                         {sortColumn?.type === 'repo' && sortColumn.repo === repo ? (
-                          <span className="text-[10px] text-slate-400">{sortDirection === 'desc' ? '↓' : '↑'}</span>
+                          <span className="text-[10px] text-slate-400 dark:text-slate-500">{sortDirection === 'desc' ? '↓' : '↑'}</span>
                         ) : null}
                       </button>
                     </th>
                   ))}
                   {showMedianColumn ? (
-                    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                    <th className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                       <button
                         type="button"
-                        className="inline-flex items-center gap-2 text-left text-slate-600 transition hover:text-slate-800"
+                        className="inline-flex items-center gap-2 text-left text-slate-600 transition hover:text-slate-800 dark:text-slate-300"
                         onClick={onSortMedian}
                       >
                         <span>Median</span>
                         {sortColumn?.type === 'median' ? (
-                          <span className="text-[10px] text-slate-400">{sortDirection === 'desc' ? '↓' : '↑'}</span>
+                          <span className="text-[10px] text-slate-400 dark:text-slate-500">{sortDirection === 'desc' ? '↓' : '↑'}</span>
                         ) : null}
                       </button>
                     </th>
@@ -74,36 +74,30 @@ export function ComparisonTable({
               </thead>
               <tbody>
                 {section.rows.map((row) => (
-                  <tr key={`${section.id}-${row.attributeId}`} className="rounded-xl border border-slate-200 bg-slate-50 align-top">
-                    <th className="rounded-l-xl border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-left text-sm font-medium text-slate-900">
+                  <tr key={`${section.id}-${row.attributeId}`} className="rounded-xl border border-slate-200 bg-slate-50 align-top dark:bg-slate-800/60 dark:border-slate-700">
+                    <th className="rounded-l-xl border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-left text-sm font-medium text-slate-900 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-100">
                       <HelpLabel label={row.label} helpText={row.helpText} />
                     </th>
                     {row.cells
                       .filter((cell) => repos.includes(cell.repo))
                       .map((cell) => (
-                        <td key={`${row.attributeId}-${cell.repo}`} className="border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
+                        <td key={`${row.attributeId}-${cell.repo}`} className="border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
                           <div className="space-y-1">
                             {cell.deltaDisplay ? (
                               <p
-                                className={`text-sm font-medium ${
-                                  cell.status === 'better'
-                                    ? 'text-emerald-700'
-                                    : cell.status === 'worse'
-                                    ? 'text-amber-700'
-                                    : 'text-slate-500'
-                                }`}
+                                className={`text-sm font-medium ${ cell.status === 'better' ? 'text-emerald-700' : cell.status === 'worse' ? 'text-amber-700' : 'text-slate-500' } dark:text-slate-400 dark:text-emerald-300 dark:text-amber-300 dark:text-slate-500 `}
                               >
                                 {cell.deltaDisplay}
                               </p>
                             ) : cell.status === 'neutral' && cell.repo === anchorRepo ? (
-                              <p className="text-sm font-medium text-sky-700">Anchor baseline</p>
+                              <p className="text-sm font-medium text-sky-700 dark:text-sky-300">Anchor baseline</p>
                             ) : null}
-                            <p className={`text-xs uppercase tracking-wide ${cell.displayValue === '—' ? 'text-slate-400' : 'text-slate-500'}`}>{cell.displayValue}</p>
+                            <p className={`text-xs uppercase tracking-wide ${cell.displayValue === '—' ? 'text-slate-400' : 'text-slate-500'} dark:text-slate-400 dark:text-slate-500 `}>{cell.displayValue}</p>
                           </div>
                         </td>
                       ))}
                     {showMedianColumn ? (
-                      <td className="rounded-r-xl border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
+                      <td className="rounded-r-xl border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
                         {row.medianDisplay}
                       </td>
                     ) : null}

--- a/components/comparison/ComparisonView.tsx
+++ b/components/comparison/ComparisonView.tsx
@@ -63,13 +63,13 @@ export function ComparisonView({ results, rateLimit }: ComparisonViewProps) {
   }, [anchorRepo, comparedResults, enabledAttributes, enabledSections, sortColumn, sortDirection])
 
   if (results.length < 2) {
-    return <p className="text-sm text-slate-600">Compare two to four repositories to open the side-by-side comparison view.</p>
+    return <p className="text-sm text-slate-600 dark:text-slate-300">Compare two to four repositories to open the side-by-side comparison view.</p>
   }
 
   return (
     <section aria-label="Comparison view" className="space-y-6">
       {results.length > COMPARISON_MAX_REPOS ? (
-        <p className="text-sm text-amber-700">{getComparisonLimitMessage(results.length)}</p>
+        <p className="text-sm text-amber-700 dark:text-amber-300">{getComparisonLimitMessage(results.length)}</p>
       ) : null}
 
       <ComparisonControls
@@ -143,13 +143,13 @@ export function ComparisonView({ results, rateLimit }: ComparisonViewProps) {
           }}
         />
       ) : (
-        <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600">
+        <div className="rounded-2xl border border-slate-200 bg-white p-6 text-sm text-slate-600 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-300">
           No comparison rows are currently visible. Re-enable a section or attribute to continue.
         </div>
       )}
 
       {rateLimit && isRateLimitLow(rateLimit) ? (
-        <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+        <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
           <p>Remaining API calls: {rateLimit.remaining.toLocaleString('en-US')}</p>
           <p>Rate limit resets at: {new Date(rateLimit.resetAt).toLocaleTimeString()}</p>
         </section>

--- a/components/contributors/ContributionBarChart.tsx
+++ b/components/contributors/ContributionBarChart.tsx
@@ -55,7 +55,7 @@ export function ContributionBarChart({
         : 'bg-gradient-to-r from-cyan-200 via-cyan-400 to-cyan-700'
 
   return (
-    <div className="mt-4 rounded-xl border border-slate-200 bg-white p-3">
+    <div className="mt-4 rounded-xl border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex min-w-0 items-start gap-2 sm:max-w-2xl">
           {onToggleCollapsed ? (
@@ -65,7 +65,7 @@ export function ContributionBarChart({
               aria-pressed={!collapsed}
               aria-expanded={!collapsed}
               aria-label={collapseToggleLabel ?? (collapsed ? 'Expand chart' : 'Collapse chart')}
-              className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
+              className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 transition hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -79,8 +79,8 @@ export function ContributionBarChart({
             </button>
           ) : null}
           <div className="min-w-0">
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{title}</p>
-            <p className="mt-1 text-xs text-slate-500">{description}</p>
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{title}</p>
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{description}</p>
           </div>
         </div>
         {actions ? <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end">{actions}</div> : null}
@@ -96,13 +96,13 @@ export function ContributionBarChart({
                 <div key={`${item.contributor}-${item.commitsLabel}`} role="listitem" className="space-y-1">
                   <div className="flex items-baseline justify-between gap-3">
                     {showLabels ? (
-                      <p className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900">{item.contributor}</p>
+                      <p className="min-w-0 flex-1 truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.contributor}</p>
                     ) : (
                       <span className="min-w-0 flex-1" aria-hidden="true" />
                     )}
-                    {showValues ? <p className="shrink-0 text-xs text-slate-500">{item.commitsLabel}</p> : null}
+                    {showValues ? <p className="shrink-0 text-xs text-slate-500 dark:text-slate-400">{item.commitsLabel}</p> : null}
                   </div>
-                  <div className="h-2 overflow-hidden rounded-full bg-slate-100" aria-label={`${item.contributor} ${item.commitsLabel}`}>
+                  <div className="h-2 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800" aria-label={`${item.contributor} ${item.commitsLabel}`}>
                     <div className={`h-full rounded-full ${barToneClass}`} style={{ width: `${barWidth}%` }} />
                   </div>
                 </div>
@@ -115,7 +115,7 @@ export function ContributionBarChart({
               <button
                 type="button"
                 onClick={() => setExpanded((current) => !current)}
-                className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200"
                 aria-pressed={expanded}
               >
                 {expanded ? `Show fewer ${entityLabel}` : `Show all ${items.length} ${entityLabel}`}
@@ -124,7 +124,7 @@ export function ContributionBarChart({
           ) : null}
         </>
       ) : (
-        <p className="mt-2 text-sm text-slate-400">{emptyText}</p>
+        <p className="mt-2 text-sm text-slate-400 dark:text-slate-500">{emptyText}</p>
       )}
     </div>
   )

--- a/components/contributors/ContributorsScorePane.tsx
+++ b/components/contributors/ContributorsScorePane.tsx
@@ -32,29 +32,29 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
   }
 
   return (
-    <section aria-label="Contributors score pane" className="rounded-2xl border border-slate-200 bg-white p-4">
+    <section aria-label="Contributors score pane" className="rounded-2xl border border-slate-200 bg-white p-4 dark:bg-slate-900 dark:border-slate-700">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">Contributors score</h3>
-          <p className="mt-1 text-sm text-slate-600">{section.contributorsScore.description}</p>
+          <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900 dark:text-slate-100">Contributors score</h3>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{section.contributorsScore.description}</p>
         </div>
         <div className="w-full md:max-w-xs">
           <ScoreBadge category="Contributors" value={section.contributorsScore.value} tone={section.contributorsScore.tone} />
         </div>
       </div>
 
-      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
+      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:bg-slate-800/60 dark:border-slate-700">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is this scored?</p>
-            <p className="mt-1 text-sm text-slate-700">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">How is this scored?</p>
+            <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">
               {section.contributorsScore.summary ?? 'Contributors combines contributor concentration, maintainer depth, repeat and new-contributor signals, and contribution breadth, scored relative to the repo\'s star bracket.'}
             </p>
           </div>
           <button
             type="button"
             onClick={() => setShowDetails((current) => !current)}
-            className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+            className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200"
             aria-pressed={showDetails}
           >
             {showDetails ? 'Hide details' : 'Show details'}
@@ -63,10 +63,10 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
         {section.contributorsScore.weightedFactors && section.contributorsScore.weightedFactors.length > 0 ? (
           <div className="mt-3 flex flex-wrap gap-2">
             {section.contributorsScore.weightedFactors.map((factor) => (
-              <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700">
-                <span className="font-semibold text-slate-900">{factor.label}</span> <span>{factor.weightLabel}</span>
+              <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-200">
+                <span className="font-semibold text-slate-900 dark:text-slate-100">{factor.label}</span> <span>{factor.weightLabel}</span>
                 {factor.percentile !== undefined ? (
-                  <span className="ml-1 text-slate-500">({formatPercentileLabel(factor.percentile)})</span>
+                  <span className="ml-1 text-slate-500 dark:text-slate-400">({formatPercentileLabel(factor.percentile)})</span>
                 ) : null}
               </div>
             ))}
@@ -76,20 +76,20 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
           <div className="mt-3 grid gap-2">
             {section.contributorsScore.weightedFactors && section.contributorsScore.weightedFactors.length > 0 ? (
               section.contributorsScore.weightedFactors.map((factor) => (
-                <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3">
+                <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
                   <div className="flex items-center justify-between">
-                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{factor.label} ({factor.weightLabel})</p>
+                    <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{factor.label} ({factor.weightLabel})</p>
                     {factor.percentile !== undefined ? (
-                      <p className="text-sm font-semibold text-slate-900">{formatPercentileLabel(factor.percentile)}</p>
+                      <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{formatPercentileLabel(factor.percentile)}</p>
                     ) : null}
                   </div>
-                  <p className="mt-1 text-xs leading-relaxed text-slate-600">{factor.description}</p>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-300">{factor.description}</p>
                 </div>
               ))
             ) : null}
-            <div className="rounded-lg border border-slate-200 bg-white p-3">
-              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Top-20% contributor share</p>
-              <p className="mt-1 text-sm text-slate-700">
+            <div className="rounded-lg border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Top-20% contributor share</p>
+              <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">
                 {formatPercentage(section.contributorsScore.concentration)}
                 {section.contributorsScore.bracketLabel ? ` — scored relative to ${section.contributorsScore.bracketLabel} repositories` : ''}
               </p>
@@ -116,8 +116,8 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
             const isGov = GOVERNANCE_CONTRIBUTORS_METRICS.has(metric.label)
             const isCommunity = COMMUNITY_CONTRIBUTORS_METRICS.has(metric.label)
             return (
-              <div key={metric.label} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                <dt className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-slate-500">
+              <div key={metric.label} className="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:bg-slate-800/60 dark:border-slate-700">
+                <dt className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                   <HelpLabel label={metric.label} helpText={metric.hoverText} />
                   <span className="inline-flex gap-1">
                     {isGov ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={handleTagClick} /> : null}
@@ -125,23 +125,23 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
                   </span>
                 </dt>
                 <dd className="mt-1 text-base"><MetricValue value={metric.value} /></dd>
-                {metric.supportingText ? <p className="mt-1 text-xs text-slate-500">{metric.supportingText}</p> : null}
+                {metric.supportingText ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{metric.supportingText}</p> : null}
               </div>
             )
           })}
       </dl>
 
       {!activeTag ? (
-      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
+      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:bg-slate-800/60 dark:border-slate-700">
         <div className="flex flex-col gap-1">
-          <p className="text-xs font-medium uppercase tracking-wide text-slate-900">Organization Affiliation</p>
-          <p className="text-sm text-slate-600">{section.experimentalWarning}</p>
-          <p className="text-sm text-slate-600">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-900 dark:text-slate-100">Organization Affiliation</p>
+          <p className="text-sm text-slate-600 dark:text-slate-300">{section.experimentalWarning}</p>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
             <a
               href="https://chaoss.community/kb/metric-elephant-factor/"
               target="_blank"
               rel="noreferrer"
-              className="font-medium text-slate-700 underline underline-offset-2"
+              className="font-medium text-slate-700 underline underline-offset-2 dark:text-slate-200"
             >
               CHAOSS Elephant Factor reference
             </a>
@@ -149,8 +149,8 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
         </div>
         <dl className="mt-3 grid gap-3 md:grid-cols-2">
           {section.experimentalMetrics.map((metric) => (
-            <div key={metric.label} className="rounded-xl border border-slate-200 bg-white p-3">
-              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            <div key={metric.label} className="rounded-xl border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
+              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 <HelpLabel label={metric.label} helpText={metric.hoverText} />
               </dt>
               <dd className="mt-1 text-base"><MetricValue value={metric.value} /></dd>
@@ -179,7 +179,7 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
                     <button
                       type="button"
                       onClick={() => setShowExperimentalNames((current) => !current)}
-                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400"
+                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 dark:border-slate-600 dark:text-slate-200"
                       aria-pressed={showExperimentalNames}
                     >
                       {showExperimentalNames ? 'Hide names' : 'Show names'}
@@ -187,7 +187,7 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
                     <button
                       type="button"
                       onClick={() => setShowExperimentalNumbers((current) => !current)}
-                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400"
+                      className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 dark:border-slate-600 dark:text-slate-200"
                       aria-pressed={showExperimentalNumbers}
                     >
                       {showExperimentalNumbers ? 'Hide numbers' : 'Show numbers'}

--- a/components/contributors/ContributorsView.tsx
+++ b/components/contributors/ContributorsView.tsx
@@ -21,11 +21,11 @@ export function ContributorsView({ results, activeTag, onTagChange }: Contributo
 
   return (
     <section aria-label="Contributors view" className="space-y-6">
-      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Recent activity window</p>
-            <p className="mt-1 text-sm text-slate-600">Change the local contributor-analysis window without rerunning repository analysis.</p>
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Recent activity window</p>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">Change the local contributor-analysis window without rerunning repository analysis.</p>
           </div>
           <div className="flex flex-wrap gap-2">
             {CONTRIBUTOR_WINDOW_DAYS.map((days) => (
@@ -33,11 +33,7 @@ export function ContributorsView({ results, activeTag, onTagChange }: Contributo
                 key={days}
                 type="button"
                 onClick={() => setWindowDays(days)}
-                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
-                  windowDays === days
-                    ? 'border-slate-900 bg-slate-900 text-white'
-                    : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900'
-                }`}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${ windowDays === days ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white' }`}
                 aria-pressed={windowDays === days}
               >
                 {`${days}d`}
@@ -49,7 +45,7 @@ export function ContributorsView({ results, activeTag, onTagChange }: Contributo
       {sections.map((section) => {
         const isCollapsed = collapsed.has(section.repo)
         return (
-          <article key={section.repo} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <article key={section.repo} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
             <button
               type="button"
               onClick={() => setCollapsed((prev) => { const next = new Set(prev); if (next.has(section.repo)) next.delete(section.repo); else next.add(section.repo); return next })}
@@ -57,11 +53,11 @@ export function ContributorsView({ results, activeTag, onTagChange }: Contributo
               aria-expanded={!isCollapsed}
             >
               <CollapseChevron expanded={!isCollapsed} />
-              <h2 className="text-lg font-semibold text-slate-900">{section.repo}</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{section.repo}</h2>
             </button>
             {!isCollapsed ? (
               <div className="mt-4 space-y-4">
-                <p className="text-sm text-slate-600">{`Contributor health and diversity signals derived from verified public repository activity over the last ${section.windowDays} days.`}</p>
+                <p className="text-sm text-slate-600 dark:text-slate-300">{`Contributor health and diversity signals derived from verified public repository activity over the last ${section.windowDays} days.`}</p>
                 <CoreContributorsPane
                   metrics={section.coreMetrics}
                   heatmap={section.heatmap}

--- a/components/contributors/CoreContributorsPane.tsx
+++ b/components/contributors/CoreContributorsPane.tsx
@@ -20,20 +20,20 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
   const [showChart, setShowChart] = useState(true)
 
   return (
-    <section aria-label="Core contributors pane" className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+    <section aria-label="Core contributors pane" className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:bg-slate-800/60 dark:border-slate-700">
       <div className="mb-3">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900">Core</h3>
-        <p className="mt-1 text-sm text-slate-600">{`Contributor metrics from verified public data for the last ${windowDays} days.`}</p>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-900 dark:text-slate-100">Core</h3>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{`Contributor metrics from verified public data for the last ${windowDays} days.`}</p>
       </div>
       <dl className="grid gap-3">
         {metrics.map((metric) => (
-          <div key={metric.label} className="rounded-xl border border-slate-200 bg-white p-3">
-            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+          <div key={metric.label} className="rounded-xl border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
               <HelpLabel label={metric.label} helpText={metric.hoverText} />
             </dt>
-            {metric.secondaryValue ? <p className="mt-1 text-xs text-slate-500">{metric.secondaryValue}</p> : null}
-            <dd className="mt-1 text-base font-semibold text-slate-900">{metric.value}</dd>
-            {metric.supportingText ? <p className="mt-1 text-xs text-slate-500">{metric.supportingText}</p> : null}
+            {metric.secondaryValue ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{metric.secondaryValue}</p> : null}
+            <dd className="mt-1 text-base font-semibold text-slate-900 dark:text-slate-100">{metric.value}</dd>
+            {metric.supportingText ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{metric.supportingText}</p> : null}
             {metric.breakdown ? (
               (() => {
                 const segments = metric.breakdown.segments
@@ -44,7 +44,7 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
 
                 return (
                   <div className="mt-3 space-y-1">
-                    <div className="h-2 overflow-hidden rounded-full bg-cyan-100">
+                    <div className="h-2 overflow-hidden rounded-full bg-cyan-100 dark:bg-cyan-900/40">
                       <div className="flex h-full w-full overflow-hidden rounded-full">
                         {segments.map((segment) => (
                           <div
@@ -63,7 +63,7 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
                         ))}
                       </div>
                     </div>
-                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-slate-500">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-slate-500 dark:text-slate-400">
                       {segments.map((segment) => (
                         <span key={segment.label}>{`${segment.label} ${segment.value}`}</span>
                       ))}
@@ -95,7 +95,7 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
                 <button
                   type="button"
                   onClick={onToggleIncludeBots}
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 sm:w-auto"
+                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 sm:w-auto dark:border-slate-600 dark:text-slate-200"
                   aria-pressed={includeBots}
                 >
                   {includeBots ? 'Exclude bots from chart' : 'Include bots in chart'}
@@ -103,7 +103,7 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
                 <button
                   type="button"
                   onClick={() => setShowNames((current) => !current)}
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 sm:w-auto"
+                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 sm:w-auto dark:border-slate-600 dark:text-slate-200"
                   aria-pressed={showNames}
                 >
                   {showNames ? 'Hide names' : 'Show names'}
@@ -111,7 +111,7 @@ export function CoreContributorsPane({ metrics, heatmap, windowDays, includeBots
                 <button
                   type="button"
                   onClick={() => setShowNumbers((current) => !current)}
-                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 sm:w-auto"
+                  className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 sm:w-auto dark:border-slate-600 dark:text-slate-200"
                   aria-pressed={showNumbers}
                 >
                   {showNumbers ? 'Hide numbers' : 'Show numbers'}

--- a/components/debug/DevToolsLink.tsx
+++ b/components/debug/DevToolsLink.tsx
@@ -84,11 +84,7 @@ function LogPanel() {
             <button
               key={level}
               onClick={() => setFilter(level)}
-              className={`px-2 py-0.5 rounded text-xs ${
-                filter === level
-                  ? 'bg-gray-700 text-white'
-                  : 'bg-gray-800 text-gray-400 hover:text-gray-200'
-              }`}
+              className={`px-2 py-0.5 rounded text-xs ${ filter === level ? 'bg-gray-700 text-white' : 'bg-gray-800 text-gray-400 hover:text-gray-200' }`}
             >
               {level || 'all'}
             </button>

--- a/components/documentation/DocumentationScoreHelp.tsx
+++ b/components/documentation/DocumentationScoreHelp.tsx
@@ -18,18 +18,18 @@ export function DocumentationScoreHelp({ score }: DocumentationScoreHelpProps) {
   ]
 
   return (
-    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
+    <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:bg-slate-800/60 dark:border-slate-700">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is Documentation scored?</p>
-          <p className="mt-1 text-sm text-slate-700">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">How is Documentation scored?</p>
+          <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">
             Composite of file presence (35%), README quality (30%), licensing compliance (25%), and inclusive naming (10%).
           </p>
         </div>
         <button
           type="button"
           onClick={() => setShowDetails((current) => !current)}
-          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200"
           aria-pressed={showDetails}
         >
           {showDetails ? 'Hide details' : 'Show details'}
@@ -37,21 +37,21 @@ export function DocumentationScoreHelp({ score }: DocumentationScoreHelpProps) {
       </div>
       <div className="mt-3 flex flex-wrap gap-2">
         {factors.map((factor) => (
-          <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700">
-            <span className="font-semibold text-slate-900">{factor.label}</span> <span>{factor.weight}</span>
-            <span className="ml-1 text-slate-500">({factor.value})</span>
+          <div key={factor.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-200">
+            <span className="font-semibold text-slate-900 dark:text-slate-100">{factor.label}</span> <span>{factor.weight}</span>
+            <span className="ml-1 text-slate-500 dark:text-slate-400">({factor.value})</span>
           </div>
         ))}
       </div>
       {showDetails ? (
         <div className="mt-3 grid gap-2 md:grid-cols-1">
           {factors.map((factor) => (
-            <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3">
+            <div key={factor.label} className="rounded-lg border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
               <div className="flex items-center justify-between">
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{factor.label} ({factor.weight})</p>
-                <p className="text-sm font-semibold text-slate-900">{factor.value}</p>
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{factor.label} ({factor.weight})</p>
+                <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{factor.value}</p>
               </div>
-              <p className="mt-1 text-xs leading-relaxed text-slate-600">{factor.description}</p>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-300">{factor.description}</p>
             </div>
           ))}
         </div>

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -48,9 +48,9 @@ function getDocFileAllTags(name: string): string[] {
 function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingResult: LicensingResult | 'unavailable'; activeTag: string | null; onTagClick: (tag: string) => void }) {
   if (licensingResult === 'unavailable') {
     return (
-      <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Licensing & Compliance</h3>
-        <p className="mt-3 text-sm text-slate-400">Licensing data unavailable.</p>
+      <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Licensing & Compliance</h3>
+        <p className="mt-3 text-sm text-slate-400 dark:text-slate-500">Licensing data unavailable.</p>
       </section>
     )
   }
@@ -60,9 +60,9 @@ function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingRe
   const isDualLicensed = additionalLicenses.length > 0
 
   return (
-    <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+    <section aria-label="Licensing" className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
       <div className="flex items-center justify-between">
-        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Licensing & Compliance</h3>
+        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Licensing & Compliance</h3>
         <span className="hidden sm:inline-flex sm:gap-1">
           {LICENSING_IS_GOVERNANCE ? <TagPill tag="governance" active={activeTag === 'governance'} onClick={onTagClick} /> : null}
           {LICENSING_IS_COMPLIANCE ? <TagPill tag="compliance" active={activeTag === 'compliance'} onClick={onTagClick} /> : null}
@@ -77,15 +77,15 @@ function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingRe
           <div className="min-w-0">
             {hasLicense ? (
               <>
-                <p className="text-sm font-medium text-slate-900">
-                  {license.name} <span className="font-normal text-slate-400">({license.spdxId})</span>
+                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                  {license.name} <span className="font-normal text-slate-400 dark:text-slate-500">({license.spdxId})</span>
                 </p>
                 {isDualLicensed ? (
-                  <p className="mt-0.5 text-xs text-slate-500">Dual-licensed</p>
+                  <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">Dual-licensed</p>
                 ) : null}
               </>
             ) : (
-              <p className="text-sm font-medium text-slate-400">No license detected</p>
+              <p className="text-sm font-medium text-slate-400 dark:text-slate-500">No license detected</p>
             )}
           </div>
         </li>
@@ -95,11 +95,11 @@ function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingRe
           <li key={addLicense.spdxId} className="flex items-start gap-2">
             <span className="mt-0.5 text-sm text-emerald-600">✓</span>
             <div className="min-w-0">
-              <p className="text-sm font-medium text-slate-900">
-                {addLicense.name ?? addLicense.spdxId} <span className="font-normal text-slate-400">({addLicense.spdxId})</span>
+              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                {addLicense.name ?? addLicense.spdxId} <span className="font-normal text-slate-400 dark:text-slate-500">({addLicense.spdxId})</span>
               </p>
               {addLicense.permissivenessTier ? (
-                <p className="mt-0.5 text-xs text-slate-500">{addLicense.permissivenessTier}</p>
+                <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">{addLicense.permissivenessTier}</p>
               ) : null}
             </div>
           </li>
@@ -111,7 +111,7 @@ function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingRe
             <span className={`mt-0.5 text-sm ${license.osiApproved ? 'text-emerald-600' : 'text-amber-500'}`}>
               {license.osiApproved ? '✓' : '!'}
             </span>
-            <p className={`text-sm font-medium ${license.osiApproved ? 'text-slate-900' : 'text-slate-400'}`}>
+            <p className={`text-sm font-medium ${license.osiApproved ? 'text-slate-900 dark:text-slate-100' : 'text-slate-400 dark:text-slate-500'}`}>
               {license.osiApproved ? 'OSI Approved' : 'Not OSI approved'}
             </p>
           </li>
@@ -120,8 +120,8 @@ function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingRe
         {/* Permissiveness tier */}
         {license.permissivenessTier ? (
           <li className="flex items-start gap-2">
-            <span className="mt-0.5 text-sm text-slate-400">·</span>
-            <p className="text-sm font-medium text-slate-900">{license.permissivenessTier}</p>
+            <span className="mt-0.5 text-sm text-slate-400 dark:text-slate-500">·</span>
+            <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{license.permissivenessTier}</p>
           </li>
         ) : null}
 
@@ -130,7 +130,7 @@ function LicensingPane({ licensingResult, activeTag, onTagClick }: { licensingRe
           <span className={`mt-0.5 text-sm ${contributorAgreement.enforced ? 'text-emerald-600' : 'text-slate-400'}`}>
             {contributorAgreement.enforced ? '✓' : contributorAgreement.signedOffByRatio === null && !contributorAgreement.dcoOrClaBot ? '·' : '✗'}
           </span>
-          <p className={`text-sm font-medium ${contributorAgreement.enforced ? 'text-slate-900' : 'text-slate-400'}`}>
+          <p className={`text-sm font-medium ${contributorAgreement.enforced ? 'text-slate-900 dark:text-slate-100' : 'text-slate-400 dark:text-slate-500'}`}>
             {contributorAgreement.enforced
               ? 'DCO/CLA enforcement detected'
               : contributorAgreement.signedOffByRatio === null && !contributorAgreement.dcoOrClaBot
@@ -152,9 +152,9 @@ const SEVERITY_COLORS: Record<string, string> = {
 function InclusiveNamingPane({ inclusiveNamingResult }: { inclusiveNamingResult: InclusiveNamingResult | 'unavailable' }) {
   if (inclusiveNamingResult === 'unavailable') {
     return (
-      <section aria-label="Inclusive Naming" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Inclusive Naming</h3>
-        <p className="mt-3 text-sm text-slate-400">Inclusive naming data unavailable.</p>
+      <section aria-label="Inclusive Naming" className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Inclusive Naming</h3>
+        <p className="mt-3 text-sm text-slate-400 dark:text-slate-500">Inclusive naming data unavailable.</p>
       </section>
     )
   }
@@ -164,8 +164,8 @@ function InclusiveNamingPane({ inclusiveNamingResult }: { inclusiveNamingResult:
   const failingChecks = allChecks.filter((c) => !c.passed)
 
   return (
-    <section aria-label="Inclusive Naming" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Inclusive Naming</h3>
+    <section aria-label="Inclusive Naming" className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Inclusive Naming</h3>
       <ul className="mt-3 space-y-2">
         {/* Branch name check */}
         <li className="flex items-start gap-2">
@@ -173,7 +173,7 @@ function InclusiveNamingPane({ inclusiveNamingResult }: { inclusiveNamingResult:
             {branchCheck.passed ? '✓' : '✗'}
           </span>
           <div className="min-w-0">
-            <p className={`text-sm font-medium ${branchCheck.passed ? 'text-slate-900' : 'text-slate-400'}`}>
+            <p className={`text-sm font-medium ${branchCheck.passed ? 'text-slate-900 dark:text-slate-100' : 'text-slate-400 dark:text-slate-500'}`}>
               Default branch: {inclusiveNamingResult.defaultBranchName ?? 'unknown'}
             </p>
             {!branchCheck.passed && branchCheck.severity ? (
@@ -189,7 +189,7 @@ function InclusiveNamingPane({ inclusiveNamingResult }: { inclusiveNamingResult:
           <li key={`${check.checkType}:${check.term}`} className="flex items-start gap-2">
             <span className="mt-0.5 text-sm text-red-400">✗</span>
             <div className="min-w-0">
-              <p className="text-sm font-medium text-slate-400">
+              <p className="text-sm font-medium text-slate-400 dark:text-slate-500">
                 &lsquo;{check.term}&rsquo; in {check.checkType}
               </p>
               {check.severity ? (
@@ -206,13 +206,13 @@ function InclusiveNamingPane({ inclusiveNamingResult }: { inclusiveNamingResult:
         {failingChecks.length === 0 ? (
           <li className="flex items-start gap-2">
             <span className="mt-0.5 text-sm text-emerald-600">✓</span>
-            <p className="text-sm font-medium text-slate-900">No non-inclusive terms detected</p>
+            <p className="text-sm font-medium text-slate-900 dark:text-slate-100">No non-inclusive terms detected</p>
           </li>
         ) : null}
       </ul>
       {failingChecks.length > 0 ? (
-        <p className="mt-3 text-xs text-slate-400">
-          Reference: <a href="https://inclusivenaming.org/" target="_blank" rel="noopener noreferrer" className="underline hover:text-slate-600">inclusivenaming.org</a>
+        <p className="mt-3 text-xs text-slate-400 dark:text-slate-500">
+          Reference: <a href="https://inclusivenaming.org/" target="_blank" rel="noopener noreferrer" className="underline hover:text-slate-600 dark:hover:text-slate-300">inclusivenaming.org</a>
         </p>
       ) : null}
     </section>
@@ -235,7 +235,7 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
         const isCollapsed = collapsed.has(result.repo)
         if (result.documentationResult === 'unavailable') {
           return (
-            <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-6">
+            <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900">
               <button
                 type="button"
                 onClick={() => setCollapsed((prev) => { const next = new Set(prev); if (next.has(result.repo)) next.delete(result.repo); else next.add(result.repo); return next })}
@@ -243,9 +243,9 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
                 aria-expanded={!isCollapsed}
               >
                 <CollapseChevron expanded={!isCollapsed} />
-                <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{result.repo}</h2>
               </button>
-              {!isCollapsed ? <p className="mt-2 text-sm text-slate-500">Documentation data unavailable.</p> : null}
+              {!isCollapsed ? <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Documentation data unavailable.</p> : null}
             </div>
           )
         }
@@ -256,7 +256,7 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
         const sectionsDetected = readmeSections.filter((s) => s.detected).length
 
         return (
-          <div key={result.repo} className="overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+          <div key={result.repo} className="overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 dark:border-slate-700 dark:bg-slate-900">
             <button
               type="button"
               onClick={() => setCollapsed((prev) => { const next = new Set(prev); if (next.has(result.repo)) next.delete(result.repo); else next.add(result.repo); return next })}
@@ -264,12 +264,12 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
               aria-expanded={!isCollapsed}
             >
               <CollapseChevron expanded={!isCollapsed} />
-              <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{result.repo}</h2>
             </button>
             {!isCollapsed ? (
               <div className="mt-4">
                 <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                  <p className="text-sm text-slate-500">
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
                     {filesFound} of {fileChecks.length} files present · {sectionsDetected} of {readmeSections.length} README sections detected
                   </p>
                   <div className="w-full md:max-w-xs">
@@ -288,8 +288,8 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
                 <div className="mt-6 grid gap-6 overflow-hidden md:grid-cols-2">
               {/* File presence */}
               {!activeTag || fileChecks.some((c) => getDocFileAllTags(c.name).includes(activeTag)) ? (
-                <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-                  <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Documentation files</h3>
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Documentation files</h3>
                   <ul className="mt-3 space-y-2">
                     {fileChecks
                       .filter((check) => !activeTag || getDocFileAllTags(check.name).includes(activeTag))
@@ -301,9 +301,9 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
                               {check.found ? '✓' : '✗'}
                             </span>
                             <div className="min-w-0 flex-1">
-                              <p className={`break-all text-sm font-medium ${check.found ? 'text-slate-900' : 'text-slate-400'}`}>
+                              <p className={`break-all text-sm font-medium ${check.found ? 'text-slate-900 dark:text-slate-100' : 'text-slate-400 dark:text-slate-500'}`}>
                                 {FILE_LABELS[check.name] ?? check.name}
-                                {check.found && check.path ? <span className="ml-1 font-normal text-slate-400">({check.path})</span> : null}
+                                {check.found && check.path ? <span className="ml-1 font-normal text-slate-400 dark:text-slate-500">({check.path})</span> : null}
                                 {tags.map((tag) => <span key={tag} className="hidden sm:inline"> <TagPill tag={tag} active={activeTag === tag} onClick={handleTagClick} /></span>)}
                               </p>
                               {!check.found ? (
@@ -321,8 +321,8 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
 
               {/* README sections — show when no filter or when contrib-ex is active */}
               {!activeTag || readmeSections.some((s) => getReadmeSectionTags(s.name).includes(activeTag)) ? (
-                <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-                  <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">README sections</h3>
+                <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">README sections</h3>
                   <ul className="mt-3 space-y-2">
                     {readmeSections
                       .filter((section) => !activeTag || getReadmeSectionTags(section.name).includes(activeTag))
@@ -334,7 +334,7 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
                               {section.detected ? '✓' : '✗'}
                             </span>
                             <div className="min-w-0 flex-1">
-                              <p className={`text-sm font-medium ${section.detected ? 'text-slate-900' : 'text-slate-400'}`}>
+                              <p className={`text-sm font-medium ${section.detected ? 'text-slate-900 dark:text-slate-100' : 'text-slate-400 dark:text-slate-500'}`}>
                                 {SECTION_LABELS[section.name] ?? section.name}
                                 {tags.map((tag) => <span key={tag} className="hidden sm:inline"> <TagPill tag={tag} active={activeTag === tag} onClick={handleTagClick} /></span>)}
                               </p>

--- a/components/ecosystem-map/EcosystemMap.tsx
+++ b/components/ecosystem-map/EcosystemMap.tsx
@@ -15,21 +15,21 @@ export function EcosystemMap({ results }: EcosystemMapProps) {
   }
 
   return (
-    <section aria-label="Ecosystem map" className="rounded border border-gray-200 bg-gray-50 p-4">
-      <section className="mt-3 rounded border border-indigo-200 bg-white p-3">
+    <section aria-label="Ecosystem map" className="rounded border border-gray-200 bg-gray-50 p-4 dark:bg-slate-800/60 dark:border-slate-700">
+      <section className="mt-3 rounded border border-indigo-200 bg-white p-3 dark:bg-slate-900 dark:border-indigo-800/60">
         <div className="space-y-3">
           <div>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div>
-                <h3 className="text-sm font-semibold text-slate-900">Ecosystem spectrum</h3>
-                <p className="mt-1 text-sm text-slate-600">
+                <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Ecosystem spectrum</h3>
+                <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
                   The ecosystem is summarized using three dimensions: reach, builder engagement, and attention.
                   Engagement and attention are scored as percentiles relative to repos in the same star bracket.
                 </p>
               </div>
               <button
                 type="button"
-                className="inline-flex items-center self-start rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                className="inline-flex items-center self-start rounded-full border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-200"
                 aria-expanded={legendExpanded}
                 onClick={() => setLegendExpanded((current) => !current)}
               >
@@ -38,18 +38,18 @@ export function EcosystemMap({ results }: EcosystemMapProps) {
             </div>
           </div>
           {legendExpanded ? (
-            <div className="space-y-2 text-sm text-slate-600">
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-                <p className="font-medium text-slate-900">Reach</p>
-                <p className="text-xs text-slate-500">stars — scored as a percentile within the star bracket</p>
+            <div className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:bg-slate-800/60 dark:border-slate-700">
+                <p className="font-medium text-slate-900 dark:text-slate-100">Reach</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">stars — scored as a percentile within the star bracket</p>
               </div>
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-                <p className="font-medium text-slate-900">Attention</p>
-                <p className="text-xs text-slate-500">watcher rate — scored as a percentile within the star bracket</p>
+              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:bg-slate-800/60 dark:border-slate-700">
+                <p className="font-medium text-slate-900 dark:text-slate-100">Attention</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">watcher rate — scored as a percentile within the star bracket</p>
               </div>
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-                <p className="font-medium text-slate-900">Builder engagement</p>
-                <p className="text-xs text-slate-500">fork rate — scored as a percentile within the star bracket</p>
+              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:bg-slate-800/60 dark:border-slate-700">
+                <p className="font-medium text-slate-900 dark:text-slate-100">Builder engagement</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">fork rate — scored as a percentile within the star bracket</p>
               </div>
             </div>
           ) : null}

--- a/components/export/ExportControls.tsx
+++ b/components/export/ExportControls.tsx
@@ -47,7 +47,7 @@ export function ExportControls({ analysisResponse, analyzedRepos }: ExportContro
         type="button"
         onClick={handleDownloadJson}
         disabled={disabled}
-        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
       >
         Download JSON
       </button>
@@ -56,7 +56,7 @@ export function ExportControls({ analysisResponse, analyzedRepos }: ExportContro
         type="button"
         onClick={handleDownloadMarkdown}
         disabled={disabled}
-        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
       >
         Download Markdown
       </button>
@@ -64,7 +64,7 @@ export function ExportControls({ analysisResponse, analyzedRepos }: ExportContro
       <button
         type="button"
         onClick={() => { void handleCopyLink() }}
-        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"
+        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
       >
         {copyState === 'copied' ? 'Copied!' : 'Copy link'}
       </button>
@@ -75,7 +75,7 @@ export function ExportControls({ analysisResponse, analyzedRepos }: ExportContro
           readOnly
           value={fallbackUrl}
           aria-label="Shareable URL"
-          className="flex-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
+          className="flex-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
           onFocus={(e) => e.currentTarget.select()}
         />
       ) : null}

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -78,7 +78,7 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
 
       {showOverrideToggle ? (
         <div
-          className={`mt-3 flex flex-wrap items-start justify-between gap-2 rounded-lg border px-3 py-2 text-xs ${isSolo ? 'border-amber-300 bg-amber-50 text-amber-900' : 'border-sky-300 bg-sky-50 text-sky-900'}`}
+          className={`mt-3 flex flex-wrap items-start justify-between gap-2 rounded-lg border px-3 py-2 text-xs ${isSolo ? 'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-200' : 'border-sky-300 bg-sky-50 text-sky-900 dark:border-sky-700/60 dark:bg-sky-900/20 dark:text-sky-200'}`}
           data-testid={`solo-profile-banner-${card.repo}`}
           role="status"
         >
@@ -98,7 +98,7 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
           <button
             type="button"
             onClick={() => setProfileOverride(isSolo ? 'community' : (autoSolo ? null : 'solo'))}
-            className="shrink-0 rounded border border-current px-2 py-0.5 font-medium hover:bg-white/50"
+            className="shrink-0 rounded border border-current px-2 py-0.5 font-medium hover:bg-white/50 dark:hover:bg-white/10"
             data-testid={`solo-profile-toggle-${card.repo}`}
           >
             {isSolo ? 'Use community scoring' : 'Use solo scoring'}
@@ -262,22 +262,22 @@ function ScorecardCell({ label, percentileLabel, detail, tooltip, toneClass, onC
 
 const PERCENTILE_TONE_CLASSES = {
   emerald: [
-    'bg-slate-100 text-slate-700 border-slate-200',
-    'bg-emerald-100 text-emerald-800 border-emerald-200',
-    'bg-emerald-200 text-emerald-900 border-emerald-300',
-    'bg-emerald-300 text-emerald-950 border-emerald-400',
+    'bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800/60 dark:text-slate-200 dark:border-slate-700',
+    'bg-emerald-100 text-emerald-800 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-800/60',
+    'bg-emerald-200 text-emerald-900 border-emerald-300 dark:bg-emerald-900/40 dark:text-emerald-100 dark:border-emerald-700/70',
+    'bg-emerald-300 text-emerald-950 border-emerald-400 dark:bg-emerald-800/50 dark:text-emerald-50 dark:border-emerald-600/70',
   ],
   sky: [
-    'bg-slate-100 text-slate-700 border-slate-200',
-    'bg-sky-100 text-sky-800 border-sky-200',
-    'bg-sky-200 text-sky-900 border-sky-300',
-    'bg-sky-300 text-sky-950 border-sky-400',
+    'bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800/60 dark:text-slate-200 dark:border-slate-700',
+    'bg-sky-100 text-sky-800 border-sky-200 dark:bg-sky-900/30 dark:text-sky-200 dark:border-sky-800/60',
+    'bg-sky-200 text-sky-900 border-sky-300 dark:bg-sky-900/40 dark:text-sky-100 dark:border-sky-700/70',
+    'bg-sky-300 text-sky-950 border-sky-400 dark:bg-sky-800/50 dark:text-sky-50 dark:border-sky-600/70',
   ],
   violet: [
-    'bg-slate-100 text-slate-700 border-slate-200',
-    'bg-violet-100 text-violet-800 border-violet-200',
-    'bg-violet-200 text-violet-900 border-violet-300',
-    'bg-violet-300 text-violet-950 border-violet-400',
+    'bg-slate-100 text-slate-700 border-slate-200 dark:bg-slate-800/60 dark:text-slate-200 dark:border-slate-700',
+    'bg-violet-100 text-violet-800 border-violet-200 dark:bg-violet-900/30 dark:text-violet-200 dark:border-violet-800/60',
+    'bg-violet-200 text-violet-900 border-violet-300 dark:bg-violet-900/40 dark:text-violet-100 dark:border-violet-700/70',
+    'bg-violet-300 text-violet-950 border-violet-400 dark:bg-violet-800/50 dark:text-violet-50 dark:border-violet-600/70',
   ],
 } as const
 

--- a/components/org-inventory/OrgInventorySummary.tsx
+++ b/components/org-inventory/OrgInventorySummary.tsx
@@ -90,14 +90,14 @@ function SummaryListCard({
     <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-800">
       <p className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{title}</p>
       {items.length === 0 ? (
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{emptyLabel}</p>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400 dark:text-slate-300">{emptyLabel}</p>
       ) : (
         <>
-          <ul className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300">
+          <ul className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
             {visibleItems.map((item) => (
               <li key={`${title}-${item.label}`} className="flex items-center justify-between gap-3">
                 <span className="truncate text-slate-900 dark:text-slate-100">{item.label}</span>
-                <span className="shrink-0 text-slate-600 dark:text-slate-400">{item.value}</span>
+                <span className="shrink-0 text-slate-600 dark:text-slate-400 dark:text-slate-300">{item.value}</span>
               </li>
             ))}
           </ul>

--- a/components/org-inventory/OrgInventoryTable.tsx
+++ b/components/org-inventory/OrgInventoryTable.tsx
@@ -41,22 +41,22 @@ export function OrgInventoryTable({
       <table className="min-w-full border-separate border-spacing-y-2">
         <thead>
           <tr>
-            <th className="w-16 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500">Select</th>
+            <th className="w-16 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Select</th>
             {(['repo', ...visibleColumns] as OrgInventorySortColumn[]).map((column) => (
-              <th key={column} className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+              <th key={column} className="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 <button type="button" className="inline-flex items-center gap-2" onClick={() => onToggleSort(column)}>
                   <span>{COLUMN_LABELS[column]}</span>
-                  {sortState.sortColumn === column ? <span className="text-[10px] text-slate-400">{sortState.sortDirection === 'asc' ? '↑' : '↓'}</span> : null}
+                  {sortState.sortColumn === column ? <span className="text-[10px] text-slate-400 dark:text-slate-500">{sortState.sortDirection === 'asc' ? '↑' : '↓'}</span> : null}
                 </button>
               </th>
             ))}
-            <th className="w-28 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500">Actions</th>
+            <th className="w-28 px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Actions</th>
           </tr>
         </thead>
         <tbody>
           {results.map((result) => (
-            <tr key={result.repo} className="rounded-xl border border-slate-200 bg-slate-50">
-              <td className="rounded-l-xl border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
+            <tr key={result.repo} className="rounded-xl border border-slate-200 bg-slate-50 dark:bg-slate-800/60 dark:border-slate-700">
+              <td className="rounded-l-xl border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
                 <input
                   type="checkbox"
                   checked={selectedRepos.includes(result.repo)}
@@ -64,16 +64,16 @@ export function OrgInventoryTable({
                   aria-label={`Select ${result.repo}`}
                 />
               </td>
-              <th className="border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-left text-sm font-medium text-slate-900">{result.repo}</th>
+              <th className="border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-left text-sm font-medium text-slate-900 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-100">{result.repo}</th>
               {visibleColumns.map((column) => (
-                <td key={`${result.repo}-${column}`} className="border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
+                <td key={`${result.repo}-${column}`} className="border border-r-0 border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
                   {renderColumnValue(result, column)}
                 </td>
               ))}
-              <td className="rounded-r-xl border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700">
+              <td className="rounded-r-xl border border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
                 <button
                   type="button"
-                  className="w-full whitespace-nowrap rounded border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                  className="w-full whitespace-nowrap rounded border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200"
                   onClick={() => onAnalyzeRepo(result.repo)}
                   aria-label={`Analyze ${result.repo}`}
                 >

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -118,9 +118,9 @@ export function OrgInventoryView({
       </div>
 
       {results.length === 0 ? (
-        <section className="rounded-2xl border border-slate-200 bg-white p-6">
-          <h3 className="text-lg font-semibold text-slate-900">No public repositories found</h3>
-          <p className="mt-2 text-sm text-slate-600">
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 dark:bg-slate-900 dark:border-slate-700">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No public repositories found</h3>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
             RepoPulse did not find any public repositories for this organization.
           </p>
         </section>
@@ -143,7 +143,7 @@ export function OrgInventoryView({
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                className={`h-4 w-4 text-slate-500 transition-transform dark:text-slate-400 ${repoTableExpanded ? '' : '-rotate-90'}`}
+                className={`h-4 w-4 text-slate-500 transition-transform dark:text-slate-400 ${repoTableExpanded ? '' : '-rotate-90'} dark:text-slate-500 `}
               >
                 <path d="M4 6l4 4 4-4" />
               </svg>
@@ -153,7 +153,7 @@ export function OrgInventoryView({
             </button>
             {repoTableExpanded ? (
               <div className="space-y-4 px-3 pb-3">
-                <div className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800">
+                <div className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800 dark:bg-slate-900">
                 <div className="flex flex-wrap items-end gap-2">
                   <label className="flex-1 min-w-[140px]">
                     <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Filter</span>
@@ -198,7 +198,7 @@ export function OrgInventoryView({
                       <option value="archived">Archived</option>
                     </select>
                   </label>
-                  <div className="flex items-center gap-3 text-xs text-slate-700 dark:text-slate-300">
+                  <div className="flex items-center gap-3 text-xs text-slate-700 dark:text-slate-300 dark:text-slate-200">
                     <label className="inline-flex items-center gap-1">
                       <input type="checkbox" checked={excludeArchivedRepos} onChange={(e) => setExcludeArchivedRepos(e.target.checked)} aria-label="Exclude archived repos" />
                       No archived
@@ -247,7 +247,7 @@ export function OrgInventoryView({
                       <button
                         type="button"
                         disabled={activeRunRepos.length === 0}
-                        className="rounded border border-sky-300 bg-sky-50 px-3 py-1 text-xs font-medium text-sky-800 transition enabled:hover:border-sky-400 enabled:hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-300"
+                        className="rounded border border-sky-300 bg-sky-50 px-3 py-1 text-xs font-medium text-sky-800 transition enabled:hover:border-sky-400 enabled:hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-300 dark:bg-sky-900/20 dark:border-sky-700/70 dark:text-sky-200"
                         onClick={() => onAnalyzeAllActive(activeRunRepos)}
                       >
                         Analyze all ({activeRunRepos.length})
@@ -263,13 +263,13 @@ export function OrgInventoryView({
                     </button>
                   </div>
                 </div>
-                {selectionError ? <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">{selectionError}</p> : null}
+                {selectionError ? <p className="mt-1 text-xs text-amber-700 dark:text-amber-400 dark:text-amber-300">{selectionError}</p> : null}
 
                 <div className="flex flex-wrap items-center justify-between gap-2 border-t border-slate-200 pt-2 dark:border-slate-700">
                   <p className="text-xs text-slate-500 dark:text-slate-400">
                     Showing {visibleRangeStart}–{visibleRangeEnd} of {sortedRows.length}
                   </p>
-                  <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                  <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
                     <span>Rows per page</span>
                     <select
                       aria-label="Rows per page"
@@ -278,7 +278,7 @@ export function OrgInventoryView({
                         setCurrentPage(1)
                         setPageSize(clampOrgInventoryPageSize(Number(event.target.value)))
                       }}
-                      className="rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900"
+                      className="rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:bg-slate-900 dark:border-slate-600 dark:text-slate-100"
                     >
                       {ORG_INVENTORY_CONFIG.pageSizeOptions.map((option) => (
                         <option key={option} value={option}>
@@ -327,8 +327,8 @@ export function OrgInventoryView({
                     </div>
                   ) : (
                     <div>
-                      <h3 className="text-lg font-semibold text-slate-900">No matching repositories</h3>
-                      <p className="mt-2 text-sm text-slate-600">
+                      <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No matching repositories</h3>
+                      <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
                         Try widening the repo, language, or archived filters to see more repositories.
                       </p>
                     </div>
@@ -352,8 +352,8 @@ export function OrgInventoryView({
                       onAnalyzeRepo={onAnalyzeRepo}
                     />
 
-                    <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-4">
-                      <p className="text-sm text-slate-600">
+                    <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-4 dark:bg-slate-900 dark:border-slate-700">
+                      <p className="text-sm text-slate-600 dark:text-slate-300">
                         Page {safeCurrentPage} of {totalPages}
                       </p>
                       <div className="flex items-center gap-2">
@@ -361,7 +361,7 @@ export function OrgInventoryView({
                           type="button"
                           disabled={safeCurrentPage === 1}
                           onClick={() => setCurrentPage((current) => Math.max(1, current - 1))}
-                          className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200"
                         >
                           Previous
                         </button>
@@ -369,7 +369,7 @@ export function OrgInventoryView({
                           type="button"
                           disabled={safeCurrentPage === totalPages}
                           onClick={() => setCurrentPage((current) => Math.min(totalPages, current + 1))}
-                          className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition enabled:hover:border-slate-400 enabled:hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200"
                         >
                           Next
                         </button>
@@ -383,7 +383,7 @@ export function OrgInventoryView({
         </>
       )}
       {rateLimit && isRateLimitLow(rateLimit) ? (
-        <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+        <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
           <p>Remaining API calls: {formatDisplayValue(rateLimit.remaining)}</p>
           <p>Rate limit resets at: {formatRateLimitReset(rateLimit.resetAt)}</p>
           {rateLimit.retryAfter !== 'unavailable' ? <p>Retry after: {formatRetryAfter(rateLimit.retryAfter)}</p> : null}

--- a/components/org-summary/EmptyState.tsx
+++ b/components/org-summary/EmptyState.tsx
@@ -11,7 +11,7 @@ export function EmptyState({ label = 'Waiting for first result' }: { label?: str
   return (
     <div
       role="status"
-      className="flex h-full min-h-[96px] items-center justify-center rounded border-2 border-dashed border-slate-300 p-4 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400"
+      className="flex h-full min-h-[96px] items-center justify-center rounded border-2 border-dashed border-slate-300 p-4 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400 dark:border-slate-600"
     >
       {label}
     </div>

--- a/components/org-summary/NotificationToggle.tsx
+++ b/components/org-summary/NotificationToggle.tsx
@@ -49,7 +49,7 @@ export function NotificationToggle({ enabled, onChange }: Props) {
   if (permState === 'unsupported') return null
 
   return (
-    <label className="inline-flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400">
+    <label className="inline-flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400 dark:text-slate-300">
       <input
         type="checkbox"
         checked={enabled}

--- a/components/org-summary/OrgSummaryView.tsx
+++ b/components/org-summary/OrgSummaryView.tsx
@@ -91,14 +91,14 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
           <button
             type="button"
             onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
-            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:bg-slate-900"
           >
             Export JSON
           </button>
           <button
             type="button"
             onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
-            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:bg-slate-900"
           >
             Export Markdown
           </button>
@@ -170,7 +170,7 @@ export function OrgSummaryView({ org, view, startedAt, onCancel, onPause, onResu
               </h3>
               <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
                 {view.missingData.map((m) => (
-                  <li key={`${m.repo}:${m.signalKey}`} className="py-2 text-sm text-slate-700 dark:text-slate-300">
+                  <li key={`${m.repo}:${m.signalKey}`} className="py-2 text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
                     <span className="font-medium">{m.repo}</span>{' '}
                     <span className="text-slate-500 dark:text-slate-400">· {m.signalKey}</span>{' '}
                     <span className="text-slate-500 dark:text-slate-400">— {m.reason}</span>
@@ -267,7 +267,7 @@ function InlineOrgSummary({
         <div className="flex items-center gap-3">
           {showPause && onPause ? (
             <button type="button" onClick={onPause} aria-label="Pause run" title="Pause run"
-              className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+              className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:bg-slate-900">
               <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor"><rect x="4" y="3" width="3" height="10" rx="0.5" /><rect x="9" y="3" width="3" height="10" rx="0.5" /></svg>
             </button>
           ) : null}
@@ -279,7 +279,7 @@ function InlineOrgSummary({
           ) : null}
           {showCancel && onCancel ? (
             <button type="button" onClick={onCancel} aria-label="Cancel run" title="Cancel run"
-              className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700">
+              className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700 dark:bg-slate-900">
               <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor"><rect x="3.5" y="3.5" width="9" height="9" rx="1" /></svg>
             </button>
           ) : null}
@@ -299,7 +299,7 @@ function InlineOrgSummary({
           </dl>
 
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400">
+            <div className="flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400 dark:text-slate-300">
               <span>Elapsed: {formatDuration(view.status.elapsedMs)}</span>
               {view.status.etaMs !== null ? <span>ETA: {formatDuration(view.status.etaMs)}</span> : null}
               <span>Concurrency: {view.status.concurrency.chosen}</span>
@@ -309,11 +309,11 @@ function InlineOrgSummary({
               {isTerminal ? (
                 <div className="flex gap-2">
                   <button type="button" onClick={() => triggerDownload(buildOrgSummaryJsonExport(org, view))}
-                    className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+                    className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:bg-slate-900">
                     Export JSON
                   </button>
                   <button type="button" onClick={() => triggerDownload(buildOrgSummaryMarkdownExport(org, view))}
-                    className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">
+                    className="rounded border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:bg-slate-900">
                     Export Markdown
                   </button>
                 </div>
@@ -369,7 +369,7 @@ function InlineOrgSummary({
               </h3>
               <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
                 {view.missingData.map((m) => (
-                  <li key={`${m.repo}:${m.signalKey}`} className="py-2 text-sm text-slate-700 dark:text-slate-300">
+                  <li key={`${m.repo}:${m.signalKey}`} className="py-2 text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
                     <span className="font-medium">{m.repo}</span>{' '}
                     <span className="text-slate-500 dark:text-slate-400">· {m.signalKey}</span>{' '}
                     <span className="text-slate-500 dark:text-slate-400">— {m.reason}</span>

--- a/components/org-summary/OrgWindowSelector.tsx
+++ b/components/org-summary/OrgWindowSelector.tsx
@@ -21,7 +21,7 @@ export function OrgWindowSelector({ selected, onChange }: Props) {
     <div className="flex items-center gap-2">
       <span className="text-xs text-slate-500 dark:text-slate-400">Time window:</span>
       <div
-        className="inline-flex overflow-hidden rounded border border-slate-300 dark:border-slate-700"
+        className="inline-flex overflow-hidden rounded border border-slate-300 dark:border-slate-700 dark:border-slate-600"
         role="tablist"
         aria-label="Analysis time window"
       >

--- a/components/org-summary/PerRepoStatusList.tsx
+++ b/components/org-summary/PerRepoStatusList.tsx
@@ -32,7 +32,7 @@ export function PerRepoStatusList({ entries, onRetry }: Props) {
             onClick={() => failedEntries.forEach((e) => onRetry(e.repo))}
             aria-label={`Retry all failed (${failedEntries.length})`}
             title={`Retry all failed (${failedEntries.length})`}
-            className="inline-flex items-center gap-1 rounded-full border border-rose-300 bg-white px-2 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-700 dark:bg-slate-800 dark:text-rose-300 dark:hover:bg-slate-700"
+            className="inline-flex items-center gap-1 rounded-full border border-rose-300 bg-white px-2 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50 dark:border-rose-700 dark:bg-slate-800 dark:text-rose-300 dark:hover:bg-slate-700 dark:bg-slate-900"
           >
             <RetryIcon />
             <span className="font-semibold">{failedEntries.length}</span>
@@ -45,16 +45,16 @@ export function PerRepoStatusList({ entries, onRetry }: Props) {
             <span className={`inline-flex rounded px-2 py-0.5 text-xs font-medium ${BADGE_STYLE[e.badge]}`}>
               {e.badge}
             </span>
-            <span className="flex-1 truncate text-sm text-slate-800 dark:text-slate-200">
+            <span className="flex-1 truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">
               {e.repo}
               {e.isFlagship ? (
-                <span className="ml-2 inline-flex rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-900 dark:bg-amber-900/40 dark:text-amber-300">
+                <span className="ml-2 inline-flex rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-900 dark:bg-amber-900/40 dark:text-amber-300 dark:text-amber-200">
                   flagship
                 </span>
               ) : null}
             </span>
             {e.errorReason ? (
-              <span className="max-w-xs truncate text-xs text-rose-700 dark:text-rose-400" title={e.errorReason}>
+              <span className="max-w-xs truncate text-xs text-rose-700 dark:text-rose-400 dark:text-rose-300" title={e.errorReason}>
                 {e.errorReason}
               </span>
             ) : null}
@@ -64,7 +64,7 @@ export function PerRepoStatusList({ entries, onRetry }: Props) {
                 onClick={() => onRetry(e.repo)}
                 aria-label={`Retry ${e.repo}`}
                 title={`Retry ${e.repo}`}
-                className="inline-flex h-7 w-7 items-center justify-center rounded border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+                className="inline-flex h-7 w-7 items-center justify-center rounded border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:bg-slate-900"
               >
                 <RetryIcon />
               </button>

--- a/components/org-summary/PreRunWarningDialog.tsx
+++ b/components/org-summary/PreRunWarningDialog.tsx
@@ -42,7 +42,7 @@ export function PreRunWarningDialog({ repoCount, onConfirm, onCancel }: PreRunWa
           Analyze {repoCount} repositories?
         </h2>
 
-        <div className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300">
+        <div className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
           <p>
             Estimated time: <strong>{estimateEta(repoCount, concurrency)}</strong>
           </p>
@@ -63,11 +63,11 @@ export function PreRunWarningDialog({ repoCount, onConfirm, onCancel }: PreRunWa
               value={concurrency}
               onChange={(e) => handleConcurrencyChange(e.target.value)}
               aria-label="Concurrency"
-              className="mt-1 w-20 rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+              className="mt-1 w-20 rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:bg-slate-900"
             />
           </label>
 
-          <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+          <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
             <input
               type="checkbox"
               checked={notificationOptIn}
@@ -85,7 +85,7 @@ export function PreRunWarningDialog({ repoCount, onConfirm, onCancel }: PreRunWa
           <button
             type="button"
             onClick={onCancel}
-            className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 dark:bg-slate-900"
           >
             Cancel
           </button>

--- a/components/org-summary/ProgressIndicator.tsx
+++ b/components/org-summary/ProgressIndicator.tsx
@@ -74,22 +74,16 @@ export function ProgressIndicator({ succeeded, failed, total, status, startedAt,
           className="h-2.5 flex-1 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700"
         >
           <div
-            className={`h-full rounded-full transition-all duration-300 ${
-              isTerminal
-                ? failed > 0
-                  ? 'bg-amber-500'
-                  : 'bg-emerald-500'
-                : 'bg-sky-500'
-            }`}
+            className={`h-full rounded-full transition-all duration-300 ${ isTerminal ? failed > 0 ? 'bg-amber-500' : 'bg-emerald-500' : 'bg-sky-500' }`}
             style={{ width: `${percent}%` }}
           />
         </div>
-        <span className="min-w-[3rem] text-right text-sm font-medium text-slate-700 dark:text-slate-300">
+        <span className="min-w-[3rem] text-right text-sm font-medium text-slate-700 dark:text-slate-300 dark:text-slate-200">
           {percent}%
         </span>
       </div>
 
-      <div className="mt-2 flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400">
+      <div className="mt-2 flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400 dark:text-slate-300">
         <span>{completed} of {total} repos</span>
         <span>Elapsed: {formatDuration(elapsed)}</span>
         {!isTerminal && etaMs !== null ? <span>ETA: {formatDuration(etaMs)}</span> : null}

--- a/components/org-summary/RateLimitPausePanel.tsx
+++ b/components/org-summary/RateLimitPausePanel.tsx
@@ -31,7 +31,7 @@ export function RateLimitPausePanel({ kind, resumesAt, reposToReDispatch, pauses
   return (
     <section
       aria-label="Rate limit pause"
-      className="rounded-lg border border-amber-200 bg-amber-50 p-4 shadow-sm dark:border-amber-800 dark:bg-amber-950/30"
+      className="rounded-lg border border-amber-200 bg-amber-50 p-4 shadow-sm dark:border-amber-800 dark:bg-amber-950/30 dark:bg-amber-900/20 dark:border-amber-800/60"
     >
       <div className="flex items-start gap-3">
         <div className="mt-0.5 text-amber-600 dark:text-amber-400">
@@ -56,7 +56,7 @@ export function RateLimitPausePanel({ kind, resumesAt, reposToReDispatch, pauses
               onClick={onCancel}
               aria-label="Cancel run"
               title="Cancel run"
-              className="mt-3 inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
+              className="mt-3 inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700 dark:bg-slate-900"
             >
               <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
                 <rect x="3.5" y="3.5" width="9" height="9" rx="1" />

--- a/components/org-summary/RunStatusHeader.tsx
+++ b/components/org-summary/RunStatusHeader.tsx
@@ -69,7 +69,7 @@ export function RunStatusHeader({ org, header, onCancel, onPause, onResume, noti
                 Org summary — {org}
               </h2>
             )}
-            <p className="text-sm text-slate-600 dark:text-slate-400">{statusLabel}</p>
+            <p className="text-sm text-slate-600 dark:text-slate-400 dark:text-slate-300">{statusLabel}</p>
           </div>
         </div>
         <div className="flex items-center gap-3">
@@ -102,7 +102,7 @@ export function RunStatusHeader({ org, header, onCancel, onPause, onResume, noti
             <Stat label="Queued" value={header.queued} />
           </dl>
 
-          <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400">
+          <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-600 dark:text-slate-400 dark:text-slate-300">
             <span>Elapsed: {formatDuration(header.elapsedMs)}</span>
             {header.etaMs !== null ? <span>ETA: {formatDuration(header.etaMs)}</span> : null}
             <span>Concurrency: {concurrencyLabel}</span>

--- a/components/org-summary/panels/ActivityRollupPanel.tsx
+++ b/components/org-summary/panels/ActivityRollupPanel.tsx
@@ -49,14 +49,14 @@ function Body({ value }: { value: ActivityRollupValue }) {
           {value.mostActiveRepo ? (
             <div className="rounded border border-slate-200 p-2 dark:border-slate-700">
               <p className="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Most active</p>
-              <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">{value.mostActiveRepo.repo}</p>
+              <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200 dark:text-slate-100">{value.mostActiveRepo.repo}</p>
               <p className="text-xs text-slate-500 dark:text-slate-400">{value.mostActiveRepo.commits} commits</p>
             </div>
           ) : null}
           {value.leastActiveRepo ? (
             <div className="rounded border border-slate-200 p-2 dark:border-slate-700">
               <p className="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">Least active</p>
-              <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">{value.leastActiveRepo.repo}</p>
+              <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200 dark:text-slate-100">{value.leastActiveRepo.repo}</p>
               <p className="text-xs text-slate-500 dark:text-slate-400">{value.leastActiveRepo.commits} commits</p>
             </div>
           ) : null}

--- a/components/org-summary/panels/AdoptersPanel.tsx
+++ b/components/org-summary/panels/AdoptersPanel.tsx
@@ -31,11 +31,11 @@ export function AdoptersPanel({ panel }: Props) {
         </p>
       ) : (
         <div>
-          <p className="text-sm text-slate-700 dark:text-slate-300">
+          <p className="text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
             ADOPTERS.md found in <span className="font-medium">{panel.value.flagshipUsed}</span>
           </p>
           {panel.value.entries.length > 0 ? (
-            <ul className="mt-2 list-disc pl-5 text-sm text-slate-600 dark:text-slate-400">
+            <ul className="mt-2 list-disc pl-5 text-sm text-slate-600 dark:text-slate-400 dark:text-slate-300">
               {panel.value.entries.map((entry, i) => (
                 <li key={i}>{entry}</li>
               ))}

--- a/components/org-summary/panels/BusFactorPanel.tsx
+++ b/components/org-summary/panels/BusFactorPanel.tsx
@@ -16,15 +16,15 @@ export function BusFactorPanel({ panel }: Props) {
       {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
         <p className="text-sm text-slate-500 dark:text-slate-400">No commit author data available.</p>
       ) : panel.value.highConcentrationRepos.length === 0 ? (
-        <p className="text-sm text-emerald-700 dark:text-emerald-400">No repos have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits.</p>
+        <p className="text-sm text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">No repos have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits.</p>
       ) : (
         <>
-          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400">{panel.value.highConcentrationRepos.length} repo(s) have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits</p>
+          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400 dark:text-amber-300">{panel.value.highConcentrationRepos.length} repo(s) have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits</p>
           <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
             {panel.value.highConcentrationRepos.map((r) => (
               <li key={r.repo} className="flex items-center justify-between gap-3 py-2">
-                <span className="truncate text-sm text-slate-800 dark:text-slate-200">{r.repo}</span>
-                <span className="text-xs font-medium text-amber-700 dark:text-amber-400">{(r.topAuthorShare * 100).toFixed(1)}%</span>
+                <span className="truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{r.repo}</span>
+                <span className="text-xs font-medium text-amber-700 dark:text-amber-400 dark:text-amber-300">{(r.topAuthorShare * 100).toFixed(1)}%</span>
               </li>
             ))}
           </ul>

--- a/components/org-summary/panels/ContributorDiversityPanel.tsx
+++ b/components/org-summary/panels/ContributorDiversityPanel.tsx
@@ -99,7 +99,7 @@ function WindowSelector({
 }) {
   return (
     <div
-      className="inline-flex overflow-hidden rounded border border-slate-300 dark:border-slate-700"
+      className="inline-flex overflow-hidden rounded border border-slate-300 dark:border-slate-700 dark:border-slate-600"
       role="tablist"
       aria-label="Contributor diversity window"
     >
@@ -207,7 +207,7 @@ function CompositionBar({
         <span className="ml-1 text-slate-400 dark:text-slate-500">(last {windowDays} days)</span>
       </p>
       <div
-        className="mt-2 flex h-2 w-full overflow-hidden rounded bg-slate-200 dark:bg-slate-800"
+        className="mt-2 flex h-2 w-full overflow-hidden rounded bg-slate-200 dark:bg-slate-800 dark:bg-slate-700"
         role="img"
         aria-label={`Contributor composition: ${repeatContributors} repeat, ${oneTimeContributors} one-time, ${total} total over ${windowDays} days`}
       >
@@ -226,7 +226,7 @@ function CompositionBar({
           />
         ) : null}
       </div>
-      <ul className="mt-2 flex flex-wrap gap-3 text-xs text-slate-600 dark:text-slate-400">
+      <ul className="mt-2 flex flex-wrap gap-3 text-xs text-slate-600 dark:text-slate-400 dark:text-slate-300">
         <LegendDot colorClass="bg-sky-600 dark:bg-sky-500" label={`Repeat ${repeatContributors}`} />
         <LegendDot colorClass="bg-sky-300 dark:bg-sky-700" label={`One-time ${oneTimeContributors}`} />
       </ul>

--- a/components/org-summary/panels/DocumentationCoveragePanel.tsx
+++ b/components/org-summary/panels/DocumentationCoveragePanel.tsx
@@ -19,7 +19,7 @@ export function DocumentationCoveragePanel({ panel }: Props) {
         <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
           {panel.value.perCheck.map((c) => (
             <li key={c.name} className="flex items-center justify-between gap-3 py-2">
-              <span className="text-sm text-slate-800 dark:text-slate-200 capitalize">{c.name.replace(/_/g, ' ')}</span>
+              <span className="text-sm text-slate-800 dark:text-slate-200 capitalize dark:text-slate-100">{c.name.replace(/_/g, ' ')}</span>
               <div className="flex items-center gap-2">
                 <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
                   <div className="h-full bg-sky-600 dark:bg-sky-500" style={{ width: `${Math.min(c.presentInPercent, 100)}%` }} />

--- a/components/org-summary/panels/GovernancePanel.tsx
+++ b/components/org-summary/panels/GovernancePanel.tsx
@@ -47,9 +47,9 @@ function Body({ value }: { value: GovernanceValue }) {
             <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Org-level (.github)</dt>
             <dd className="text-lg font-semibold">
               {value.orgLevel.present ? (
-                <span className="text-emerald-700 dark:text-emerald-400">Present</span>
+                <span className="text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">Present</span>
               ) : (
-                <span className="text-slate-400">Not found</span>
+                <span className="text-slate-400 dark:text-slate-500">Not found</span>
               )}
             </dd>
           </div>
@@ -65,9 +65,9 @@ function Body({ value }: { value: GovernanceValue }) {
       <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
         {value.perRepo.map((r) => (
           <li key={r.repo} className="flex items-center justify-between gap-3 py-2">
-            <span className="truncate text-sm text-slate-800 dark:text-slate-200">{r.repo}</span>
+            <span className="truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{r.repo}</span>
             {r.present ? (
-              <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300">
+              <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300 dark:text-emerald-200">
                 present
               </span>
             ) : (

--- a/components/org-summary/panels/InactiveReposPanel.tsx
+++ b/components/org-summary/panels/InactiveReposPanel.tsx
@@ -21,15 +21,15 @@ export function InactiveReposPanel({ panel }: Props) {
       {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
         <p className="text-sm text-slate-500 dark:text-slate-400">No activity data available.</p>
       ) : panel.value.repos.length === 0 ? (
-        <p className="text-sm text-emerald-700 dark:text-emerald-400">All repos have recent default-branch commit activity.</p>
+        <p className="text-sm text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">All repos have recent default-branch commit activity.</p>
       ) : (
         <>
-          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400">
+          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400 dark:text-amber-300">
             {panel.value.repos.length} repo(s) with no commits on the default branch in the last 90 days
           </p>
           <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
             {panel.value.repos.map((r) => (
-              <li key={r.repo} className="py-2 text-sm text-slate-800 dark:text-slate-200">{r.repo}</li>
+              <li key={r.repo} className="py-2 text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{r.repo}</li>
             ))}
           </ul>
         </>

--- a/components/org-summary/panels/LanguagesPanel.tsx
+++ b/components/org-summary/panels/LanguagesPanel.tsx
@@ -19,7 +19,7 @@ export function LanguagesPanel({ panel }: Props) {
         <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
           {panel.value.perLanguage.map((l) => (
             <li key={l.language} className="flex items-center justify-between gap-3 py-2">
-              <span className="text-sm text-slate-800 dark:text-slate-200">{l.language}</span>
+              <span className="text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{l.language}</span>
               <span className="text-xs text-slate-500 dark:text-slate-400">{l.repoCount} {l.repoCount === 1 ? 'repo' : 'repos'}</span>
             </li>
           ))}

--- a/components/org-summary/panels/LicenseConsistencyPanel.tsx
+++ b/components/org-summary/panels/LicenseConsistencyPanel.tsx
@@ -112,19 +112,19 @@ function PanelBody({
 
   return (
     <div className="space-y-3">
-      <p className="text-sm text-slate-700 dark:text-slate-300">
+      <p className="text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
         {contributingReposCount} of {totalReposInRun} repos contributed
         {value.nonOsiCount > 0 ? (
           <>
             {' · '}
-            <span className="text-amber-700 dark:text-amber-400">
+            <span className="text-amber-700 dark:text-amber-400 dark:text-amber-300">
               {value.nonOsiCount} use non-OSI-approved licenses
             </span>
           </>
         ) : (
           <>
             {' · '}
-            <span className="text-emerald-700 dark:text-emerald-400">All use OSI-approved licenses</span>
+            <span className="text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">All use OSI-approved licenses</span>
           </>
         )}
       </p>
@@ -156,7 +156,7 @@ function GroupSection({
   return (
     <details
       open={defaultOpen}
-      className={`group rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName}`}
+      className={`group rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName} dark:bg-slate-800/60 `}
       data-testid={`license-consistency-group-${classification}`}
     >
       <summary
@@ -184,7 +184,7 @@ function GroupChevron() {
     <svg
       aria-hidden="true"
       data-testid="group-chevron"
-      className="h-4 w-4 shrink-0 -rotate-90 text-slate-400 transition-transform group-open:rotate-0"
+      className="h-4 w-4 shrink-0 -rotate-90 text-slate-400 transition-transform group-open:rotate-0 dark:text-slate-500"
       viewBox="0 0 20 20"
       fill="currentColor"
     >

--- a/components/org-summary/panels/MaintainersPanel.tsx
+++ b/components/org-summary/panels/MaintainersPanel.tsx
@@ -109,10 +109,10 @@ function MaintainerRow({
         aria-expanded={open}
         className="flex w-full items-center justify-between gap-3 rounded px-1 -mx-1 hover:bg-slate-50 dark:hover:bg-slate-800"
       >
-        <span className="flex items-center gap-2 truncate text-sm text-slate-800 dark:text-slate-200">
+        <span className="flex items-center gap-2 truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">
           <span className="truncate font-mono">{entry.token}</span>
           {entry.kind === 'team' ? (
-            <span className="rounded bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-300">
+            <span className="rounded bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium text-sky-800 dark:bg-sky-900/40 dark:text-sky-300 dark:text-sky-200">
               team
             </span>
           ) : null}
@@ -140,7 +140,7 @@ function MaintainerRow({
           </p>
           <ul className="space-y-1">
             {entry.reposListed.map((repo) => (
-              <li key={repo} className="text-xs text-slate-700 dark:text-slate-300 font-mono">
+              <li key={repo} className="text-xs text-slate-700 dark:text-slate-300 font-mono dark:text-slate-200">
                 {repo}
               </li>
             ))}

--- a/components/org-summary/panels/OrgAffiliationsPanel.tsx
+++ b/components/org-summary/panels/OrgAffiliationsPanel.tsx
@@ -15,12 +15,12 @@ export function OrgAffiliationsPanel({ panel }: Props) {
   return (
     <section
       aria-label="Org affiliations"
-      className="rounded-lg border border-amber-200 bg-white p-4 shadow-sm dark:border-amber-800 dark:bg-slate-900"
+      className="rounded-lg border border-amber-200 bg-white p-4 shadow-sm dark:border-amber-800 dark:bg-slate-900 dark:border-amber-800/60"
     >
       <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
           Org affiliations
-          <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+          <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 dark:text-amber-200">
             Experimental
           </span>
         </h3>
@@ -50,7 +50,7 @@ function Body({ value }: { value: OrgAffiliationsValue }) {
 
   return (
     <>
-      <p className="mb-3 text-xs text-amber-700 dark:text-amber-400">
+      <p className="mb-3 text-xs text-amber-700 dark:text-amber-400 dark:text-amber-300">
         Derived from publicly visible GitHub profile org membership. Not all contributors have public affiliations.
       </p>
       <dl className="mb-4 grid grid-cols-2 gap-3">
@@ -66,7 +66,7 @@ function Body({ value }: { value: OrgAffiliationsValue }) {
           <ul role="list" className="mt-2 divide-y divide-slate-200 dark:divide-slate-700">
             {topOrgs.map((o) => (
               <li key={o.org} className="flex items-center justify-between gap-3 py-2">
-                <span className="truncate text-sm font-mono text-slate-800 dark:text-slate-200">{o.org}</span>
+                <span className="truncate text-sm font-mono text-slate-800 dark:text-slate-200 dark:text-slate-100">{o.org}</span>
                 <span className="text-xs text-slate-500 dark:text-slate-400">
                   {o.commits.toLocaleString()} commits
                 </span>

--- a/components/org-summary/panels/PlaceholderPanel.tsx
+++ b/components/org-summary/panels/PlaceholderPanel.tsx
@@ -19,7 +19,7 @@ export function PlaceholderPanel({ panelId, label, panel }: Props) {
     <section
       aria-label={label}
       data-panel-id={panelId}
-      className="rounded-lg border border-dashed border-slate-300 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+      className="rounded-lg border border-dashed border-slate-300 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:border-slate-600"
     >
       <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{label}</h3>

--- a/components/org-summary/panels/ReleaseCadencePanel.tsx
+++ b/components/org-summary/panels/ReleaseCadencePanel.tsx
@@ -50,7 +50,7 @@ function Body({ value }: { value: ReleaseCadenceValue }) {
           <ul role="list" className="mt-2 divide-y divide-slate-200 dark:divide-slate-700">
             {value.perFlagship.map((f) => (
               <li key={f.repo} className="flex items-center justify-between gap-3 py-2">
-                <span className="truncate text-sm text-slate-800 dark:text-slate-200">{f.repo}</span>
+                <span className="truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{f.repo}</span>
                 <span className="text-xs text-slate-500 dark:text-slate-400">
                   {f.releases12mo} releases
                 </span>

--- a/components/org-summary/panels/SecurityRollupPanel.tsx
+++ b/components/org-summary/panels/SecurityRollupPanel.tsx
@@ -51,7 +51,7 @@ function Body({ value }: { value: SecurityRollupValue }) {
           <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
             <HelpLabel label="Worst score" helpText="Lowest OpenSSF Scorecard score across the repo set." />
           </dt>
-          <dd className={`text-2xl font-semibold ${value.worstScore !== null ? scoreTone(value.worstScore) : 'text-slate-400'}`}>
+          <dd className={`text-2xl font-semibold ${value.worstScore !== null ? scoreTone(value.worstScore) : 'text-slate-400'} dark:text-slate-500 dark:text-slate-400 `}>
             {value.worstScore !== null ? value.worstScore.toFixed(1) : '—'}
           </dd>
         </div>
@@ -79,7 +79,7 @@ function Body({ value }: { value: SecurityRollupValue }) {
       <ul role="list" className="mt-2 divide-y divide-slate-200 dark:divide-slate-700">
         {value.perRepo.map((r) => (
           <li key={r.repo} className="flex items-center justify-between gap-3 py-2">
-            <span className="truncate text-sm text-slate-800 dark:text-slate-200">{r.repo}</span>
+            <span className="truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{r.repo}</span>
             {typeof r.score === 'number' ? (
               <span className={`text-sm font-semibold ${scoreTone(r.score)}`}>{r.score.toFixed(1)}</span>
             ) : (
@@ -98,7 +98,7 @@ function DirectCheckCard({ label, present, total }: { label: string; present: nu
   return (
     <div className="rounded border border-slate-200 p-2 dark:border-slate-700">
       <p className="text-[10px] uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</p>
-      <p className={`text-lg font-semibold ${total > 0 ? tone : 'text-slate-400'}`}>
+      <p className={`text-lg font-semibold ${total > 0 ? tone : 'text-slate-400'} dark:text-slate-500 dark:text-slate-400 `}>
         {pct(present, total)}
       </p>
       <p className="text-[10px] text-slate-400 dark:text-slate-500">{present} of {total}</p>

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -152,11 +152,11 @@ function ScoringHelp({ section }: { section: StaleAdminsSection | null }) {
     <details className="relative" data-testid="stale-admins-scoring-help">
       <summary
         aria-label="How is this scored?"
-        className="inline-flex h-4 w-4 cursor-pointer select-none items-center justify-center rounded-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-500 list-none hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200 [&::-webkit-details-marker]:hidden"
+        className="inline-flex h-4 w-4 cursor-pointer select-none items-center justify-center rounded-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-500 list-none hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200 [&::-webkit-details-marker]:hidden dark:bg-slate-900"
       >
         ?
       </summary>
-      <div className="absolute left-0 top-6 z-10 w-72 rounded-md border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+      <div className="absolute left-0 top-6 z-10 w-72 rounded-md border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:bg-slate-900">
         <p className="mb-1 font-medium text-slate-700 dark:text-slate-200">How is this scored?</p>
         <ThresholdDisclosure section={section} />
       </div>
@@ -176,7 +176,7 @@ function SectionBody({ section }: { section: StaleAdminsSection }) {
 
   if (section.applicability === 'admin-list-unavailable') {
     return (
-      <p className="text-sm text-rose-700 dark:text-rose-400" data-testid="stale-admins-unavailable">
+      <p className="text-sm text-rose-700 dark:text-rose-400 dark:text-rose-300" data-testid="stale-admins-unavailable">
         Admin list could not be retrieved —{' '}
         <span className="font-medium">{section.adminListUnavailableReason ?? 'unknown'}</span>.
       </p>
@@ -220,7 +220,7 @@ function GroupSection({
   return (
     <details
       open={defaultOpen}
-      className={`group rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName}`}
+      className={`group rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName} dark:bg-slate-800/60 `}
       data-testid={`stale-admins-group-${classification}`}
     >
       <summary
@@ -248,7 +248,7 @@ function GroupChevron() {
     <svg
       aria-hidden="true"
       data-testid="group-chevron"
-      className="h-4 w-4 shrink-0 -rotate-90 text-slate-400 transition-transform group-open:rotate-0"
+      className="h-4 w-4 shrink-0 -rotate-90 text-slate-400 transition-transform group-open:rotate-0 dark:text-slate-500"
       viewBox="0 0 20 20"
       fill="currentColor"
     >

--- a/components/recommendations/RecommendationsView.tsx
+++ b/components/recommendations/RecommendationsView.tsx
@@ -51,7 +51,7 @@ function getTagsForKey(key: string, isSecurityRec: boolean): string[] {
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
     <svg
-      className={`h-4 w-4 shrink-0 text-slate-400 transition-transform ${expanded ? 'rotate-0' : '-rotate-90'}`}
+      className={`h-4 w-4 shrink-0 text-slate-400 transition-transform ${expanded ? 'rotate-0' : '-rotate-90'} dark:text-slate-500 dark:text-slate-400 `}
       viewBox="0 0 20 20"
       fill="currentColor"
     >
@@ -63,11 +63,11 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
 function SecurityRecommendationCard({ rec, referenceId, activeTag, onTagClick }: { rec: SecurityRecommendation; referenceId?: string; activeTag: string | null; onTagClick: (tag: string) => void }) {
   const tags = getTagsForKey(rec.item, true)
   return (
-    <div className="rounded-lg border border-slate-200 bg-white p-4">
+    <div className="rounded-lg border border-slate-200 bg-white p-4 dark:bg-slate-900 dark:border-slate-700">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <h4 className="text-sm font-semibold text-slate-900">
+        <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
           {referenceId ? (
-            <span className="mr-1.5 inline-flex rounded bg-slate-200 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-500">{referenceId}</span>
+            <span className="mr-1.5 inline-flex rounded bg-slate-200 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-500 dark:bg-slate-700 dark:text-slate-400">{referenceId}</span>
           ) : null}
           {rec.title ?? rec.text}
         </h4>
@@ -80,19 +80,19 @@ function SecurityRecommendationCard({ rec, referenceId, activeTag, onTagClick }:
               {rec.riskLevel}
             </span>
           ) : null}
-          <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+          <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             {SOURCE_LABELS[rec.category] ?? rec.category}
           </span>
         </div>
       </div>
       {rec.evidence ? (
-        <p className="mt-1.5 text-xs text-slate-500">{rec.evidence}</p>
+        <p className="mt-1.5 text-xs text-slate-500 dark:text-slate-400">{rec.evidence}</p>
       ) : null}
       {rec.explanation ? (
-        <p className="mt-2 text-sm text-slate-600">{rec.explanation}</p>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{rec.explanation}</p>
       ) : null}
       {rec.remediationHint ? (
-        <div className="mt-2 rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-800">
+        <div className="mt-2 rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
           {rec.remediationHint}
         </div>
       ) : null}
@@ -101,7 +101,7 @@ function SecurityRecommendationCard({ rec, referenceId, activeTag, onTagClick }:
           href={rec.docsUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-2 inline-block text-xs text-blue-600 underline hover:text-blue-800"
+          className="mt-2 inline-block text-xs text-blue-600 underline hover:text-blue-800 dark:text-blue-400"
         >
           OpenSSF Scorecard docs
         </a>
@@ -156,7 +156,7 @@ function SecurityRecommendationsGroup({
     .map((cat) => ({ category: cat, entries: groups.get(cat.key)! }))
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:bg-slate-800/60 dark:border-slate-700">
       <button
         type="button"
         onClick={onToggle}
@@ -167,7 +167,7 @@ function SecurityRecommendationsGroup({
         <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${BUCKET_COLORS.Security}`}>
           Security
         </span>
-        <span className="text-xs text-slate-400">{filtered.length} recommendation{filtered.length !== 1 ? 's' : ''}</span>
+        <span className="text-xs text-slate-400 dark:text-slate-500">{filtered.length} recommendation{filtered.length !== 1 ? 's' : ''}</span>
       </button>
       {expanded ? (
         <div className="mt-3 space-y-4">
@@ -182,8 +182,8 @@ function SecurityRecommendationsGroup({
                   aria-expanded={!collapsed}
                 >
                   <ChevronIcon expanded={!collapsed} />
-                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500">{category.label}</span>
-                  <span className="text-xs text-slate-400">{entries.length}</span>
+                  <span className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{category.label}</span>
+                  <span className="text-xs text-slate-400 dark:text-slate-500">{entries.length}</span>
                 </button>
                 {!collapsed ? (
                   <div className="space-y-2">
@@ -231,7 +231,7 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
         const totalCount = nonSecurityRecs.length + securityRecs.length
         if (totalCount === 0) {
           return (
-            <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-6">
+            <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-6 dark:bg-slate-900 dark:border-slate-700">
               <button
                 type="button"
                 onClick={() => setCollapsedRepos((prev) => { const next = new Set(prev); if (next.has(result.repo)) next.delete(result.repo); else next.add(result.repo); return next })}
@@ -239,9 +239,9 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
                 aria-expanded={!isRepoCollapsed}
               >
                 <CollapseChevron expanded={!isRepoCollapsed} />
-                <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{result.repo}</h2>
               </button>
-              {!isRepoCollapsed ? <p className="mt-2 text-sm text-slate-500">No recommendations — this project scores well across all dimensions.</p> : null}
+              {!isRepoCollapsed ? <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">No recommendations — this project scores well across all dimensions.</p> : null}
             </div>
           )
         }
@@ -297,7 +297,7 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
         }
 
         return (
-          <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+          <div key={result.repo} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 dark:bg-slate-900 dark:border-slate-700">
             <button
               type="button"
               onClick={() => setCollapsedRepos((prev) => { const next = new Set(prev); if (next.has(result.repo)) next.delete(result.repo); else next.add(result.repo); return next })}
@@ -305,12 +305,12 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
               aria-expanded={!isRepoCollapsed}
             >
               <CollapseChevron expanded={!isRepoCollapsed} />
-              <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{result.repo}</h2>
             </button>
             {!isRepoCollapsed ? (
               <div className="mt-4">
                 <div className="flex items-start justify-between">
-                  <p className="text-sm text-slate-500">
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
                     {activeTag
                       ? `${filteredTotal} of ${totalCount} recommendation${totalCount !== 1 ? 's' : ''} matching "${activeTag}"`
                       : `${totalCount} recommendation${totalCount !== 1 ? 's' : ''} across ${bucketCount} dimension${bucketCount !== 1 ? 's' : ''}`}
@@ -318,7 +318,7 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
                   <button
                     type="button"
                     onClick={handleToggleAll}
-                    className="shrink-0 rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50"
+                    className="shrink-0 rounded-md border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300"
                   >
                     {allExpanded ? 'Collapse all' : 'Expand all'}
                   </button>
@@ -331,14 +331,14 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
                 ) : null}
 
                 {filteredTotal === 0 && activeTag ? (
-                  <p className="mt-4 text-center text-sm text-slate-400">No recommendations match the &ldquo;{activeTag}&rdquo; tag.</p>
+                  <p className="mt-4 text-center text-sm text-slate-400 dark:text-slate-500">No recommendations match the &ldquo;{activeTag}&rdquo; tag.</p>
                 ) : null}
 
                 <div className="mt-4 space-y-4">
               {Array.from(bucketGroups.entries()).map(([bucket, recs]) => {
                 const isExpanded = !collapsedBuckets[bucket]
                 return (
-                  <div key={bucket} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                  <div key={bucket} className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:bg-slate-800/60 dark:border-slate-700">
                     <button
                       type="button"
                       onClick={() => setCollapsedBuckets((prev) => ({ ...prev, [bucket]: !prev[bucket] }))}
@@ -346,18 +346,18 @@ export function RecommendationsView({ results, activeTag: externalTag, onTagChan
                       aria-expanded={isExpanded}
                     >
                       <ChevronIcon expanded={isExpanded} />
-                      <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${BUCKET_COLORS[bucket] ?? 'bg-slate-100 text-slate-800'}`}>
+                      <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${BUCKET_COLORS[bucket] ?? 'bg-slate-100 text-slate-800'} dark:bg-slate-800 dark:text-slate-100 `}>
                         {bucket}
                       </span>
-                      <span className="text-xs text-slate-400">{recs.length} recommendation{recs.length !== 1 ? 's' : ''}</span>
+                      <span className="text-xs text-slate-400 dark:text-slate-500">{recs.length} recommendation{recs.length !== 1 ? 's' : ''}</span>
                     </button>
                     {isExpanded ? (
                       <ul className="mt-3 space-y-2">
                         {recs.map((rec, i) => (
                           <li key={i} className="flex items-start gap-2">
-                            <span className="shrink-0 rounded bg-slate-200 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-500">{rec.referenceId}</span>
+                            <span className="shrink-0 rounded bg-slate-200 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-500 dark:bg-slate-700 dark:text-slate-400">{rec.referenceId}</span>
                             <div className="min-w-0 flex-1">
-                              <p className="text-sm text-slate-700">{rec.message}</p>
+                              <p className="text-sm text-slate-700 dark:text-slate-200">{rec.message}</p>
                               {rec.tags.length > 0 && (
                                 <div className="mt-1.5 flex flex-wrap gap-1">
                                   {rec.tags.map((tag) => (

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -389,33 +389,33 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     <div className="space-y-4">
       {isEmptyState && inputMode === 'repos' ? (
         <div className="space-y-3">
-          <p className="text-sm text-slate-500">
-            Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
           {emptyQuote ? (
-            <p className="text-xs italic text-slate-400">
+            <p className="text-xs italic text-slate-400 dark:text-slate-500">
               &ldquo;{emptyQuote.text}&rdquo; — {emptyQuote.author}{emptyQuote.context ? `, ${emptyQuote.context}` : ''}
             </p>
           ) : null}
         </div>
       ) : null}
       {submissionError ? (
-        <p role="alert" data-testid="analysis-error" className="text-sm text-red-600">
+        <p role="alert" data-testid="analysis-error" className="text-sm text-red-600 dark:text-red-300">
           {submissionError}
         </p>
       ) : null}
       {loadingRepos.length > 0 && inputMode === 'repos' ? (
-        <section aria-label="Analysis loading state" className="rounded border border-blue-200 bg-blue-50 p-4">
+        <section aria-label="Analysis loading state" className="rounded border border-blue-200 bg-blue-50 p-4 dark:bg-blue-900/20 dark:border-blue-800/60">
           <div className="flex items-center justify-between">
-            <h2 className="font-semibold text-blue-900">Analyzing repositories...</h2>
+            <h2 className="font-semibold text-blue-900 dark:text-blue-200">Analyzing repositories...</h2>
             <div className="flex items-center gap-3">
-              <span className="text-xs tabular-nums text-blue-700">{formatElapsedTime(elapsedSeconds)}</span>
+              <span className="text-xs tabular-nums text-blue-700 dark:text-blue-300">{formatElapsedTime(elapsedSeconds)}</span>
               <button
                 type="button"
                 onClick={handleCancelRepoFetch}
                 aria-label="Cancel"
                 title="Cancel"
-                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
+                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700 dark:bg-slate-900"
               >
                 <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
                   <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
@@ -423,40 +423,40 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               </button>
             </div>
           </div>
-          <ul className="mt-2 list-disc pl-5 text-sm text-blue-900">
+          <ul className="mt-2 list-disc pl-5 text-sm text-blue-900 dark:text-blue-200">
             {loadingRepos.map((repo) => (
               <li key={repo}>{repo}</li>
             ))}
           </ul>
           {elapsedSeconds >= 10 ? (
-            <p className="mt-3 text-xs text-blue-700">
+            <p className="mt-3 text-xs text-blue-700 dark:text-blue-300">
               Large repositories with extensive commit history may take longer to analyze.
             </p>
           ) : null}
           {elapsedSeconds >= 30 ? (
-            <p className="mt-1 text-xs text-blue-700">
+            <p className="mt-1 text-xs text-blue-700 dark:text-blue-300">
               Still working — fetching commit history and computing contributor metrics.
             </p>
           ) : null}
           {currentQuote ? (
-            <p className="mt-3 border-t border-blue-200 pt-3 text-xs italic text-blue-600">
+            <p className="mt-3 border-t border-blue-200 pt-3 text-xs italic text-blue-600 dark:border-blue-800/60 dark:text-blue-400">
               &ldquo;{currentQuote.text}&rdquo; — {currentQuote.author}{currentQuote.context ? `, ${currentQuote.context}` : ''}
             </p>
           ) : null}
         </section>
       ) : null}
       {loadingOrg ? (
-        <section aria-label="Org inventory loading state" className="rounded border border-blue-200 bg-blue-50 p-4">
+        <section aria-label="Org inventory loading state" className="rounded border border-blue-200 bg-blue-50 p-4 dark:bg-blue-900/20 dark:border-blue-800/60">
           <div className="flex items-center justify-between">
-            <h2 className="font-semibold text-blue-900">Loading org inventory for:</h2>
+            <h2 className="font-semibold text-blue-900 dark:text-blue-200">Loading org inventory for:</h2>
             <div className="flex items-center gap-3">
-              <span className="text-xs tabular-nums text-blue-700">{formatElapsedTime(elapsedSeconds)}</span>
+              <span className="text-xs tabular-nums text-blue-700 dark:text-blue-300">{formatElapsedTime(elapsedSeconds)}</span>
               <button
                 type="button"
                 onClick={handleCancelOrgFetch}
                 aria-label="Cancel"
                 title="Cancel"
-                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
+                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700 dark:bg-slate-900"
               >
                 <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
                   <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
@@ -464,14 +464,14 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               </button>
             </div>
           </div>
-          <p className="mt-2 text-sm text-blue-900">{loadingOrg}</p>
+          <p className="mt-2 text-sm text-blue-900 dark:text-blue-200">{loadingOrg}</p>
           {elapsedSeconds >= 10 ? (
-            <p className="mt-3 text-xs text-blue-700">
+            <p className="mt-3 text-xs text-blue-700 dark:text-blue-300">
               Large organizations with many repositories may take longer to load.
             </p>
           ) : null}
           {currentQuote ? (
-            <p className="mt-3 border-t border-blue-200 pt-3 text-xs italic text-blue-600">
+            <p className="mt-3 border-t border-blue-200 pt-3 text-xs italic text-blue-600 dark:border-blue-800/60 dark:text-blue-400">
               &ldquo;{currentQuote.text}&rdquo; — {currentQuote.author}{currentQuote.context ? `, ${currentQuote.context}` : ''}
             </p>
           ) : null}
@@ -480,7 +480,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       {inputMode === 'repos' && analysisResponse ? (
         <section aria-label="Analysis results" className="space-y-4">
           {orgInventoryResponse && orgAggregation.view ? (
-            <section className="flex items-center gap-3 rounded-lg border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200">
+            <section className="flex items-center gap-3 rounded-lg border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200 dark:bg-sky-900/20 dark:border-sky-800/60">
               <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5 flex-shrink-0 text-sky-600 dark:text-sky-400">
                 <path fillRule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clipRule="evenodd" />
               </svg>
@@ -491,9 +491,9 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           ) : null}
           <MetricCardsOverview results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
           {analysisResponse.failures.length > 0 ? (
-            <section className="rounded border border-amber-200 bg-amber-50 p-4">
-              <h2 className="font-semibold text-amber-900">Failed repositories</h2>
-              <ul className="mt-2 list-disc pl-5 text-sm text-amber-900">
+            <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
+              <h2 className="font-semibold text-amber-900 dark:text-amber-200">Failed repositories</h2>
+              <ul className="mt-2 list-disc pl-5 text-sm text-amber-900 dark:text-amber-200">
                 {analysisResponse.failures.map((failure) => (
                   <li key={failure.repo}>
                     {failure.repo}: {failure.reason}
@@ -503,7 +503,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
             </section>
           ) : null}
           {analysisResponse.rateLimit && !orgInventoryResponse && isRateLimitLow(analysisResponse.rateLimit) ? (
-            <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+            <section className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
               <p>Remaining API calls: {formatDisplayValue(analysisResponse.rateLimit.remaining)}</p>
               <p>Rate limit resets at: {formatRateLimitReset(analysisResponse.rateLimit.resetAt)}</p>
               {analysisResponse.rateLimit.retryAfter !== 'unavailable' ? (
@@ -516,7 +516,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       {inputMode === 'org' && orgInventoryResponse ? (
         <section aria-label="Org inventory results" className="space-y-4">
           {orgInventoryResponse.failure ? (
-            <section className="rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            <section className="rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:bg-amber-900/20 dark:border-amber-800/60 dark:text-amber-200">
               <p>{orgInventoryResponse.failure.message}</p>
             </section>
           ) : (
@@ -561,8 +561,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         </section>
       ) : null}
       {showOrgWorkspace && !loadingOrg && !orgInventoryResponse && !submissionError ? (
-        <section className="rounded border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
-          <h2 className="font-semibold text-slate-900">Organization inventory</h2>
+        <section className="rounded border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:bg-slate-800/60 dark:border-slate-700 dark:text-slate-200">
+          <h2 className="font-semibold text-slate-900 dark:text-slate-100">Organization inventory</h2>
           <p className="mt-2">
             Enter a GitHub organization slug or org URL above to browse its public repository inventory.
           </p>
@@ -607,8 +607,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         ) : analysisResponse ? (
           <ContributorsView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
-          <p className="text-sm text-slate-500">
-            Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
         )
       }
@@ -618,8 +618,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         ) : analysisResponse ? (
           <ActivityView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
-          <p className="text-sm text-slate-500">
-            Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
         )
       }
@@ -629,8 +629,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         ) : analysisResponse ? (
           <ResponsivenessView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
-          <p className="text-sm text-slate-500">
-            Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
         )
       }
@@ -644,8 +644,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         ) : analysisResponse ? (
           <DocumentationView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
-          <p className="text-sm text-slate-500">
-            Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
         )
       }
@@ -665,8 +665,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         ) : analysisResponse ? (
           <SecurityView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
-          <p className="text-sm text-slate-500">
-            Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
         )
       }
@@ -674,8 +674,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         analysisResponse ? (
           <RecommendationsView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
         ) : (
-          <p className="text-sm text-slate-500">
-            Enter repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
         )
       }
@@ -683,21 +683,21 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         analysisResponse && successfulRepoCount >= 2 ? (
           <ComparisonView results={analysisResponse.results} rateLimit={analysisResponse.rateLimit} />
         ) : loadingRepos.length >= 2 ? (
-          <p className="text-sm text-slate-600">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
             {loadingRepos.length > 4
               ? <>Preparing comparison for the first 4 of {loadingRepos.length}:{' '}</>
               : <>Preparing comparison for{' '}</>}
             {loadingRepos.slice(0, 4).map((repo, i, arr) => (
               <span key={repo}>
-                <span className="font-medium text-slate-800">{repo}</span>
+                <span className="font-medium text-slate-800 dark:text-slate-100">{repo}</span>
                 {i < arr.length - 1 ? ', ' : ''}
               </span>
             ))}
             …
           </p>
         ) : (
-          <p className="text-sm text-slate-500">
-            Enter 2 or more repositories and click <span className="font-medium text-slate-700">Analyze</span> to get started.
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Enter 2 or more repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
         )
       }

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -84,11 +84,7 @@ export function RepoInputForm({
       <div className="mb-3 flex flex-wrap gap-2">
         <button
           type="button"
-          className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
-            mode === 'repos'
-              ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900'
-              : 'border-slate-300 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200'
-          }`}
+          className={`rounded-full border px-4 py-2 text-sm font-medium transition ${ mode === 'repos' ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-slate-300 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200' }`}
           onClick={() => {
             updateMode('repos')
             setError(null)
@@ -98,11 +94,7 @@ export function RepoInputForm({
         </button>
         <button
           type="button"
-          className={`rounded-full border px-4 py-2 text-sm font-medium transition ${
-            mode === 'org'
-              ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900'
-              : 'border-slate-300 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200'
-          }`}
+          className={`rounded-full border px-4 py-2 text-sm font-medium transition ${ mode === 'org' ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-slate-300 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200' }`}
           onClick={() => {
             updateMode('org')
             setError(null)
@@ -150,7 +142,7 @@ export function RepoInputForm({
           onChange={(e) => setRepoValue(e.target.value)}
           placeholder={'facebook/react ollama/ollama\ngithub.com/kubernetes/kubernetes\nhttps://github.com/pytorch/pytorch'}
           rows={3}
-          className="w-full resize-none overflow-hidden rounded border border-slate-300 bg-white p-2 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
+          className="w-full resize-none overflow-hidden rounded border border-slate-300 bg-white p-2 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
           aria-label="Repository list"
           aria-describedby={error ? 'repo-input-error' : undefined}
         />
@@ -160,13 +152,13 @@ export function RepoInputForm({
           value={orgValue}
           onChange={(e) => setOrgValue(e.target.value)}
           placeholder="facebook, github.com/facebook, or https://github.com/facebook"
-          className="w-full rounded border border-slate-300 bg-white p-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
+          className="w-full rounded border border-slate-300 bg-white p-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
           aria-label="Organization input"
           aria-describedby={error ? 'repo-input-error' : undefined}
         />
       )}
       {error && (
-        <p id="repo-input-error" role="alert" data-testid="repo-error" className="mt-1 text-sm text-red-600 dark:text-red-400">
+        <p id="repo-input-error" role="alert" data-testid="repo-error" className="mt-1 text-sm text-red-600 dark:text-red-300">
           {error}
         </p>
       )}

--- a/components/responsiveness/ResponsivenessScoreHelp.tsx
+++ b/components/responsiveness/ResponsivenessScoreHelp.tsx
@@ -12,16 +12,16 @@ export function ResponsivenessScoreHelp({ score }: ResponsivenessScoreHelpProps)
   const [showDetails, setShowDetails] = useState(false)
 
   return (
-    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-3 dark:bg-slate-800/60 dark:border-slate-700">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">How is Responsiveness scored?</p>
-          <p className="mt-1 text-sm text-slate-700">{score.summary}</p>
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">How is Responsiveness scored?</p>
+          <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">{score.summary}</p>
         </div>
         <button
           type="button"
           onClick={() => setShowDetails((current) => !current)}
-          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+          className="rounded-full border border-slate-300 px-3 py-1 text-xs font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200"
           aria-pressed={showDetails}
         >
           {showDetails ? 'Hide details' : 'Show details'}
@@ -29,10 +29,10 @@ export function ResponsivenessScoreHelp({ score }: ResponsivenessScoreHelpProps)
       </div>
       <div className="mt-3 flex flex-wrap gap-2">
         {score.weightedCategories.map((category) => (
-          <div key={category.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700">
-            <span className="font-semibold text-slate-900">{category.label}</span> <span>{category.weightLabel}</span>
+          <div key={category.label} className="rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs text-slate-700 dark:bg-slate-900 dark:border-slate-700 dark:text-slate-200">
+            <span className="font-semibold text-slate-900 dark:text-slate-100">{category.label}</span> <span>{category.weightLabel}</span>
             {category.percentile !== undefined ? (
-              <span className="ml-1 text-slate-500">({formatPercentileLabel(category.percentile)})</span>
+              <span className="ml-1 text-slate-500 dark:text-slate-400">({formatPercentileLabel(category.percentile)})</span>
             ) : null}
           </div>
         ))}
@@ -40,20 +40,20 @@ export function ResponsivenessScoreHelp({ score }: ResponsivenessScoreHelpProps)
       {showDetails ? (
         <div className="mt-3 grid gap-2 md:grid-cols-1">
           {score.weightedCategories.map((category) => (
-            <div key={category.label} className="rounded-lg border border-slate-200 bg-white p-3">
+            <div key={category.label} className="rounded-lg border border-slate-200 bg-white p-3 dark:bg-slate-900 dark:border-slate-700">
               <div className="flex items-center justify-between">
-                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{category.label} ({category.weightLabel})</p>
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{category.label} ({category.weightLabel})</p>
                 {category.percentile !== undefined ? (
-                  <p className="text-sm font-semibold text-slate-900">{formatPercentileLabel(category.percentile)}</p>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{formatPercentileLabel(category.percentile)}</p>
                 ) : null}
               </div>
-              <p className="mt-1 text-xs leading-relaxed text-slate-600">{category.description}</p>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-300">{category.description}</p>
             </div>
           ))}
         </div>
       ) : null}
       {score.missingInputs.length > 0 ? (
-        <p className="mt-3 text-xs text-amber-800">Missing inputs: {score.missingInputs.join(', ')}</p>
+        <p className="mt-3 text-xs text-amber-800 dark:text-amber-200">Missing inputs: {score.missingInputs.join(', ')}</p>
       ) : null}
     </div>
   )

--- a/components/responsiveness/ResponsivenessView.tsx
+++ b/components/responsiveness/ResponsivenessView.tsx
@@ -41,11 +41,11 @@ export function ResponsivenessView({ results, activeTag: externalTag, onTagChang
 
   return (
     <section aria-label="Responsiveness view" className="space-y-6">
-      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Recent responsiveness window</p>
-            <p className="mt-1 text-sm text-slate-600">Change the local responsiveness window without rerunning repository analysis.</p>
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Recent responsiveness window</p>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">Change the local responsiveness window without rerunning repository analysis.</p>
           </div>
           <div className="flex flex-wrap gap-2">
             {windowOptions.map((option) => (
@@ -53,11 +53,7 @@ export function ResponsivenessView({ results, activeTag: externalTag, onTagChang
                 key={option.days}
                 type="button"
                 onClick={() => setWindowDays(option.days)}
-                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
-                  windowDays === option.days
-                    ? 'border-slate-900 bg-slate-900 text-white'
-                    : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900'
-                }`}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition ${ windowDays === option.days ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white' }`}
                 aria-pressed={windowDays === option.days}
               >
                 {option.label}
@@ -69,7 +65,7 @@ export function ResponsivenessView({ results, activeTag: externalTag, onTagChang
       {sections.map((section) => {
         const isCollapsed = collapsed.has(section.repo)
         return (
-          <article key={section.repo} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <article key={section.repo} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-900">
             <button
               type="button"
               onClick={() => setCollapsed((prev) => { const next = new Set(prev); if (next.has(section.repo)) next.delete(section.repo); else next.add(section.repo); return next })}
@@ -77,16 +73,16 @@ export function ResponsivenessView({ results, activeTag: externalTag, onTagChang
               aria-expanded={!isCollapsed}
             >
               <CollapseChevron expanded={!isCollapsed} />
-              <h2 className="text-lg font-semibold text-slate-900">{section.repo}</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{section.repo}</h2>
             </button>
             {!isCollapsed ? (
               <div className="mt-4 space-y-4">
                 <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                   <div>
-                    <p className="text-sm text-slate-600">
+                    <p className="text-sm text-slate-600 dark:text-slate-300">
                       Public GitHub issue and pull-request event history summarized into responsiveness signals.
                     </p>
-                    <p className="mt-2 text-sm text-slate-700">{section.score.description}</p>
+                    <p className="mt-2 text-sm text-slate-700 dark:text-slate-200">{section.score.description}</p>
                   </div>
                   <div className="w-full md:max-w-xs">
                     <ScoreBadge category="Responsiveness" value={section.score.value} tone={section.score.tone} />
@@ -105,15 +101,15 @@ export function ResponsivenessView({ results, activeTag: externalTag, onTagChang
                     .map((pane) => {
                       const tags = getResponsivenessPaneTags(pane.title)
                       return (
-                    <div key={pane.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+                    <div key={pane.title} className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
                       <div className="flex items-center justify-between">
-                        <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{pane.title}</p>
+                        <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{pane.title}</p>
                         {tags.map((tag) => <TagPill key={tag} tag={tag} active={activeTag === tag} onClick={handleTagClick} />)}
                       </div>
                       <dl className="mt-3 space-y-2">
                         {pane.metrics.map((metric) => (
                           <div key={metric.label} className="flex items-baseline justify-between gap-4">
-                            <dt className="text-sm text-slate-600">
+                            <dt className="text-sm text-slate-600 dark:text-slate-300">
                               <HelpLabel label={metric.label} helpText={metric.helpText} />
                             </dt>
                             <dd className="text-base"><MetricValue value={metric.value} /></dd>

--- a/components/search/ReportSearchBar.tsx
+++ b/components/search/ReportSearchBar.tsx
@@ -14,7 +14,7 @@ export function ReportSearchBar({ query, onQueryChange, totalMatches, matchedTab
     <div className="flex flex-wrap items-center gap-2">
       <div className="relative flex-1 min-w-[200px] sm:min-w-[240px]">
         <svg
-          className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 pointer-events-none"
+          className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 pointer-events-none dark:text-slate-500"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -28,14 +28,14 @@ export function ReportSearchBar({ query, onQueryChange, totalMatches, matchedTab
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           placeholder="Search report..."
-          className="w-full rounded-md border border-slate-200 bg-white py-1.5 pl-8 pr-8 text-sm text-slate-700 shadow-sm transition placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400"
+          className="w-full rounded-md border border-slate-200 bg-white py-1.5 pl-8 pr-8 text-sm text-slate-700 shadow-sm transition placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-slate-500 dark:focus:ring-slate-500"
         />
         {query ? (
           <button
             type="button"
             onClick={() => onQueryChange('')}
             aria-label="Clear search"
-            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-slate-400 hover:text-slate-600"
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-200"
           >
             <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -44,7 +44,7 @@ export function ReportSearchBar({ query, onQueryChange, totalMatches, matchedTab
         ) : null}
       </div>
       {showSummary ? (
-        <span className="text-xs text-slate-500 whitespace-nowrap">
+        <span className="text-xs text-slate-500 whitespace-nowrap dark:text-slate-400">
           {totalMatches === 0
             ? '0 matches'
             : `${totalMatches} match${totalMatches === 1 ? '' : 'es'} across ${matchedTabCount} tab${matchedTabCount === 1 ? '' : 's'}`}

--- a/components/security/SecurityView.tsx
+++ b/components/security/SecurityView.tsx
@@ -42,17 +42,17 @@ function ScorecardChecksTable({ checks, activeTag, onTagClick }: { checks: Score
   if (filtered.length === 0) return null
 
   return (
-    <section aria-label="OpenSSF Scorecard Checks" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">OpenSSF Scorecard Checks</h3>
+    <section aria-label="OpenSSF Scorecard Checks" className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">OpenSSF Scorecard Checks</h3>
       <div className="mt-3 space-y-1.5">
         {filtered.map((check) => {
           const tags = getAllScorecardTags(check.name)
           return (
             <div key={check.name}>
               <div className="grid grid-cols-[1fr_auto] gap-2">
-                <span className="text-sm text-slate-700">{check.name}</span>
+                <span className="text-sm text-slate-700 dark:text-slate-200">{check.name}</span>
                 {check.score === -1 ? (
-                  <span className="text-xs text-slate-400">indeterminate</span>
+                  <span className="text-xs text-slate-400 dark:text-slate-500">indeterminate</span>
                 ) : (
                   <span className={`text-sm font-medium ${check.score >= 7 ? 'text-emerald-600' : check.score >= 4 ? 'text-amber-600' : 'text-red-500'}`}>
                     {check.score}/10
@@ -77,26 +77,26 @@ function DirectChecksSection({ checks, activeTag, onTagClick }: { checks: Direct
   if (filtered.length === 0) return null
 
   return (
-    <section aria-label="Direct Security Checks" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">Direct Security Checks</h3>
+    <section aria-label="Direct Security Checks" className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Direct Security Checks</h3>
       <ul className="mt-3 space-y-2">
         {filtered.map((check) => {
           const tags = getAllDirectCheckTags(check.name)
           return (
             <li key={check.name} className="flex items-start gap-2">
               {check.detected === 'unavailable' ? (
-                <span className="mt-0.5 text-sm text-slate-400">—</span>
+                <span className="mt-0.5 text-sm text-slate-400 dark:text-slate-500">—</span>
               ) : check.detected ? (
                 <span className="mt-0.5 text-sm text-emerald-600">✓</span>
               ) : (
                 <span className="mt-0.5 text-sm text-red-400">✗</span>
               )}
               <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-slate-700">{DIRECT_CHECK_LABELS[check.name] ?? check.name}</p>
+                <p className="text-sm font-medium text-slate-700 dark:text-slate-200">{DIRECT_CHECK_LABELS[check.name] ?? check.name}</p>
                 {check.details ? (
-                  <p className="text-xs text-slate-500">{check.details}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{check.details}</p>
                 ) : check.detected === 'unavailable' ? (
-                  <p className="text-xs text-slate-400">
+                  <p className="text-xs text-slate-400 dark:text-slate-500">
                     {check.name === 'branch_protection'
                       ? 'Requires admin access to the repository'
                       : 'Unavailable'}
@@ -131,17 +131,17 @@ function SecuritySummary({
         tone={score.tone}
       />
       <div className="min-w-0">
-        <p className="text-sm text-slate-500" data-testid="security-composite-score">
+        <p className="text-sm text-slate-500 dark:text-slate-400" data-testid="security-composite-score">
           {typeof score.value === 'number'
             ? `${score.value}/100`
             : score.value}
         </p>
         {scorecardOverallScore !== null ? (
-          <p className="text-sm text-slate-500" data-testid="security-openssf-score">
+          <p className="text-sm text-slate-500 dark:text-slate-400" data-testid="security-openssf-score">
             OpenSSF Scorecard: {scorecardOverallScore}/10
           </p>
         ) : null}
-        <p className="text-xs text-slate-400" data-testid="security-mode">{modeLabel}</p>
+        <p className="text-xs text-slate-400 dark:text-slate-500" data-testid="security-mode">{modeLabel}</p>
       </div>
     </div>
   )
@@ -165,7 +165,7 @@ export function SecurityView({ results, activeTag: externalTag, onTagChange }: S
         const isCollapsed = collapsed.has(result.repo)
         if (result.securityResult === 'unavailable') {
           return (
-            <div key={result.repo} className="rounded-xl border border-slate-200 bg-white p-6">
+            <div key={result.repo} className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900">
               <button
                 type="button"
                 onClick={() => setCollapsed((prev) => { const next = new Set(prev); if (next.has(result.repo)) next.delete(result.repo); else next.add(result.repo); return next })}
@@ -173,9 +173,9 @@ export function SecurityView({ results, activeTag: externalTag, onTagChange }: S
                 aria-expanded={!isCollapsed}
               >
                 <CollapseChevron expanded={!isCollapsed} />
-                <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{result.repo}</h2>
               </button>
-              {!isCollapsed ? <p className="mt-2 text-sm text-slate-400">Security data unavailable.</p> : null}
+              {!isCollapsed ? <p className="mt-2 text-sm text-slate-400 dark:text-slate-500">Security data unavailable.</p> : null}
             </div>
           )
         }
@@ -187,7 +187,7 @@ export function SecurityView({ results, activeTag: externalTag, onTagChange }: S
           : null
 
         return (
-          <div key={result.repo} className="rounded-xl border border-slate-200 bg-white p-6">
+          <div key={result.repo} className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900">
             <button
               type="button"
               onClick={() => setCollapsed((prev) => { const next = new Set(prev); if (next.has(result.repo)) next.delete(result.repo); else next.add(result.repo); return next })}
@@ -195,7 +195,7 @@ export function SecurityView({ results, activeTag: externalTag, onTagChange }: S
               aria-expanded={!isCollapsed}
             >
               <CollapseChevron expanded={!isCollapsed} />
-              <h2 className="text-lg font-semibold text-slate-900">{result.repo}</h2>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{result.repo}</h2>
             </button>
             {!isCollapsed ? (
               <div className="mt-4">
@@ -215,9 +215,9 @@ export function SecurityView({ results, activeTag: externalTag, onTagChange }: S
                       onTagClick={handleTagClick}
                     />
                   ) : !activeTag ? (
-                    <section aria-label="OpenSSF Scorecard" className="rounded-xl border border-slate-200 bg-slate-50 p-4">
-                      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">OpenSSF Scorecard</h3>
-                      <p className="mt-3 text-sm text-slate-400">Scorecard data not available for this repository.</p>
+                    <section aria-label="OpenSSF Scorecard" className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/60">
+                      <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">OpenSSF Scorecard</h3>
+                      <p className="mt-3 text-sm text-slate-400 dark:text-slate-500">Scorecard data not available for this repository.</p>
                     </section>
                   ) : null}
 

--- a/components/shared/CollapseChevron.tsx
+++ b/components/shared/CollapseChevron.tsx
@@ -4,7 +4,7 @@ export function CollapseChevron({ expanded }: { expanded: boolean }) {
   return (
     <svg
       aria-hidden="true"
-      className={`h-5 w-5 shrink-0 text-slate-400 transition-transform ${expanded ? 'rotate-0' : '-rotate-90'}`}
+      className={`h-5 w-5 shrink-0 text-slate-400 transition-transform ${expanded ? 'rotate-0' : '-rotate-90'} dark:text-slate-500 dark:text-slate-400 `}
       viewBox="0 0 20 20"
       fill="currentColor"
     >

--- a/components/shared/MetricValue.tsx
+++ b/components/shared/MetricValue.tsx
@@ -6,6 +6,6 @@ interface MetricValueProps {
 }
 
 export function MetricValue({ value, className = '' }: MetricValueProps) {
-  const colorClass = value === '—' ? 'text-slate-400' : 'font-semibold text-slate-900'
+  const colorClass = value === '—' ? 'text-slate-400 dark:text-slate-500' : 'font-semibold text-slate-900 dark:text-slate-100'
   return <span className={`${colorClass}${className ? ` ${className}` : ''}`}>{value}</span>
 }

--- a/components/tags/TagPill.tsx
+++ b/components/tags/TagPill.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 const TAG_COLORS: Record<string, string> = {
-  governance: 'bg-indigo-50 text-indigo-700 border-indigo-200',
-  community: 'bg-amber-50 text-amber-700 border-amber-200',
-  'supply-chain': 'bg-orange-50 text-orange-700 border-orange-200',
-  'quick-win': 'bg-emerald-50 text-emerald-700 border-emerald-200',
-  compliance: 'bg-rose-50 text-rose-700 border-rose-200',
-  'contrib-ex': 'bg-cyan-50 text-cyan-700 border-cyan-200',
+  governance: 'bg-indigo-50 text-indigo-700 border-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-200 dark:border-indigo-800/60',
+  community: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-200 dark:border-amber-800/60',
+  'supply-chain': 'bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-900/30 dark:text-orange-200 dark:border-orange-800/60',
+  'quick-win': 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-800/60',
+  compliance: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-900/30 dark:text-rose-200 dark:border-rose-800/60',
+  'contrib-ex': 'bg-cyan-50 text-cyan-700 border-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-200 dark:border-cyan-800/60',
 }
 
 const TAG_RING_COLORS: Record<string, string> = {
@@ -17,7 +17,7 @@ const TAG_RING_COLORS: Record<string, string> = {
   compliance: 'ring-rose-400',
   'contrib-ex': 'ring-cyan-400',
 }
-const DEFAULT_TAG_COLOR = 'bg-slate-50 text-slate-600 border-slate-200'
+const DEFAULT_TAG_COLOR = 'bg-slate-50 text-slate-600 border-slate-200 dark:bg-slate-800/60 dark:text-slate-300 dark:border-slate-700'
 
 export function TagPill({ tag, active, onClick }: { tag: string; active: boolean; onClick: (tag: string) => void }) {
   const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
@@ -35,13 +35,13 @@ export function TagPill({ tag, active, onClick }: { tag: string; active: boolean
 export function ActiveFilterBar({ tag, onClear }: { tag: string; onClear: () => void }) {
   const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
-      <span className="text-xs text-slate-600">Filtering by</span>
+    <div className="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/60">
+      <span className="text-xs text-slate-600 dark:text-slate-300">Filtering by</span>
       <span className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium ${color}`}>{tag}</span>
       <button
         type="button"
         onClick={onClear}
-        className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+        className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full text-slate-400 hover:bg-slate-100 hover:text-slate-600 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:text-slate-200"
         aria-label="Clear filter"
       >
         <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2">

--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect, type Locator, type Page } from '@playwright/test'
+
+// Regression guard for #326. Light-mode-only `bg-*` classes on tab containers,
+// score cards, or controls used to ship unnoticed — dark-mode rendering was
+// only caught via manual review. This test mocks an analyze response, walks
+// every tab in dark mode, and asserts the visible panel background is actually
+// dark (no channel > 80/255). If a future panel lands without a `dark:` bg
+// variant, this will fail with the offending tab + color.
+
+const DARK_CHANNEL_MAX = 80
+
+function parseRGB(color: string): [number, number, number, number] | null {
+  const m = color.match(/\d+(?:\.\d+)?/g)
+  if (!m || m.length < 3) return null
+  const [r, g, b, a = '1'] = m
+  return [Number(r), Number(g), Number(b), Number(a)]
+}
+
+function isDarkSurface(color: string): boolean {
+  const rgba = parseRGB(color)
+  if (!rgba) return false
+  const [r, g, b, a] = rgba
+  // Fully transparent — no surface of its own, don't fail on it.
+  if (a === 0) return true
+  return r <= DARK_CHANNEL_MAX && g <= DARK_CHANNEL_MAX && b <= DARK_CHANNEL_MAX
+}
+
+async function assertDarkBg(locator: Locator, label: string) {
+  await expect(locator, `${label}: not found`).toBeVisible()
+  const color = await locator.evaluate((el) => getComputedStyle(el).backgroundColor)
+  expect(isDarkSurface(color), `${label}: expected dark bg, got ${color}`).toBe(true)
+}
+
+const MOCK_RESULT = {
+  repo: 'facebook/react',
+  name: 'react',
+  description: 'A UI library',
+  createdAt: '2013-05-24T16:15:54Z',
+  primaryLanguage: 'TypeScript',
+  stars: 244295,
+  forks: 50872,
+  watchers: 6660,
+  commits30d: 7,
+  commits90d: 18,
+  releases12mo: 'unavailable',
+  prsOpened90d: 4,
+  prsMerged90d: 3,
+  issuesOpen: 5,
+  issuesClosed90d: 6,
+  activityMetricsByWindow: {
+    30: { commits: 7, prsOpened: 2, prsMerged: 1, issuesOpened: 4, issuesClosed: 3, releases: 'unavailable', staleIssueRatio: 'unavailable', medianTimeToMergeHours: 'unavailable', medianTimeToCloseHours: 'unavailable' },
+    60: { commits: 12, prsOpened: 3, prsMerged: 2, issuesOpened: 6, issuesClosed: 5, releases: 'unavailable', staleIssueRatio: 'unavailable', medianTimeToMergeHours: 'unavailable', medianTimeToCloseHours: 'unavailable' },
+    90: { commits: 18, prsOpened: 4, prsMerged: 3, issuesOpened: 8, issuesClosed: 6, releases: 'unavailable', staleIssueRatio: 'unavailable', medianTimeToMergeHours: 'unavailable', medianTimeToCloseHours: 'unavailable' },
+    180: { commits: 30, prsOpened: 7, prsMerged: 5, issuesOpened: 10, issuesClosed: 8, releases: 'unavailable', staleIssueRatio: 'unavailable', medianTimeToMergeHours: 'unavailable', medianTimeToCloseHours: 'unavailable' },
+    365: { commits: 55, prsOpened: 12, prsMerged: 9, issuesOpened: 16, issuesClosed: 13, releases: 'unavailable', staleIssueRatio: 'unavailable', medianTimeToMergeHours: 'unavailable', medianTimeToCloseHours: 'unavailable' },
+  },
+  uniqueCommitAuthors90d: 'unavailable',
+  totalContributors: 'unavailable',
+  commitCountsByAuthor: 'unavailable',
+  issueFirstResponseTimestamps: 'unavailable',
+  issueCloseTimestamps: 'unavailable',
+  prMergeTimestamps: 'unavailable',
+  securityResult: 'unavailable',
+  documentationResult: 'unavailable',
+  licensingResult: 'unavailable',
+  inclusiveNamingResult: 'unavailable',
+  responsivenessMetrics: 'unavailable',
+  contributorMetricsByWindow: {
+    30: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+    60: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+    90: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+    180: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+    365: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+  },
+  missingFields: ['releases12mo'],
+}
+
+async function setupAnalyzed(page: Page) {
+  // Pre-seed dark-mode preference before any script runs, so the layout's
+  // head-script adds the `dark` class during initial paint.
+  await page.addInitScript(() => {
+    try { window.localStorage.setItem('repopulse-theme', 'dark') } catch {}
+  })
+
+  await page.route('**/api/analyze', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ results: [MOCK_RESULT], failures: [], rateLimit: null }),
+    })
+  })
+
+  await page.goto('/#token=gho_test_token&username=test-user')
+  await expect(page.locator('html')).toHaveClass(/(^|\s)dark(\s|$)/)
+
+  await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react')
+  await page.getByRole('button', { name: /analyze/i }).click()
+  await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible()
+}
+
+test.describe('#326 dark mode surfaces', () => {
+  test('Overview top-bar controls render on dark surfaces', async ({ page }) => {
+    await setupAnalyzed(page)
+
+    await assertDarkBg(
+      page.getByPlaceholder('Search report...'),
+      'Search report input',
+    )
+    await assertDarkBg(
+      page.getByRole('button', { name: /download json/i }),
+      'Download JSON button',
+    )
+    await assertDarkBg(
+      page.getByRole('button', { name: /download markdown/i }),
+      'Download Markdown button',
+    )
+    await assertDarkBg(
+      page.getByRole('button', { name: /copy link/i }),
+      'Copy link button',
+    )
+  })
+
+  test('Overview metric card renders on a dark surface', async ({ page }) => {
+    await setupAnalyzed(page)
+    await assertDarkBg(
+      page.getByTestId('metric-card-facebook/react'),
+      'Metric card article',
+    )
+  })
+
+  // Recommendations is dynamic — only appears when there are recommendations,
+  // which the minimal-unavailable mock doesn't produce. Other tabs are always
+  // present on the default desktop viewport.
+  const TAB_NAMES = ['Overview', 'Contributors', 'Activity', 'Responsiveness', 'Documentation', 'Security'] as const
+
+  for (const name of TAB_NAMES) {
+    test(`${name} tab: main panel renders on a dark surface`, async ({ page }) => {
+      await setupAnalyzed(page)
+
+      const tab = page.getByRole('tab', { name, exact: true })
+      await tab.click()
+      await expect(tab).toHaveAttribute('aria-selected', 'true')
+
+      // Grab the first article/section under the main panel that has a
+      // non-transparent background — that's the user-visible surface.
+      const panel = page.locator('[role="region"], section, article').first()
+      await expect(panel).toBeVisible()
+      const color = await panel.evaluate((el) => getComputedStyle(el).backgroundColor)
+      expect(isDarkSurface(color), `${name} panel: expected dark bg, got ${color}`).toBe(true)
+    })
+  }
+})

--- a/lib/metric-cards/score-config.ts
+++ b/lib/metric-cards/score-config.ts
@@ -148,12 +148,12 @@ function getTopFactorDetail(factors: Array<{ label: string; percentile?: number 
 export function scoreToneClass(tone: ScoreTone) {
   switch (tone) {
     case 'success':
-      return 'border-emerald-200 bg-emerald-50 text-emerald-800'
+      return 'border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-800/60 dark:bg-emerald-900/30 dark:text-emerald-200'
     case 'warning':
-      return 'border-amber-200 bg-amber-50 text-amber-800'
+      return 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800/60 dark:bg-amber-900/30 dark:text-amber-200'
     case 'danger':
-      return 'border-red-200 bg-red-50 text-red-800'
+      return 'border-red-200 bg-red-50 text-red-800 dark:border-red-800/60 dark:bg-red-900/30 dark:text-red-200'
     default:
-      return 'border-slate-200 bg-slate-50 text-slate-700'
+      return 'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200'
   }
 }


### PR DESCRIPTION
## Summary

Closes #326.

- Adds Tailwind `dark:` variants to every report surface that was still rendering with its light-mode fill in dark mode: search bar, export buttons, OSS Health Score panel, percentile cells (REACH / ATTENTION / ENGAGEMENT), CHAOSS score cards (Contributors, Activity, Responsiveness, Documentation, Security), lens badges, tag pills, solo-profile callout, and every tab view's container / card / section chrome.
- Centralized shared helpers (`scoreToneClass`, `percentileToneClass`, `TAG_COLORS`) now emit dark-mode-safe surfaces, so any component that consumes them — including score badges, lens pills, recommendation cards, and tag pills — inherits correct dark styling automatically.
- Scope covers every tab listed in the issue (Overview, Contributors, Activity, Responsiveness, Documentation, Security, More/Organization, Recommendations) plus the repo-input landing surface.
- Fixes `MetricValue` (the component that renders metric numbers across every tab), whose color classes were in a string literal and missed by the bulk edit — values were rendering in dark-on-dark.
- Adds a Playwright regression guard (`e2e/dark-mode.spec.ts`) that mocks an analyze response, walks every tab in dark mode, and asserts the main panel's computed background is dark (every RGB channel ≤ 80).

## Test plan

- [x] In dark mode, open the Overview tab for any analyzed repo and visually confirm the search bar, Download JSON / Markdown / Copy link buttons render with dark surfaces — no white/cream fills.
- [x] Confirm OSS Health Score + Contributors / Activity / Responsiveness / Documentation / Security score cards render with dark-mode-tinted backgrounds matching the surrounding chrome.
- [x] Confirm REACH / ATTENTION / ENGAGEMENT percentile cells render with dark-mode color ramps for each percentile bucket.
- [x] Confirm COMMUNITY and GOVERNANCE lens badges render with dark surfaces.
- [x] Tab through Contributors, Activity, Responsiveness, Documentation, Security, More (all sub-panels), Organization, Recommendations in dark mode — every panel, card, filter bar, window-selector, and sub-section should use dark surfaces.
- [x] Confirm the solo-maintained / community-override info callout renders with dark amber/sky tones (no pastel fill).
- [x] Toggle between light and dark mode — no regressions in light mode.
- [x] Playwright regression test added (`e2e/dark-mode.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)