### PR TITLE
Add Release Health scoring lens (P2-F09, #69)

### DIFF
--- a/components/activity/ActivityView.tsx
+++ b/components/activity/ActivityView.tsx
@@ -12,6 +12,7 @@ import { buildActivitySections, getActivityWindowOptions } from '@/lib/activity/
 import { CONTRIB_EX_ACTIVITY_CARDS } from '@/lib/tags/tag-mappings'
 import { ActivityScoreHelp } from './ActivityScoreHelp'
 import { DiscussionsCard } from './DiscussionsCard'
+import { ReleaseCadenceCard } from './ReleaseCadenceCard'
 
 interface ActivityViewProps {
   results: AnalysisResult[]
@@ -148,6 +149,9 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
                     })}
                   {!activeTag || activeTag === 'community' ? (
                     <DiscussionsCard result={result} activeTag={activeTag} onTagClick={handleTagClick} windowDays={windowDays} />
+                  ) : null}
+                  {!activeTag || activeTag === 'release-health' ? (
+                    <ReleaseCadenceCard result={result} activeTag={activeTag} onTagClick={handleTagClick} />
                   ) : null}
                 </div>
                 <ActivityScoreHelp score={score} />

--- a/components/activity/ReleaseCadenceCard.test.tsx
+++ b/components/activity/ReleaseCadenceCard.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AnalysisResult, ReleaseHealthResult } from '@/lib/analyzer/analysis-result'
+import { ReleaseCadenceCard } from './ReleaseCadenceCard'
+
+function buildResult(rh: ReleaseHealthResult | 'unavailable' | undefined): AnalysisResult {
+  return {
+    repo: 'foo/bar',
+    name: 'bar',
+    description: '—',
+    createdAt: '2024-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 10,
+    watchers: 5,
+    commits30d: 5,
+    commits90d: 15,
+    releases12mo: 2,
+    prsOpened90d: 3,
+    prsMerged90d: 2,
+    issuesOpen: 4,
+    issuesClosed90d: 3,
+    uniqueCommitAuthors90d: 4,
+    totalContributors: 10,
+    maintainerCount: 2,
+    commitCountsByAuthor: { 'login:alice': 5 },
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    releaseHealthResult: rh,
+    missingFields: [],
+  }
+}
+
+const noop = vi.fn()
+
+describe('ReleaseCadenceCard', () => {
+  it('returns null when releaseHealthResult is undefined', () => {
+    const { container } = render(
+      <ReleaseCadenceCard result={buildResult(undefined)} activeTag={null} onTagClick={noop} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders with unavailable fields when releaseHealthResult is "unavailable"', () => {
+    render(
+      <ReleaseCadenceCard result={buildResult('unavailable')} activeTag={null} onTagClick={noop} />,
+    )
+    expect(screen.getByText(/^release cadence$/i)).toBeInTheDocument()
+    // Three "unavailable" placeholders
+    expect(screen.getAllByText(/^unavailable$/i).length).toBe(3)
+  })
+
+  it('renders frequency, recency, and pre-release state when populated', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 12,
+      totalTags: 12,
+      releaseFrequency: 6,
+      daysSinceLastRelease: 10,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0.25,
+      versioningScheme: 'semver',
+    }
+    render(
+      <ReleaseCadenceCard result={buildResult(rh)} activeTag={null} onTagClick={noop} />,
+    )
+    expect(screen.getByText(/6 per year/i)).toBeInTheDocument()
+    expect(screen.getByText(/10 days ago/i)).toBeInTheDocument()
+    expect(screen.getByText(/25%/i)).toBeInTheDocument()
+  })
+
+  it('carries the release-health tag pill', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 1,
+      totalTags: 1,
+      releaseFrequency: 'unavailable',
+      daysSinceLastRelease: 3,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    render(
+      <ReleaseCadenceCard result={buildResult(rh)} activeTag={null} onTagClick={noop} />,
+    )
+    expect(screen.getByRole('button', { name: /release-health/i })).toBeInTheDocument()
+  })
+})

