### PR TITLE
Restore header summary strip on Org admin activity panel (#334)

### DIFF
--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { AuthProvider } from '@/components/auth/AuthContext'
 import { StaleAdminsPanel } from './StaleAdminsPanel'
 import type { StaleAdminsSection } from '@/lib/governance/stale-admins'
@@ -86,9 +86,6 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     })
     renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
 
-    // Standalone count strip is removed; per-group pills carry the counts.
-    expect(screen.queryByTestId('stale-admins-count-strip')).not.toBeInTheDocument()
-
     const staleSummary = screen.getByTestId('stale-admins-group-stale').querySelector('summary')!
     const activeSummary = screen.getByTestId('stale-admins-group-active').querySelector('summary')!
     const noActivitySummary = screen
@@ -102,6 +99,48 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     expect(within(activeSummary).getByText('2')).toBeInTheDocument()
     expect(within(noActivitySummary).getByText('1')).toBeInTheDocument()
     expect(within(unavailableSummary).getByText('1')).toBeInTheDocument()
+  })
+
+  it('renders a header summary strip with totals across all classifications', () => {
+    const section = makeSection({
+      admins: [
+        mkAdmin('a1', 'active'),
+        mkAdmin('a2', 'active'),
+        mkAdmin('s1', 'stale'),
+        mkAdmin('n1', 'no-public-activity'),
+        mkAdmin('u1', 'unavailable'),
+      ],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+
+    const strip = screen.getByTestId('stale-admins-count-strip')
+    expect(strip).toHaveAttribute('aria-label', 'Admin summary — 5 admins')
+    expect(within(strip).getByText('5 admins')).toBeInTheDocument()
+    expect(within(strip).getByTestId('stale-admins-count-stale').textContent).toMatch(/1 stale/i)
+    expect(within(strip).getByTestId('stale-admins-count-unavailable').textContent).toMatch(/1 unavailable/i)
+    expect(
+      within(strip).getByTestId('stale-admins-count-no-public-activity').textContent,
+    ).toMatch(/1 no public activity/i)
+    expect(within(strip).getByTestId('stale-admins-count-active').textContent).toMatch(/2 active/i)
+  })
+
+  it('keeps the header summary strip visible when the panel is collapsed', () => {
+    const section = makeSection({
+      admins: [mkAdmin('s1', 'stale'), mkAdmin('a1', 'active')],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+
+    const toggle = screen.getByTestId('stale-admins-panel-toggle')
+    fireEvent.click(toggle)
+
+    expect(screen.queryByTestId('stale-admins-group-stale')).not.toBeInTheDocument()
+    expect(screen.getByTestId('stale-admins-count-strip')).toBeInTheDocument()
+  })
+
+  it('omits the header summary strip when applicability is not applicable', () => {
+    const section = makeSection({ applicability: 'not-applicable-non-org', admins: [] })
+    renderWithSession(<StaleAdminsPanel org={null} ownerType="User" sectionOverride={section} />)
+    expect(screen.queryByTestId('stale-admins-count-strip')).not.toBeInTheDocument()
   })
 
   it('renders a commit-search badge with an explanatory tooltip on admins whose activity was inferred from org commit search', () => {

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -124,17 +124,24 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     expect(within(strip).getByTestId('stale-admins-count-active').textContent).toMatch(/2 active/i)
   })
 
-  it('keeps the header summary strip visible when the panel is collapsed', () => {
+  it('hides the description, summary strip, and group list when the panel is collapsed', () => {
     const section = makeSection({
       admins: [mkAdmin('s1', 'stale'), mkAdmin('a1', 'active')],
     })
     renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
 
+    // Expanded by default — strip and description are visible.
+    expect(screen.getByTestId('stale-admins-count-strip')).toBeInTheDocument()
+    expect(screen.getByText(/stale admin detection/i)).toBeInTheDocument()
+
     const toggle = screen.getByTestId('stale-admins-panel-toggle')
     fireEvent.click(toggle)
 
     expect(screen.queryByTestId('stale-admins-group-stale')).not.toBeInTheDocument()
-    expect(screen.getByTestId('stale-admins-count-strip')).toBeInTheDocument()
+    expect(screen.queryByTestId('stale-admins-count-strip')).not.toBeInTheDocument()
+    expect(screen.queryByText(/stale admin detection/i)).not.toBeInTheDocument()
+    // Title stays visible.
+    expect(screen.getByRole('heading', { name: /org admin activity/i })).toBeInTheDocument()
   })
 
   it('omits the header summary strip when applicability is not applicable', () => {

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -113,14 +113,16 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
                 </h3>
                 <ScoringHelp section={section} />
               </div>
-              <p className="text-xs text-slate-500 dark:text-slate-400">
-                Stale admin detection — an inactive admin is a privilege-escalation risk.
-              </p>
+              {expanded ? (
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Stale admin detection — an inactive admin is a privilege-escalation risk.
+                </p>
+              ) : null}
             </div>
           </div>
           {section ? <ModeBadge mode={section.mode} /> : null}
         </div>
-        {section ? <HeaderCountStrip section={section} /> : null}
+        {expanded && section ? <HeaderCountStrip section={section} /> : null}
       </header>
 
       {expanded ? (

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -92,32 +92,35 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
       className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
       data-testid="stale-admins-panel"
     >
-      <header className={`flex flex-wrap items-start justify-between gap-2 ${expanded ? 'mb-3' : ''}`}>
-        <div className="flex min-w-0 items-start gap-2">
-          <button
-            type="button"
-            onClick={() => setExpanded((e) => !e)}
-            aria-label={expanded ? 'Collapse Org admin activity' : 'Expand Org admin activity'}
-            aria-expanded={expanded}
-            title={expanded ? 'Collapse' : 'Expand'}
-            data-testid="stale-admins-panel-toggle"
-            className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
-          >
-            <PanelChevron expanded={expanded} />
-          </button>
-          <div className="min-w-0">
-            <div className="flex items-center gap-1.5">
-              <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-                Org admin activity
-              </h3>
-              <ScoringHelp section={section} />
+      <header className={expanded ? 'mb-3' : ''}>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="flex min-w-0 items-start gap-2">
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              aria-label={expanded ? 'Collapse Org admin activity' : 'Expand Org admin activity'}
+              aria-expanded={expanded}
+              title={expanded ? 'Collapse' : 'Expand'}
+              data-testid="stale-admins-panel-toggle"
+              className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+            >
+              <PanelChevron expanded={expanded} />
+            </button>
+            <div className="min-w-0">
+              <div className="flex items-center gap-1.5">
+                <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  Org admin activity
+                </h3>
+                <ScoringHelp section={section} />
+              </div>
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Stale admin detection — an inactive admin is a privilege-escalation risk.
+              </p>
             </div>
-            <p className="text-xs text-slate-500 dark:text-slate-400">
-              Stale admin detection — an inactive admin is a privilege-escalation risk.
-            </p>
           </div>
+          {section ? <ModeBadge mode={section.mode} /> : null}
         </div>
-        {section ? <ModeBadge mode={section.mode} /> : null}
+        {section ? <HeaderCountStrip section={section} /> : null}
       </header>
 
       {expanded ? (
@@ -145,6 +148,64 @@ function PanelChevron({ expanded }: { expanded: boolean }) {
       <path d="M4 6l4 4 4-4" />
     </svg>
   )
+}
+
+function HeaderCountStrip({ section }: { section: StaleAdminsSection }) {
+  if (section.applicability !== 'applicable' || section.admins.length === 0) return null
+  const counts = countByClassification(section.admins)
+  const total = section.admins.length
+  return (
+    <div
+      className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs"
+      data-testid="stale-admins-count-strip"
+      aria-label={`Admin summary — ${total} admins`}
+    >
+      <span className="font-medium text-slate-700 dark:text-slate-200">
+        {total} admin{total === 1 ? '' : 's'}
+      </span>
+      <span aria-hidden="true" className="text-slate-300 dark:text-slate-600">
+        ·
+      </span>
+      {GROUP_ORDER.map((c) => (
+        <CountPill key={c} classification={c} count={counts[c]} />
+      ))}
+    </div>
+  )
+}
+
+function CountPill({
+  classification,
+  count,
+}: {
+  classification: StaleAdminClassification
+  count: number
+}) {
+  const config = GROUP_CONFIG[classification]
+  const dim = count === 0
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium ${config.pillClassName} ${dim ? 'opacity-40' : ''}`}
+      data-testid={`stale-admins-count-${classification}`}
+    >
+      <span aria-hidden="true">{config.icon}</span>
+      <span>
+        {count} {config.label.toLowerCase()}
+      </span>
+    </span>
+  )
+}
+
+function countByClassification(
+  admins: StaleAdminRecord[],
+): Record<StaleAdminClassification, number> {
+  const counts: Record<StaleAdminClassification, number> = {
+    active: 0,
+    stale: 0,
+    'no-public-activity': 0,
+    unavailable: 0,
+  }
+  for (const a of admins) counts[a.classification]++
+  return counts
 }
 
 function ScoringHelp({ section }: { section: StaleAdminsSection | null }) {


### PR DESCRIPTION
## Summary

Closes #334. **Supersedes #336's `AdminCountSummary` pill** — that pill only surfaced 2 of the 5 buckets (stale + unavailable, or "All active"); this PR replaces it with a full 5-bucket strip per the #334 acceptance criteria.

Brings back the compact rollup of totals the Org admin activity panel
lost in PR #322 — per-group pills alone required expanding each section
to see the counts.

- Adds `HeaderCountStrip` inside the panel **header**, below the
  title/description row, so totals sit at the top of the panel without
  expanding any group.
- Shows: `N admins · ⚠ N stale · ? N unavailable · – N no public activity · ✓ N active`.
- Removes `AdminCountSummary` (the partial pill added in #336) — the new
  strip is a superset and satisfies #334's acceptance fully.
- Uses minimal, border-less layout (small pills + total, no containing
  box) to stay within the denser baseline established by #318.
- Renders only when `applicability === 'applicable'` and there is at
  least one admin; hidden for `not-applicable-non-org`,
  `admin-list-unavailable`, and the `applicable`/zero-admins case.
- Per-group count pills on each group summary are kept — they remain
  useful anchors inside the expanded body and read fine alongside the
  strip.
- Tightens the collapsed state: when the panel is collapsed, the
  description paragraph and the count strip are also hidden — only the
  title row (title + `?` help + mode badge) stays visible.

## Test plan

- [x] `Org admin activity` panel header shows a new row of counts:
  `<N> admins · ⚠ <N> stale · ? <N> unavailable · – <N> no public activity · ✓ <N> active`.
- [x] Counts match per-group pill counts (Stale, Unavailable, No public activity, Active).
- [x] Collapsing the panel (panel-level chevron) hides the description, the summary strip, and the group list — only the title row (title + `?` + mode badge) stays visible.
- [x] For a non-org target (`ownerType = User`), the strip is not rendered (N/A state still shows). — **Unreachable via UI** (Governance tab only renders under the Organization flow, which rejects user accounts at org-inventory time); covered by unit test `StaleAdminsPanel — US4 N/A for non-org targets` → *"renders an explicit N/A state when applicability is not-applicable-non-org"*.
- [x] For an org where the admin list could not be retrieved, the strip is not rendered and the unavailable message still shows. — **Not deterministically reproducible in UI** (requires rate-limit / auth / scope / network error); covered by unit test `StaleAdminsPanel — admin-list-unavailable` → *"renders a labeled unavailable state with the reason"*.
- [x] For an applicable org with zero admins, the strip is not rendered and `No admins were returned for this organization.` is shown. — verified on `sanatan-learnings`.
- [x] Vertical density is not visibly worse than before: the strip is a single flex-wrap row of small pills, no surrounding bordered box.
- [x] `npx vitest run components/org-summary/panels/StaleAdminsPanel.test.tsx` — 16/16 pass, including new tests for header strip totals, collapsed-state suppression (description + strip + groups), and N/A suppression.
- [x] `npm run lint` — no new warnings introduced.
- [x] `npx tsc --noEmit` — no new type errors introduced (pre-existing failures on `main` are unchanged).
- [x] No remnants of `AdminCountSummary` or `stale-admins-panel-summary` testid in the rendered UI — confirm the partial pill is gone from the panel title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)