### PR TITLE
Change default Org tab page size from 25 to 10 (#329)

### DIFF
--- a/components/org-inventory/OrgInventoryView.test.tsx
+++ b/components/org-inventory/OrgInventoryView.test.tsx
@@ -154,14 +154,14 @@ describe('OrgInventoryView', () => {
       />,
     )
 
-    expect(screen.getByText(/Showing 1–25 of 30/)).toBeInTheDocument()
-    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
-    expect(screen.queryByText('facebook/repo-26')).not.toBeInTheDocument()
+    expect(screen.getByText(/Showing 1–10 of 30/)).toBeInTheDocument()
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument()
+    expect(screen.queryByText('facebook/repo-11')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByRole('button', { name: 'Next' }))
-    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
-    expect(screen.getByText('facebook/repo-26')).toBeInTheDocument()
-    expect(screen.getByText(/Showing 26–30 of 30/)).toBeInTheDocument()
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument()
+    expect(screen.getByText('facebook/repo-11')).toBeInTheDocument()
+    expect(screen.getByText(/Showing 11–20 of 30/)).toBeInTheDocument()
 
     await userEvent.selectOptions(screen.getByLabelText('Rows per page'), '50')
     expect(screen.getByText('Page 1 of 1')).toBeInTheDocument()

--- a/lib/config/org-inventory.test.ts
+++ b/lib/config/org-inventory.test.ts
@@ -5,7 +5,7 @@ describe('org-inventory config', () => {
   it('exposes the Phase 1 default and max bulk-selection limits', () => {
     expect(ORG_INVENTORY_CONFIG.defaultBulkSelectionLimit).toBe(5)
     expect(ORG_INVENTORY_CONFIG.maxBulkSelectionLimit).toBe(5)
-    expect(ORG_INVENTORY_CONFIG.defaultPageSize).toBe(25)
+    expect(ORG_INVENTORY_CONFIG.defaultPageSize).toBe(10)
     expect(ORG_INVENTORY_CONFIG.pageSizeOptions).toEqual([10, 25, 50, 100])
   })
 
@@ -19,6 +19,6 @@ describe('org-inventory config', () => {
     expect(clampOrgInventoryPageSize(25)).toBe(25)
     expect(clampOrgInventoryPageSize(50)).toBe(50)
     expect(clampOrgInventoryPageSize(10)).toBe(10)
-    expect(clampOrgInventoryPageSize(15)).toBe(25)
+    expect(clampOrgInventoryPageSize(15)).toBe(10)
   })
 })

--- a/lib/config/org-inventory.ts
+++ b/lib/config/org-inventory.ts
@@ -1,7 +1,7 @@
 export const ORG_INVENTORY_CONFIG = {
   defaultBulkSelectionLimit: 5,
   maxBulkSelectionLimit: 5,
-  defaultPageSize: 25,
+  defaultPageSize: 10,
   pageSizeOptions: [10, 25, 50, 100],
 } as const
 


### PR DESCRIPTION
## Summary
- `ORG_INVENTORY_CONFIG.defaultPageSize`: `25` → `10` so the initial Org Inventory view is more scannable.
- `clampOrgInventoryPageSize` test updated (the fallback for non-matching sizes now clamps to `10`).
- `OrgInventoryView` pagination test updated to assert the new default (30 repos → 3 pages of 10, not 2 pages of 25).

Closes #329.

## Test plan
- [x] `npx vitest run lib/config/org-inventory.test.ts components/org-inventory/OrgInventoryView.test.tsx` passes
- [x] `npm run lint` shows no new errors
- [x] Load an org in the Org tab on the dev server — the table defaults to 10 rows per page
- [x] Page-size selector still offers 10 / 25 / 50 / 100 and switching to 25/50/100 works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)