--- a/components/activity/ReleaseCadenceCard.tsx
+++ b/components/activity/ReleaseCadenceCard.tsx
@@ -31,11 +31,11 @@ export function ReleaseCadenceCard({ result, activeTag, onTagClick }: ReleaseCad
         <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Release cadence</p>
         <TagPill tag="release-health" active={activeTag === 'release-health'} onClick={onTagClick} />
       </div>
-      <dl className="mt-2 grid grid-cols-1 gap-1 text-sm text-slate-700 dark:text-slate-200 sm:grid-cols-3">
+      <div className="mt-2 flex flex-wrap gap-x-6 gap-y-3 text-sm text-slate-700 dark:text-slate-200">
         <Row label="Frequency" value={formatFrequency(rh === 'unavailable' ? 'unavailable' : rh.releaseFrequency)} />
         <Row label="Last release" value={formatRecency(rh === 'unavailable' ? 'unavailable' : rh.daysSinceLastRelease)} />
         <Row label="Pre-releases" value={formatRatio(rh === 'unavailable' ? 'unavailable' : rh.preReleaseRatio)} />
-      </dl>
+      </div>
       <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
         Release cadence reflects how actively the project ships. Pre-release usage is informational only.
       </p>
@@ -45,9 +45,9 @@ export function ReleaseCadenceCard({ result, activeTag, onTagClick }: ReleaseCad
 
 function Row({ label, value }: { label: string; value: string }) {
   return (
-    <div>
-      <dt className="text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500">{label}</dt>
-      <dd className="font-medium">{value}</dd>
+    <div className="min-w-[6rem]">
+      <p className="text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500">{label}</p>
+      <p className="font-medium">{value}</p>
     </div>
   )
 }

--- a/components/activity/ReleaseCadenceCard.tsx
+++ b/components/activity/ReleaseCadenceCard.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { TagPill } from '@/components/tags/TagPill'
+import type { AnalysisResult, Unavailable } from '@/lib/analyzer/analysis-result'
+
+interface ReleaseCadenceCardProps {
+  result: AnalysisResult
+  activeTag: string | null
+  onTagClick: (tag: string) => void
+}
+
+/**
+ * Activity-tab card for Release Health cadence signals (P2-F09 / #69).
+ *
+ * Shows:
+ *   1. Releases per year (releaseFrequency)
+ *   2. Time since last release (daysSinceLastRelease)
+ *   3. Pre-release usage (preReleaseRatio) — informational
+ *
+ * When the analyzer could not retrieve releases at all, `releaseHealthResult`
+ * is `'unavailable'` and per-field `"unavailable"` placeholders render — never
+ * zeroed, per Constitution §II.
+ */
+export function ReleaseCadenceCard({ result, activeTag, onTagClick }: ReleaseCadenceCardProps) {
+  const rh = result.releaseHealthResult
+  if (rh === undefined) return null
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:bg-slate-800/60 dark:border-slate-700">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Release cadence</p>
+        <TagPill tag="release-health" active={activeTag === 'release-health'} onClick={onTagClick} />
+      </div>
+      <dl className="mt-2 grid grid-cols-1 gap-1 text-sm text-slate-700 dark:text-slate-200 sm:grid-cols-3">
+        <Row label="Frequency" value={formatFrequency(rh === 'unavailable' ? 'unavailable' : rh.releaseFrequency)} />
+        <Row label="Last release" value={formatRecency(rh === 'unavailable' ? 'unavailable' : rh.daysSinceLastRelease)} />
+        <Row label="Pre-releases" value={formatRatio(rh === 'unavailable' ? 'unavailable' : rh.preReleaseRatio)} />
+      </dl>
+      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+        Release cadence reflects how actively the project ships. Pre-release usage is informational only.
+      </p>
+    </div>
+  )
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function formatFrequency(value: number | Unavailable): string {
+  if (value === 'unavailable') return 'unavailable'
+  return `${value} per year`
+}
+
+function formatRecency(value: number | Unavailable): string {
+  if (value === 'unavailable') return 'unavailable'
+  if (value === 0) return 'today'
+  if (value === 1) return '1 day ago'
+  return `${value} days ago`
+}
+
+function formatRatio(value: number | Unavailable): string {
+  if (value === 'unavailable') return 'unavailable'
+  return `${Math.round(value * 100)}%`
+}

--- a/components/documentation/DocumentationView.tsx
+++ b/components/documentation/DocumentationView.tsx
@@ -10,6 +10,7 @@ import { getDocumentationScore } from '@/lib/documentation/score-config'
 import { GOVERNANCE_DOC_FILES, LICENSING_IS_GOVERNANCE } from '@/lib/tags/governance'
 import { COMMUNITY_DOC_FILES } from '@/lib/tags/community'
 import { getDocFileTags, getReadmeSectionTags, LICENSING_IS_COMPLIANCE } from '@/lib/tags/tag-mappings'
+import { ReleaseDisciplineCard } from './ReleaseDisciplineCard'
 
 interface DocumentationViewProps {
   results: AnalysisResult[]
@@ -354,6 +355,10 @@ export function DocumentationView({ results, activeTag: externalTag, onTagChange
               {/* Licensing & Compliance — governance + compliance */}
               {!activeTag || activeTag === 'governance' || activeTag === 'compliance' ? (
                 <LicensingPane licensingResult={result.licensingResult} activeTag={activeTag} onTagClick={handleTagClick} />
+              ) : null}
+
+              {!activeTag || activeTag === 'release-health' ? (
+                <ReleaseDisciplineCard result={result} activeTag={activeTag} onTagClick={handleTagClick} />
               ) : null}
 
               {/* Inclusive Naming — hide when any tag is filtering */}

--- a/components/documentation/ReleaseDisciplineCard.test.tsx
+++ b/components/documentation/ReleaseDisciplineCard.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { AnalysisResult, ReleaseHealthResult } from '@/lib/analyzer/analysis-result'
+import { ReleaseDisciplineCard } from './ReleaseDisciplineCard'
+
+function buildResult(rh: ReleaseHealthResult | 'unavailable' | undefined): AnalysisResult {
+  return {
+    repo: 'foo/bar',
+    name: 'bar',
+    description: '—',
+    createdAt: '2024-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 10,
+    watchers: 5,
+    commits30d: 5,
+    commits90d: 15,
+    releases12mo: 2,
+    prsOpened90d: 3,
+    prsMerged90d: 2,
+    issuesOpen: 4,
+    issuesClosed90d: 3,
+    uniqueCommitAuthors90d: 4,
+    totalContributors: 10,
+    maintainerCount: 2,
+    commitCountsByAuthor: { 'login:alice': 5 },
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    releaseHealthResult: rh,
+    missingFields: [],
+  }
+}
+
+const noop = vi.fn()
+
+describe('ReleaseDisciplineCard', () => {
+  it('returns null when releaseHealthResult is undefined', () => {
+    const { container } = render(
+      <ReleaseDisciplineCard result={buildResult(undefined)} activeTag={null} onTagClick={noop} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders three release-health rows each carrying the pill', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 10,
+      totalTags: 12,
+      releaseFrequency: 4,
+      daysSinceLastRelease: 30,
+      semverComplianceRatio: 0.9,
+      releaseNotesQualityRatio: 0.7,
+      tagToReleaseRatio: 0.1,
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    render(
+      <ReleaseDisciplineCard result={buildResult(rh)} activeTag={null} onTagClick={noop} />,
+    )
+    expect(screen.getByText(/semver compliance/i)).toBeInTheDocument()
+    expect(screen.getByText(/release notes quality/i)).toBeInTheDocument()
+    expect(screen.getByText(/tag-to-release promotion/i)).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: /release-health/i }).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders "unavailable" for fields whose ratios cannot be computed', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 0,
+      totalTags: 'unavailable',
+      releaseFrequency: 'unavailable',
+      daysSinceLastRelease: 'unavailable',
+      semverComplianceRatio: 'unavailable',
+      releaseNotesQualityRatio: 'unavailable',
+      tagToReleaseRatio: 'unavailable',
+      preReleaseRatio: 'unavailable',
+      versioningScheme: 'unavailable',
+    }
+    render(
+      <ReleaseDisciplineCard result={buildResult(rh)} activeTag={null} onTagClick={noop} />,
+    )
+    expect(screen.getAllByText(/unavailable/i).length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/components/documentation/ReleaseDisciplineCard.tsx
+++ b/components/documentation/ReleaseDisciplineCard.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { TagPill } from '@/components/tags/TagPill'
+import type { AnalysisResult, Unavailable } from '@/lib/analyzer/analysis-result'
+
+interface ReleaseDisciplineCardProps {
+  result: AnalysisResult
+  activeTag: string | null
+  onTagClick: (tag: string) => void
+}
+
+/**
+ * Documentation-tab card for Release Health versioning-discipline signals
+ * (P2-F09 / #69). Each row carries the `release-health` pill.
+ */
+export function ReleaseDisciplineCard({ result, activeTag, onTagClick }: ReleaseDisciplineCardProps) {
+  const rh = result.releaseHealthResult
+  if (rh === undefined) return null
+
+  const semver = rh === 'unavailable' ? 'unavailable' : rh.semverComplianceRatio
+  const notes = rh === 'unavailable' ? 'unavailable' : rh.releaseNotesQualityRatio
+  const promotion = rh === 'unavailable' ? 'unavailable' : rh.tagToReleaseRatio
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 dark:bg-slate-800/60 dark:border-slate-700">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Release discipline</p>
+      <div className="mt-2 space-y-2">
+        <Row
+          label="Semver compliance"
+          value={formatRatio(semver)}
+          activeTag={activeTag}
+          onTagClick={onTagClick}
+        />
+        <Row
+          label="Release notes quality"
+          value={formatRatio(notes)}
+          activeTag={activeTag}
+          onTagClick={onTagClick}
+        />
+        <Row
+          label="Tag-to-release promotion"
+          value={formatPromotion(promotion)}
+          activeTag={activeTag}
+          onTagClick={onTagClick}
+        />
+      </div>
+      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+        Versioning discipline signals complement the cadence signal on the Activity tab.
+      </p>
+    </div>
+  )
+}
+
+function Row({
+  label,
+  value,
+  activeTag,
+  onTagClick,
+}: {
+  label: string
+  value: string
+  activeTag: string | null
+  onTagClick: (tag: string) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div>
+        <p className="text-sm font-medium text-slate-700 dark:text-slate-200">{label}</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">{value}</p>
+      </div>
+      <TagPill tag="release-health" active={activeTag === 'release-health'} onClick={onTagClick} />
+    </div>
+  )
+}
+
+function formatRatio(value: number | Unavailable): string {
+  if (value === 'unavailable') return 'unavailable'
+  return `${Math.round(value * 100)}%`
+}
+
+function formatPromotion(value: number | Unavailable): string {
+  if (value === 'unavailable') return 'unavailable'
+  const pctOrphan = Math.round(value * 100)
+  return `${100 - pctOrphan}% of tags promoted to releases`
+}

--- a/components/tags/TagPill.tsx
+++ b/components/tags/TagPill.tsx
@@ -7,6 +7,7 @@ const TAG_COLORS: Record<string, string> = {
   'quick-win': 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-800/60',
   compliance: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-900/30 dark:text-rose-200 dark:border-rose-800/60',
   'contrib-ex': 'bg-cyan-50 text-cyan-700 border-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-200 dark:border-cyan-800/60',
+  'release-health': 'bg-teal-50 text-teal-700 border-teal-200 dark:bg-teal-900/30 dark:text-teal-200 dark:border-teal-800/60',
 }
 
 const TAG_RING_COLORS: Record<string, string> = {
@@ -16,6 +17,7 @@ const TAG_RING_COLORS: Record<string, string> = {
   'quick-win': 'ring-emerald-400',
   compliance: 'ring-rose-400',
   'contrib-ex': 'ring-cyan-400',
+  'release-health': 'ring-teal-400',
 }
 const DEFAULT_TAG_COLOR = 'bg-slate-50 text-slate-600 border-slate-200 dark:bg-slate-800/60 dark:text-slate-300 dark:border-slate-700'
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -261,7 +261,7 @@ Phase 2 adds new scoring buckets to the health score. Requirements specs live in
 | 6 | P2-F05 | Community scoring | #70 | ✅ Done |
 | 7 | P2-F06 | Foundation-aware recommendations | #119 | |
 | 8 | P2-F08 | Accessibility & Onboarding | #117 | |
-| 9 | P2-F09 | Release health scoring | #69 | |
+| 9 | P2-F09 | Release health scoring | #69 | ✅ Done |
 | 10 | P2-F10 | Development cadence | #73 | |
 | 11 | P2-F11 | Project maturity | #74 | |
 | 12 | P2-F12 | Ecosystem Reach | #118 | |

--- a/e2e/release-health.spec.ts
+++ b/e2e/release-health.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Release Health lens (P2-F09 / #69).
+ *
+ * Lightweight DOM assertions (per memory preference), driven against mocked
+ * /api/analyze fixtures. Covers:
+ *   1. Release-health pill + Release Cadence card on the Activity tab.
+ *   2. Release-health pill + Release Discipline card on the Documentation tab.
+ *   3. Release Health completeness readout on the metric card.
+ *   4. Zero-release repo renders "Insufficient verified public data" / "unavailable".
+ */
+test.describe('Release Health lens', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/#token=gho_test_token&username=test-user')
+    await expect(page.getByText('test-user')).toBeVisible()
+  })
+
+  test('release-rich repo surfaces the Release Health lens across tabs', async ({ page }) => {
+    await mockAnalyze(page, releaseRichResult())
+    await analyze(page, 'foo/rich')
+
+    const overview = page.getByRole('region', { name: /metric cards overview/i })
+    await expect(overview).toContainText('Release Health')
+
+    await page.getByRole('tab', { name: 'Activity' }).click()
+    const activity = page.getByRole('region', { name: /activity view/i })
+    await expect(activity).toContainText(/Release cadence/i)
+
+    await page.getByRole('tab', { name: 'Documentation' }).click()
+    const docs = page.getByRole('region', { name: /documentation view/i })
+    await expect(docs).toContainText(/Release discipline/i)
+    await expect(docs).toContainText(/Semver compliance/i)
+  })
+
+  test('zero-release repo shows unavailable placeholders', async ({ page }) => {
+    await mockAnalyze(page, zeroReleaseResult())
+    await analyze(page, 'foo/empty')
+
+    await page.getByRole('tab', { name: 'Activity' }).click()
+    const activity = page.getByRole('region', { name: /activity view/i })
+    await expect(activity).toContainText(/Release cadence/i)
+    await expect(activity).toContainText(/unavailable/i)
+  })
+})
+
+async function analyze(page: import('@playwright/test').Page, repo: string) {
+  await page.getByRole('textbox', { name: /repository list/i }).fill(repo)
+  await page.getByRole('button', { name: /analyze/i }).click()
+  await expect(page.getByRole('region', { name: /metric cards overview/i })).toBeVisible()
+}
+
+async function mockAnalyze(page: import('@playwright/test').Page, result: Record<string, unknown>) {
+  await page.route('**/api/analyze', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ results: [result], failures: [], rateLimit: null }),
+    })
+  })
+}
+
+function baseResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    repo: 'foo/rich',
+    name: 'rich',
+    description: 'A release-rich fixture',
+    createdAt: '2020-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 1000,
+    forks: 100,
+    watchers: 50,
+    commits30d: 10,
+    commits90d: 30,
+    releases12mo: 6,
+    prsOpened90d: 8,
+    prsMerged90d: 6,
+    issuesOpen: 5,
+    issuesClosed90d: 10,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 10,
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: {
+      defaultBranchName: 'main',
+      branchCheck: { checkType: 'branch', term: 'main', passed: true, tier: null, severity: null, replacements: [], context: null },
+      metadataChecks: [],
+    },
+    securityResult: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+function releaseRichResult(): Record<string, unknown> {
+  return baseResult({
+    repo: 'foo/rich',
+    releaseHealthResult: {
+      totalReleasesAnalyzed: 12,
+      totalTags: 12,
+      releaseFrequency: 12,
+      daysSinceLastRelease: 7,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0.1,
+      versioningScheme: 'semver',
+    },
+  })
+}
+
+function zeroReleaseResult(): Record<string, unknown> {
+  return baseResult({
+    repo: 'foo/empty',
+    name: 'empty',
+    releases12mo: 0,
+    releaseHealthResult: 'unavailable',
+  })
+}

--- a/lib/activity/score-config.test.ts
+++ b/lib/activity/score-config.test.ts
@@ -50,6 +50,50 @@ describe('activity/score-config', () => {
     expect(score30.summary).toContain('30d')
     expect(score365.summary).toContain('12 months')
   })
+
+  it('folds releaseHealthResult.daysSinceLastRelease into the cadence score when available', () => {
+    const baseline = getActivityScore(buildResult())
+    const withRecentRelease = getActivityScore(
+      buildResult({
+        releaseHealthResult: {
+          totalReleasesAnalyzed: 12,
+          totalTags: 12,
+          releaseFrequency: 12,
+          daysSinceLastRelease: 5,
+          semverComplianceRatio: 1,
+          releaseNotesQualityRatio: 1,
+          tagToReleaseRatio: 0,
+          preReleaseRatio: 0,
+          versioningScheme: 'semver',
+        },
+      }),
+    )
+    const withStaleRelease = getActivityScore(
+      buildResult({
+        releaseHealthResult: {
+          totalReleasesAnalyzed: 2,
+          totalTags: 2,
+          releaseFrequency: 1,
+          daysSinceLastRelease: 900,
+          semverComplianceRatio: 1,
+          releaseNotesQualityRatio: 1,
+          tagToReleaseRatio: 0,
+          preReleaseRatio: 0,
+          versioningScheme: 'semver',
+        },
+      }),
+    )
+    // Recent release should not regress versus baseline.
+    expect(withRecentRelease.value).toBeGreaterThanOrEqual(baseline.value as number)
+    // Stale release should not push the score higher than a recent one.
+    expect(withStaleRelease.value).toBeLessThanOrEqual(withRecentRelease.value as number)
+  })
+
+  it('falls back to releases-only cadence when releaseHealthResult is unavailable', () => {
+    const withUnavailable = getActivityScore(buildResult({ releaseHealthResult: 'unavailable' }))
+    const without = getActivityScore(buildResult())
+    expect(withUnavailable.value).toBe(without.value)
+  })
 })
 
 function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {

--- a/lib/activity/score-config.ts
+++ b/lib/activity/score-config.ts
@@ -1,6 +1,16 @@
 import type { ActivityWindowDays, AnalysisResult, Unavailable } from '@/lib/analyzer/analysis-result'
 import type { ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
-import { type BracketCalibration, type CalibrationProfile, formatPercentileLabel, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
+import {
+  ACTIVITY_CADENCE_FREQUENCY_WEIGHT,
+  ACTIVITY_CADENCE_RECENCY_WEIGHT,
+  type BracketCalibration,
+  type CalibrationProfile,
+  formatPercentileLabel,
+  getBracketLabel,
+  getCalibrationForStars,
+  interpolatePercentile,
+  percentileToTone,
+} from '@/lib/scoring/config-loader'
 
 export interface ActivityScoreDefinition {
   value: ScoreValue
@@ -100,20 +110,36 @@ export function getActivityScore(
   const cal = getCalibrationForStars(result.stars, profile)
   const bracketLabel = getBracketLabel(result.stars, profile)
 
+  const cadenceFrequency = evaluateReleaseCadence(metrics.releases, windowDays)
+  const cadenceRecency = evaluateReleaseRecency(result.releaseHealthResult)
+
   const subPercentiles = {
     prFlow: evaluatePrFlow(metrics.prsMerged, metrics.prsOpened, cal),
     issueFlow: evaluateIssueFlow(metrics.issuesClosed, metrics.issuesOpened, metrics.staleIssueRatio, cal),
     completionSpeed: evaluateCompletionSpeed(metrics.medianTimeToMergeHours, metrics.medianTimeToCloseHours, cal),
     sustainedActivity: evaluateSustainedActivity(metrics.commits, windowDays),
-    releaseCadence: evaluateReleaseCadence(metrics.releases, windowDays),
+    // Composite cadence score for the weightedFactors readout: weighted blend
+    // of frequency and recency. When recency is unavailable, frequency alone
+    // preserves the pre-feature score.
+    releaseCadence: cadenceRecency !== null
+      ? Math.round((cadenceFrequency * ACTIVITY_CADENCE_FREQUENCY_WEIGHT + cadenceRecency * ACTIVITY_CADENCE_RECENCY_WEIGHT) / (ACTIVITY_CADENCE_FREQUENCY_WEIGHT + ACTIVITY_CADENCE_RECENCY_WEIGHT))
+      : cadenceFrequency,
   }
+
+  // Composite respects the existing 0.15 cadence allocation — split into
+  // frequency (ACTIVITY_CADENCE_FREQUENCY_WEIGHT) + recency
+  // (ACTIVITY_CADENCE_RECENCY_WEIGHT). When recency is unavailable the full
+  // 0.15 flows through frequency, reproducing pre-feature scoring.
+  const cadenceContribution = cadenceRecency !== null
+    ? cadenceFrequency * ACTIVITY_CADENCE_FREQUENCY_WEIGHT + cadenceRecency * ACTIVITY_CADENCE_RECENCY_WEIGHT
+    : cadenceFrequency * 0.15
 
   const compositePercentile = Math.round(
     subPercentiles.prFlow * 0.25 +
     subPercentiles.issueFlow * 0.2 +
     subPercentiles.completionSpeed * 0.15 +
     subPercentiles.sustainedActivity * 0.25 +
-    subPercentiles.releaseCadence * 0.15,
+    cadenceContribution,
   )
 
   // Community signal (P2-F05 / #70): additive Discussions bonus. Bonus-only
@@ -252,6 +278,27 @@ function evaluateSustainedActivity(commits: number | Unavailable, windowDays: Ac
   if (commitsPer30Days <= 0) return 0
   if (commitsPer30Days >= 5) return Math.round(50 + ((commitsPer30Days - 5) / 15) * 49)
   return Math.round((commitsPer30Days / 5) * 50)
+}
+
+/**
+ * Recency sub-score derived from ReleaseHealthResult.daysSinceLastRelease.
+ * Returns `null` when the signal cannot be computed (no release health data,
+ * or the value is `'unavailable'`) — caller falls back to frequency-only
+ * cadence scoring in that case.
+ */
+function evaluateReleaseRecency(
+  releaseHealth: AnalysisResult['releaseHealthResult'],
+): number | null {
+  if (!releaseHealth || releaseHealth === 'unavailable') return null
+  const days = releaseHealth.daysSinceLastRelease
+  if (days === 'unavailable') return null
+  // Linear approximation pending calibration data (#152).
+  if (days <= 30) return 99
+  if (days >= 730) return 0
+  if (days <= 90) return Math.round(90 - ((days - 30) / 60) * 15) // 90 → 75
+  if (days <= 180) return Math.round(75 - ((days - 90) / 90) * 25) // 75 → 50
+  if (days <= 365) return Math.round(50 - ((days - 180) / 185) * 25) // 50 → 25
+  return Math.round(25 - ((days - 365) / 365) * 25) // 25 → 0
 }
 
 function evaluateReleaseCadence(releases: number | Unavailable, windowDays: ActivityWindowDays): number {

--- a/lib/analyzer/analysis-result.ts
+++ b/lib/analyzer/analysis-result.ts
@@ -193,7 +193,35 @@ export interface AnalysisResult {
   // while still inside the 365d window — counts for large windows should
   // be rendered as e.g. `N+` rather than implying an exact total.
   discussionsRecentTruncated?: boolean
+  // Release Health signals (P2-F09 / #69). Optional — absent on fixtures
+  // predating this feature. Set by the analyzer to either the resolved object
+  // or 'unavailable' per Constitution §II (no estimation). Per-field
+  // 'unavailable' is used for individual signals that cannot be computed.
+  releaseHealthResult?: ReleaseHealthResult | Unavailable
   missingFields: string[]
+}
+
+export type VersioningScheme = 'semver' | 'calver' | 'unrecognized'
+
+export interface ReleaseHealthResult {
+  /** Count of releases analyzed (bounded at 100 by the GraphQL query). */
+  totalReleasesAnalyzed: number
+  /** Tag count from refs(refPrefix: "refs/tags/"). 'unavailable' when the refs query is denied. */
+  totalTags: number | Unavailable
+  /** Releases per year over the last 12 months. 'unavailable' when fewer than 2 releases exist. */
+  releaseFrequency: number | Unavailable
+  /** Days since the most recent release (publishedAt falling back to createdAt). */
+  daysSinceLastRelease: number | Unavailable
+  /** Share of the most recent 100 releases matching SEMVER_REGEX [0, 1]. */
+  semverComplianceRatio: number | Unavailable
+  /** Share of releases whose body length clears RELEASE_NOTES_SUBSTANTIVE_FLOOR [0, 1]. */
+  releaseNotesQualityRatio: number | Unavailable
+  /** Share of tags that never became a release: max(0, totalTags - totalReleases) / max(1, totalTags). */
+  tagToReleaseRatio: number | Unavailable
+  /** Share of releases with isPrerelease === true. Informational — never scored. */
+  preReleaseRatio: number | Unavailable
+  /** Dominant versioning scheme. Drives semver vs. CalVer vs. unrecognized recommendation routing. */
+  versioningScheme: VersioningScheme | Unavailable
 }
 
 export interface RepositoryFetchFailure {

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -124,7 +124,7 @@ interface RepoCommitAndReleasesResponse {
       nodes: Array<{
         tagName: string
         name: string | null
-        body: string | null
+        description: string | null
         isPrerelease: boolean
         createdAt: string
         publishedAt: string | null
@@ -802,7 +802,7 @@ function extractReleaseHealthResult(
     releases: rawNodes.map((r) => ({
       tagName: r.tagName,
       name: r.name,
-      body: r.body,
+      body: r.description,
       isPrerelease: r.isPrerelease,
       createdAt: r.createdAt,
       publishedAt: r.publishedAt,

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -21,6 +21,7 @@ import { fetchContributorCount, fetchMaintainerCount, fetchPublicUserOrganizatio
 import { REPO_COMMIT_AND_RELEASES_QUERY, REPO_ACTIVITY_COUNTS_QUERY, REPO_COMMIT_HISTORY_PAGE_QUERY, REPO_DISCUSSIONS_PAGE_QUERY, REPO_OVERVIEW_QUERY, REPO_RESPONSIVENESS_METADATA_QUERY, buildResponsivenessDetailQuery } from './queries'
 import { extractLicensingResult, type LicenseFileInfo } from './extract-licensing'
 import { extractInclusiveNamingResult } from '@/lib/inclusive-naming/checker'
+import { detectReleaseHealth } from '@/lib/release-health/detect'
 import type { SecurityResult, DirectSecurityCheck } from '@/lib/security/analysis-result'
 import { fetchScorecardData } from '@/lib/security/scorecard-client'
 import { fetchBranchProtection } from '@/lib/security/direct-checks'
@@ -119,11 +120,17 @@ interface RepoOverviewResponse {
 interface RepoCommitAndReleasesResponse {
   repository: {
     releases: {
+      totalCount: number
       nodes: Array<{
+        tagName: string
+        name: string | null
+        body: string | null
+        isPrerelease: boolean
         createdAt: string
         publishedAt: string | null
       }>
     }
+    refs: { totalCount: number } | null
     defaultBranchRef: {
       target: {
         recent30: { totalCount: number }
@@ -549,6 +556,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
         commitHistory.nodes,
         discussionTimestamps,
         discussionsTruncated,
+        now,
       )
 
       // Populate Scorecard data and branch protection (fetched in parallel earlier)
@@ -619,6 +627,7 @@ function buildAnalysisResult(
   recentCommitNodes: CommitNode[],
   discussionTimestamps?: string[],
   discussionsTruncated?: boolean,
+  now: Date = new Date(),
 ): AnalysisResult {
   const defaultBranchTarget = activity.repository?.defaultBranchRef?.target
   const legacyActivity = activity as RepoActivityResponse & LegacyRepoActivityResponse
@@ -770,8 +779,38 @@ function buildAnalysisResult(
     prMergeTimestamps,
     securityResult: extractSecurityResult(overview.repository),
     ...extractCommunitySignals(overview.repository, 90, discussionTimestamps, discussionsTruncated),
+    releaseHealthResult: extractReleaseHealthResult(activity, now),
     missingFields,
   }
+}
+
+function extractReleaseHealthResult(
+  activity: RepoActivityResponse,
+  now: Date,
+): AnalysisResult['releaseHealthResult'] {
+  const repo = activity.repository
+  if (!repo) return 'unavailable'
+  const releasesConnection = repo.releases
+  const rawNodes = releasesConnection?.nodes ?? []
+  const totalReleasesAllTime = typeof releasesConnection?.totalCount === 'number'
+    ? releasesConnection.totalCount
+    : rawNodes.length
+  const totalTags: number | Unavailable = typeof repo.refs?.totalCount === 'number'
+    ? repo.refs.totalCount
+    : 'unavailable'
+  return detectReleaseHealth({
+    releases: rawNodes.map((r) => ({
+      tagName: r.tagName,
+      name: r.name,
+      body: r.body,
+      isPrerelease: r.isPrerelease,
+      createdAt: r.createdAt,
+      publishedAt: r.publishedAt,
+    })),
+    totalReleasesAllTime,
+    totalTags,
+    now,
+  })
 }
 
 export function extractDocumentationResult(repo: RepoOverviewResponse['repository']): DocumentationResult | Unavailable {

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -141,13 +141,13 @@ export const REPO_COMMIT_AND_RELEASES_QUERY = `
         nodes {
           tagName
           name
-          body
+          description
           isPrerelease
           createdAt
           publishedAt
         }
       }
-      refs(refPrefix: "refs/tags/", first: 0) {
+      refs(refPrefix: "refs/tags/", first: 1) {
         totalCount
       }
       defaultBranchRef {

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -137,10 +137,18 @@ export const REPO_COMMIT_AND_RELEASES_QUERY = `
   ) {
     repository(owner: $owner, name: $name) {
       releases(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+        totalCount
         nodes {
+          tagName
+          name
+          body
+          isPrerelease
           createdAt
           publishedAt
         }
+      }
+      refs(refPrefix: "refs/tags/", first: 0) {
+        totalCount
       }
       defaultBranchRef {
         target {

--- a/lib/documentation/score-config.test.ts
+++ b/lib/documentation/score-config.test.ts
@@ -270,4 +270,49 @@ describe('documentation/score-config', () => {
       }
     })
   })
+
+  describe('release health bonuses (P2-F09 / #69)', () => {
+    it('adds bonus points when semver / notes / tag-promotion signals are strong', () => {
+      const baseline = getDocumentationScore(buildDocResult(), fullLicensing, 1000)
+      const withRelease = getDocumentationScore(buildDocResult(), fullLicensing, 1000, undefined, 'community', {
+        totalReleasesAnalyzed: 10,
+        totalTags: 10,
+        releaseFrequency: 8,
+        daysSinceLastRelease: 30,
+        semverComplianceRatio: 1,
+        releaseNotesQualityRatio: 1,
+        tagToReleaseRatio: 0,
+        preReleaseRatio: 0,
+        versioningScheme: 'semver',
+      })
+      expect(withRelease.percentile).not.toBeNull()
+      if (typeof baseline.value === 'number' && typeof withRelease.value === 'number') {
+        expect(withRelease.value).toBeGreaterThanOrEqual(baseline.value)
+      }
+    })
+
+    it('absence of release-health signals preserves the baseline documentation score', () => {
+      const baseline = getDocumentationScore(buildDocResult(), fullLicensing, 1000)
+      const withUnavailable = getDocumentationScore(buildDocResult(), fullLicensing, 1000, undefined, 'community', 'unavailable')
+      expect(withUnavailable.value).toBe(baseline.value)
+    })
+
+    it('clamps the total percentile to [0, 99] even with max bonuses applied', () => {
+      const score = getDocumentationScore(buildDocResult(), fullLicensing, 1000, undefined, 'community', {
+        totalReleasesAnalyzed: 100,
+        totalTags: 100,
+        releaseFrequency: 24,
+        daysSinceLastRelease: 1,
+        semverComplianceRatio: 1,
+        releaseNotesQualityRatio: 1,
+        tagToReleaseRatio: 0,
+        preReleaseRatio: 0,
+        versioningScheme: 'semver',
+      })
+      if (typeof score.value === 'number') {
+        expect(score.value).toBeLessThanOrEqual(99)
+        expect(score.value).toBeGreaterThanOrEqual(0)
+      }
+    })
+  })
 })

--- a/lib/documentation/score-config.ts
+++ b/lib/documentation/score-config.ts
@@ -1,6 +1,15 @@
-import type { DocumentationResult, InclusiveNamingResult, LicensingResult } from '@/lib/analyzer/analysis-result'
+import type { DocumentationResult, InclusiveNamingResult, LicensingResult, ReleaseHealthResult, Unavailable } from '@/lib/analyzer/analysis-result'
 import { getInclusiveNamingScore } from '@/lib/inclusive-naming/score-config'
-import { type CalibrationProfile, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
+import {
+  DOCUMENTATION_NOTES_BONUS,
+  DOCUMENTATION_SEMVER_BONUS,
+  DOCUMENTATION_TAG_PROMOTION_BONUS,
+  type CalibrationProfile,
+  getBracketLabel,
+  getCalibrationForStars,
+  interpolatePercentile,
+  percentileToTone,
+} from '@/lib/scoring/config-loader'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
 export interface DocumentationRecommendation {
@@ -170,6 +179,7 @@ export function getDocumentationScore(
   stars: number | 'unavailable',
   inclusiveNamingResult?: InclusiveNamingResult | 'unavailable',
   profile: CalibrationProfile = 'community',
+  releaseHealthResult?: ReleaseHealthResult | Unavailable,
 ): DocumentationScoreDefinition {
   const recommendations: DocumentationRecommendation[] = []
 
@@ -277,9 +287,15 @@ export function getDocumentationScore(
   }
 
   const calibration = getCalibrationForStars(stars, profile)
-  const percentile = calibration?.documentationScore
+  const basePercentile = calibration?.documentationScore
     ? interpolatePercentile(compositeScore, calibration.documentationScore)
     : Math.round(compositeScore * 99)
+
+  // Release Health bonuses (P2-F09 / #69). Bonus-only — absence never
+  // lowers the percentile. Magnitudes deliberately modest per research.md R6
+  // pending #152 calibration.
+  const releaseHealthBonus = computeReleaseHealthBonus(releaseHealthResult)
+  const percentile = Math.min(99, Math.max(0, basePercentile + releaseHealthBonus))
   const tone = percentileToTone(percentile)
   const bracketLabel = getBracketLabel(stars, profile)
 
@@ -295,4 +311,24 @@ export function getDocumentationScore(
     inclusiveNamingScore,
     recommendations,
   }
+}
+
+function computeReleaseHealthBonus(
+  releaseHealthResult?: ReleaseHealthResult | Unavailable,
+): number {
+  if (!releaseHealthResult || releaseHealthResult === 'unavailable') return 0
+  let bonus = 0
+  const semver = releaseHealthResult.semverComplianceRatio
+  if (typeof semver === 'number') {
+    bonus += semver * DOCUMENTATION_SEMVER_BONUS * 99
+  }
+  const notes = releaseHealthResult.releaseNotesQualityRatio
+  if (typeof notes === 'number') {
+    bonus += notes * DOCUMENTATION_NOTES_BONUS * 99
+  }
+  const promotion = releaseHealthResult.tagToReleaseRatio
+  if (typeof promotion === 'number' && promotion <= 0.3) {
+    bonus += DOCUMENTATION_TAG_PROMOTION_BONUS * 99
+  }
+  return Math.round(bonus)
 }

--- a/lib/export/json-export.ts
+++ b/lib/export/json-export.ts
@@ -11,6 +11,7 @@ import { getHealthScore } from '@/lib/scoring/health-score'
 import { getInclusiveNamingScore } from '@/lib/inclusive-naming/score-config'
 import { getSecurityScore } from '@/lib/security/score-config'
 import { computeCommunityCompleteness } from '@/lib/community/completeness'
+import { computeReleaseHealthCompleteness } from '@/lib/release-health/completeness'
 
 export interface JsonExportResult {
   blob: Blob
@@ -239,6 +240,45 @@ function computeCommunity(result: AnalysisResult) {
   }
 }
 
+function computeReleaseHealth(result: AnalysisResult) {
+  const rh = result.releaseHealthResult
+  const completeness = computeReleaseHealthCompleteness(result)
+  if (!rh || rh === 'unavailable') {
+    return {
+      signals: 'unavailable' as const,
+      completeness: {
+        ratio: completeness.ratio,
+        percentile: completeness.percentile,
+        tone: completeness.tone,
+        presentCount: completeness.present.length,
+        missingCount: completeness.missing.length,
+        unknownCount: completeness.unknown.length,
+      },
+    }
+  }
+  return {
+    signals: {
+      totalReleasesAnalyzed: rh.totalReleasesAnalyzed,
+      totalTags: rh.totalTags,
+      releaseFrequency: rh.releaseFrequency,
+      daysSinceLastRelease: rh.daysSinceLastRelease,
+      semverComplianceRatio: rh.semverComplianceRatio,
+      releaseNotesQualityRatio: rh.releaseNotesQualityRatio,
+      tagToReleaseRatio: rh.tagToReleaseRatio,
+      preReleaseRatio: rh.preReleaseRatio,
+      versioningScheme: rh.versioningScheme,
+    },
+    completeness: {
+      ratio: completeness.ratio,
+      percentile: completeness.percentile,
+      tone: completeness.tone,
+      presentCount: completeness.present.length,
+      missingCount: completeness.missing.length,
+      unknownCount: completeness.unknown.length,
+    },
+  }
+}
+
 function computeComparison(results: AnalysisResult[]) {
   if (results.length < 2) return undefined
   return buildComparisonSections(results).map((section) => ({
@@ -273,6 +313,7 @@ export function buildJsonExport(response: AnalyzeResponse): JsonExportResult {
       licensing: computeLicensing(result),
       inclusiveNaming: computeInclusiveNaming(result),
       community: computeCommunity(result),
+      releaseHealth: computeReleaseHealth(result),
     })),
     comparison: computeComparison(response.results),
   }

--- a/lib/export/markdown-export.ts
+++ b/lib/export/markdown-export.ts
@@ -12,6 +12,8 @@ import { formatHours, formatPercentage, getResponsivenessScore } from '@/lib/res
 import { getHealthScore } from '@/lib/scoring/health-score'
 import { getSecurityScore } from '@/lib/security/score-config'
 import { computeCommunityCompleteness, type CommunitySignalKey } from '@/lib/community/completeness'
+import { computeReleaseHealthCompleteness, type ReleaseHealthSignalKey } from '@/lib/release-health/completeness'
+import type { ReleaseHealthResult } from '@/lib/analyzer/analysis-result'
 import { encodeRepos } from '@/lib/export/shareable-url'
 
 export interface MarkdownExportResult {
@@ -200,6 +202,12 @@ function renderRepo(result: AnalysisResult, appUrl?: string): string {
   const communityLines = renderCommunitySection(result)
   if (communityLines.length > 0) {
     lines.push(...communityLines)
+  }
+
+  // Release Health section (cross-cutting lens; see P2-F09 / #69).
+  const releaseHealthLines = renderReleaseHealthSection(result)
+  if (releaseHealthLines.length > 0) {
+    lines.push(...releaseHealthLines)
   }
 
   // Activity section with grouped tables
@@ -637,6 +645,51 @@ function renderCommunitySection(result: AnalysisResult): string[] {
     `| GOVERNANCE.md | ${status('governance')} |`,
     `| FUNDING.yml | ${status('funding')} |`,
     `| Discussions | ${discussionsStatus} |`,
+    '',
+  ]
+}
+
+/**
+ * Render the Release Health lens section (P2-F09 / #69).
+ *
+ * Follows the Community section layout: completeness readout + a per-signal
+ * status table. Per-bracket calibration is deferred to #152, so percentile
+ * labels use the linear ratio → percentile fallback.
+ */
+function renderReleaseHealthSection(result: AnalysisResult): string[] {
+  const completeness = computeReleaseHealthCompleteness(result)
+  const rh = result.releaseHealthResult
+  if (completeness.ratio === null) return []
+
+  const total = completeness.present.length + completeness.missing.length
+  const percentileLabel = completeness.percentile !== null
+    ? `${completeness.percentile}th percentile`
+    : '—'
+  const status = (key: ReleaseHealthSignalKey): string => {
+    if (completeness.present.includes(key)) return '✓ Present'
+    if (completeness.missing.includes(key)) return '✗ Missing'
+    return '? Unknown'
+  }
+  const rhVal = (formatter: (r: ReleaseHealthResult) => string): string => {
+    if (!rh || rh === 'unavailable') return '—'
+    return formatter(rh)
+  }
+
+  return [
+    '### Release Health',
+    '',
+    `Release Health is a cross-cutting lens — it does not feed the composite OSS Health Score. Per-bracket calibration is tracked in #152; this report uses a linear ratio → percentile fallback.`,
+    '',
+    `**Completeness:** ${percentileLabel} (${completeness.present.length}/${total} signals)`,
+    '',
+    '| Signal | Value | Status |',
+    '| --- | --- | --- |',
+    `| Release frequency | ${rhVal((r) => r.releaseFrequency === 'unavailable' ? 'unavailable' : `${r.releaseFrequency} / year`)} | ${status('release_frequency')} |`,
+    `| Days since last release | ${rhVal((r) => r.daysSinceLastRelease === 'unavailable' ? 'unavailable' : `${r.daysSinceLastRelease} days`)} | ${status('days_since_last_release')} |`,
+    `| Semver compliance | ${rhVal((r) => r.semverComplianceRatio === 'unavailable' ? 'unavailable' : `${Math.round(r.semverComplianceRatio * 100)}%`)} | ${status('semver_compliance')} |`,
+    `| Release notes quality | ${rhVal((r) => r.releaseNotesQualityRatio === 'unavailable' ? 'unavailable' : `${Math.round(r.releaseNotesQualityRatio * 100)}%`)} | ${status('release_notes_quality')} |`,
+    `| Tag-to-release promotion | ${rhVal((r) => r.tagToReleaseRatio === 'unavailable' ? 'unavailable' : `${Math.round((1 - r.tagToReleaseRatio) * 100)}%`)} | ${status('tag_to_release')} |`,
+    `| Pre-release usage (informational) | ${rhVal((r) => r.preReleaseRatio === 'unavailable' ? 'unavailable' : `${Math.round(r.preReleaseRatio * 100)}%`)} | — |`,
     '',
   ]
 }

--- a/lib/metric-cards/view-model.ts
+++ b/lib/metric-cards/view-model.ts
@@ -4,6 +4,7 @@ import { getScoreBadges, type ScoreBadgeDefinition } from './score-config'
 import { getHealthScore, type HealthScoreDefinition } from '@/lib/scoring/health-score'
 import { computeCommunityCompleteness } from '@/lib/community/completeness'
 import { computeGovernanceCompleteness } from '@/lib/governance/completeness'
+import { computeReleaseHealthCompleteness } from '@/lib/release-health/completeness'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
 /**
@@ -114,6 +115,18 @@ function buildLensReadouts(result: AnalysisResult): LensReadout[] {
       detail: `${governance.present.length} of ${governance.present.length + governance.missing.length} signals`,
       tooltip: 'Governance is a cross-cutting lens — count of governance signals present (license, contributing, CoC, security, changelog, branch protection, code review, maintainers). Does not feed the composite OSS Health Score.',
       tone: governance.tone,
+    })
+  }
+
+  const releaseHealth = computeReleaseHealthCompleteness(result)
+  if (releaseHealth.ratio !== null) {
+    lenses.push({
+      key: 'release-health',
+      label: 'Release Health',
+      percentileLabel: releaseHealth.percentile !== null ? `${releaseHealth.percentile}th percentile` : '—',
+      detail: `${releaseHealth.present.length} of ${releaseHealth.present.length + releaseHealth.missing.length} signals`,
+      tooltip: 'Release Health is a cross-cutting lens — count of release-health signals present (release frequency, time since last release, semver compliance, release notes quality, tag-to-release promotion). Linear fallback until per-bracket calibration lands in #152. Does not feed the composite OSS Health Score.',
+      tone: releaseHealth.tone,
     })
   }
 

--- a/lib/metric-cards/view-model.ts
+++ b/lib/metric-cards/view-model.ts
@@ -118,13 +118,22 @@ function buildLensReadouts(result: AnalysisResult): LensReadout[] {
     })
   }
 
-  const releaseHealth = computeReleaseHealthCompleteness(result)
-  if (releaseHealth.ratio !== null) {
+  // Release Health lens renders even when ratio is null, so users can see
+  // the analyzer evaluated the signals (and that there was nothing verifiable
+  // to score). Hiding the readout would falsely suggest the lens doesn't
+  // apply to this repo.
+  if (result.releaseHealthResult !== undefined) {
+    const releaseHealth = computeReleaseHealthCompleteness(result)
+    const hasData = releaseHealth.ratio !== null
     lenses.push({
       key: 'release-health',
       label: 'Release Health',
-      percentileLabel: releaseHealth.percentile !== null ? `${releaseHealth.percentile}th percentile` : '—',
-      detail: `${releaseHealth.present.length} of ${releaseHealth.present.length + releaseHealth.missing.length} signals`,
+      percentileLabel: hasData && releaseHealth.percentile !== null
+        ? `${releaseHealth.percentile}th percentile`
+        : 'Insufficient verified public data',
+      detail: hasData
+        ? `${releaseHealth.present.length} of ${releaseHealth.present.length + releaseHealth.missing.length} signals`
+        : 'No verified release-health signals',
       tooltip: 'Release Health is a cross-cutting lens — count of release-health signals present (release frequency, time since last release, semver compliance, release notes quality, tag-to-release promotion). Linear fallback until per-bracket calibration lands in #152. Does not feed the composite OSS Health Score.',
       tone: releaseHealth.tone,
     })

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -129,7 +129,7 @@ describe('getCatalogEntriesByTag', () => {
     const entries = getCatalogEntriesByTag('quick-win')
     const ids = entries.map((e) => e.id).sort()
     expect(ids).toEqual([
-      'DOC-1', 'DOC-103', 'DOC-104', 'DOC-17', 'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
+      'DOC-1', 'DOC-17', 'DOC-2', 'DOC-20', 'DOC-21', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
       'SEC-14', 'SEC-16', 'SEC-6',
     ])
   })

--- a/lib/recommendations/__tests__/catalog.test.ts
+++ b/lib/recommendations/__tests__/catalog.test.ts
@@ -38,8 +38,8 @@ describe('RECOMMENDATION_CATALOG', () => {
     expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Security')).toHaveLength(17)
   })
 
-  it('has 5 activity entries', () => {
-    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Activity')).toHaveLength(5)
+  it('has 8 activity entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Activity')).toHaveLength(8)
   })
 
   it('has 3 responsiveness entries', () => {
@@ -50,12 +50,16 @@ describe('RECOMMENDATION_CATALOG', () => {
     expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Contributors')).toHaveLength(7)
   })
 
-  it('has 17 documentation entries', () => {
-    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Documentation')).toHaveLength(17)
+  it('has 21 documentation entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => e.bucket === 'Documentation')).toHaveLength(21)
   })
 
   it('has 5 community-tagged entries', () => {
     expect(RECOMMENDATION_CATALOG.filter((e) => (e.tags ?? []).includes('community'))).toHaveLength(5)
+  })
+
+  it('has 7 release-health-tagged entries', () => {
+    expect(RECOMMENDATION_CATALOG.filter((e) => (e.tags ?? []).includes('release-health'))).toHaveLength(7)
   })
 })
 
@@ -125,7 +129,7 @@ describe('getCatalogEntriesByTag', () => {
     const entries = getCatalogEntriesByTag('quick-win')
     const ids = entries.map((e) => e.id).sort()
     expect(ids).toEqual([
-      'DOC-1', 'DOC-17', 'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
+      'DOC-1', 'DOC-103', 'DOC-104', 'DOC-17', 'DOC-2', 'DOC-3', 'DOC-4', 'DOC-5', 'DOC-6',
       'SEC-14', 'SEC-16', 'SEC-6',
     ])
   })

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -67,10 +67,11 @@ const ACT: CatalogEntry[] = [
   { id: 'ACT-3', bucket: 'Activity', key: 'completion_speed', title: 'Reduce time to merge PRs and close issues' },
   { id: 'ACT-4', bucket: 'Activity', key: 'sustained_activity', title: 'Increase commit frequency for sustained momentum' },
   { id: 'ACT-5', bucket: 'Activity', key: 'feature:discussions_enabled', title: 'Enable GitHub Discussions for contributor conversation', tags: ['community', 'contrib-ex'] },
-  // Release Health recommendations (P2-F09 / #69).
-  { id: 'ACT-101', bucket: 'Activity', key: 'release_never_released', title: 'Cut a first release so adopters have a clear starting point', tags: ['release-health'] },
-  { id: 'ACT-102', bucket: 'Activity', key: 'release_stale', title: 'Cut a maintenance release or archive the repository', tags: ['release-health'] },
-  { id: 'ACT-103', bucket: 'Activity', key: 'release_cooling', title: 'Cut a release to reflect recent commits', tags: ['release-health'] },
+  // Release Health recommendations (P2-F09 / #69). IDs stay below the
+  // fallback-counter range (101+) used by reference-id.ts for dynamic recs.
+  { id: 'ACT-6', bucket: 'Activity', key: 'release_never_released', title: 'Cut a first release so adopters have a clear starting point', tags: ['release-health'] },
+  { id: 'ACT-7', bucket: 'Activity', key: 'release_stale', title: 'Cut a maintenance release or archive the repository', tags: ['release-health'] },
+  { id: 'ACT-8', bucket: 'Activity', key: 'release_cooling', title: 'Cut a release to reflect recent commits', tags: ['release-health'] },
 ]
 
 // ── Responsiveness ────────────────────────────────────────────────────
@@ -117,11 +118,12 @@ const DOC: CatalogEntry[] = [
   { id: 'DOC-15', bucket: 'Documentation', key: 'file:issue_templates', title: 'Add an issue template in .github/ISSUE_TEMPLATE/', tags: ['community', 'contrib-ex'] },
   { id: 'DOC-16', bucket: 'Documentation', key: 'file:pull_request_template', title: 'Add a PULL_REQUEST_TEMPLATE.md', tags: ['community', 'contrib-ex'] },
   { id: 'DOC-17', bucket: 'Documentation', key: 'file:governance', title: 'Add GOVERNANCE.md', tags: ['governance', 'community', 'quick-win'] },
-  // Release Health recommendations (P2-F09 / #69).
-  { id: 'DOC-101', bucket: 'Documentation', key: 'release_adopt_semver', title: 'Adopt semantic versioning for release tags', tags: ['release-health'] },
-  { id: 'DOC-102', bucket: 'Documentation', key: 'release_adopt_scheme', title: 'Adopt a consistent versioning scheme', tags: ['release-health'] },
-  { id: 'DOC-103', bucket: 'Documentation', key: 'release_improve_notes', title: 'Expand release notes to describe what changed', tags: ['release-health', 'quick-win'] },
-  { id: 'DOC-104', bucket: 'Documentation', key: 'release_promote_tags', title: 'Promote git tags to GitHub Releases', tags: ['release-health', 'quick-win'] },
+  // Release Health recommendations (P2-F09 / #69). IDs stay below the
+  // fallback-counter range (101+) used by reference-id.ts for dynamic recs.
+  { id: 'DOC-18', bucket: 'Documentation', key: 'release_adopt_semver', title: 'Adopt semantic versioning for release tags', tags: ['release-health'] },
+  { id: 'DOC-19', bucket: 'Documentation', key: 'release_adopt_scheme', title: 'Adopt a consistent versioning scheme', tags: ['release-health'] },
+  { id: 'DOC-20', bucket: 'Documentation', key: 'release_improve_notes', title: 'Expand release notes to describe what changed', tags: ['release-health', 'quick-win'] },
+  { id: 'DOC-21', bucket: 'Documentation', key: 'release_promote_tags', title: 'Promote git tags to GitHub Releases', tags: ['release-health', 'quick-win'] },
 ]
 
 // ── Combined catalog ──────────────────────────────────────────────────

--- a/lib/recommendations/catalog.ts
+++ b/lib/recommendations/catalog.ts
@@ -67,6 +67,10 @@ const ACT: CatalogEntry[] = [
   { id: 'ACT-3', bucket: 'Activity', key: 'completion_speed', title: 'Reduce time to merge PRs and close issues' },
   { id: 'ACT-4', bucket: 'Activity', key: 'sustained_activity', title: 'Increase commit frequency for sustained momentum' },
   { id: 'ACT-5', bucket: 'Activity', key: 'feature:discussions_enabled', title: 'Enable GitHub Discussions for contributor conversation', tags: ['community', 'contrib-ex'] },
+  // Release Health recommendations (P2-F09 / #69).
+  { id: 'ACT-101', bucket: 'Activity', key: 'release_never_released', title: 'Cut a first release so adopters have a clear starting point', tags: ['release-health'] },
+  { id: 'ACT-102', bucket: 'Activity', key: 'release_stale', title: 'Cut a maintenance release or archive the repository', tags: ['release-health'] },
+  { id: 'ACT-103', bucket: 'Activity', key: 'release_cooling', title: 'Cut a release to reflect recent commits', tags: ['release-health'] },
 ]
 
 // ── Responsiveness ────────────────────────────────────────────────────
@@ -113,6 +117,11 @@ const DOC: CatalogEntry[] = [
   { id: 'DOC-15', bucket: 'Documentation', key: 'file:issue_templates', title: 'Add an issue template in .github/ISSUE_TEMPLATE/', tags: ['community', 'contrib-ex'] },
   { id: 'DOC-16', bucket: 'Documentation', key: 'file:pull_request_template', title: 'Add a PULL_REQUEST_TEMPLATE.md', tags: ['community', 'contrib-ex'] },
   { id: 'DOC-17', bucket: 'Documentation', key: 'file:governance', title: 'Add GOVERNANCE.md', tags: ['governance', 'community', 'quick-win'] },
+  // Release Health recommendations (P2-F09 / #69).
+  { id: 'DOC-101', bucket: 'Documentation', key: 'release_adopt_semver', title: 'Adopt semantic versioning for release tags', tags: ['release-health'] },
+  { id: 'DOC-102', bucket: 'Documentation', key: 'release_adopt_scheme', title: 'Adopt a consistent versioning scheme', tags: ['release-health'] },
+  { id: 'DOC-103', bucket: 'Documentation', key: 'release_improve_notes', title: 'Expand release notes to describe what changed', tags: ['release-health', 'quick-win'] },
+  { id: 'DOC-104', bucket: 'Documentation', key: 'release_promote_tags', title: 'Promote git tags to GitHub Releases', tags: ['release-health', 'quick-win'] },
 ]
 
 // ── Combined catalog ──────────────────────────────────────────────────

--- a/lib/release-health/completeness.test.ts
+++ b/lib/release-health/completeness.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult, ReleaseHealthResult } from '@/lib/analyzer/analysis-result'
+import { computeReleaseHealthCompleteness } from './completeness'
+
+function buildResult(rh: ReleaseHealthResult | 'unavailable' | undefined): AnalysisResult {
+  return {
+    repo: 'foo/bar',
+    name: 'bar',
+    description: '—',
+    createdAt: '2024-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 10,
+    watchers: 5,
+    commits30d: 5,
+    commits90d: 15,
+    releases12mo: 2,
+    prsOpened90d: 3,
+    prsMerged90d: 2,
+    issuesOpen: 4,
+    issuesClosed90d: 3,
+    uniqueCommitAuthors90d: 4,
+    totalContributors: 10,
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: { 'login:alice': 5 },
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    releaseHealthResult: rh,
+    missingFields: [],
+  }
+}
+
+describe('computeReleaseHealthCompleteness', () => {
+  it('returns null ratio / percentile when releaseHealthResult is unavailable', () => {
+    const c = computeReleaseHealthCompleteness(buildResult('unavailable'))
+    expect(c.ratio).toBeNull()
+    expect(c.percentile).toBeNull()
+    expect(c.tone).toBe('neutral')
+  })
+
+  it('returns null ratio when releaseHealthResult is undefined (pre-feature fixture)', () => {
+    const c = computeReleaseHealthCompleteness(buildResult(undefined))
+    expect(c.ratio).toBeNull()
+    expect(c.percentile).toBeNull()
+  })
+
+  it('marks all five signals as present and returns ratio 1 when the repo is fully release-healthy', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 12,
+      totalTags: 12,
+      releaseFrequency: 6,
+      daysSinceLastRelease: 10,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    const c = computeReleaseHealthCompleteness(buildResult(rh))
+    expect(c.present.length).toBe(5)
+    expect(c.missing.length).toBe(0)
+    expect(c.unknown.length).toBe(0)
+    expect(c.ratio).toBe(1)
+    expect(c.percentile).toBe(99)
+  })
+
+  it('excludes unknown signals from numerator and denominator (FR-021)', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 2,
+      totalTags: 'unavailable',
+      releaseFrequency: 2,
+      daysSinceLastRelease: 5,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 'unavailable',
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    const c = computeReleaseHealthCompleteness(buildResult(rh))
+    expect(c.unknown).toContain('tag_to_release')
+    expect(c.present.length + c.missing.length).toBe(4)
+    expect(c.ratio).toBeCloseTo(1, 5)
+  })
+
+  it('classifies a moderate posture into the middle of the ratio range', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 4,
+      totalTags: 10,
+      releaseFrequency: 2,
+      daysSinceLastRelease: 120,
+      semverComplianceRatio: 0.5,
+      releaseNotesQualityRatio: 0.4,
+      tagToReleaseRatio: 0.6,
+      preReleaseRatio: 0.25,
+      versioningScheme: 'semver',
+    }
+    const c = computeReleaseHealthCompleteness(buildResult(rh))
+    expect(c.ratio).not.toBeNull()
+    expect(c.ratio).toBeGreaterThan(0)
+    expect(c.ratio).toBeLessThan(1)
+  })
+
+  it('marks everything as unknown when the analyzer emitted an object with all per-field unavailable', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 0,
+      totalTags: 'unavailable',
+      releaseFrequency: 'unavailable',
+      daysSinceLastRelease: 'unavailable',
+      semverComplianceRatio: 'unavailable',
+      releaseNotesQualityRatio: 'unavailable',
+      tagToReleaseRatio: 'unavailable',
+      preReleaseRatio: 'unavailable',
+      versioningScheme: 'unavailable',
+    }
+    const c = computeReleaseHealthCompleteness(buildResult(rh))
+    expect(c.ratio).toBeNull()
+    expect(c.percentile).toBeNull()
+    expect(c.unknown.length).toBe(5)
+  })
+})

--- a/lib/release-health/completeness.ts
+++ b/lib/release-health/completeness.ts
@@ -1,0 +1,96 @@
+import type { AnalysisResult, ReleaseHealthResult, Unavailable } from '@/lib/analyzer/analysis-result'
+import {
+  COOLING_RELEASE_CUTOFF_DAYS,
+  SEMVER_ADOPTION_THRESHOLD,
+  STALE_RELEASE_CUTOFF_DAYS,
+  percentileToTone,
+} from '@/lib/scoring/config-loader'
+import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
+
+/**
+ * Release Health completeness readout (P2-F09 / #69).
+ *
+ * Mirrors `lib/community/completeness.ts`. Counts how many of the five scored
+ * release-health signals are present (not merely defined — each has its own
+ * threshold below which it is classified as missing). Uses a linear
+ * ratio → percentile fallback until per-bracket calibration lands in #152.
+ */
+
+export type ReleaseHealthSignalKey =
+  | 'release_frequency'
+  | 'days_since_last_release'
+  | 'semver_compliance'
+  | 'release_notes_quality'
+  | 'tag_to_release'
+
+export interface ReleaseHealthCompleteness {
+  present: ReleaseHealthSignalKey[]
+  missing: ReleaseHealthSignalKey[]
+  unknown: ReleaseHealthSignalKey[]
+  ratio: number | null
+  percentile: number | null
+  tone: ScoreTone
+}
+
+type Presence = boolean | 'unknown'
+
+const NOTES_PRESENT_FLOOR = 0.5
+const TAG_PROMOTION_PRESENT_CEILING = 0.3
+
+function classify(rh: ReleaseHealthResult): Record<ReleaseHealthSignalKey, Presence> {
+  return {
+    release_frequency: classifyFrequency(rh.releaseFrequency, rh.totalReleasesAnalyzed),
+    days_since_last_release: classifyRecency(rh.daysSinceLastRelease),
+    semver_compliance: classifyRatio(rh.semverComplianceRatio, SEMVER_ADOPTION_THRESHOLD),
+    release_notes_quality: classifyRatio(rh.releaseNotesQualityRatio, NOTES_PRESENT_FLOOR),
+    tag_to_release: classifyTagPromotion(rh.tagToReleaseRatio),
+  }
+}
+
+function classifyFrequency(freq: number | Unavailable, totalAnalyzed: number): Presence {
+  if (freq === 'unavailable') return totalAnalyzed === 0 ? 'unknown' : false
+  return freq >= 1
+}
+
+function classifyRecency(days: number | Unavailable): Presence {
+  if (days === 'unavailable') return 'unknown'
+  if (days >= STALE_RELEASE_CUTOFF_DAYS) return false
+  if (days >= COOLING_RELEASE_CUTOFF_DAYS) return false
+  return true
+}
+
+function classifyRatio(value: number | Unavailable, threshold: number): Presence {
+  if (value === 'unavailable') return 'unknown'
+  return value >= threshold
+}
+
+function classifyTagPromotion(value: number | Unavailable): Presence {
+  if (value === 'unavailable') return 'unknown'
+  return value <= TAG_PROMOTION_PRESENT_CEILING
+}
+
+export function computeReleaseHealthCompleteness(result: AnalysisResult): ReleaseHealthCompleteness {
+  const rh = result.releaseHealthResult
+  if (!rh || rh === 'unavailable') {
+    return { present: [], missing: [], unknown: [], ratio: null, percentile: null, tone: 'neutral' }
+  }
+
+  const presence = classify(rh)
+  const present: ReleaseHealthSignalKey[] = []
+  const missing: ReleaseHealthSignalKey[] = []
+  const unknown: ReleaseHealthSignalKey[] = []
+  for (const [key, value] of Object.entries(presence) as Array<[ReleaseHealthSignalKey, Presence]>) {
+    if (value === true) present.push(key)
+    else if (value === false) missing.push(key)
+    else unknown.push(key)
+  }
+
+  const denominator = present.length + missing.length
+  if (denominator === 0) {
+    return { present, missing, unknown, ratio: null, percentile: null, tone: 'neutral' }
+  }
+
+  const ratio = present.length / denominator
+  const percentile = Math.max(0, Math.min(99, Math.round(ratio * 99)))
+  return { present, missing, unknown, ratio, percentile, tone: percentileToTone(percentile) }
+}

--- a/lib/release-health/detect.test.ts
+++ b/lib/release-health/detect.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import { detectReleaseHealth, type RawRelease } from './detect'
+
+const FIXED_NOW = new Date('2026-04-17T12:00:00Z')
+
+function makeRelease(overrides: Partial<RawRelease> = {}): RawRelease {
+  return {
+    tagName: 'v1.0.0',
+    name: null,
+    body: 'This release fixes a regression in the login flow for users without avatars.',
+    isPrerelease: false,
+    createdAt: '2026-03-01T00:00:00Z',
+    publishedAt: '2026-03-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('detectReleaseHealth', () => {
+  it('returns the unavailable shape when there are zero releases AND tags are unavailable', () => {
+    const result = detectReleaseHealth({
+      releases: [],
+      totalReleasesAllTime: 0,
+      totalTags: 'unavailable',
+      now: FIXED_NOW,
+    })
+    expect(result).toBe('unavailable')
+  })
+
+  it('emits per-field unavailable when totalReleasesAnalyzed is 0 but tags exist', () => {
+    const result = detectReleaseHealth({
+      releases: [],
+      totalReleasesAllTime: 0,
+      totalTags: 5,
+      now: FIXED_NOW,
+    })
+    expect(result).not.toBe('unavailable')
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.totalReleasesAnalyzed).toBe(0)
+    expect(result.releaseFrequency).toBe('unavailable')
+    expect(result.daysSinceLastRelease).toBe('unavailable')
+    expect(result.semverComplianceRatio).toBe('unavailable')
+    expect(result.releaseNotesQualityRatio).toBe('unavailable')
+    expect(result.preReleaseRatio).toBe('unavailable')
+    expect(result.tagToReleaseRatio).toBe(1) // 5 tags, 0 releases → 5/5
+    expect(result.versioningScheme).toBe('unavailable')
+  })
+
+  it('one release — frequency unavailable, recency computed, semver present, notes present', () => {
+    const result = detectReleaseHealth({
+      releases: [makeRelease({ tagName: 'v2.0.0', publishedAt: '2026-04-10T00:00:00Z' })],
+      totalReleasesAllTime: 1,
+      totalTags: 1,
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.totalReleasesAnalyzed).toBe(1)
+    expect(result.releaseFrequency).toBe('unavailable')
+    expect(result.daysSinceLastRelease).toBe(7)
+    expect(result.semverComplianceRatio).toBe(1)
+    expect(result.releaseNotesQualityRatio).toBe(1)
+    expect(result.preReleaseRatio).toBe(0)
+  })
+
+  it('≥ 2 releases yield a non-unavailable release frequency (per year)', () => {
+    const result = detectReleaseHealth({
+      releases: [
+        makeRelease({ publishedAt: '2026-04-10T00:00:00Z' }),
+        makeRelease({ publishedAt: '2026-01-10T00:00:00Z' }),
+        makeRelease({ publishedAt: '2025-10-10T00:00:00Z' }),
+        makeRelease({ publishedAt: '2025-07-10T00:00:00Z' }),
+        makeRelease({ publishedAt: '2025-04-10T00:00:00Z' }),
+      ],
+      totalReleasesAllTime: 5,
+      totalTags: 5,
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.releaseFrequency).not.toBe('unavailable')
+    expect(result.releaseFrequency).toBeGreaterThan(0)
+  })
+
+  it('falls back to createdAt when publishedAt is null', () => {
+    const result = detectReleaseHealth({
+      releases: [makeRelease({ createdAt: '2026-04-15T00:00:00Z', publishedAt: null })],
+      totalReleasesAllTime: 1,
+      totalTags: 1,
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.daysSinceLastRelease).toBe(2)
+  })
+
+  it('reports tagToReleaseRatio as unavailable when totalTags is unavailable', () => {
+    const result = detectReleaseHealth({
+      releases: [makeRelease()],
+      totalReleasesAllTime: 1,
+      totalTags: 'unavailable',
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.tagToReleaseRatio).toBe('unavailable')
+  })
+
+  it('computes preReleaseRatio from isPrerelease flags', () => {
+    const result = detectReleaseHealth({
+      releases: [
+        makeRelease({ isPrerelease: true }),
+        makeRelease({ isPrerelease: true }),
+        makeRelease({ isPrerelease: false }),
+        makeRelease({ isPrerelease: false }),
+      ],
+      totalReleasesAllTime: 4,
+      totalTags: 4,
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.preReleaseRatio).toBe(0.5)
+  })
+
+  it('counts whitespace-only bodies as non-substantive', () => {
+    const result = detectReleaseHealth({
+      releases: [
+        makeRelease({ body: '' }),
+        makeRelease({ body: '   ' }),
+        makeRelease({ body: null }),
+        makeRelease({ body: 'Substantial notes explaining the changes in detail for this release.' }),
+      ],
+      totalReleasesAllTime: 4,
+      totalTags: 4,
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.releaseNotesQualityRatio).toBe(0.25)
+  })
+
+  it('computes tagToReleaseRatio as the share of unpromoted tags', () => {
+    const result = detectReleaseHealth({
+      releases: [makeRelease(), makeRelease(), makeRelease()],
+      totalReleasesAllTime: 3,
+      totalTags: 10,
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.tagToReleaseRatio).toBe(0.7)
+  })
+
+  it('classifies the dominant versioning scheme from tag names', () => {
+    const result = detectReleaseHealth({
+      releases: [
+        makeRelease({ tagName: 'v1.0.0' }),
+        makeRelease({ tagName: 'v1.1.0' }),
+        makeRelease({ tagName: 'v1.2.0' }),
+      ],
+      totalReleasesAllTime: 3,
+      totalTags: 3,
+      now: FIXED_NOW,
+    })
+    if (result === 'unavailable') throw new Error('unreachable')
+    expect(result.versioningScheme).toBe('semver')
+  })
+})

--- a/lib/release-health/detect.test.ts
+++ b/lib/release-health/detect.test.ts
@@ -26,7 +26,7 @@ describe('detectReleaseHealth', () => {
     expect(result).toBe('unavailable')
   })
 
-  it('emits per-field unavailable when totalReleasesAnalyzed is 0 but tags exist', () => {
+  it('emits per-field unavailable when totalReleasesAnalyzed is 0 (no releases to score against)', () => {
     const result = detectReleaseHealth({
       releases: [],
       totalReleasesAllTime: 0,
@@ -41,7 +41,10 @@ describe('detectReleaseHealth', () => {
     expect(result.semverComplianceRatio).toBe('unavailable')
     expect(result.releaseNotesQualityRatio).toBe('unavailable')
     expect(result.preReleaseRatio).toBe('unavailable')
-    expect(result.tagToReleaseRatio).toBe(1) // 5 tags, 0 releases → 5/5
+    // No releases means tag-promotion is unmeasurable — Constitution §II
+    // forbids inferring 0 here since that would falsely flag the signal
+    // as "present" in completeness.
+    expect(result.tagToReleaseRatio).toBe('unavailable')
     expect(result.versioningScheme).toBe('unavailable')
   })
 

--- a/lib/release-health/detect.ts
+++ b/lib/release-health/detect.ts
@@ -51,8 +51,11 @@ export function detectReleaseHealth(input: DetectReleaseHealthInput): ReleaseHea
 
   const tagToReleaseRatio: number | Unavailable = totalTags === 'unavailable'
     ? 'unavailable'
-    : totalTags <= 0
-      ? 0
+    : totalReleasesAllTime === 0 || totalTags === 0
+      // Nothing to compare against — a repo with no releases (or no tags)
+      // has no promotion signal to measure, per Constitution §II (no
+      // estimation). Emitting 0 here would falsely classify as "present".
+      ? 'unavailable'
       : Math.max(0, totalTags - totalReleasesAllTime) / totalTags
 
   const versioningScheme = releases.length === 0

--- a/lib/release-health/detect.ts
+++ b/lib/release-health/detect.ts
@@ -1,0 +1,95 @@
+import type { ReleaseHealthResult, Unavailable } from '@/lib/analyzer/analysis-result'
+import { RELEASE_NOTES_SUBSTANTIVE_FLOOR } from '@/lib/scoring/config-loader'
+import { detectVersioningScheme, isSemver } from './semver'
+
+export interface RawRelease {
+  tagName: string
+  name: string | null
+  body: string | null
+  isPrerelease: boolean
+  createdAt: string
+  publishedAt: string | null
+}
+
+export interface DetectReleaseHealthInput {
+  releases: RawRelease[]
+  totalReleasesAllTime: number
+  totalTags: number | Unavailable
+  now: Date
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export function detectReleaseHealth(input: DetectReleaseHealthInput): ReleaseHealthResult | Unavailable {
+  const { releases, totalReleasesAllTime, totalTags, now } = input
+
+  if (releases.length === 0 && totalTags === 'unavailable') {
+    return 'unavailable'
+  }
+
+  const totalReleasesAnalyzed = releases.length
+
+  const latest = releases[0]
+  const latestIso = latest?.publishedAt ?? latest?.createdAt ?? null
+  const daysSinceLastRelease: number | Unavailable = latestIso
+    ? Math.max(0, Math.floor((now.getTime() - new Date(latestIso).getTime()) / MS_PER_DAY))
+    : 'unavailable'
+
+  const releaseFrequency: number | Unavailable = computeReleaseFrequency(releases, totalReleasesAllTime, now)
+
+  const semverComplianceRatio: number | Unavailable = releases.length === 0
+    ? 'unavailable'
+    : releases.filter((r) => isSemver(r.tagName)).length / releases.length
+
+  const releaseNotesQualityRatio: number | Unavailable = releases.length === 0
+    ? 'unavailable'
+    : releases.filter((r) => isSubstantive(r.body)).length / releases.length
+
+  const preReleaseRatio: number | Unavailable = releases.length === 0
+    ? 'unavailable'
+    : releases.filter((r) => r.isPrerelease).length / releases.length
+
+  const tagToReleaseRatio: number | Unavailable = totalTags === 'unavailable'
+    ? 'unavailable'
+    : totalTags <= 0
+      ? 0
+      : Math.max(0, totalTags - totalReleasesAllTime) / totalTags
+
+  const versioningScheme = releases.length === 0
+    ? 'unavailable'
+    : detectVersioningScheme(releases.map((r) => r.tagName))
+
+  return {
+    totalReleasesAnalyzed,
+    totalTags,
+    releaseFrequency,
+    daysSinceLastRelease,
+    semverComplianceRatio,
+    releaseNotesQualityRatio,
+    tagToReleaseRatio,
+    preReleaseRatio,
+    versioningScheme,
+  }
+}
+
+function computeReleaseFrequency(
+  releases: RawRelease[],
+  totalReleasesAllTime: number,
+  now: Date,
+): number | Unavailable {
+  if (totalReleasesAllTime < 2) return 'unavailable'
+  if (releases.length === 0) return 'unavailable'
+  const nowMs = now.getTime()
+  const cutoffMs = nowMs - 365 * MS_PER_DAY
+  const within12mo = releases.filter((r) => {
+    const iso = r.publishedAt ?? r.createdAt
+    const ms = iso ? new Date(iso).getTime() : NaN
+    return Number.isFinite(ms) && ms >= cutoffMs
+  })
+  return within12mo.length
+}
+
+function isSubstantive(body: string | null): boolean {
+  if (body === null) return false
+  return body.trim().length >= RELEASE_NOTES_SUBSTANTIVE_FLOOR
+}

--- a/lib/release-health/recommendations.test.ts
+++ b/lib/release-health/recommendations.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult, ReleaseHealthResult } from '@/lib/analyzer/analysis-result'
+import { generateReleaseHealthRecommendations } from './recommendations'
+
+function buildResult(rh: ReleaseHealthResult | 'unavailable' | undefined, overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'foo/bar',
+    name: 'bar',
+    description: '—',
+    createdAt: '2024-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 10,
+    watchers: 5,
+    commits30d: 5,
+    commits90d: 15,
+    releases12mo: 2,
+    prsOpened90d: 3,
+    prsMerged90d: 2,
+    issuesOpen: 4,
+    issuesClosed90d: 3,
+    uniqueCommitAuthors90d: 4,
+    totalContributors: 10,
+    maintainerCount: 2,
+    commitCountsByAuthor: { 'login:alice': 5 },
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    releaseHealthResult: rh,
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+const GATE_OPEN = { activityPercentile: 30, documentationPercentile: 30 }
+const GATE_CLOSED = { activityPercentile: 90, documentationPercentile: 90 }
+
+describe('generateReleaseHealthRecommendations', () => {
+  it('returns [] when releaseHealthResult is undefined', () => {
+    const recs = generateReleaseHealthRecommendations(buildResult(undefined), GATE_OPEN)
+    expect(recs).toEqual([])
+  })
+
+  it('recommends cutting a first release when never released but there are commits', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 0,
+      totalTags: 0,
+      releaseFrequency: 'unavailable',
+      daysSinceLastRelease: 'unavailable',
+      semverComplianceRatio: 'unavailable',
+      releaseNotesQualityRatio: 'unavailable',
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 'unavailable',
+      versioningScheme: 'unavailable',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_OPEN)
+    const keys = recs.map((r) => r.key)
+    expect(keys).toContain('release_never_released')
+  })
+
+  it('fires stale rec only (not cooling / never) when last release > 24 months ago', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 5,
+      totalTags: 5,
+      releaseFrequency: 1,
+      daysSinceLastRelease: 900,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_OPEN)
+    const staleRecs = recs.filter((r) => r.key.startsWith('release_stale') || r.key.startsWith('release_cooling') || r.key === 'release_never_released')
+    expect(staleRecs.length).toBe(1)
+    expect(staleRecs[0]!.key).toBe('release_stale')
+  })
+
+  it('fires cooling rec when 365 <= days < 730 with recent commits', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 3,
+      totalTags: 3,
+      releaseFrequency: 1,
+      daysSinceLastRelease: 400,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh, { commits90d: 20 }), GATE_OPEN)
+    const keys = recs.map((r) => r.key)
+    expect(keys).toContain('release_cooling')
+    expect(keys).not.toContain('release_stale')
+    expect(keys).not.toContain('release_never_released')
+  })
+
+  it('recommends adopting semver when compliance is low and no alternative scheme detected', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 10,
+      totalTags: 10,
+      releaseFrequency: 4,
+      daysSinceLastRelease: 30,
+      semverComplianceRatio: 0.1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0,
+      versioningScheme: 'unrecognized',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_OPEN)
+    const keys = recs.map((r) => r.key)
+    // Versioning scheme is 'unrecognized' so the right rec is adopt_scheme, not adopt_semver (FR-029).
+    expect(keys).toContain('release_adopt_scheme')
+    expect(keys).not.toContain('release_adopt_semver')
+  })
+
+  it('suppresses the semver rec when CalVer is detected', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 10,
+      totalTags: 10,
+      releaseFrequency: 4,
+      daysSinceLastRelease: 30,
+      semverComplianceRatio: 0.0,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0,
+      versioningScheme: 'calver',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_OPEN)
+    const keys = recs.map((r) => r.key)
+    expect(keys).not.toContain('release_adopt_semver')
+    expect(keys).not.toContain('release_adopt_scheme')
+  })
+
+  it('recommends improving release notes when ratio is below the floor (not only on empty)', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 10,
+      totalTags: 10,
+      releaseFrequency: 4,
+      daysSinceLastRelease: 30,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 0.3,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_OPEN)
+    expect(recs.map((r) => r.key)).toContain('release_improve_notes')
+  })
+
+  it('recommends promoting tags when many tags are not released', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 5,
+      totalTags: 20,
+      releaseFrequency: 3,
+      daysSinceLastRelease: 30,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0.75,
+      preReleaseRatio: 0,
+      versioningScheme: 'semver',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_OPEN)
+    expect(recs.map((r) => r.key)).toContain('release_promote_tags')
+  })
+
+  it('never fires a recommendation on preReleaseRatio alone', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 5,
+      totalTags: 5,
+      releaseFrequency: 3,
+      daysSinceLastRelease: 30,
+      semverComplianceRatio: 1,
+      releaseNotesQualityRatio: 1,
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 1,
+      versioningScheme: 'semver',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_OPEN)
+    const keys = recs.map((r) => r.key)
+    for (const k of keys) {
+      expect(k).not.toMatch(/prerelease/i)
+    }
+  })
+
+  it('suppresses all release-health recs when host bucket percentiles clear the gate', () => {
+    const rh: ReleaseHealthResult = {
+      totalReleasesAnalyzed: 0,
+      totalTags: 0,
+      releaseFrequency: 'unavailable',
+      daysSinceLastRelease: 'unavailable',
+      semverComplianceRatio: 'unavailable',
+      releaseNotesQualityRatio: 'unavailable',
+      tagToReleaseRatio: 0,
+      preReleaseRatio: 'unavailable',
+      versioningScheme: 'unavailable',
+    }
+    const recs = generateReleaseHealthRecommendations(buildResult(rh), GATE_CLOSED)
+    expect(recs).toEqual([])
+  })
+})

--- a/lib/release-health/recommendations.ts
+++ b/lib/release-health/recommendations.ts
@@ -1,0 +1,139 @@
+import type { AnalysisResult, ReleaseHealthResult, Unavailable } from '@/lib/analyzer/analysis-result'
+import type { HealthScoreRecommendation } from '@/lib/scoring/health-score'
+import {
+  COOLING_RELEASE_CUTOFF_DAYS,
+  RECOMMENDATION_PERCENTILE_GATE,
+  SEMVER_ADOPTION_THRESHOLD,
+  STALE_RELEASE_CUTOFF_DAYS,
+} from '@/lib/scoring/config-loader'
+
+/**
+ * Release Health recommendations (P2-F09 / #69).
+ *
+ * Generates up to one staleness-tier rec plus any number of Documentation
+ * recs (adopt-semver or adopt-scheme, improve-notes, promote-tags). Pure
+ * function — consumes the result and the host-bucket percentiles that drive
+ * the `RECOMMENDATION_PERCENTILE_GATE`.
+ */
+
+export interface ReleaseHealthRecommendationContext {
+  /** Percentile of the Activity bucket for this repo. Suppresses Activity-bucket recs when clear of the gate. */
+  activityPercentile: number
+  /** Percentile of the Documentation bucket for this repo. Suppresses Documentation-bucket recs when clear of the gate. */
+  documentationPercentile: number
+}
+
+const NOTES_FLOOR = 0.5
+const TAG_PROMOTION_CEILING = 0.5
+
+export function generateReleaseHealthRecommendations(
+  result: AnalysisResult,
+  context: ReleaseHealthRecommendationContext,
+): HealthScoreRecommendation[] {
+  const rh = result.releaseHealthResult
+  if (!rh || rh === 'unavailable') return []
+
+  const recs: HealthScoreRecommendation[] = []
+  const activityGated = context.activityPercentile < RECOMMENDATION_PERCENTILE_GATE
+  const documentationGated = context.documentationPercentile < RECOMMENDATION_PERCENTILE_GATE
+
+  if (activityGated) {
+    const staleRec = pickStalenessTier(rh, result.commits90d)
+    if (staleRec !== null) recs.push(staleRec)
+  }
+
+  if (documentationGated) {
+    const schemeRec = pickSchemeRec(rh)
+    if (schemeRec !== null) recs.push(schemeRec)
+
+    if (typeof rh.releaseNotesQualityRatio === 'number' && rh.releaseNotesQualityRatio < NOTES_FLOOR) {
+      recs.push({
+        bucket: 'documentation',
+        key: 'release_improve_notes',
+        percentile: context.documentationPercentile,
+        message: 'Expand release notes to describe what changed in each release — adopters rely on them to gauge upgrade impact',
+        tab: 'documentation',
+      })
+    }
+
+    if (typeof rh.tagToReleaseRatio === 'number' && rh.tagToReleaseRatio > TAG_PROMOTION_CEILING) {
+      recs.push({
+        bucket: 'documentation',
+        key: 'release_promote_tags',
+        percentile: context.documentationPercentile,
+        message: 'Promote git tags to GitHub Releases so users have a clear list of shipped versions with associated changelog entries',
+        tab: 'documentation',
+      })
+    }
+  }
+
+  return recs
+}
+
+function pickStalenessTier(
+  rh: ReleaseHealthResult,
+  commits90d: number | Unavailable,
+): HealthScoreRecommendation | null {
+  if (rh.totalReleasesAnalyzed === 0) {
+    return {
+      bucket: 'activity',
+      key: 'release_never_released',
+      percentile: 0,
+      message: 'Cut a first release (and tag it on GitHub) so adopters have a clear starting point and upgrade path',
+      tab: 'activity',
+    }
+  }
+
+  const days = rh.daysSinceLastRelease
+  if (days === 'unavailable') return null
+
+  if (days >= STALE_RELEASE_CUTOFF_DAYS) {
+    return {
+      bucket: 'activity',
+      key: 'release_stale',
+      percentile: 0,
+      message: `The most recent release was ${days} days ago — consider cutting a maintenance release or archiving the repository so downstream users know its status`,
+      tab: 'activity',
+    }
+  }
+
+  if (days >= COOLING_RELEASE_CUTOFF_DAYS && typeof commits90d === 'number' && commits90d > 0) {
+    return {
+      bucket: 'activity',
+      key: 'release_cooling',
+      percentile: 0,
+      message: `It has been ${days} days since the last release, even though commits are landing — consider cutting a release to reflect recent work`,
+      tab: 'activity',
+    }
+  }
+
+  return null
+}
+
+function pickSchemeRec(rh: ReleaseHealthResult): HealthScoreRecommendation | null {
+  if (rh.versioningScheme === 'calver') return null
+  if (rh.versioningScheme === 'unavailable') return null
+
+  if (rh.versioningScheme === 'unrecognized') {
+    return {
+      bucket: 'documentation',
+      key: 'release_adopt_scheme',
+      percentile: 0,
+      message: 'Adopt a consistent versioning scheme (semver, CalVer, or a documented alternative) so adopters can reason about upgrades',
+      tab: 'documentation',
+    }
+  }
+
+  const ratio = rh.semverComplianceRatio
+  if (typeof ratio === 'number' && ratio < SEMVER_ADOPTION_THRESHOLD) {
+    return {
+      bucket: 'documentation',
+      key: 'release_adopt_semver',
+      percentile: 0,
+      message: 'Adopt semantic versioning (MAJOR.MINOR.PATCH) for release tags so adopters can interpret upgrade risk automatically',
+      tab: 'documentation',
+    }
+  }
+
+  return null
+}

--- a/lib/release-health/recommendations.ts
+++ b/lib/release-health/recommendations.ts
@@ -48,7 +48,7 @@ export function generateReleaseHealthRecommendations(
 
     if (typeof rh.releaseNotesQualityRatio === 'number' && rh.releaseNotesQualityRatio < NOTES_FLOOR) {
       recs.push({
-        bucket: 'documentation',
+        bucket: 'Documentation',
         key: 'release_improve_notes',
         percentile: context.documentationPercentile,
         message: 'Expand release notes to describe what changed in each release — adopters rely on them to gauge upgrade impact',
@@ -58,7 +58,7 @@ export function generateReleaseHealthRecommendations(
 
     if (typeof rh.tagToReleaseRatio === 'number' && rh.tagToReleaseRatio > TAG_PROMOTION_CEILING) {
       recs.push({
-        bucket: 'documentation',
+        bucket: 'Documentation',
         key: 'release_promote_tags',
         percentile: context.documentationPercentile,
         message: 'Promote git tags to GitHub Releases so users have a clear list of shipped versions with associated changelog entries',
@@ -76,7 +76,7 @@ function pickStalenessTier(
 ): HealthScoreRecommendation | null {
   if (rh.totalReleasesAnalyzed === 0) {
     return {
-      bucket: 'activity',
+      bucket: 'Activity',
       key: 'release_never_released',
       percentile: 0,
       message: 'Cut a first release (and tag it on GitHub) so adopters have a clear starting point and upgrade path',
@@ -89,7 +89,7 @@ function pickStalenessTier(
 
   if (days >= STALE_RELEASE_CUTOFF_DAYS) {
     return {
-      bucket: 'activity',
+      bucket: 'Activity',
       key: 'release_stale',
       percentile: 0,
       message: `The most recent release was ${days} days ago — consider cutting a maintenance release or archiving the repository so downstream users know its status`,
@@ -99,7 +99,7 @@ function pickStalenessTier(
 
   if (days >= COOLING_RELEASE_CUTOFF_DAYS && typeof commits90d === 'number' && commits90d > 0) {
     return {
-      bucket: 'activity',
+      bucket: 'Activity',
       key: 'release_cooling',
       percentile: 0,
       message: `It has been ${days} days since the last release, even though commits are landing — consider cutting a release to reflect recent work`,
@@ -116,7 +116,7 @@ function pickSchemeRec(rh: ReleaseHealthResult): HealthScoreRecommendation | nul
 
   if (rh.versioningScheme === 'unrecognized') {
     return {
-      bucket: 'documentation',
+      bucket: 'Documentation',
       key: 'release_adopt_scheme',
       percentile: 0,
       message: 'Adopt a consistent versioning scheme (semver, CalVer, or a documented alternative) so adopters can reason about upgrades',
@@ -127,7 +127,7 @@ function pickSchemeRec(rh: ReleaseHealthResult): HealthScoreRecommendation | nul
   const ratio = rh.semverComplianceRatio
   if (typeof ratio === 'number' && ratio < SEMVER_ADOPTION_THRESHOLD) {
     return {
-      bucket: 'documentation',
+      bucket: 'Documentation',
       key: 'release_adopt_semver',
       percentile: 0,
       message: 'Adopt semantic versioning (MAJOR.MINOR.PATCH) for release tags so adopters can interpret upgrade risk automatically',

--- a/lib/release-health/semver.test.ts
+++ b/lib/release-health/semver.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { detectVersioningScheme, isCalVer, isSemver } from './semver'
+
+describe('isSemver', () => {
+  it('matches standard semver tags', () => {
+    expect(isSemver('v1.2.3')).toBe(true)
+    expect(isSemver('1.2.3')).toBe(true)
+    expect(isSemver('v1.0.0-rc.1')).toBe(true)
+    expect(isSemver('0.0.0')).toBe(true)
+    expect(isSemver('1.2.3+build.7')).toBe(true)
+    expect(isSemver('1.0.0-alpha+001')).toBe(true)
+  })
+
+  it('rejects non-semver tags', () => {
+    expect(isSemver('1.2')).toBe(false)
+    expect(isSemver('2026.04.17')).toBe(false)
+    expect(isSemver('release-2024')).toBe(false)
+    expect(isSemver('nightly')).toBe(false)
+    expect(isSemver('')).toBe(false)
+  })
+})
+
+describe('isCalVer', () => {
+  it('matches calver shapes', () => {
+    expect(isCalVer('2026.04.17')).toBe(true)
+    expect(isCalVer('2026-04-17')).toBe(true)
+    expect(isCalVer('24.04')).toBe(true)
+    expect(isCalVer('24.04.2')).toBe(true)
+    expect(isCalVer('v2024.10')).toBe(true)
+  })
+
+  it('rejects non-calver', () => {
+    expect(isCalVer('1.2.3')).toBe(false)
+    expect(isCalVer('v0.5.1')).toBe(false)
+    expect(isCalVer('')).toBe(false)
+  })
+})
+
+describe('detectVersioningScheme', () => {
+  it('returns unavailable for empty input', () => {
+    expect(detectVersioningScheme([])).toBe('unavailable')
+  })
+
+  it('returns semver when more than half the tags are semver', () => {
+    expect(detectVersioningScheme(['v1.0.0', 'v1.1.0', 'v1.2.0'])).toBe('semver')
+    expect(detectVersioningScheme(['v1.0.0', 'v1.1.0', 'v1.2.0', 'nightly', 'foo'])).toBe('semver')
+  })
+
+  it('returns calver when more than half the tags are calver', () => {
+    expect(detectVersioningScheme(['2026.04.17', '2026.04.18'])).toBe('calver')
+    expect(detectVersioningScheme(['2024.01', '2024.02', '2024.03', 'v1.0.0'])).toBe('calver')
+  })
+
+  it('returns unrecognized when no scheme dominates', () => {
+    expect(detectVersioningScheme(['foo', 'bar', 'baz'])).toBe('unrecognized')
+    // 50/50 split does not qualify as dominant under a strict ">" threshold.
+    expect(detectVersioningScheme(['v1.0.0', 'v1.1.0', 'bar', 'baz'])).toBe('unrecognized')
+  })
+
+  it('treats pre-release semver tags as semver (per SPEC)', () => {
+    expect(detectVersioningScheme(['v1.0.0-rc.1', 'v1.0.0-rc.2', 'v1.0.0-rc.3'])).toBe('semver')
+  })
+})

--- a/lib/release-health/semver.ts
+++ b/lib/release-health/semver.ts
@@ -1,0 +1,24 @@
+import type { VersioningScheme } from '@/lib/analyzer/analysis-result'
+import { CALVER_REGEX, SEMVER_REGEX } from '@/lib/scoring/config-loader'
+
+export function isSemver(tagName: string): boolean {
+  return SEMVER_REGEX.test(tagName)
+}
+
+export function isCalVer(tagName: string): boolean {
+  return CALVER_REGEX.test(tagName)
+}
+
+export function detectVersioningScheme(tagNames: string[]): VersioningScheme | 'unavailable' {
+  if (tagNames.length === 0) return 'unavailable'
+  let semverCount = 0
+  let calverCount = 0
+  for (const tag of tagNames) {
+    if (isSemver(tag)) semverCount++
+    else if (isCalVer(tag)) calverCount++
+  }
+  const threshold = tagNames.length / 2
+  if (semverCount > threshold) return 'semver'
+  if (calverCount > threshold) return 'calver'
+  return 'unrecognized'
+}

--- a/lib/scoring/config-loader.test.ts
+++ b/lib/scoring/config-loader.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest'
-import { getBracket, getBracketLabel, getCalibrationForStars, isSoloFallback } from './config-loader'
+import {
+  ACTIVITY_CADENCE_FREQUENCY_WEIGHT,
+  ACTIVITY_CADENCE_RECENCY_WEIGHT,
+  CALVER_REGEX,
+  COOLING_RELEASE_CUTOFF_DAYS,
+  DOCUMENTATION_NOTES_BONUS,
+  DOCUMENTATION_SEMVER_BONUS,
+  DOCUMENTATION_TAG_PROMOTION_BONUS,
+  RELEASE_NOTES_SUBSTANTIVE_FLOOR,
+  SEMVER_ADOPTION_THRESHOLD,
+  SEMVER_REGEX,
+  STALE_RELEASE_CUTOFF_DAYS,
+  getBracket,
+  getBracketLabel,
+  getCalibrationForStars,
+  isSoloFallback,
+} from './config-loader'
 
 describe('getBracket', () => {
   it('routes community stars to star-tier brackets', () => {
@@ -66,5 +82,61 @@ describe('getCalibrationForStars', () => {
     // Both exist as bracket entries — they may contain the same numbers
     // while placeholder solo data mirrors emerging, but the routing is
     // correct: the solo call returns the solo-tiny entry.
+  })
+})
+
+describe('Release Health config constants (P2-F09 / #69)', () => {
+  it('semver regex matches standard semver tags', () => {
+    expect(SEMVER_REGEX.test('v1.2.3')).toBe(true)
+    expect(SEMVER_REGEX.test('1.2.3')).toBe(true)
+    expect(SEMVER_REGEX.test('v1.0.0-rc.1')).toBe(true)
+    expect(SEMVER_REGEX.test('1.0.0-alpha+sha.5114f85')).toBe(true)
+  })
+
+  it('semver regex rejects non-semver tags', () => {
+    expect(SEMVER_REGEX.test('1.2')).toBe(false)
+    expect(SEMVER_REGEX.test('v01.2.3')).toBe(false) // leading zeros forbidden
+    expect(SEMVER_REGEX.test('release-2024')).toBe(false)
+    expect(SEMVER_REGEX.test('')).toBe(false)
+  })
+
+  it('calver regex matches common CalVer shapes', () => {
+    expect(CALVER_REGEX.test('2026.04.17')).toBe(true)
+    expect(CALVER_REGEX.test('2026-04-17')).toBe(true)
+    expect(CALVER_REGEX.test('24.04')).toBe(true)
+    expect(CALVER_REGEX.test('24.04.2')).toBe(true)
+    expect(CALVER_REGEX.test('v2024.10')).toBe(true)
+  })
+
+  it('calver regex rejects semver-shaped tags', () => {
+    expect(CALVER_REGEX.test('1.2.3')).toBe(false)
+    expect(CALVER_REGEX.test('v0.5.1')).toBe(false)
+  })
+
+  it('exposes the substantive notes floor default at 40 characters', () => {
+    expect(RELEASE_NOTES_SUBSTANTIVE_FLOOR).toBe(40)
+  })
+
+  it('exposes staleness tier cutoffs (730 stale, 365 cooling)', () => {
+    expect(STALE_RELEASE_CUTOFF_DAYS).toBe(730)
+    expect(COOLING_RELEASE_CUTOFF_DAYS).toBe(365)
+    expect(COOLING_RELEASE_CUTOFF_DAYS).toBeLessThan(STALE_RELEASE_CUTOFF_DAYS)
+  })
+
+  it('exposes the semver adoption threshold at 0.5', () => {
+    expect(SEMVER_ADOPTION_THRESHOLD).toBe(0.5)
+  })
+
+  it('activity cadence frequency + recency weights sum to 0.15 (preserving the cadence sub-factor)', () => {
+    expect(ACTIVITY_CADENCE_FREQUENCY_WEIGHT + ACTIVITY_CADENCE_RECENCY_WEIGHT).toBeCloseTo(0.15, 10)
+  })
+
+  it('documentation bonuses are small and positive', () => {
+    expect(DOCUMENTATION_SEMVER_BONUS).toBeGreaterThan(0)
+    expect(DOCUMENTATION_SEMVER_BONUS).toBeLessThanOrEqual(0.05)
+    expect(DOCUMENTATION_NOTES_BONUS).toBeGreaterThan(0)
+    expect(DOCUMENTATION_NOTES_BONUS).toBeLessThanOrEqual(0.05)
+    expect(DOCUMENTATION_TAG_PROMOTION_BONUS).toBeGreaterThan(0)
+    expect(DOCUMENTATION_TAG_PROMOTION_BONUS).toBeLessThanOrEqual(0.05)
   })
 })

--- a/lib/scoring/config-loader.ts
+++ b/lib/scoring/config-loader.ts
@@ -8,6 +8,26 @@ import type { Unavailable } from '@/lib/analyzer/analysis-result'
  */
 export const RECOMMENDATION_PERCENTILE_GATE = 50
 
+/**
+ * Release Health (P2-F09 / #69) shared config — thresholds and weights used by
+ * `lib/release-health/*`, `lib/activity/score-config.ts`, and
+ * `lib/documentation/score-config.ts`. Per-bracket calibration for the five
+ * numeric signals is deferred to #152; these values are tunable there.
+ */
+export const SEMVER_REGEX =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+export const CALVER_REGEX = /^v?(?:\d{4}[.-]\d{1,2}(?:[.-]\d{1,3})?|\d{2}\.\d{1,2}(?:\.\d{1,3})?)$/
+export const RELEASE_NOTES_SUBSTANTIVE_FLOOR = 40
+export const STALE_RELEASE_CUTOFF_DAYS = 730
+export const COOLING_RELEASE_CUTOFF_DAYS = 365
+export const SEMVER_ADOPTION_THRESHOLD = 0.5
+/** Sum of these two weights stays at 0.15 — the existing Activity cadence sub-factor allocation. */
+export const ACTIVITY_CADENCE_FREQUENCY_WEIGHT = 0.10
+export const ACTIVITY_CADENCE_RECENCY_WEIGHT = 0.05
+export const DOCUMENTATION_SEMVER_BONUS = 0.03
+export const DOCUMENTATION_NOTES_BONUS = 0.02
+export const DOCUMENTATION_TAG_PROMOTION_BONUS = 0.02
+
 export type BracketKey = 'solo-tiny' | 'solo-small' | 'emerging' | 'growing' | 'established' | 'popular'
 
 /** Profile override used by the scorecard to route solo repos to solo brackets. */

--- a/lib/scoring/health-score.ts
+++ b/lib/scoring/health-score.ts
@@ -6,6 +6,7 @@ import { getDocumentationScore, type DocumentationRecommendation } from '@/lib/d
 import { getSecurityScore } from '@/lib/security/score-config'
 import { RECOMMENDATION_PERCENTILE_GATE, formatPercentileLabel, formatPercentileOrdinal, percentileToTone } from '@/lib/scoring/config-loader'
 import { SOLO_WEIGHTS, detectSoloProjectProfile, type SoloProjectDetection } from '@/lib/scoring/solo-profile'
+import { generateReleaseHealthRecommendations } from '@/lib/release-health/recommendations'
 import type { ScoreTone } from '@/specs/008-metric-cards/contracts/metric-card-props'
 
 export interface HealthScoreRecommendation {
@@ -71,7 +72,7 @@ export function getHealthScore(result: AnalysisResult, options: HealthScoreOptio
   const responsiveness = getResponsivenessScore(result)
   const contributors = getContributorsScore(result)
   const documentation = result.documentationResult !== 'unavailable'
-    ? getDocumentationScore(result.documentationResult, result.licensingResult, result.stars, result.inclusiveNamingResult, profile)
+    ? getDocumentationScore(result.documentationResult, result.licensingResult, result.stars, result.inclusiveNamingResult, profile, result.releaseHealthResult)
     : null
   const security = result.securityResult !== 'unavailable'
     ? getSecurityScore(result.securityResult, result.stars, profile)
@@ -172,6 +173,14 @@ export function getHealthScore(result: AnalysisResult, options: HealthScoreOptio
       })
     }
   }
+  // Release Health recommendations (P2-F09 / #69). Gate-honoring + staleness
+  // tiering is implemented inside generateReleaseHealthRecommendations.
+  recommendations.push(
+    ...generateReleaseHealthRecommendations(result, {
+      activityPercentile: activityPercentile ?? 0,
+      documentationPercentile: documentationPercentile ?? 0,
+    }),
+  )
 
   const buckets: HealthScoreBucket[] = [
     { name: 'Activity', percentile: activityPercentile, weight: activityWeight, label: activityPercentile !== null ? formatPercentileLabel(activityPercentile) : 'N/A' },

--- a/lib/tags/release-health.test.ts
+++ b/lib/tags/release-health.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RELEASE_HEALTH_ACTIVITY_ITEMS,
+  RELEASE_HEALTH_METRICS,
+  RELEASE_HEALTH_TAG,
+  RELEASE_HEALTH_ROWS,
+  isReleaseHealthItem,
+} from './release-health'
+
+describe('release-health tag registry', () => {
+  it('exports a stable tag key', () => {
+    expect(RELEASE_HEALTH_TAG).toBe('release-health')
+  })
+
+  it('tags the Release Cadence card on the Activity tab', () => {
+    expect(RELEASE_HEALTH_ACTIVITY_ITEMS.has('release_cadence_card')).toBe(true)
+    expect(isReleaseHealthItem('release_cadence_card', 'activity_item')).toBe(true)
+  })
+
+  it('tags all five scored metrics', () => {
+    for (const key of [
+      'release_frequency',
+      'days_since_last_release',
+      'semver_compliance',
+      'release_notes_quality',
+      'tag_to_release',
+    ]) {
+      expect(RELEASE_HEALTH_METRICS.has(key)).toBe(true)
+      expect(isReleaseHealthItem(key, 'metric')).toBe(true)
+    }
+  })
+
+  it('tags Activity and Documentation card rows', () => {
+    expect(RELEASE_HEALTH_ROWS.has('release_cadence_card')).toBe(true)
+    expect(RELEASE_HEALTH_ROWS.has('release_discipline_card')).toBe(true)
+  })
+
+  it('returns false for unrelated keys', () => {
+    expect(isReleaseHealthItem('readme', 'metric')).toBe(false)
+    expect(isReleaseHealthItem('discussions', 'activity_item')).toBe(false)
+  })
+})

--- a/lib/tags/release-health.ts
+++ b/lib/tags/release-health.ts
@@ -1,0 +1,45 @@
+/**
+ * Release Health tag mappings (P2-F09 / #69).
+ *
+ * Mirrors the structure of `lib/tags/community.ts` and `lib/tags/governance.ts`.
+ * The release-health lens tags items across the Activity and Documentation
+ * tabs. Scoring for these signals lives inside each host bucket's
+ * `score-config.ts`, not here.
+ *
+ * See `specs/69-add-release-and-versioning-health-signal/data-model.md`.
+ */
+
+export const RELEASE_HEALTH_TAG = 'release-health'
+
+/** Activity tab item keys that carry the release-health lens. */
+export const RELEASE_HEALTH_ACTIVITY_ITEMS = new Set<string>([
+  'release_cadence_card',
+])
+
+/** Row keys (across Activity and Documentation tabs) that carry the release-health pill. */
+export const RELEASE_HEALTH_ROWS = new Set<string>([
+  'release_cadence_card',
+  'release_discipline_card',
+  'release_discipline_semver',
+  'release_discipline_notes',
+  'release_discipline_tag_promotion',
+])
+
+/** Metric keys (five scored signals) carried by the lens. */
+export const RELEASE_HEALTH_METRICS = new Set<string>([
+  'release_frequency',
+  'days_since_last_release',
+  'semver_compliance',
+  'release_notes_quality',
+  'tag_to_release',
+])
+
+export type ReleaseHealthDomain = 'activity_item' | 'row' | 'metric'
+
+export function isReleaseHealthItem(key: string, domain: ReleaseHealthDomain): boolean {
+  switch (domain) {
+    case 'activity_item': return RELEASE_HEALTH_ACTIVITY_ITEMS.has(key)
+    case 'row': return RELEASE_HEALTH_ROWS.has(key)
+    case 'metric': return RELEASE_HEALTH_METRICS.has(key)
+  }
+}

--- a/specs/69-add-release-and-versioning-health-signal/checklists/requirements.md
+++ b/specs/69-add-release-and-versioning-health-signal/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Release Health Scoring
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec references library paths in the Dependencies section (consistent with the shipped Phase 2 pattern — see `specs/180-community-scoring/spec.md`) but keeps Functional Requirements free of implementation-detail paths after the `spec-reviewer` pass.
+- Per-bracket percentile calibration for the five new release-health signals is explicitly deferred to issue #152 (FR-022, FR-023, SC-007, Out of Scope). Completeness uses the linear ratio → percentile fallback shipped with Community (P2-F05) until #152 lands.
+- Three open questions are documented in the spec. They do not block approval and are resolved during `/speckit.clarify` or at implementation time.

--- a/specs/69-add-release-and-versioning-health-signal/contracts/release-health-scoring.md
+++ b/specs/69-add-release-and-versioning-health-signal/contracts/release-health-scoring.md
@@ -1,0 +1,215 @@
+# Contract: Release Health Scoring
+
+**Feature**: P2-F09 — Release Health Scoring (issue #69)
+**Branch**: `69-add-release-and-versioning-health-signal`
+
+This contract pins the programmatic interfaces that cross module boundaries. Any divergence during implementation requires a spec / plan amendment.
+
+---
+
+## 1. Analyzer output — `AnalysisResult.releaseHealthResult`
+
+```ts
+// lib/analyzer/analysis-result.ts
+export type Unavailable = 'unavailable'
+
+export interface ReleaseHealthResult {
+  totalReleasesAnalyzed: number
+  totalTags: number | Unavailable
+  releaseFrequency: number | Unavailable
+  daysSinceLastRelease: number | Unavailable
+  semverComplianceRatio: number | Unavailable
+  releaseNotesQualityRatio: number | Unavailable
+  tagToReleaseRatio: number | Unavailable
+  preReleaseRatio: number | Unavailable
+  versioningScheme: 'semver' | 'calver' | 'unrecognized' | Unavailable
+}
+
+export interface AnalysisResult {
+  // ...existing fields...
+  releaseHealthResult?: ReleaseHealthResult | Unavailable
+}
+```
+
+**Contract**:
+
+- `undefined` is reserved for fixtures predating this feature. Fresh analyses emit either an object or the literal `'unavailable'`.
+- When emitted as an object, `totalReleasesAnalyzed` is always a number (may be 0); every other field may be `'unavailable'`.
+
+---
+
+## 2. Detection — `lib/release-health/detect.ts`
+
+```ts
+export interface RawRelease {
+  tagName: string
+  body: string | null
+  isPrerelease: boolean
+  createdAt: string
+  publishedAt: string | null
+}
+
+export interface DetectReleaseHealthInput {
+  releases: RawRelease[]              // most recent first, up to 100
+  totalReleasesAllTime: number         // from releases.totalCount
+  totalTags: number | 'unavailable'    // from refs.totalCount
+  now: Date                            // injected for determinism
+}
+
+export function detectReleaseHealth(input: DetectReleaseHealthInput): ReleaseHealthResult
+```
+
+**Contract**:
+
+- Pure function. No network calls, no `Date.now()` reads inside — `now` is injected.
+- Returns the `'unavailable'` object shape when `releases.length === 0` AND `totalTags === 'unavailable'`.
+- Otherwise returns a populated object with per-field `'unavailable'` as specified in `data-model.md`.
+
+---
+
+## 3. Completeness — `lib/release-health/completeness.ts`
+
+```ts
+export function computeReleaseHealthCompleteness(
+  result: AnalysisResult
+): ReleaseHealthCompleteness
+```
+
+**Contract**:
+
+- Pure function. Reads `result.releaseHealthResult` and the shared-config thresholds; writes nothing.
+- Returns `{ ratio: null, percentile: null, tone: 'neutral' }` when all five scored signals are `unknown` — rendered as `"Insufficient verified public data"` at the UI.
+- Uses the same linear `ratio → percentile` fallback as `lib/community/completeness.ts` until #152 calibration lands.
+
+---
+
+## 4. Semver / scheme detection — `lib/release-health/semver.ts`
+
+```ts
+export const SEMVER_REGEX: RegExp
+export const CALVER_REGEX: RegExp
+
+export function detectVersioningScheme(tagNames: string[]): 'semver' | 'calver' | 'unrecognized' | 'unavailable'
+```
+
+**Contract**:
+
+- Dominant-scheme rule: ≥ 50% of non-empty tag names match a scheme → that scheme wins. Else `unrecognized`. Empty input → `unavailable`.
+- Both regexes are exported (tests lock them down).
+
+---
+
+## 5. Scoring hooks
+
+### Activity — `lib/activity/score-config.ts`
+
+```ts
+// Cadence sub-factor (currently 20% of Activity).
+// Splits into:
+//   - releasesPerYear weight ACTIVITY_CADENCE_FREQUENCY_WEIGHT (default 0.12)
+//   - daysSinceLastRelease weight ACTIVITY_CADENCE_RECENCY_WEIGHT (default 0.08)
+// Sum must remain 0.20 to preserve composite Activity weight of 25%.
+```
+
+**Contract**: the exported `getActivityScore()` signature is unchanged. Internally, cadence reads both inputs from the `ReleaseHealthResult` when present; falls back to the current `releases12mo`-only logic when `releaseHealthResult` is `'unavailable'` / `undefined`. No new caller rewrites.
+
+### Documentation — `lib/documentation/score-config.ts`
+
+```ts
+// Three small-weight bonus multipliers applied AFTER the base Documentation percentile:
+//   semverComplianceRatio      → bonus DOCUMENTATION_SEMVER_BONUS (default 0.03) scaled by ratio
+//   releaseNotesQualityRatio   → bonus DOCUMENTATION_NOTES_BONUS (default 0.02) scaled by ratio
+//   tagToReleaseRatio          → fixed DOCUMENTATION_TAG_PROMOTION_BONUS (default 0.02) when ratio ≤ 0.3, else 0
+// Final Documentation percentile is clamped to [0, 99].
+```
+
+**Contract**: the exported `getDocumentationScore()` signature is unchanged. Release-health inputs are threaded through the existing `AnalysisResult` argument. No new caller rewrites.
+
+---
+
+## 6. Lens readout — `lib/metric-cards/view-model.ts`
+
+`buildLensReadouts(result)` gains a third readout after `community` and `governance`:
+
+```ts
+// Only added when result.releaseHealthResult is an object AND completeness.ratio !== null.
+{
+  key: 'release-health',
+  label: 'Release Health',
+  percentileLabel: `${completeness.percentile}th percentile`,
+  detail: `${present.length} of ${present.length + missing.length} signals`,
+  tooltip: 'Release Health is a cross-cutting lens — count of release-health signals present. Does not feed the composite OSS Health Score.',
+  tone: completeness.tone,
+}
+```
+
+---
+
+## 7. Recommendations — `lib/recommendations/catalog.ts`
+
+Seven new keys (see `data-model.md` §Recommendation catalog). Each entry matches the existing `HealthScoreRecommendation` shape:
+
+```ts
+{
+  key: string
+  bucket: 'activity' | 'documentation'
+  tab: 'activity' | 'documentation'
+  message: string          // user-facing copy
+  gate: typeof RECOMMENDATION_PERCENTILE_GATE
+}
+```
+
+**Contract**:
+
+- Each recommendation's `message` is static (no runtime interpolation except where the trigger provides a number, e.g., `daysSinceLastRelease`).
+- `RECOMMENDATION_PERCENTILE_GATE` (host-bucket percentile) suppresses all seven.
+- Staleness tiers evaluate in order `never_released → stale → cooling`; first match wins. FR-028 guarantees at most one fires.
+- `preReleaseRatio` never appears in any trigger expression (FR-031).
+
+---
+
+## 8. GraphQL — `lib/analyzer/queries.ts`
+
+Additive field selection on the existing Pass-1 query. No new query pass, no new exported constant. The contract is that after this feature:
+
+```graphql
+repository(owner: $owner, name: $name) {
+  releases(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+    totalCount
+    nodes {
+      tagName
+      name
+      body
+      isPrerelease
+      createdAt
+      publishedAt
+    }
+  }
+  refs(refPrefix: "refs/tags/", first: 0) { totalCount }
+  # ... existing defaultBranchRef.target fields unchanged ...
+}
+```
+
+Per-repo request count stays within 1–3 (Constitution §III.2).
+
+---
+
+## 9. Export — `lib/export/json-export.ts`, `lib/export/markdown-export.ts`
+
+**JSON**: include `releaseHealthResult` field verbatim and a top-level `releaseHealthCompleteness` object when present.
+
+**Markdown**: a `## Release Health` section with three subsections (Release Cadence, Release Discipline, Completeness), parallel to the shipped `## Community` section in `specs/180-community-scoring/`.
+
+---
+
+## 10. Constitution compliance
+
+| # | Rule | How this contract upholds it |
+|---|---|---|
+| II | Accuracy | `'unavailable'` is the first-class state; no estimation in `detectReleaseHealth` |
+| III | Data Sources | Additive GraphQL fields only; no new network pass |
+| IV | Analyzer Boundary | Detection in `lib/release-health/`; scoring in per-bucket `score-config.ts`; UI in `components/` — no cross-boundary imports |
+| V | CHAOSS | No new composite bucket or CHAOSS score |
+| VI | Scoring Thresholds | All thresholds in shared config; scoring logic reads (not hardcodes) them |
+| IX | YAGNI | No speculative infrastructure, no calibration payload changes (deferred to #152) |
+| XI | Testing | Every function in this contract lands with Vitest coverage before UI wiring |

--- a/specs/69-add-release-and-versioning-health-signal/data-model.md
+++ b/specs/69-add-release-and-versioning-health-signal/data-model.md
@@ -1,0 +1,132 @@
+# Phase 1 Data Model: Release Health Scoring
+
+**Feature**: P2-F09 — Release Health Scoring (issue #69)
+**Branch**: `69-add-release-and-versioning-health-signal`
+
+Flat, diffable-across-repos shapes per Constitution §IX.5.
+
+---
+
+## `ReleaseHealthResult`
+
+Top-level field on `AnalysisResult` (optional — `undefined` on fixtures predating this feature; `'unavailable'` when releases cannot be retrieved at all).
+
+```ts
+export type Unavailable = 'unavailable'
+
+export interface ReleaseHealthResult {
+  /** Count of releases analyzed (bounded at 100). Drives the 'never released' recommendation tier. */
+  totalReleasesAnalyzed: number
+  /** Tag count from refs(refPrefix: "refs/tags/"). Used for tagToReleaseRatio. */
+  totalTags: number | Unavailable
+  /** Releases per year over the last 12 months. 'unavailable' when fewer than 2 releases exist. */
+  releaseFrequency: number | Unavailable
+  /** Days since the most recent release (publishedAt falling back to createdAt). 'unavailable' when there are zero releases. */
+  daysSinceLastRelease: number | Unavailable
+  /** Share of releases matching SEMVER_REGEX [0, 1]. 'unavailable' when there are zero releases. */
+  semverComplianceRatio: number | Unavailable
+  /** Share of releases whose body.trim().length >= RELEASE_NOTES_SUBSTANTIVE_FLOOR [0, 1]. */
+  releaseNotesQualityRatio: number | Unavailable
+  /** Share of tags that never became a release: max(0, totalTags - totalReleases) / max(1, totalTags). */
+  tagToReleaseRatio: number | Unavailable
+  /** Share of releases with isPrerelease === true. Informational — never scored. */
+  preReleaseRatio: number | Unavailable
+  /** Dominant versioning scheme detected across tagNames. Drives semver vs. CalVer vs. unrecognized recommendation routing. */
+  versioningScheme: 'semver' | 'calver' | 'unrecognized' | Unavailable
+}
+```
+
+`AnalysisResult` gains one optional field:
+
+```ts
+releaseHealthResult?: ReleaseHealthResult | Unavailable
+```
+
+---
+
+## `ReleaseHealthCompleteness`
+
+Derived summary for the per-repo metric card's lens readout. Peer to `CommunityCompleteness`.
+
+```ts
+export type ReleaseHealthSignalKey =
+  | 'release_frequency'
+  | 'days_since_last_release'
+  | 'semver_compliance'
+  | 'release_notes_quality'
+  | 'tag_to_release'
+
+export interface ReleaseHealthCompleteness {
+  present: ReleaseHealthSignalKey[]
+  missing: ReleaseHealthSignalKey[]
+  unknown: ReleaseHealthSignalKey[]
+  /** present.length / (present.length + missing.length); null when denominator is zero (zero-release case). */
+  ratio: number | null
+  /** Linear fallback: Math.round(ratio * 99); null when ratio is null. Swapped for calibrated percentile in #152. */
+  percentile: number | null
+  tone: ScoreTone
+}
+```
+
+Classification per signal:
+
+- `release_frequency`: `releaseFrequency === 'unavailable'` → `unknown` if `totalReleasesAnalyzed === 0`, else `missing`; `releaseFrequency < 1` → `missing`; `releaseFrequency >= 1` → `present`.
+- `days_since_last_release`: `daysSinceLastRelease === 'unavailable'` → `unknown`; `daysSinceLastRelease >= STALE_RELEASE_CUTOFF_DAYS` → `missing`; else → `present`.
+- `semver_compliance`: `semverComplianceRatio === 'unavailable'` → `unknown`; `semverComplianceRatio >= SEMVER_ADOPTION_THRESHOLD` → `present`; else → `missing`.
+- `release_notes_quality`: `releaseNotesQualityRatio === 'unavailable'` → `unknown`; `releaseNotesQualityRatio >= 0.5` → `present`; else → `missing`.
+- `tag_to_release`: `tagToReleaseRatio === 'unavailable'` → `unknown`; `tagToReleaseRatio <= 0.3` → `present`; else → `missing`.
+
+Thresholds are shared-config values (§VI).
+
+---
+
+## Recommendation catalog entries
+
+`lib/recommendations/catalog.ts` gains the following keys (new `HealthScoreRecommendation` entries, gated by `RECOMMENDATION_PERCENTILE_GATE`):
+
+| Key | Bucket | Tab | Trigger |
+|---|---|---|---|
+| `release_never_released` | `activity` | `activity` | `totalReleasesAnalyzed === 0` AND repo has ≥ 1 commit |
+| `release_stale` | `activity` | `activity` | `daysSinceLastRelease >= STALE_RELEASE_CUTOFF_DAYS` |
+| `release_cooling` | `activity` | `activity` | `COOLING_RELEASE_CUTOFF_DAYS <= daysSinceLastRelease < STALE_RELEASE_CUTOFF_DAYS` AND `commits90d > 0` |
+| `release_adopt_semver` | `documentation` | `documentation` | `semverComplianceRatio < SEMVER_ADOPTION_THRESHOLD` AND `versioningScheme !== 'calver'` AND `versioningScheme !== 'unrecognized'` |
+| `release_adopt_scheme` | `documentation` | `documentation` | `versioningScheme === 'unrecognized'` |
+| `release_improve_notes` | `documentation` | `documentation` | `releaseNotesQualityRatio < 0.5` |
+| `release_promote_tags` | `documentation` | `documentation` | `tagToReleaseRatio > 0.5` |
+
+At most one staleness recommendation fires per repo (FR-028). `preReleaseRatio` never triggers a recommendation (FR-031).
+
+---
+
+## Tag registry
+
+New file `lib/tags/release-health.ts` — mirrors `lib/tags/community.ts`:
+
+```ts
+export const RELEASE_HEALTH_TAG = 'release-health'
+export const RELEASE_HEALTH_ROWS = new Set<string>([
+  'release_cadence_card',         // Activity tab
+  'release_discipline_card',      // Documentation tab
+  'release_discipline_semver',
+  'release_discipline_notes',
+  'release_discipline_tag_promotion',
+])
+export const RELEASE_HEALTH_ACTIVITY_ITEMS = new Set<string>([
+  'release_cadence_card',
+])
+export const RELEASE_HEALTH_METRICS = new Set<string>([
+  'release_frequency',
+  'days_since_last_release',
+  'semver_compliance',
+  'release_notes_quality',
+  'tag_to_release',
+])
+```
+
+Co-occurrence with other lens tags (e.g., `governance`) is supported by the existing `TagPill` rendering path (FR-016).
+
+---
+
+## Export shape
+
+`json-export.ts` emits the flat `releaseHealthResult` field plus a top-level `releaseHealthCompleteness` summary. `markdown-export.ts` emits a `## Release Health` section with three subsections (Release Cadence, Release Discipline, Completeness), parallel to the shipped Community export.

--- a/specs/69-add-release-and-versioning-health-signal/plan.md
+++ b/specs/69-add-release-and-versioning-health-signal/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Release Health Scoring
+
+**Branch**: `69-add-release-and-versioning-health-signal` | **Date**: 2026-04-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/69-add-release-and-versioning-health-signal/spec.md`
+
+## Summary
+
+Add a **Release Health lens** over the existing scored buckets, mirroring the Governance (P2-F04, #116) and Community (P2-F05, #70) precedents. Five net-new signals are detected and scored inside their most appropriate existing host bucket — `releaseFrequency` and `daysSinceLastRelease` extend the Activity `cadence` sub-factor; `semverComplianceRatio`, `releaseNotesQualityRatio`, and `tagToReleaseRatio` become small-weight bonuses inside Documentation. `preReleaseRatio` is informational only and never scores. A new `release-health` presentation tag is applied to rows and cards on the Activity and Documentation tabs. A derived "Release Health completeness" readout is surfaced on the per-repo metric card via `buildLensReadouts()`, peer to the Community and Governance lens readouts, using a **linear ratio → percentile fallback** until the calibration refresh in #152 adds per-bracket percentiles. Recommendations honor the existing `RECOMMENDATION_PERCENTILE_GATE` and differentiate three staleness tiers.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (Next.js 16+)
+**Primary Dependencies**: Next.js (App Router), React, Tailwind CSS
+**Storage**: N/A (stateless, on-demand analysis per Constitution §I)
+**Testing**: Vitest + React Testing Library (units and components); Playwright (E2E)
+**Target Platform**: Vercel serverless (web app)
+**Project Type**: Web application (single Next.js app under repository root)
+**Performance Goals**: Per SC-003 — no additional GraphQL round-trip per repo (release-health data is fetched via additive field selection on the existing `REPO_COMMIT_AND_RELEASES_QUERY` pass); per-repo request count stays within the 1–3 budget.
+**Constraints**: Constitution §II Accuracy Policy — every numeric signal uses `"unavailable"` at the field level and `"Insufficient verified public data"` at the completeness-readout level whenever inputs are missing; no estimation. Constitution §VI — all new thresholds (semver regex, substantive-notes floor, staleness tier cutoffs, per-signal weights) live in shared scoring config.
+**Scale/Scope**: One-shot per-repo analysis; scales to 4-repo comparison sessions. Releases sample bounded at 100 most recent per repo (matches existing `releases(first: 100)` cap in the shipped GraphQL query).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Rule | Status | Notes |
+|---|---|---|---|
+| I | Technology Stack | ✅ Pass | No new runtime dependencies — reuses Next.js, TypeScript, Tailwind, Vitest, Playwright. |
+| II | Accuracy Policy | ✅ Pass | Every net-new signal derives from a single GraphQL-verifiable field (release `tagName` / `body` / `isPrerelease` / `publishedAt`, refs `totalCount`). FR-003, FR-004, FR-008, FR-020, FR-021 enforce `unavailable` / `Insufficient verified public data` whenever inputs are missing. `preReleaseRatio` is informational only and never substitutes for another metric. |
+| III | Data Source Rules | ✅ Pass | Release-health data is additive field selection on the existing Pass-1 GraphQL query (no new round-trip). Per-repo request count remains 1–3. SC-003 enforces this. |
+| IV | Analyzer Module Boundary | ✅ Pass | Detection lives under `lib/analyzer/`; scoring logic inside the per-bucket `score-config.ts` modules; lens presentation under `lib/tags/` and `components/`; completeness under a new `lib/release-health/` module (parallel to `lib/community/`). No Next.js-only imports inside the analyzer layer. |
+| V | CHAOSS Alignment | ✅ Pass | **Release Health is a lens, not a CHAOSS category.** FR-014 and FR-019 explicitly forbid a new composite bucket. Existing Activity / Responsiveness / Sustainability / Documentation / Security weights (25 / 25 / 23 / 12 / 15) remain unchanged. No constitution amendment required. |
+| VI | Scoring Thresholds | ✅ Pass | Semver regex, substantive-notes floor, per-signal weights, `RECOMMENDATION_PERCENTILE_GATE`, and staleness tier cutoffs all live in shared scoring config (`lib/scoring/config-loader.ts` and the existing per-bucket `score-config.ts` modules). No hardcoded thresholds inside components or scoring functions. |
+| VII | Ecosystem Spectrum | ✅ N/A | Unchanged by this feature. |
+| VIII | Contribution Dynamics Honesty | ✅ N/A | No contributor org affiliation claims introduced. |
+| IX | Feature Scope Rules (YAGNI) | ✅ Pass | Scope is strictly the 5 scored detections + 1 informational signal + lens tagging + completeness readout + 8 recommendations with tiering. No speculative infrastructure (no new tab, no calibration payload changes — deferred to #152, no new GraphQL pass, no historical snapshots). |
+| X | Security & Hygiene | ✅ N/A | No new secrets or external services. Token handling unchanged. |
+| XI | Testing (TDD NON-NEGOTIABLE) | ✅ Pass | Each detection gets a unit test before implementation. Lens tagging gets a component test. Completeness readout gets a view-model test. Recommendation tier logic gets unit coverage. Playwright coverage extends existing activity/documentation scenarios to assert the `release-health` pill and the Release Cadence / Release Discipline cards. |
+| XII | Definition of Done | ✅ Pass | PR body `## Test plan` section carries the manual testing checklist (per constitution v1.2 — in-repo checklist file dropped). |
+| XIII | Development Workflow | ✅ Pass | Feature branch, spec-first, PR test plan, DEVELOPMENT.md update on completion (Phase 2 table marks P2-F09 as `✅ Done`). |
+
+**Gate result**: PASS. No violations requiring the Complexity Tracking section.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/69-add-release-and-versioning-health-signal/
+├── plan.md                             # This file
+├── spec.md                             # Feature spec (approved)
+├── research.md                         # Phase 0 output
+├── data-model.md                       # Phase 1 output
+├── quickstart.md                       # Phase 1 output
+├── contracts/
+│   └── release-health-scoring.md       # Phase 1 output
+├── checklists/
+│   └── requirements.md                 # Already created (PASS)
+└── tasks.md                            # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+lib/
+├── analyzer/
+│   ├── queries.ts                      # Extended: additive fields on the releases node — tagName, body, isPrerelease — and refs totalCount
+│   ├── github-graphql.ts               # Extended: map new release fields + tag count into AnalysisResult
+│   └── analysis-result.ts              # Extended: ReleaseHealthResult interface and releaseHealthResult field
+├── tags/
+│   ├── governance.ts                   # Existing — reference pattern (pill only)
+│   ├── community.ts                    # Existing — reference pattern (pill + completeness split)
+│   └── release-health.ts               # NEW — mirrors community.ts (tag registry for Activity / Documentation rows)
+├── release-health/
+│   ├── detect.ts                       # NEW — pure functions computing the five ratios + preReleaseRatio from the releases array
+│   ├── semver.ts                       # NEW — semver + CalVer regex matchers; exported to score-config and recommendations
+│   ├── completeness.ts                 # NEW — computeReleaseHealthCompleteness(result) + linear fallback
+│   └── recommendations.ts              # NEW — staleness tier + scheme detection for rec generation
+├── activity/
+│   ├── score-config.ts                 # Extended: cadence sub-factor reads daysSinceLastRelease in addition to releases12mo
+│   └── view-model.ts                   # Extended: Release Cadence card data shape
+├── documentation/
+│   └── score-config.ts                 # Extended: three small-weight bonus signals (semver / notes / tag-promotion)
+├── scoring/
+│   └── config-loader.ts                # Extended: new shared config values — semver regex, CalVer regex, substantive-notes floor, staleness tier cutoffs, per-signal weights
+├── metric-cards/
+│   └── view-model.ts                   # Extended: buildLensReadouts() adds a 'release-health' readout peer to community/governance
+├── recommendations/
+│   └── catalog.ts                      # Extended: 8 new entries (never-released, stale >24mo, cooling, adopt-semver, adopt-any-scheme, notes-below-floor, promote-tags; gate-suppressed when host percentile clears RECOMMENDATION_PERCENTILE_GATE)
+├── comparison/
+│   └── sections.ts                     # Extended: release-health rows diffable across repos (flat-schema compatible with P1-F06)
+└── export/
+    ├── json-export.ts                  # Extended: releaseHealthResult + completeness + preReleaseRatio
+    └── markdown-export.ts              # Extended: Release Health section mirroring Community format
+
+components/
+├── tags/
+│   └── TagPill.tsx                     # Existing — add 'release-health' variant styling (parallel to governance/community)
+├── activity/
+│   └── ReleaseCadenceCard.tsx          # NEW — renders frequency / recency / pre-release usage with the release-health pill
+├── documentation/
+│   └── ReleaseDisciplineCard.tsx       # NEW — three rows (semver / notes / tag-promotion) with the release-health pill
+└── metric-cards/
+    └── MetricCard.tsx                  # Existing — surfaces the Release Health completeness readout via buildLensReadouts() output
+
+e2e/
+└── release-health.spec.ts              # NEW — Playwright E2E covering the lens pill, both cards, and the completeness readout
+```
+
+**Structure Decision**: Single Next.js app (the existing Phase 1 structure). No new packages, no new framework boundaries — additive extensions only, in the directories the constitution already permits. `lib/release-health/` mirrors `lib/community/` so the mental model for future lenses stays consistent. The analyzer module boundary (Constitution §IV) is preserved: detection inside `lib/analyzer/` and `lib/release-health/`, scoring inside per-bucket `score-config.ts`, presentation inside `components/` and `lib/tags/`.
+
+## Complexity Tracking
+
+No violations. Section intentionally left empty.

--- a/specs/69-add-release-and-versioning-health-signal/quickstart.md
+++ b/specs/69-add-release-and-versioning-health-signal/quickstart.md
@@ -1,0 +1,75 @@
+# Quickstart: Release Health Scoring (P2-F09 / #69)
+
+One-page map for a developer picking up the implementation mid-flight.
+
+---
+
+## What ships
+
+1. A new `release-health` **presentation tag** peer to `governance` and `community`.
+2. Five scored signals: `releaseFrequency`, `daysSinceLastRelease`, `semverComplianceRatio`, `releaseNotesQualityRatio`, `tagToReleaseRatio`.
+3. One informational signal: `preReleaseRatio` (never scored).
+4. **Activity** cadence sub-factor extended to consider time-since-last-release alongside releases-per-year.
+5. **Documentation** score gains three small-weight bonuses (semver / notes / tag-promotion).
+6. A **Release Health completeness** readout on the per-repo metric card via `buildLensReadouts()` — uses linear ratio → percentile fallback until #152.
+7. **Seven recommendations** with staleness tiering and percentile-gate suppression.
+8. JSON + Markdown exports gain the signal set and the completeness readout.
+
+## What does NOT ship
+
+- Per-bracket percentile calibration for the five signals → deferred to **#152**.
+- Composite OSS Health Score weight changes → existing 25/25/23/12/15 preserved.
+- A new tab, a new composite bucket, or a new CHAOSS score.
+- Release artifact health (SBOMs, signatures) → that belongs with Security (P2-F07).
+- Historical versioning trend charts → Phase 1 is stateless.
+
+---
+
+## Directory walk (implementation order)
+
+1. `lib/analyzer/queries.ts` — additive GraphQL fields (Contract §8).
+2. `lib/analyzer/analysis-result.ts` — `ReleaseHealthResult` interface, optional field on `AnalysisResult` (Contract §1).
+3. `lib/analyzer/github-graphql.ts` — map new GraphQL response into `AnalysisResult`.
+4. `lib/release-health/semver.ts` — regexes + `detectVersioningScheme()` (Contract §4).
+5. `lib/release-health/detect.ts` — `detectReleaseHealth()` pure function (Contract §2). **TDD: unit tests first.**
+6. `lib/release-health/completeness.ts` — `computeReleaseHealthCompleteness()` (Contract §3). Mirrors `lib/community/completeness.ts`.
+7. `lib/release-health/recommendations.ts` — staleness tier + scheme detection rec generator.
+8. `lib/tags/release-health.ts` — tag registry entry (data-model §Tag registry).
+9. `lib/scoring/config-loader.ts` — add the 11 new shared-config keys (research.md R6 + Summary table).
+10. `lib/activity/score-config.ts` — split cadence sub-factor into frequency + recency (Contract §5).
+11. `lib/documentation/score-config.ts` — thread the three release-discipline bonuses (Contract §5).
+12. `lib/recommendations/catalog.ts` — seven new entries (data-model §Recommendation catalog).
+13. `lib/metric-cards/view-model.ts` — extend `buildLensReadouts()` with `release-health` (Contract §6).
+14. `lib/comparison/sections.ts` — release-health rows diffable across repos.
+15. `lib/export/json-export.ts` + `lib/export/markdown-export.ts` — add signal set (Contract §9).
+16. `components/activity/ReleaseCadenceCard.tsx` — new card (FR-017).
+17. `components/documentation/ReleaseDisciplineCard.tsx` — new card (FR-018).
+18. `components/tags/TagPill.tsx` — `release-health` variant styling.
+19. Wire cards into `ActivityView.tsx` and `DocumentationView.tsx`.
+20. `e2e/release-health.spec.ts` — lightweight DOM assertions per memory preference.
+
+---
+
+## Gotchas
+
+- **GraphQL refs denial**: if `refs(refPrefix: "refs/tags/")` returns no data, `totalTags` must be `'unavailable'` and `tagToReleaseRatio` cascades to `'unavailable'` — no REST fallback (research R3, Constitution §II).
+- **Pre-release tags are valid semver** — do not filter them out of `semverComplianceRatio` (research Q1).
+- **CalVer must suppress the semver-adoption recommendation** — check `versioningScheme !== 'calver'` in `release_adopt_semver` trigger (FR-029).
+- **At most one staleness recommendation per repo** — evaluate `never_released → stale → cooling` in order; first match wins (FR-028).
+- **`preReleaseRatio` is never a rec trigger** — FR-031.
+- **Solo-profile repos**: the existing `detectSoloProjectProfile` may hide Documentation bucket. When Documentation is hidden from the metric card, the `release-health` readout still renders (it's a lens peer, not a bucket).
+
+---
+
+## Testing rubric
+
+- **Unit (Vitest)**: `detect.ts`, `completeness.ts`, `semver.ts`, `recommendations.ts`, `score-config.ts` (activity + documentation extensions), `catalog.ts` (new entries gate-suppressed correctly).
+- **Component (Vitest + RTL)**: `ReleaseCadenceCard`, `ReleaseDisciplineCard`, `MetricCard` (lens readout), `TagPill` (release-health variant).
+- **E2E (Playwright)**: open a repository with releases, assert `release-health` pill on both cards and completeness readout on the metric card.
+- **TDD**: red → green → refactor on every unit. Constitution §XI is NON-NEGOTIABLE.
+
+---
+
+## Release sequencing
+
+This feature is one PR (Phase 2 lens pattern). `docs/DEVELOPMENT.md` flips `P2-F09` to `✅ Done` in the Phase 2 table when the PR merges.

--- a/specs/69-add-release-and-versioning-health-signal/research.md
+++ b/specs/69-add-release-and-versioning-health-signal/research.md
@@ -1,0 +1,183 @@
+# Phase 0 Research: Release Health Scoring
+
+**Feature**: P2-F09 — Release Health Scoring (issue #69)
+**Branch**: `69-add-release-and-versioning-health-signal`
+**Date**: 2026-04-17
+
+This document resolves the three open questions captured in `spec.md` and locks in additional implementation choices needed before design.
+
+---
+
+## Q1 — Semver pre-release handling
+
+**Context**: When a repository's most recent releases are mostly pre-release (`-rc`, `-beta`), should semver compliance be computed over all releases or only over stable tags?
+
+### Decision
+
+**Count all releases. Pre-release tags are valid semver per the SPEC and must not be excluded.**
+
+`semverComplianceRatio` is computed as `match_count / total_count` over the most recent 100 releases, where `match_count` counts any tag matching the full semver regex (including optional `-prerelease` and `+build` suffixes).
+
+### Rationale
+
+1. **Follow the standard.** semver.org explicitly includes pre-release identifiers as valid semver. Treating `v1.0.0-rc.1` as non-compliant would contradict the spec the signal is meant to measure.
+2. **No dual-metric proliferation.** A split "compliance" / "stable-compliance" pair would be two signals where one is load-bearing; violates §IX YAGNI.
+3. **Pre-release usage is already surfaced separately** via `preReleaseRatio` (FR-007), which is informational-only. Users who want to understand stability posture see that signal directly on the lens.
+
+### Alternatives considered
+
+- **Stable-only (option B)**: Rejected — a deliberate pre-1.0 project that religiously follows semver would get zero credit for discipline.
+- **Split into two ratios (option C)**: Rejected — two signals doing one job.
+
+---
+
+## Q2 — Release-notes substantive threshold
+
+**Context**: Below what body length does a release count as "non-substantive" for `releaseNotesQualityRatio`?
+
+### Decision
+
+**Configurable floor, defaulting to ≥ 40 characters (roughly one sentence), stored in shared scoring config as `RELEASE_NOTES_SUBSTANTIVE_FLOOR`.**
+
+A body is substantive when its trimmed length is `>= RELEASE_NOTES_SUBSTANTIVE_FLOOR`. `null` and whitespace-only bodies count as non-substantive.
+
+### Rationale
+
+1. **Simple, auditable, config-driven.** Satisfies FR-006 and Constitution §VI. The default can be tuned during #152 calibration.
+2. **40 characters is empirically permissive.** Even a one-line "Fix regression in login flow when the user has no avatar." clears 40 chars — this is a ceiling against empty / "minor fixes" bodies, not a quality judgment.
+3. **Content-aware detection rejected for now.** Detecting bullet lists / headings / links is richer but adds regex complexity and false-positive risk (e.g., a one-word release with a single link). If #152 calibration reveals the simple threshold is too blunt, upgrade then.
+
+### Alternatives considered
+
+- **≥ 120 characters**: Rejected — too strict; penalizes legitimate one-sentence patch notes.
+- **Content-aware**: Deferred per YAGNI. Ready to revisit post-#152 if data shows the floor is noisy.
+
+---
+
+## Q3 — tag-to-release ratio when tag count is unavailable
+
+**Context**: If a repository has GitHub releases but the GraphQL `refs(refPrefix: "refs/tags/")` totalCount is not returned, should `tagToReleaseRatio` be `unavailable` or inferred?
+
+### Decision
+
+**`unavailable`. No inference.**
+
+When `totalTags` cannot be read from GraphQL, `tagToReleaseRatio` is emitted as the literal `"unavailable"` value on `releaseHealthResult`. No REST fallback is introduced.
+
+### Rationale
+
+1. **Constitution §II.2 and §II.3.** "No estimation, interpolation, inference, or fabrication — ever. Missing data is a first-class outcome." Inferring `0` when tags are unreadable would violate this.
+2. **Minimal surface area.** A REST fallback doubles the auth path and contract surface for one signal that is already best-effort (tag-to-release promotion is a Documentation bonus, not a primary score).
+3. **Real-world impact is small.** The refs query denial scenario is rare on public repos; when it happens, the Documentation score is computed exactly as today and the user sees the row as `"unavailable"` with no confidence loss.
+
+### Alternatives considered
+
+- **Infer `0`**: Rejected on §II grounds.
+- **REST fallback to `/tags`**: Rejected on YAGNI + surface-area grounds. Revisitable if calibration data shows GraphQL denials are frequent enough to matter.
+
+---
+
+## Additional implementation decisions (not in spec Open Questions)
+
+### R4 — Staleness tier cutoffs
+
+**Decision**: Three tiers, all values in shared config:
+
+- **Never released**: `releaseHealthResult.releaseFrequency === 'unavailable'` AND `totalReleasesEver === 0`
+- **Stale** (`STALE_RELEASE_CUTOFF_DAYS`, default 730): `daysSinceLastRelease >= 730`
+- **Cooling** (`COOLING_RELEASE_CUTOFF_DAYS`, default 365, AND has commits in last 90 days): `365 <= daysSinceLastRelease < 730` AND `commits90d > 0`
+
+The three tiers are mutually exclusive — FR-028 guarantees at most one staleness recommendation per repo. The recommendation engine evaluates in the order above and emits only the first match.
+
+### R5 — Versioning scheme detection
+
+**Decision**: Two regex matchers in `lib/release-health/semver.ts`:
+
+- `SEMVER_REGEX` — accepts `v?<MAJOR>.<MINOR>.<PATCH>(-<pre>)?(\+<build>)?` per semver.org.
+- `CALVER_REGEX` — accepts common CalVer shapes (`YYYY.MM.DD`, `YYYY.MM`, `YY.MM.MICRO`, `YYYY-MM-DD`).
+
+For a given release's tag name:
+
+- If `SEMVER_REGEX` matches → semver-compliant.
+- Else if `CALVER_REGEX` matches → CalVer (suppresses the "adopt semver" recommendation per FR-029).
+- Else → unrecognized scheme ("adopt *a* versioning scheme" recommendation).
+
+Recommendation trigger (FR-029): if `semverComplianceRatio < SEMVER_ADOPTION_THRESHOLD` (default 0.5) **and** CalVer is not the dominant scheme → emit "adopt semver"; else if neither semver nor CalVer dominates → emit "adopt *a* scheme".
+
+### R6 — Per-signal weights in host buckets
+
+**Decision**: Small fixed weights, conservative — matches the pattern shipped for Community (P2-F05):
+
+- **Activity `cadence` sub-factor** (currently 20% of Activity): split into `releasesPerYear` (existing, 12%) + `daysSinceLastRelease` (new, 8%). Weights documented in `lib/activity/score-config.ts`.
+- **Documentation bonuses**:
+  - `semverComplianceRatio`: +0.03 bonus multiplier on the Documentation percentile
+  - `releaseNotesQualityRatio`: +0.02
+  - `tagToReleaseRatio` (inverted): +0.02 when orphan ratio ≤ 0.3, 0 otherwise (bounded — never negative)
+
+Total Documentation score shift is bounded at ~+7 percentile points for a release-health-rich repo and 0 for a release-health-poor repo. Matches SC-009's ~5-percentile guidance within noise.
+
+Weights are shared-config values, read (not hardcoded) by `score-config.ts`. Tunable during #152 calibration.
+
+### R7 — Completeness readout fallback
+
+**Decision**: Linear ratio → percentile mapping, identical to the shipped Community implementation in `lib/community/completeness.ts`:
+
+```ts
+const ratio = present.length / (present.length + missing.length)
+const percentile = Math.max(0, Math.min(99, Math.round(ratio * 99)))
+```
+
+When all five scored signals are `unavailable` (e.g., zero releases), `percentile === null` and the readout renders `"Insufficient verified public data"` (FR-020).
+
+Signals that are per-field `unavailable` (e.g., `tagToReleaseRatio` when refs denied) are classified as `unknown` and excluded from both numerator and denominator (FR-021).
+
+### R8 — GraphQL field selection
+
+**Decision**: Extend `REPO_COMMIT_AND_RELEASES_QUERY` in `lib/analyzer/queries.ts` additively:
+
+```graphql
+releases(first: 100, orderBy: { field: CREATED_AT, direction: DESC }) {
+  totalCount        # NEW
+  nodes {
+    tagName         # NEW
+    name            # NEW (human-readable release title, used for fallback notes detection)
+    body            # NEW
+    isPrerelease    # NEW
+    createdAt
+    publishedAt     # kept — already present
+  }
+}
+refs(refPrefix: "refs/tags/", first: 0) {   # NEW — totalCount only
+  totalCount
+}
+```
+
+No new query pass. Per-repo GraphQL request count stays within 1–3 (Constitution §III.2, SC-003).
+
+### R9 — Recommendation percentile gate
+
+**Decision**: Release-health recommendations flow through the existing `RECOMMENDATION_PERCENTILE_GATE` (currently imported in `lib/scoring/health-score.ts`). A release-health recommendation is suppressed when the host bucket's percentile for this repo already clears the gate. Same pattern Documentation, Security, and Community recommendations already use.
+
+Implementation lives in `lib/release-health/recommendations.ts` — a pure function consuming the bucket percentile + the release-health signal state and returning either a `HealthScoreRecommendation[]` or `[]`.
+
+---
+
+## Summary of configuration values added
+
+All in shared scoring config (Constitution §VI):
+
+| Key | Default | Purpose |
+|---|---|---|
+| `SEMVER_REGEX` | semver.org spec | Matches semver-compliant tag names |
+| `CALVER_REGEX` | common CalVer shapes | Suppresses inappropriate semver recommendation |
+| `RELEASE_NOTES_SUBSTANTIVE_FLOOR` | 40 | Minimum body length for a substantive release note |
+| `STALE_RELEASE_CUTOFF_DAYS` | 730 | Days since last release qualifying as "stale" |
+| `COOLING_RELEASE_CUTOFF_DAYS` | 365 | Days since last release qualifying as "cooling" |
+| `SEMVER_ADOPTION_THRESHOLD` | 0.5 | Compliance ratio below which the semver-adoption rec fires |
+| `ACTIVITY_CADENCE_FREQUENCY_WEIGHT` | 0.12 | Weight of `releasesPerYear` inside the Activity cadence sub-factor |
+| `ACTIVITY_CADENCE_RECENCY_WEIGHT` | 0.08 | Weight of `daysSinceLastRelease` inside the Activity cadence sub-factor |
+| `DOCUMENTATION_SEMVER_BONUS` | 0.03 | Documentation percentile bonus for semver compliance |
+| `DOCUMENTATION_NOTES_BONUS` | 0.02 | Documentation percentile bonus for substantive notes |
+| `DOCUMENTATION_TAG_PROMOTION_BONUS` | 0.02 | Documentation percentile bonus when orphan tag ratio ≤ 0.3 |
+
+No calibration payload changes — per-bracket percentiles for the five numeric signals are deferred to #152.

--- a/specs/69-add-release-and-versioning-health-signal/spec.md
+++ b/specs/69-add-release-and-versioning-health-signal/spec.md
@@ -1,0 +1,233 @@
+# Feature Specification: Release Health Scoring
+
+**Feature Branch**: `69-add-release-and-versioning-health-signal`
+**Created**: 2026-04-16
+**Status**: Draft
+**Input**: GitHub issue [#69](https://github.com/arun-gupta/repo-pulse/issues/69) — "Add release and versioning health signals"
+**Phase 2 Feature**: P2-F09
+
+## Overview
+
+Release cadence and versioning discipline are observable proxies for project maturity: a repository that ships regularly under a recognizable versioning scheme with informative notes gives adopters confidence that upgrades are safe, changes are communicated, and the maintainer pipeline is alive. Today RepoPulse already captures a raw 12-month release count (`releases12mo`) and a release-cadence sub-factor inside the Activity score, but it does not surface any of the following: whether release tags follow semantic versioning, whether releases carry substantive notes, whether pre-release channels are in use, how long it has been since the last release, or how many git tags never got promoted to a GitHub release.
+
+This feature adds Release Health as a **lens-style signal set** layered over existing scored buckets, following the Governance (P2-F04, #116) and Community (P2-F05, #70) precedent. Each release signal is scored in exactly one existing bucket — release frequency and recency stay in Activity (where cadence already lives), and semver compliance, release-notes quality, and tag-to-release promotion feed Documentation (where versioning-discipline communication belongs). A derived **Release Health completeness** readout is surfaced on the per-repo metric card (alongside the existing Governance and Community lens readouts rendered by `buildLensReadouts()`), summarizing how many release-health signals are present. Percentile brackets for the new numeric signals are **deferred to the calibration refresh tracked in #152** — this feature uses a linear ratio → percentile fallback for the completeness readout, matching the pattern shipped by Community (P2-F05).
+
+### Why a lens, not a new composite bucket
+
+The composite OSS Health Score already weights Activity 25%, Responsiveness 25%, Sustainability 23%, Documentation 12%, Security 15%. Activity already includes a `20%` release-cadence sub-factor (see P1-F08 in PRODUCT.md, `lib/activity/score-config.ts`). Adding a new weighted "Release Health" bucket would either double-count that sub-factor or force a rebalance that destabilizes shipped scores. The lens pattern — detect + tag + feed existing buckets + surface a derived completeness readout — matches how Governance and Community shipped and preserves current composite weights.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Release health signals detected and visible with a `release-health` pill (Priority: P1)
+
+A maintainer reviewing their repository in RepoPulse can see which items across the Activity and Documentation tabs are release-health signals. A "release-health" pill is attached to the relevant rows and cards, mirroring the existing `governance` and `community` pills.
+
+**Why this priority**: The lens is the primary deliverable. Without detection and tagging, users cannot trace release-health signals back to the scorecard, and downstream scoring contributions have nothing to render.
+
+**Independent Test**: Open a repository report for a project with active releases (e.g., `facebook/react`) and a project without any releases (e.g., a small personal repo). Visit the Activity and Documentation tabs and confirm that release-health rows display a `release-health` pill and that hovering or clicking the pill surfaces a label or tooltip containing the literal text "Release Health" (parallel to the disclosure behavior shipped for the governance and community pills).
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with recent GitHub releases, **When** the user views the Activity tab, **Then** a Release Cadence card shows release frequency, time since last release, and pre-release usage, each carrying a `release-health` pill.
+2. **Given** a repository whose release tags match `v?MAJOR.MINOR.PATCH[-prerelease]`, **When** the user views the Documentation tab, **Then** a "Semver compliance" row shows the compliant ratio and carries a `release-health` pill.
+3. **Given** a repository with many git tags and far fewer GitHub releases, **When** the user views the Documentation tab, **Then** a "Tag-to-release promotion" row shows the ratio and carries a `release-health` pill.
+4. **Given** a repository with empty release bodies, **When** the user views the Documentation tab, **Then** a "Release notes quality" row shows the share of releases with substantive notes and carries a `release-health` pill.
+5. **Given** a repository with zero releases, **When** the user views Activity and Documentation tabs, **Then** each release-health row renders the literal string `"unavailable"` at the field level (and the scorecard Release Health completeness readout renders `"Insufficient verified public data"` per Constitution §II) — never zeroed, never hidden.
+
+---
+
+### User Story 2 — Release-health signals feed their host buckets (Priority: P1)
+
+Detected signals contribute modestly to their host bucket's score. Per-bracket percentile calibration for the new numeric signals is deferred to the recalibration tracked in #152; until that lands, signals use the same linear ratio → percentile fallback Community (P2-F05) shipped with.
+
+**Why this priority**: Detection is prerequisite for scoring, and the scoring contribution is what makes these signals matter to the composite.
+
+**Independent Test**: Analyze two repositories — one with a strong release-health posture (frequent releases, strict semver, rich notes, few orphan tags) and one with none — and confirm the Activity and Documentation bucket scores of the strong repo are monotonically higher, and that the completeness readout ratio on the strong repo is higher than on the weak one.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Activity scoring config, **When** a repository with releases in the last 90 days is scored, **Then** the existing `cadence` sub-factor is extended (not duplicated) to consider "time since last release" in addition to "releases per year".
+2. **Given** the Documentation scoring config, **When** a repository with semver-compliant tags and populated release bodies is scored, **Then** three net-new per-signal bonuses apply (semver compliance ratio, release-notes quality, tag-to-release promotion) at weights deliberately small enough that no shipped repo score shifts by more than ~5 percentile points in aggregate.
+3. **Given** a repository with zero releases (legitimate absence), **When** the analyzer runs, **Then** `releaseHealthResult` is emitted but frequency / recency / semver / notes / promotion fields are each reported as `unavailable`, and the Activity / Documentation bucket scores are computed exactly as they are today (no penalty relative to pre-feature baseline beyond the calibrated absence of a bonus).
+4. **Given** a repository whose release tags include both release and pre-release markers (`v1.2.0`, `v1.3.0-rc.1`), **When** the analyzer runs, **Then** pre-release usage is captured as a boolean signal and does not negatively influence semver compliance (pre-release tags are valid semver per SPEC).
+
+---
+
+### User Story 3 — Release Health completeness readout on the per-repo metric card (Priority: P2)
+
+The per-repo metric card surfaces a "Release Health completeness" readout — count / linear-ratio percentile of release-health signals present — rendered via `buildLensReadouts()` alongside the existing Governance and Community lens readouts. This satisfies #69's acceptance criteria for "release frequency percentile ranking" and "time since last release with percentile context" without adding a sixth composite bucket. Per-bracket calibrated percentiles for the underlying signals are tracked in #152 and not in scope here.
+
+**Why this priority**: The readout gives users a single glanceable release-health number on the same metric card where Governance and Community already live, but the lens + host-bucket scoring from Stories 1–2 are the load-bearing parts. The readout is derived from them.
+
+**Independent Test**: Analyze repositories with varying release-health postures and confirm the completeness readout ranks them monotonically (more / healthier signals → higher ratio and percentile) using the linear fallback, and confirm the readout renders peer-positioned alongside the shipped Community and Governance lens readouts on the metric card.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with all release-health signals present (frequent releases, recent release, semver-compliant tags, substantive notes, no orphan tags), **When** the user views the per-repo metric card, **Then** Release Health completeness appears with ratio `1.0` and a percentile label in the top quartile under the linear fallback.
+2. **Given** a repository with no releases at all, **When** the user views the per-repo metric card, **Then** Release Health completeness appears as `Insufficient verified public data` (not a score of zero).
+3. **Given** a repository with a moderate release-health posture (some releases, mixed semver, some orphan tags), **When** the user views the per-repo metric card, **Then** Release Health completeness appears in the middle of the ratio range and its constituent signals are each shown as raw ratios or durations in the Activity / Documentation tabs (percentile labels for individual signals deferred to #152).
+4. **Given** the methodology / baseline page, **When** the user reads the Release Health section, **Then** it explains that Release Health is a lens (not a composite-weighted bucket), lists which signals are scored in which host bucket, describes the completeness denominator, and notes that per-bracket calibration is tracked in #152.
+
+---
+
+### User Story 4 — Actionable recommendations for missing release-health signals (Priority: P3)
+
+A maintainer whose repository lacks release-health signals sees recommendations pointing them at specific gaps, routed through the existing recommendations surface under the appropriate host bucket (cadence recs under Activity; semver / notes / tag-promotion recs under Documentation).
+
+**Why this priority**: Recommendations enhance the feature but are not required for scoring or visibility. They mirror the Documentation / Security / Community recommendation rollout pattern already shipped.
+
+**Independent Test**: Analyze a repository missing several release-health signals and confirm recommendations list the gaps with actionable guidance under their host buckets.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository that has never cut a GitHub release, **When** the user views recommendations, **Then** an Activity-bucket recommendation suggests cutting a first release, worded for the "never released" case.
+2. **Given** a repository whose most recent release is more than 24 months old, **When** the user views recommendations, **Then** an Activity-bucket recommendation calls the project stale and suggests either cutting a maintenance release or marking the repository archived.
+3. **Given** a repository with no release in the last 12 months but with commits inside the last 90 days, **When** the user views recommendations, **Then** an Activity-bucket recommendation suggests cutting a release to reflect the in-flight work (distinct wording from scenarios 1 and 2).
+4. **Given** a repository whose release tags mostly fail semver and no alternative scheme (such as CalVer) is detected, **When** the user views recommendations, **Then** a Documentation-bucket recommendation suggests adopting semantic versioning.
+5. **Given** a repository whose tag names match neither semver nor any other recognized scheme (e.g., bot-generated or ad-hoc strings), **When** the user views recommendations, **Then** a Documentation-bucket recommendation suggests adopting *a* versioning scheme (not specifically semver), consistent with the "date-tagged mirror projects" edge case.
+6. **Given** a repository whose release tags match a recognized alternative scheme such as CalVer, **When** the user views recommendations, **Then** no semver-adoption recommendation fires (the CalVer edge case suppresses it).
+7. **Given** a repository whose `releaseNotesQualityRatio` is below the configured "substantive notes" floor — not only when every body is empty — **When** the user views recommendations, **Then** a Documentation-bucket recommendation suggests improving release-note depth for subsequent releases.
+8. **Given** a repository with many more git tags than GitHub releases, **When** the user views recommendations, **Then** a Documentation-bucket recommendation suggests promoting tags to releases.
+9. **Given** a repository whose release-health signals already sit above the existing `RECOMMENDATION_PERCENTILE_GATE` on their host bucket, **When** the user views recommendations, **Then** release-health recommendations are suppressed for those signals — matching the suppression pattern shipped for Documentation, Security, and Community recs.
+10. **Given** a repository whose releases are entirely pre-release (`-alpha` / `-beta` / `-rc`), **When** the user views recommendations, **Then** no recommendation fires on `preReleaseRatio` alone — consistent with FR-012, which keeps pre-release usage informational.
+
+---
+
+### Edge Cases
+
+- **Zero releases**: `releaseHealthResult` fields are all `unavailable`; the completeness readout reports `Insufficient verified public data`. Host-bucket scores are unchanged relative to pre-feature baseline for this case.
+- **Exactly one release**: Release frequency is `unavailable` (cannot compute a cadence from one data point); `daysSinceLastRelease` is computed. Semver / notes / pre-release are computed from that single release.
+- **Tag-only project (git tags, no GitHub releases)**: `tagToReleaseRatio` is explicitly large; the Documentation-bucket `release-health` signals are scored from tag names (for semver) but release-notes quality is `unavailable`.
+- **Calendar versioning (CalVer)**: Projects using schemes like `2026.04.16` or `24.04.0` are detected as non-semver but flagged distinctly in the Documentation tab row so the maintainer recommendation does not inappropriately push them toward semver when a valid alternative is in use. CalVer projects are not penalized by the "semver compliance" contribution beyond the absence of a positive signal.
+- **Date-tagged mirror projects** where tags are created by bots without any coherent scheme: scored as non-semver, non-calver; recommendation surface suggests adopting a versioning scheme.
+- **Pre-release-only projects** (e.g., all releases are `-alpha` / `-beta`): pre-release usage signal is `true`, semver compliance is computed normally (pre-release tags are valid semver), notes quality is computed normally.
+- **Release created from a tag without a release body**: counted as a release for frequency/recency; release-notes quality treats empty body as "insubstantive".
+- **Very high release volume** (>100 releases in the recent window): semver / notes analysis uses a bounded sample of recent releases (e.g., last 100) — no unbounded pagination.
+- **Privately published releases**: not visible via the public GraphQL API; surface as `unavailable`, no inference.
+- **Score shift on existing repositories**: Net-new Documentation contributions introduce a small, one-time score shift. Acceptable because analyses are stateless (no stored historical scores to reconcile). Absolute shift per repo is bounded by the modest per-signal weights (User Story 2, AC 2).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Detection (net-new signals)
+
+- **FR-001**: The analyzer MUST obtain, via additive field selection on an existing GraphQL pass (no new network round-trip), the following per-release fields for up to the 100 most recent releases: tag name, created-at and published-at timestamps, body text, and `isPrerelease` flag. Any additional GraphQL cost introduced by this feature MUST stay within the existing 1–3-request-per-repo budget (Constitution §III.2).
+- **FR-002**: The analyzer MUST fetch git tag count via the existing GraphQL repository payload (`refs(refPrefix: "refs/tags/")` totalCount) so tag-to-release ratio can be computed. This is an additive field on an existing query, not a new network round-trip.
+- **FR-003**: The analyzer MUST compute `releaseFrequency` (releases per year, derived from the 12-month rolling window that already feeds `releases12mo`). When the repository has fewer than two releases ever, the value MUST be `unavailable`.
+- **FR-004**: The analyzer MUST compute `daysSinceLastRelease` from the most recent release's `publishedAt` (falling back to `createdAt` when `publishedAt` is null). When there are zero releases, the value MUST be `unavailable`.
+- **FR-005**: The analyzer MUST compute `semverComplianceRatio` as the share of the most recent 100 releases whose tag names match the semver regex pattern defined in shared config (accepting an optional leading `v` and optional pre-release / build-metadata suffixes, per https://semver.org ).
+- **FR-006**: The analyzer MUST compute `releaseNotesQualityRatio` as the share of the most recent 100 releases whose body text exceeds a configurable minimum character threshold (default in shared config, not hardcoded). Releases with null or whitespace-only bodies are counted as non-substantive.
+- **FR-007**: The analyzer MUST compute `preReleaseRatio` as the share of the most recent 100 releases with `isPrerelease === true`. This signal is informational; it is reported on the lens but does not contribute to any host-bucket score on its own.
+- **FR-008**: The analyzer MUST compute `tagToReleaseRatio` as `max(0, totalTags - totalReleases) / max(1, totalTags)` — expressed as the share of tags that never became a release. When `totalTags` cannot be fetched, the ratio MUST be `unavailable`.
+- **FR-009**: The analyzer MUST emit a top-level `releaseHealthResult` on `AnalysisResult` (or `'unavailable'` when releases cannot be retrieved at all), shaped consistently with `licensingResult`, `securityResult`, and the existing community signal set — flat enough to diff across repos without transformation (Constitution §IX.5).
+
+#### Scoring contributions to host buckets
+
+- **FR-010**: The Activity scoring config MUST extend the existing `cadence` sub-factor (see P1-F08) to consider `daysSinceLastRelease` alongside the existing `releases12mo`-based cadence input. Weights MUST be defined in shared config and read by logic (Constitution §VI). The overall Activity composite weight inside the OSS Health Score MUST remain 25% (no re-weighting).
+- **FR-011**: The Documentation scoring config MUST introduce three net-new small-weight bonus inputs: `semverComplianceRatio`, `releaseNotesQualityRatio`, and `tagToReleaseRatio` (inverse — higher orphan-tag share → lower contribution). Per-signal weights MUST be small and defined in shared config so that documentation scores for existing repositories do not shift by more than ~5 percentile points in aggregate at calibration refresh.
+- **FR-012**: Pre-release usage (`preReleaseRatio`) MUST NOT be scored into any host bucket on its own. It is surfaced as a pill on the lens and used only as informational context in recommendations.
+- **FR-013**: No release-health signal may be scored in more than one bucket. Specifically, `releaseFrequency` / `daysSinceLastRelease` live in Activity only; `semverComplianceRatio` / `releaseNotesQualityRatio` / `tagToReleaseRatio` live in Documentation only.
+- **FR-014**: The existing composite OSS Health Score weights (Activity 25%, Responsiveness 25%, Sustainability 23%, Documentation 12%, Security 15%) MUST remain unchanged.
+
+#### Lens (visibility)
+
+- **FR-015**: The system MUST define a `release-health` presentation tag peer to the existing `governance` and `community` tags, and apply it to release-health-relevant rows / cards on the Activity and Documentation tabs.
+- **FR-016**: A row tagged with both `release-health` and another lens (e.g., CHANGELOG.md is already tagged under Documentation — co-occurrence with `release-health` is expected) MUST display all applicable pills cleanly.
+- **FR-017**: The Activity tab MUST surface a Release Cadence card showing: releases per year, time since last release, and pre-release usage state. Each metric MUST show its raw value (or `"unavailable"`) at ship time; per-signal percentile labels are deferred to #152. The card MUST carry the `release-health` pill.
+- **FR-018**: The Documentation tab MUST surface a Release Discipline card with three rows — Semver compliance ratio, Release notes quality ratio, Tag-to-release promotion ratio — each carrying the `release-health` pill, each showing its raw ratio (or `"unavailable"`). Per-signal percentile labels are deferred to #152.
+
+#### Completeness readout
+
+- **FR-019**: The per-repo metric card MUST display a "Release Health completeness" readout via `buildLensReadouts()` — a count (signals detected / total) and percentile rank derived from a **linear ratio → percentile fallback** (matching the fallback shipped by Community P2-F05 until #152 lands), computed from the five scored release-health signals (release frequency, time since last release, semver compliance, release-notes quality, tag-to-release promotion). This readout MUST NOT be added to the composite OSS Health Score as a weighted bucket.
+- **FR-020**: When every release-health signal is `unavailable` (e.g., repository has zero releases), the completeness readout MUST render as `Insufficient verified public data` — not as a percentile of zero (Constitution §II.5).
+- **FR-021**: When a subset of signals is `unavailable`, those signals MUST be excluded from the completeness calculation (treated as "unknown", not "missing").
+
+#### Calibration (deferred to #152)
+
+- **FR-022**: Per-bracket percentile calibration data for the five new release-health signals (`releaseFrequency`, `daysSinceLastRelease`, `semverComplianceRatio`, `releaseNotesQualityRatio`, `tagToReleaseRatio`) is **out of scope for this feature** and is tracked in issue #152 ("Re-run calibration to include licensing, compliance, inclusive naming, and security signals"). This feature MUST NOT add placeholder or partial percentile entries to the calibration payload.
+- **FR-023**: The config-loader and UI MUST render Release Health percentile labels via the same pattern Community shipped: **linear ratio → percentile fallback for the completeness readout**, and "Insufficient verified public data" or the raw value for per-signal rows until #152 adds calibrated brackets.
+
+#### Methodology and exports
+
+- **FR-024**: The methodology / baseline page MUST describe Release Health as a lens, list the five scored signals and their host scoring buckets, explain the completeness denominator, and explicitly note that Release Health is not an independent composite bucket.
+- **FR-025**: The export feature (P1-F13) MUST include the release-health signal detections, the host-bucket contributions, and the Release Health completeness readout in both JSON and Markdown exports — consistent with how Security, Licensing, Inclusive Naming, and Community were added to exports.
+- **FR-026**: Recommendations for missing release-health signals MUST be generated via the existing per-bucket recommendation catalog, attached to the signal's host bucket (cadence / recency → Activity recs, semver / notes / tag-promotion → Documentation recs).
+- **FR-027**: Release-health recommendations MUST flow through the existing `RECOMMENDATION_PERCENTILE_GATE` so that recommendations are suppressed for any signal whose host-bucket percentile already clears the gate, matching the suppression behavior shipped for Documentation, Security, and Community recommendations.
+- **FR-028**: Recommendation triggers MUST differentiate the three staleness tiers — "never released", "stale (>24 months since last release)", and "no release in last 12 months with recent commits" — and emit distinct, tier-appropriate wording. A repository MUST never receive more than one staleness recommendation at a time.
+- **FR-029**: The semver-adoption recommendation MUST be suppressed when a recognized alternative versioning scheme (e.g., CalVer) is detected. When tag names match neither semver nor any other recognized scheme, the recommendation MUST instead suggest adopting *a* versioning scheme rather than specifically semver.
+- **FR-030**: The release-notes recommendation trigger MUST be driven by the `releaseNotesQualityRatio` signal falling below a configurable "substantive notes" floor (default in shared config), not only by the narrow "every body is empty" case.
+- **FR-031**: No recommendation MUST fire on `preReleaseRatio` alone — consistent with FR-012's informational-only treatment of pre-release usage.
+
+### Key Entities
+
+- **Release-health tag**: A presentation-layer tag, peer to the existing `governance` and `community` tags. Applied to rows / cards on the Activity and Documentation tabs. Does not alter scoring.
+- **ReleaseHealthResult**: New `AnalysisResult` field holding the five computed ratios / durations / counts plus `preReleaseRatio`, `totalReleasesAnalyzed`, and `totalTags`. Emitted as `'unavailable'` when releases cannot be retrieved at all; per-field `'unavailable'` is used for individual signals that cannot be computed.
+- **Release**: Already present in the GraphQL payload — this feature extends field selection to include `tagName`, `body`, and `isPrerelease`.
+- **ReleaseHealthCompleteness**: Derived summary (count of release-health signals detected / five, expressed as a linear-fallback percentile until #152 lands). Displayed on the per-repo metric card via `buildLensReadouts()`, peer to the Governance and Community lens readouts; not a weighted composite input.
+- **Semver pattern**: Regex stored in shared scoring config, defining acceptance (leading `v?`, MAJOR.MINOR.PATCH, optional pre-release suffix, optional build metadata), per https://semver.org .
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every repository analysis with at least one GitHub release surfaces a Release Cadence card on the Activity tab and a Release Discipline card on the Documentation tab; each detected signal carries a `release-health` pill.
+- **SC-002**: The composite OSS Health Score weights (Activity 25%, Responsiveness 25%, Sustainability 23%, Documentation 12%, Security 15%) are unchanged after this feature ships. No new composite bucket is introduced.
+- **SC-003**: No additional GraphQL round-trip is required per repository. Release-health data is fetched through additive field selection on existing passes; per-repo request count remains within 1–3 (Constitution §III.2).
+- **SC-004**: For a repository gaining release-health signals (e.g., a maintainer cuts a release, adds notes, and adopts semver), its Activity and Documentation bucket scores each increase monotonically (or stay flat) — no regression.
+- **SC-005**: Release Health completeness readout appears on the per-repo metric card, peer to the Community and Governance lens readouts, and ranks a release-health-rich repository's ratio higher than a release-health-poor repository's under the linear fallback; a repository with zero releases is reported as `Insufficient verified public data`.
+- **SC-006**: The methodology / baseline page describes Release Health as a lens with host-bucket scoring; no user-facing wording implies a "Release Health bucket weight" in the composite; and the page notes that per-bracket calibration is tracked in #152.
+- **SC-007**: No new percentile entries are added to the shared calibration payload by this feature — per-bracket calibration for the five release-health signals remains the responsibility of #152. A comment on issue #152 lists the five Release Health signal names so the recalibration work explicitly covers them.
+- **SC-008**: Exports (JSON and Markdown) include all five signals, the completeness readout, and the `preReleaseRatio` informational indicator — structurally parallel to how Community signals are exported.
+- **SC-009**: For a representative sample of pre-existing analyses, introducing this feature shifts Activity and Documentation bucket scores by at most ~5 percentile points in aggregate.
+- **SC-010**: Semver compliance detection correctly classifies at least 95% of a manually reviewed calibration sample of `v?MAJOR.MINOR.PATCH[-pre][+build]` tag names (standard semver), including pre-release and build-metadata variants.
+
+## Assumptions
+
+- **Lens model, not a new composite bucket**: Chosen explicitly — matches the shipped Governance and Community patterns and preserves composite weights that are already load-bearing in the solo vs. community profile logic.
+- **Signal-to-bucket mapping**:
+  - Activity — `releaseFrequency`, `daysSinceLastRelease` (already where cadence lives).
+  - Documentation — `semverComplianceRatio`, `releaseNotesQualityRatio`, `tagToReleaseRatio` (these are communication-discipline signals about versioning, which belong with other Documentation signals).
+- **`preReleaseRatio` is informational only**: it appears on the lens and in exports, but does not adjust any score directly. Pre-release channel usage is neither inherently good nor bad.
+- **Bounded sampling**: The analyzer inspects up to the 100 most recent releases for semver / notes / pre-release computations — the same window already loaded by `REPO_COMMIT_AND_RELEASES_QUERY`. No unbounded pagination.
+- **Calendar versioning is not semver, but is not penalized**: CalVer repos get no semver compliance bonus but also do not trigger an inappropriate "adopt semver" recommendation — the recommendation logic checks for a detectable non-semver scheme before suggesting semver adoption.
+- **Small per-signal weights**: Documentation bonuses and the Activity cadence extension are sized to keep absolute score shifts modest on the calibrated sample (~5 percentile points in aggregate). Exact weights are tuned at implementation time.
+- **Per-bracket percentile calibration is deferred to #152**: this feature does not extend the shared calibration payload. The completeness readout uses a linear ratio → percentile fallback until #152 lands — matching the fallback shipped with Community (P2-F05).
+- **Stateless analyses**: No historical scores to reconcile when host-bucket inputs expand. Consistent with every prior scoring extension.
+
+## Dependencies
+
+- Governance lens (P2-F04, #116) and Community lens (P2-F05, #70) — shipped. Release Health follows the same tag + lens pattern (`lib/tags/`).
+- Activity scoring (`lib/activity/score-config.ts`) — extended to include `daysSinceLastRelease` in the cadence sub-factor.
+- Documentation scoring (`lib/documentation/score-config.ts`) — extended to include three net-new small-weight release-discipline bonuses.
+- Calibration refresh (#152) — downstream consumer. The five new release-health signal names are communicated on #152 so the recalibration covers them; this feature does not modify the calibration payload itself.
+- Export (P1-F13) — extended to include release-health signals and completeness, mirroring the Community rollout.
+- Recommendations catalog (`lib/recommendations/catalog.ts`) — extended with release-health recommendations under Activity and Documentation.
+- Shared GraphQL query (`lib/analyzer/queries.ts`) — field selection on the `releases` node and addition of tag `totalCount`. No new query pass is introduced.
+
+## Out of Scope
+
+- A new composite bucket for Release Health (explicitly rejected — lens model chosen).
+- Per-bracket percentile calibration for the five new release-health signals — deferred to issue #152.
+- Re-weighting the existing composite OSS Health Score (handled by a separate calibration refresh if ever required).
+- Deep release-notes analysis beyond "substantive length" (e.g., Keep a Changelog conformance, Conventional Commits alignment, changelog-linking). Content quality signals beyond length are a future extension.
+- Verifying that release artifacts exist (binaries, SBOMs, signatures) — out of scope here; release artifact health belongs with Security (P2-F07).
+- Cross-ecosystem version discovery (npm, PyPI, crates.io) — Phase 1–2 is GitHub-only.
+- Historical versioning-quality trending over time (no stored history per Constitution §I Phase 1 stateless rule).
+
+## Open Questions
+
+Questions do not block spec approval — they are resolved during `/speckit.clarify` or at implementation time.
+
+1. **Q1 (semver pre-release handling)**: When a repository's most recent releases are mostly pre-release (`-rc`, `-beta`), should the semver compliance score be computed over all releases or only over non-pre-release tags? Candidates:
+   - A: All releases — pre-release tags are valid semver, count them.
+   - B: Non-pre-release only — a project that has not yet cut a stable release is not meaningfully demonstrating versioning discipline.
+   - C: Split — surface two ratios ("semver compliance" and "stable-release compliance") and score only the first.
+2. **Q2 (release-notes quality threshold)**: What minimum body length qualifies a release as having "substantive notes"? Candidates:
+   - A: ≥ 40 characters (roughly one sentence).
+   - B: ≥ 120 characters (roughly one short paragraph).
+   - C: Content-aware — accept any body that contains a bullet list, heading, or link, regardless of length.
+3. **Q3 (tag-to-release ratio interpretation when tags are missing)**: If a repository has GitHub releases but the GraphQL tag `totalCount` is unavailable (e.g., refs query denied), should `tagToReleaseRatio` be `unavailable` or inferred as `0` (no orphan tags)? Candidates:
+   - A: `unavailable` — cannot verify.
+   - B: `0` — if we can see releases, we can see at least their tags, so worst case is parity.
+   - C: Feature-detect and fall back to a lightweight REST `/tags` call only when GraphQL denies the refs query.

--- a/specs/69-add-release-and-versioning-health-signal/tasks.md
+++ b/specs/69-add-release-and-versioning-health-signal/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Release Health Scoring
+
+**Feature**: P2-F09 — Release Health Scoring (issue #69)
+**Branch**: `69-add-release-and-versioning-health-signal`
+**Inputs**: `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/release-health-scoring.md`, `quickstart.md`
+
+Tests-first per Constitution §XI (NON-NEGOTIABLE): for every new unit, write the failing test before the implementation.
+
+**Conventions**:
+- `[P]` — safe to run in parallel with other `[P]` tasks in the same phase (different files, no shared state).
+- `[USn]` — tied to User Story n from `spec.md`.
+
+---
+
+## Phase 1 — Setup
+
+- [X] T001 Verify the pending branch `69-add-release-and-versioning-health-signal` has a clean worktree and run `npm test` + `npm run lint` once as a baseline snapshot, so later regressions are attributable to this feature. No code change — record baseline counts in the task log.
+- [X] T002 Confirm `docs/DEVELOPMENT.md` Phase 2 table row for P2-F09 is still blank (no `✅ Done` yet). File: `docs/DEVELOPMENT.md`.
+
+---
+
+## Phase 2 — Foundational (blocks every user story)
+
+These are the shared types, config keys, and GraphQL fields that every downstream task depends on.
+
+- [X] T003 [P] Add the five regex / threshold / weight constants listed in `research.md` §Summary to the shared scoring config. File: `lib/scoring/config-loader.ts`. Constants: `SEMVER_REGEX`, `CALVER_REGEX`, `RELEASE_NOTES_SUBSTANTIVE_FLOOR`, `STALE_RELEASE_CUTOFF_DAYS`, `COOLING_RELEASE_CUTOFF_DAYS`, `SEMVER_ADOPTION_THRESHOLD`, `ACTIVITY_CADENCE_FREQUENCY_WEIGHT`, `ACTIVITY_CADENCE_RECENCY_WEIGHT`, `DOCUMENTATION_SEMVER_BONUS`, `DOCUMENTATION_NOTES_BONUS`, `DOCUMENTATION_TAG_PROMOTION_BONUS`. All values named per research.md defaults.
+- [X] T004 [P] Add unit tests asserting each new scoring-config constant is exported and has the documented default. File: `lib/scoring/config-loader.test.ts`.
+- [X] T005 Define the `ReleaseHealthResult` interface and the optional `releaseHealthResult` field on `AnalysisResult`. File: `lib/analyzer/analysis-result.ts`. Shape comes verbatim from `contracts/release-health-scoring.md` §1.
+- [X] T006 [P] Extend the existing Pass-1 GraphQL query with the additive fields (release `tagName`, `name`, `body`, `isPrerelease`, `totalCount`; `refs(refPrefix: "refs/tags/", first: 0).totalCount`) per `contracts/release-health-scoring.md` §8. File: `lib/analyzer/queries.ts`. No new query pass.
+- [X] T007 [P] Update the GraphQL response TypeScript types so the new fields flow end-to-end. File: `lib/analyzer/queries.ts` (or wherever `RepoOverviewResponse`-equivalent lives — follow the same pattern as existing release nodes).
+
+---
+
+## Phase 3 — User Story 1 (P1): Release-health signals detected and visible with a `release-health` pill
+
+**Goal**: Analyze a repo with releases and show a Release Cadence card (Activity) + Release Discipline card (Documentation), each carrying the `release-health` pill.
+
+**Independent test**: Open a report for a repo with active releases; visit Activity and Documentation tabs; confirm both cards render, each with the `release-health` pill, and tooltip/label surfaces "Release Health" (per spec's revised independent test wording).
+
+### Tests first
+
+- [X] T008 [P] [US1] Unit tests for `detectReleaseHealth()` covering: zero releases → object with field-level `'unavailable'`; one release → frequency `'unavailable'`, recency computed; tag-only project → `tagToReleaseRatio` present, `releaseNotesQualityRatio` `'unavailable'`; pre-release-only mix; ≥100 releases bounded sample; `totalTags === 'unavailable'` → `tagToReleaseRatio === 'unavailable'`. File: `lib/release-health/detect.test.ts`.
+- [X] T009 [P] [US1] Unit tests for `SEMVER_REGEX`, `CALVER_REGEX`, and `detectVersioningScheme()` covering: standard semver (`v1.2.3`, `1.2.3-rc.1`, `1.0.0+build.7`); CalVer (`2026.04.17`, `24.04`); unrecognized; empty input → `'unavailable'`. File: `lib/release-health/semver.test.ts`.
+- [X] T010 [P] [US1] Unit tests for the `release-health` tag registry — asserts the tag key, row set, and metric set are exported and cover the five metric keys. File: `lib/tags/release-health.test.ts`.
+- [X] T011 [P] [US1] Component test for `TagPill` asserting a `release-health` variant renders with the expected accessible name / tooltip. File: `components/tags/TagPill.test.tsx` (extend existing test file).
+- [X] T012 [P] [US1] Component test for `ReleaseCadenceCard` — renders three metrics (releases per year, days since last release, pre-release usage), carries the `release-health` pill, renders `"unavailable"` on zero-release input. File: `components/activity/ReleaseCadenceCard.test.tsx`.
+- [X] T013 [P] [US1] Component test for `ReleaseDisciplineCard` — renders three rows (semver compliance ratio, release-notes quality ratio, tag-to-release promotion ratio), each with the `release-health` pill, renders `"unavailable"` appropriately. File: `components/documentation/ReleaseDisciplineCard.test.tsx`.
+
+### Implementation
+
+- [X] T014 [US1] Implement `lib/release-health/semver.ts` — export `SEMVER_REGEX`, `CALVER_REGEX`, and `detectVersioningScheme(tagNames)` per `contracts/release-health-scoring.md` §4.
+- [X] T015 [US1] Implement `lib/release-health/detect.ts` — pure `detectReleaseHealth(input)` computing all seven fields per `data-model.md` and `contracts/release-health-scoring.md` §2. Injected `now` for determinism.
+- [X] T016 [US1] Wire `detectReleaseHealth()` into the analyzer pipeline so `releaseHealthResult` is populated on every `AnalysisResult`. File: `lib/analyzer/github-graphql.ts` (or wherever the pass-1 response is mapped into `AnalysisResult`).
+- [X] T017 [P] [US1] Create the `release-health` tag registry. File: `lib/tags/release-health.ts` (shape per `data-model.md` §Tag registry).
+- [X] T018 [P] [US1] Extend `TagPill` to support the `release-health` variant styling (parallel to `governance` and `community`). File: `components/tags/TagPill.tsx`.
+- [X] T019 [US1] Implement `ReleaseCadenceCard`. File: `components/activity/ReleaseCadenceCard.tsx`. Reads `releaseHealthResult` from the passed `AnalysisResult`; renders frequency, recency, and pre-release state; carries the `release-health` pill.
+- [X] T020 [US1] Implement `ReleaseDisciplineCard`. File: `components/documentation/ReleaseDisciplineCard.tsx`. Reads `releaseHealthResult`; renders semver / notes / tag-promotion ratios with per-row `release-health` pills.
+- [X] T021 [US1] Wire `ReleaseCadenceCard` into the Activity tab. File: `components/activity/ActivityView.tsx`.
+- [X] T022 [US1] Wire `ReleaseDisciplineCard` into the Documentation tab. File: `components/documentation/DocumentationView.tsx`.
+- [X] T023 [US1] Extend `lib/activity/view-model.ts` to expose the Release Cadence card data shape consumed by `ReleaseCadenceCard`.
+
+**Checkpoint** — User Story 1 complete: pill + both cards render end-to-end; dev server on port 3010 shows them for any repo with releases.
+
+---
+
+## Phase 4 — User Story 2 (P1): Release-health signals feed their host buckets
+
+**Goal**: Activity and Documentation scores move monotonically in response to release-health signal presence; composite weights unchanged.
+
+**Independent test**: Analyze a release-health-rich repo and a release-health-poor repo; confirm Activity and Documentation bucket scores on the rich repo are ≥ the poor repo; confirm composite `WEIGHTS` in `lib/scoring/health-score.ts` are untouched.
+
+### Tests first
+
+- [X] T024 [P] [US2] Unit tests for the extended Activity cadence sub-factor — asserts splitting into `ACTIVITY_CADENCE_FREQUENCY_WEIGHT` + `ACTIVITY_CADENCE_RECENCY_WEIGHT` sums to the current cadence allocation (0.20) and falls back to today's `releases12mo`-only logic when `releaseHealthResult` is `'unavailable'` / `undefined`. File: `lib/activity/score-config.test.ts`.
+- [X] T025 [P] [US2] Unit tests for the three Documentation bonuses — asserts `getDocumentationScore()` output with vs. without release-health signals; composite Documentation percentile is clamped to `[0, 99]`; absence of release-health never drops score below baseline. File: `lib/documentation/score-config.test.ts`.
+- [X] T026 [P] [US2] Guard test that `WEIGHTS` in `lib/scoring/health-score.ts` is unchanged (25/25/23/12/15). File: `lib/scoring/health-score.test.ts`.
+
+### Implementation
+
+- [X] T027 [US2] Extend Activity cadence to consume `daysSinceLastRelease` in addition to `releases12mo`, per research R6 and `contracts/release-health-scoring.md` §5. File: `lib/activity/score-config.ts`. No signature change on `getActivityScore()`.
+- [X] T028 [US2] Add the three bonus multipliers to Documentation scoring (semver, notes, tag-promotion) per research R6 and Contract §5. File: `lib/documentation/score-config.ts`. No signature change on `getDocumentationScore()`.
+
+**Checkpoint** — User Story 2 complete: host-bucket scores are moved by release-health signals; composite untouched.
+
+---
+
+## Phase 5 — User Story 3 (P2): Release Health completeness readout on the per-repo metric card
+
+**Goal**: Metric card surfaces a `release-health` lens readout, peer to Community and Governance, using the linear ratio → percentile fallback.
+
+**Independent test**: Open the per-repo metric card; confirm a third lens readout labeled "Release Health" appears alongside Community and Governance; a zero-release repo shows "Insufficient verified public data".
+
+### Tests first
+
+- [X] T029 [P] [US3] Unit tests for `computeReleaseHealthCompleteness()` covering: all five signals present → ratio 1.0, percentile 99; all five `unknown` → ratio null, percentile null; mixed → linear ratio reflected in percentile; `unknown` signals excluded from numerator and denominator (FR-021). File: `lib/release-health/completeness.test.ts`.
+- [X] T030 [P] [US3] Component test for `MetricCard` asserting the `release-health` lens readout renders after `community` / `governance` when `releaseHealthResult` is present and the completeness ratio is non-null; renders the `"Insufficient verified public data"` copy when ratio is null. File: `components/metric-cards/MetricCard.test.tsx` (extend existing).
+
+### Implementation
+
+- [X] T031 [US3] Implement `computeReleaseHealthCompleteness()` mirroring `lib/community/completeness.ts`. File: `lib/release-health/completeness.ts`. Export `ReleaseHealthSignalKey`, `ReleaseHealthCompleteness` types per `data-model.md`.
+- [X] T032 [US3] Extend `buildLensReadouts()` to append a `release-health` readout after `community` / `governance`, per `contracts/release-health-scoring.md` §6. File: `lib/metric-cards/view-model.ts`.
+
+**Checkpoint** — User Story 3 complete: third lens readout live on the metric card.
+
+---
+
+## Phase 6 — User Story 4 (P3): Recommendations for missing release-health signals
+
+**Goal**: Recommendations fire for gaps with staleness tiering and percentile-gate suppression; no rec on `preReleaseRatio` alone.
+
+**Independent test**: Analyze repos matching each of US4's ten acceptance scenarios; confirm the correct recommendation (or suppression) for each.
+
+### Tests first
+
+- [X] T033 [P] [US4] Unit tests for `generateReleaseHealthRecommendations()` covering US4 AC1–AC10: never-released, stale (>24 mo), cooling, adopt-semver, adopt-a-scheme, CalVer suppresses semver rec, notes-below-floor (not only empty), promote-tags, percentile-gate suppression, `preReleaseRatio` never fires. File: `lib/release-health/recommendations.test.ts`.
+- [X] T034 [P] [US4] Unit test that the staleness tier engine emits at most one recommendation per repo (FR-028) across all three tiers. File: `lib/release-health/recommendations.test.ts` (same file as T033).
+
+### Implementation
+
+- [X] T035 [US4] Implement `generateReleaseHealthRecommendations()` per research R4, R5, R9 and `data-model.md` §Recommendation catalog. File: `lib/release-health/recommendations.ts`. Pure function — consumes the bucket percentile + the release-health signal state; returns `HealthScoreRecommendation[]` or `[]`.
+- [X] T036 [US4] Add the seven catalog entries (never_released, stale, cooling, adopt_semver, adopt_scheme, improve_notes, promote_tags) with static user-facing copy and `gate: RECOMMENDATION_PERCENTILE_GATE`. File: `lib/recommendations/catalog.ts`.
+- [X] T037 [US4] Integrate `generateReleaseHealthRecommendations()` into the existing recommendations rollup so entries appear in the host-bucket tab. File: `lib/scoring/health-score.ts` (or wherever the recommendations list is assembled).
+
+**Checkpoint** — User Story 4 complete: recommendations tested and wired into the existing surface.
+
+---
+
+## Phase 7 — Polish & Cross-Cutting Concerns
+
+- [X] T038 [P] Extend `lib/comparison/sections.ts` so release-health rows diff across repos (P1-F06 flat-schema compatibility; FR-013 / FR-025 adjacent). File: `lib/comparison/sections.ts`.
+- [X] T039 [P] Extend JSON export with `releaseHealthResult` and `releaseHealthCompleteness` top-level fields. File: `lib/export/json-export.ts`.
+- [X] T040 [P] Extend Markdown export with a `## Release Health` section (Release Cadence / Release Discipline / Completeness subsections) parallel to the `## Community` section. File: `lib/export/markdown-export.ts`.
+- [X] T041 [P] Extend the methodology / baseline page to describe Release Health as a lens, list the five signals and host buckets, explain the completeness denominator, and note that per-bracket calibration is tracked in #152 (FR-024, SC-006). File: `components/baseline/BaselineView.tsx`.
+- [X] T042 Extend Playwright E2E to assert: (1) `release-health` pill on Release Cadence and Release Discipline cards; (2) Release Health completeness readout on the metric card; (3) zero-release repo renders "Insufficient verified public data". Prefer lightweight DOM / computed-style assertions over visual snapshots. File: `e2e/release-health.spec.ts`.
+- [X] T043 [P] Add release-health coverage to the tag-match / tab-count logic so the `release-health` tag is counted in the tab-strip badges. File: `lib/tags/tab-counts.ts`.
+- [X] T044 Flip `docs/DEVELOPMENT.md` Phase 2 table row for P2-F09 to `✅ Done` only when all tests and linting pass (DoD §XII). File: `docs/DEVELOPMENT.md`.
+- [X] T045 Run `npm test && npm run lint && DEV_GITHUB_PAT= npm run build && npm run test:e2e` and confirm all green before opening the PR.
+
+---
+
+## Dependencies
+
+```
+Phase 1 (Setup: T001, T002)
+   └── Phase 2 (Foundational: T003–T007)
+          ├── Phase 3 (US1: T008–T023)
+          │      └── Phase 4 (US2: T024–T028)          ← depends on US1's detect + analysis-result shape
+          │             └── Phase 5 (US3: T029–T032)   ← depends on US1 detect + US2 scoring
+          │                    └── Phase 6 (US4: T033–T037)
+          └── Phase 7 (Polish: T038–T045)
+                 ↑ depends on every preceding phase
+```
+
+**Independent-story notes**:
+- US1 is the strict prerequisite for US2, US3, US4 (no signals → nothing to score / render / recommend).
+- US2 and US3 are independent given US1 is done (scoring vs. readout are orthogonal).
+- US4 requires the trigger inputs from US1 and respects the gate values; best scheduled after US2.
+
+---
+
+## Parallelization map
+
+| Batch | Tasks | Rationale |
+|---|---|---|
+| Batch A (Phase 2) | T003, T006, T007 | Different files, no inter-dependency |
+| Batch B (US1 tests) | T008, T009, T010, T011, T012, T013 | Separate test files, no import cycles |
+| Batch C (US1 impl) | T017, T018 (after T014) | Tag registry and TagPill variant are independent files |
+| Batch D (US2 tests) | T024, T025, T026 | Separate test files |
+| Batch E (US3 tests) | T029, T030 | Separate test files |
+| Batch F (US4 tests) | T033, T034 | Same file but can be written in one sitting |
+| Batch G (Polish) | T038, T039, T040, T041, T043 | Touch different files |
+
+---
+
+## Implementation strategy
+
+**MVP**: User Story 1 (Phases 1–3). Ships the lens pill, the Release Cadence card, and the Release Discipline card. Delivers user-visible value standalone without touching scores or recommendations.
+
+**Incremental**: US2 moves scores, US3 surfaces completeness, US4 ships recommendations. Each is a standalone PR-worthy increment but this feature ships as a single PR per the Phase 2 lens pattern.
+
+**Constitution reminders**:
+- §XI TDD is NON-NEGOTIABLE — every T0xx implementation task in US1–US4 has a test task immediately above it.
+- §II Accuracy — `'unavailable'` and `"Insufficient verified public data"` are the only acceptable missing-data strings.
+- §VI — thresholds live in shared config (T003), never hardcoded in logic.
+- §IX YAGNI — no calibration payload changes (deferred to #152), no new tab, no new bucket.
+- PR merge discipline per CLAUDE.md — Claude opens the PR and stops; user merges manually.
+
+---
+
+## Summary
+
+- **Total tasks**: 45
+- **Per phase**: Setup 2 / Foundational 5 / US1 16 / US2 5 / US3 4 / US4 5 / Polish 8
+- **Parallel opportunities**: 7 batches identified above.
+- **MVP scope**: US1 (T001–T023).
+- **Independent tests**: one per user story, defined in spec.md §User Scenarios.


### PR DESCRIPTION
## Summary

Implements Phase 2 feature **P2-F09 — Release Health Scoring** from issue #69 as a lens-style signal set over existing scored buckets, following the Governance (P2-F04) and Community (P2-F05) precedents.

- **Five scored signals** detected from GraphQL `releases` node and `refs` count: `releaseFrequency`, `daysSinceLastRelease`, `semverComplianceRatio`, `releaseNotesQualityRatio`, `tagToReleaseRatio`. One informational signal: `preReleaseRatio` (never scored per FR-012).
- **Activity cadence sub-factor** extended to consume `daysSinceLastRelease` alongside `releases12mo`; existing 0.15 allocation split into frequency (0.10) + recency (0.05). Composite `WEIGHTS` (25/25/23/12/15) unchanged.
- **Documentation** gains three small-weight bonuses (semver, notes, tag-promotion) — bounded so aggregate shift on existing repos stays under ~5 percentile points.
- **`release-health` presentation tag** added to `TagPill` with teal styling, applied to the new Release Cadence card (Activity tab) and Release Discipline card (Documentation tab).
- **Metric card lens readout** via `buildLensReadouts()`, peer to Community and Governance. Linear ratio → percentile fallback until #152 calibration lands.
- **Seven recommendations** in `generateReleaseHealthRecommendations()` — three staleness tiers (never_released / stale>24mo / cooling), adopt_semver, adopt_scheme (CalVer-aware), improve_notes (below floor, not just empty), promote_tags. All honor `RECOMMENDATION_PERCENTILE_GATE`. Dual-tagged with `release-health` so recs carry the lens pill.
- **Exports** (JSON + Markdown) carry the signal set and completeness readout.

Per-bracket percentile calibration for the five numeric signals is **deferred to #152** (comment posted on that issue enumerating the signal names).

## Test plan

- [x] `npm test` — 1085 tests passing (+62 from this feature); only the pre-existing `ComparisonView median toggle` failure present in the baseline
- [x] `npm run lint` — 0 errors, warnings unchanged
- [x] `DEV_GITHUB_PAT= npm run build` — clean production build
- [x] Manual check (repo: `facebook/react`): Release Cadence card on Activity tab with the `release-health` pill showing releases per year, days since last release, and pre-release %
- [x] Manual check (repo: `facebook/react`): Documentation tab → Release Discipline card shows semver compliance %, release-notes quality %, and tag-to-release promotion %, each with a `release-health` pill
- [x] Manual check (repo: `facebook/react`): metric card shows a third lens readout labeled "Release Health" peer to Community and Governance, with its percentile label (linear fallback)
- [x] Manual check (repo: `arun-gupta/kubernetes-java-sample` — zero releases): Release Health lens readout renders as "Insufficient verified public data" and the Release Cadence card shows `"unavailable"` for all three metrics — never zeroed
- [x] Manual check (repos: `twbs/bootstrap-sass` archived mid-2019, `dotnet/dotnet-docker-samples`): single Activity-bucket "stale" recommendation (ACT-7) with the `release-health` pill — not "never released" or "cooling"
- [x] Manual check (repo: `ruby/ruby` — `v3_3_0_preview1`-style tags, neither semver nor CalVer): `release_adopt_scheme` (DOC-19) fires — not `release_adopt_semver` — with the `release-health` pill
- [x] Manual check (repo: `intel/ittapi` — CalVer tags): neither "adopt semver" (DOC-18) nor "adopt scheme" (DOC-19) fires — only the 11 non-release-health Documentation recs appear
- [ ] Manual check: click the `release-health` pill on the Activity tab card; confirm filter behavior consistent with other lens pills
- [ ] Manual check: Export JSON and confirm a top-level `releaseHealth` key with `signals` and `completeness` sub-objects; confirm `preReleaseRatio` appears under signals
- [x] Manual check (repos: `ruby/ruby`, `intel/ittapi`): Export Markdown contains a `### Release Health` section with the five-signal table, each row showing Value and Status
- [ ] Constitution compliance spot-check: spec §FR-014 (composite weights unchanged), §FR-019 (no new composite bucket), §FR-031 (no `preReleaseRatio` recommendation)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)