### PR TITLE
Governance tab: add panel-level chevron to Maintainers & Governance, rename inner panel (#336)

### DIFF
--- a/components/org-summary/panels/GovernancePanel.test.tsx
+++ b/components/org-summary/panels/GovernancePanel.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { GovernancePanel } from './GovernancePanel'
+import type { AggregatePanel } from '@/lib/org-aggregation/types'
+import type { GovernanceValue } from '@/lib/org-aggregation/aggregators/types'
+
+function makePanel(
+  override: Partial<AggregatePanel<GovernanceValue>> = {},
+): AggregatePanel<GovernanceValue> {
+  return {
+    panelId: 'governance',
+    contributingReposCount: 3,
+    totalReposInRun: 3,
+    status: 'final',
+    value: {
+      orgLevel: null,
+      perRepo: [
+        { repo: 'acme/a', present: true },
+        { repo: 'acme/b', present: false },
+        { repo: 'acme/c', present: false },
+      ],
+    },
+    ...override,
+  }
+}
+
+describe('GovernancePanel — panel-level chevron (#336)', () => {
+  it('starts expanded with the body visible and aria-expanded=true', () => {
+    render(<GovernancePanel panel={makePanel()} />)
+    const toggle = screen.getByTestId('governance-panel-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(toggle).toHaveAttribute('aria-label', 'Collapse GOVERNANCE.md coverage')
+    expect(screen.getByText('acme/a')).toBeInTheDocument()
+  })
+
+  it('collapses on click — body hides, aria-expanded flips, aria-label updates', async () => {
+    const user = userEvent.setup()
+    render(<GovernancePanel panel={makePanel()} />)
+    const toggle = screen.getByTestId('governance-panel-toggle')
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveAttribute('aria-label', 'Expand GOVERNANCE.md coverage')
+    expect(screen.queryByText('acme/a')).not.toBeInTheDocument()
+  })
+
+  it('re-expands on a second click', async () => {
+    const user = userEvent.setup()
+    render(<GovernancePanel panel={makePanel()} />)
+    const toggle = screen.getByTestId('governance-panel-toggle')
+
+    await user.click(toggle)
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(toggle).toHaveAttribute('aria-label', 'Collapse GOVERNANCE.md coverage')
+    expect(screen.getByText('acme/a')).toBeInTheDocument()
+  })
+
+  it('renders the panel title "GOVERNANCE.md coverage" (not "Governance") and section aria-label', () => {
+    render(<GovernancePanel panel={makePanel()} />)
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'GOVERNANCE.md coverage' }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'GOVERNANCE.md coverage' })).toBeInTheDocument()
+  })
+
+  it('keeps the summary pill visible in both collapsed and expanded states', async () => {
+    const user = userEvent.setup()
+    render(<GovernancePanel panel={makePanel()} />)
+    const pill = screen.getByTestId('governance-panel-summary')
+    expect(pill).toHaveTextContent('1 of 3 repos')
+
+    await user.click(screen.getByTestId('governance-panel-toggle'))
+
+    expect(screen.getByTestId('governance-panel-summary')).toHaveTextContent('1 of 3 repos')
+  })
+
+  it('colors the summary pill emerald when every repo has GOVERNANCE.md', () => {
+    const panel = makePanel({
+      value: {
+        orgLevel: null,
+        perRepo: [
+          { repo: 'acme/a', present: true },
+          { repo: 'acme/b', present: true },
+        ],
+      },
+    })
+    render(<GovernancePanel panel={panel} />)
+    const pill = screen.getByTestId('governance-panel-summary')
+    expect(pill).toHaveTextContent('2 of 2 repos')
+    expect(pill.className).toMatch(/emerald/)
+  })
+
+  it('omits the summary pill entirely when panel has no value', () => {
+    render(<GovernancePanel panel={makePanel({ status: 'unavailable', value: null })} />)
+    expect(screen.queryByTestId('governance-panel-summary')).not.toBeInTheDocument()
+  })
+})

--- a/components/org-summary/panels/GovernancePanel.tsx
+++ b/components/org-summary/panels/GovernancePanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { GovernanceValue } from '@/lib/org-aggregation/aggregators/types'
 import { EmptyState } from '../EmptyState'
@@ -9,13 +10,28 @@ interface Props {
 }
 
 export function GovernancePanel({ panel }: Props) {
+  const [expanded, setExpanded] = useState(true)
   return (
     <section
-      aria-label="Governance"
+      aria-label="GOVERNANCE.md coverage"
       className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+      data-testid="governance-panel"
     >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Governance</h3>
+      <header className={`flex flex-wrap items-center justify-between gap-2 ${expanded ? 'mb-3' : ''}`}>
+        <div className="flex min-w-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            aria-label={expanded ? 'Collapse GOVERNANCE.md coverage' : 'Expand GOVERNANCE.md coverage'}
+            aria-expanded={expanded}
+            title={expanded ? 'Collapse' : 'Expand'}
+            data-testid="governance-panel-toggle"
+            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <PanelChevron expanded={expanded} />
+          </button>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">GOVERNANCE.md coverage</h3>
+        </div>
         {panel.lastUpdatedAt ? (
           <span className="text-xs text-slate-400 dark:text-slate-500">
             updated {panel.lastUpdatedAt.toLocaleTimeString()}
@@ -23,16 +39,35 @@ export function GovernancePanel({ panel }: Props) {
         ) : null}
       </header>
 
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          No governance data available across this run.
-        </p>
-      ) : (
-        <Body value={panel.value} />
-      )}
+      {expanded ? (
+        panel.status === 'in-progress' && !panel.value ? (
+          <EmptyState />
+        ) : panel.status === 'unavailable' || !panel.value ? (
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            No governance data available across this run.
+          </p>
+        ) : (
+          <Body value={panel.value} />
+        )
+      ) : null}
     </section>
+  )
+}
+
+function PanelChevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`h-4 w-4 transition-transform ${expanded ? '' : '-rotate-90'}`}
+    >
+      <path d="M4 6l4 4 4-4" />
+    </svg>
   )
 }
 

--- a/components/org-summary/panels/GovernancePanel.tsx
+++ b/components/org-summary/panels/GovernancePanel.tsx
@@ -11,6 +11,7 @@ interface Props {
 
 export function GovernancePanel({ panel }: Props) {
   const [expanded, setExpanded] = useState(true)
+  const summary = buildSummary(panel.value)
   return (
     <section
       aria-label="GOVERNANCE.md coverage"
@@ -31,6 +32,14 @@ export function GovernancePanel({ panel }: Props) {
             <PanelChevron expanded={expanded} />
           </button>
           <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">GOVERNANCE.md coverage</h3>
+          {summary ? (
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${summary.className}`}
+              data-testid="governance-panel-summary"
+            >
+              {summary.label}
+            </span>
+          ) : null}
         </div>
         {panel.lastUpdatedAt ? (
           <span className="text-xs text-slate-400 dark:text-slate-500">
@@ -52,6 +61,19 @@ export function GovernancePanel({ panel }: Props) {
       ) : null}
     </section>
   )
+}
+
+function buildSummary(value: GovernanceValue | null): { label: string; className: string } | null {
+  if (!value) return null
+  const total = value.perRepo.length
+  if (total === 0) return null
+  const withGovernance = value.perRepo.filter((r) => r.present).length
+  const label = `${withGovernance} of ${total} repos`
+  const className =
+    withGovernance === total
+      ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400'
+      : 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300'
+  return { label, className }
 }
 
 function PanelChevron({ expanded }: { expanded: boolean }) {

--- a/components/org-summary/panels/LicenseConsistencyPanel.tsx
+++ b/components/org-summary/panels/LicenseConsistencyPanel.tsx
@@ -38,6 +38,7 @@ const GROUP_CONFIG: Record<
 
 export function LicenseConsistencyPanel({ panel }: Props) {
   const [expanded, setExpanded] = useState(true)
+  const summary = buildSummary(panel.value)
   return (
     <section
       aria-label="License consistency"
@@ -58,6 +59,14 @@ export function LicenseConsistencyPanel({ panel }: Props) {
             <PanelChevron expanded={expanded} />
           </button>
           <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">License consistency</h3>
+          {summary ? (
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${summary.className}`}
+              data-testid="license-consistency-panel-summary"
+            >
+              {summary.label}
+            </span>
+          ) : null}
         </div>
         {panel.lastUpdatedAt ? (
           <span className="text-xs text-slate-400 dark:text-slate-500">
@@ -76,6 +85,21 @@ export function LicenseConsistencyPanel({ panel }: Props) {
       ) : null}
     </section>
   )
+}
+
+function buildSummary(value: LicenseConsistencyValue | null): { label: string; className: string } | null {
+  if (!value) return null
+  if (value.perRepo.length === 0) return null
+  if (value.nonOsiCount > 0) {
+    return {
+      label: `${value.nonOsiCount} non-OSI`,
+      className: 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400',
+    }
+  }
+  return {
+    label: 'All OSI',
+    className: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400',
+  }
 }
 
 function PanelChevron({ expanded }: { expanded: boolean }) {
@@ -114,19 +138,6 @@ function PanelBody({
     <div className="space-y-3">
       <p className="text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
         {contributingReposCount} of {totalReposInRun} repos contributed
-        {value.nonOsiCount > 0 ? (
-          <>
-            {' · '}
-            <span className="text-amber-700 dark:text-amber-400 dark:text-amber-300">
-              {value.nonOsiCount} use non-OSI-approved licenses
-            </span>
-          </>
-        ) : (
-          <>
-            {' · '}
-            <span className="text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">All use OSI-approved licenses</span>
-          </>
-        )}
       </p>
       {GROUP_ORDER.filter((c) => grouped[c].length > 0).map((classification) => (
         <GroupSection

--- a/components/org-summary/panels/MaintainersPanel.test.tsx
+++ b/components/org-summary/panels/MaintainersPanel.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MaintainersPanel } from './MaintainersPanel'
+import type { AggregatePanel } from '@/lib/org-aggregation/types'
+import type { MaintainersValue } from '@/lib/org-aggregation/aggregators/types'
+
+function makePanel(
+  override: Partial<AggregatePanel<MaintainersValue>> = {},
+): AggregatePanel<MaintainersValue> {
+  return {
+    panelId: 'maintainers',
+    contributingReposCount: 2,
+    totalReposInRun: 2,
+    status: 'final',
+    value: {
+      projectWide: [
+        { token: 'alice', kind: 'user', reposListed: ['acme/a', 'acme/b'] },
+        { token: '@acme/core', kind: 'team', reposListed: ['acme/a'] },
+      ],
+      perRepo: [],
+    },
+    ...override,
+  }
+}
+
+describe('MaintainersPanel — panel-level chevron (#336)', () => {
+  it('starts expanded with the body visible and aria-expanded=true', () => {
+    render(<MaintainersPanel panel={makePanel()} />)
+    const toggle = screen.getByTestId('maintainers-panel-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(toggle).toHaveAttribute('aria-label', 'Collapse Maintainers')
+    // Body content (a maintainer row) is rendered.
+    expect(screen.getByText('alice')).toBeInTheDocument()
+  })
+
+  it('collapses on click — body hides, aria-expanded flips, aria-label updates', async () => {
+    const user = userEvent.setup()
+    render(<MaintainersPanel panel={makePanel()} />)
+    const toggle = screen.getByTestId('maintainers-panel-toggle')
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveAttribute('aria-label', 'Expand Maintainers')
+    expect(screen.queryByText('alice')).not.toBeInTheDocument()
+  })
+
+  it('re-expands on a second click', async () => {
+    const user = userEvent.setup()
+    render(<MaintainersPanel panel={makePanel()} />)
+    const toggle = screen.getByTestId('maintainers-panel-toggle')
+
+    await user.click(toggle)
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(toggle).toHaveAttribute('aria-label', 'Collapse Maintainers')
+    expect(screen.getByText('alice')).toBeInTheDocument()
+  })
+
+  it('keeps the summary pill visible in both collapsed and expanded states', async () => {
+    const user = userEvent.setup()
+    render(<MaintainersPanel panel={makePanel()} />)
+    const pill = screen.getByTestId('maintainers-panel-summary')
+    // Expanded: pill present with both user + team breakdown.
+    expect(pill).toHaveTextContent('2 maintainers · 1 team')
+
+    await user.click(screen.getByTestId('maintainers-panel-toggle'))
+
+    // Collapsed: same pill still rendered (summary-at-a-glance).
+    expect(screen.getByTestId('maintainers-panel-summary')).toHaveTextContent(
+      '2 maintainers · 1 team',
+    )
+  })
+
+  it('omits the team breakdown when there are no team handles', () => {
+    const panel = makePanel({
+      value: {
+        projectWide: [{ token: 'alice', kind: 'user', reposListed: ['acme/a'] }],
+        perRepo: [],
+      },
+    })
+    render(<MaintainersPanel panel={panel} />)
+    expect(screen.getByTestId('maintainers-panel-summary')).toHaveTextContent(
+      '1 maintainer',
+    )
+    expect(
+      screen.getByTestId('maintainers-panel-summary').textContent,
+    ).not.toMatch(/team/)
+  })
+
+  it('omits the summary pill entirely when panel has no value', () => {
+    render(<MaintainersPanel panel={makePanel({ status: 'unavailable', value: null })} />)
+    expect(screen.queryByTestId('maintainers-panel-summary')).not.toBeInTheDocument()
+  })
+})

--- a/components/org-summary/panels/MaintainersPanel.tsx
+++ b/components/org-summary/panels/MaintainersPanel.tsx
@@ -25,6 +25,7 @@ export function MaintainersPanel({ panel }: Props) {
     panel.value && panel.contributingReposCount < panel.totalReposInRun
       ? `${panel.contributingReposCount} of ${panel.totalReposInRun} repos`
       : null
+  const summary = buildSummary(panel.value)
 
   return (
     <section
@@ -46,6 +47,14 @@ export function MaintainersPanel({ panel }: Props) {
             <PanelChevron expanded={expanded} />
           </button>
           <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Maintainers</h3>
+          {summary ? (
+            <span
+              className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300"
+              data-testid="maintainers-panel-summary"
+            >
+              {summary}
+            </span>
+          ) : null}
         </div>
         <div className="flex items-center gap-3">
           {panel.status === 'unavailable' ? (
@@ -77,6 +86,17 @@ export function MaintainersPanel({ panel }: Props) {
       ) : null}
     </section>
   )
+}
+
+function buildSummary(value: MaintainersValue | null): string | null {
+  if (!value) return null
+  const unique = value.projectWide.length
+  if (unique === 0) return null
+  const teams = value.projectWide.filter((e) => e.kind === 'team').length
+  const uniqueLabel = `${unique} maintainer${unique === 1 ? '' : 's'}`
+  if (teams === 0) return uniqueLabel
+  const teamsLabel = `${teams} team${teams === 1 ? '' : 's'}`
+  return `${uniqueLabel} · ${teamsLabel}`
 }
 
 function PanelChevron({ expanded }: { expanded: boolean }) {

--- a/components/org-summary/panels/MaintainersPanel.tsx
+++ b/components/org-summary/panels/MaintainersPanel.tsx
@@ -20,6 +20,7 @@ interface Props {
 }
 
 export function MaintainersPanel({ panel }: Props) {
+  const [expanded, setExpanded] = useState(true)
   const partialCoverageLabel =
     panel.value && panel.contributingReposCount < panel.totalReposInRun
       ? `${panel.contributingReposCount} of ${panel.totalReposInRun} repos`
@@ -29,9 +30,23 @@ export function MaintainersPanel({ panel }: Props) {
     <section
       aria-label="Maintainers"
       className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+      data-testid="maintainers-panel"
     >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Maintainers</h3>
+      <header className={`flex flex-wrap items-center justify-between gap-2 ${expanded ? 'mb-3' : ''}`}>
+        <div className="flex min-w-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            aria-label={expanded ? 'Collapse Maintainers' : 'Expand Maintainers'}
+            aria-expanded={expanded}
+            title={expanded ? 'Collapse' : 'Expand'}
+            data-testid="maintainers-panel-toggle"
+            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+          >
+            <PanelChevron expanded={expanded} />
+          </button>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Maintainers</h3>
+        </div>
         <div className="flex items-center gap-3">
           {panel.status === 'unavailable' ? (
             <span className="text-xs text-slate-500 dark:text-slate-400">unavailable</span>
@@ -49,16 +64,35 @@ export function MaintainersPanel({ panel }: Props) {
         </div>
       </header>
 
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          No OWNERS / MAINTAINERS / CODEOWNERS files were verified across this run.
-        </p>
-      ) : (
-        <Body value={panel.value} />
-      )}
+      {expanded ? (
+        panel.status === 'in-progress' && !panel.value ? (
+          <EmptyState />
+        ) : panel.status === 'unavailable' || !panel.value ? (
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            No OWNERS / MAINTAINERS / CODEOWNERS files were verified across this run.
+          </p>
+        ) : (
+          <Body value={panel.value} />
+        )
+      ) : null}
     </section>
+  )
+}
+
+function PanelChevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`h-4 w-4 transition-transform ${expanded ? '' : '-rotate-90'}`}
+    >
+      <path d="M4 6l4 4 4-4" />
+    </svg>
   )
 }
 

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -106,11 +106,12 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
             <PanelChevron expanded={expanded} />
           </button>
           <div className="min-w-0">
-            <div className="flex items-center gap-1.5">
+            <div className="flex flex-wrap items-center gap-1.5">
               <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
                 Org admin activity
               </h3>
               <ScoringHelp section={section} />
+              <AdminCountSummary section={section} />
             </div>
             <p className="text-xs text-slate-500 dark:text-slate-400">
               Stale admin detection — an inactive admin is a privilege-escalation risk.
@@ -144,6 +145,48 @@ function PanelChevron({ expanded }: { expanded: boolean }) {
     >
       <path d="M4 6l4 4 4-4" />
     </svg>
+  )
+}
+
+function AdminCountSummary({ section }: { section: StaleAdminsSection | null }) {
+  if (!section || section.applicability !== 'admins-available') return null
+  const stale = section.admins.filter((a) => a.classification === 'stale').length
+  const unavailable = section.admins.filter((a) => a.classification === 'unavailable').length
+  if (stale === 0 && unavailable === 0) {
+    if (section.admins.length === 0) return null
+    return (
+      <span
+        className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+        data-testid="stale-admins-panel-summary"
+      >
+        All active
+      </span>
+    )
+  }
+  const parts: { label: string; className: string }[] = []
+  if (stale > 0) {
+    parts.push({
+      label: `${stale} stale`,
+      className: 'bg-rose-50 text-rose-700 dark:bg-rose-950 dark:text-rose-400',
+    })
+  }
+  if (unavailable > 0) {
+    parts.push({
+      label: `${unavailable} unavailable`,
+      className: 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400',
+    })
+  }
+  return (
+    <span className="flex flex-wrap items-center gap-1" data-testid="stale-admins-panel-summary">
+      {parts.map((p) => (
+        <span
+          key={p.label}
+          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${p.className}`}
+        >
+          {p.label}
+        </span>
+      ))}
+    </span>
   )
 }
 

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -149,7 +149,7 @@ function PanelChevron({ expanded }: { expanded: boolean }) {
 }
 
 function AdminCountSummary({ section }: { section: StaleAdminsSection | null }) {
-  if (!section || section.applicability !== 'admins-available') return null
+  if (!section || section.applicability !== 'applicable') return null
   const stale = section.admins.filter((a) => a.classification === 'stale').length
   const unavailable = section.admins.filter((a) => a.classification === 'unavailable').length
   if (stale === 0 && unavailable === 0) {

--- a/components/org-summary/panels/registry.tsx
+++ b/components/org-summary/panels/registry.tsx
@@ -123,7 +123,7 @@ export const PANEL_LABELS: Record<PanelId, string> = {
   'responsiveness-rollup': 'Responsiveness',
   'stale-work': 'Stale work',
   'security-rollup': 'Security (OpenSSF Scorecard)',
-  governance: 'Governance',
+  governance: 'GOVERNANCE.md coverage',
   'license-consistency': 'License consistency',
   'inclusive-naming-rollup': 'Inclusive naming',
   'documentation-coverage': 'Documentation coverage',

--- a/lib/export/org-summary-markdown-export.ts
+++ b/lib/export/org-summary-markdown-export.ts
@@ -30,7 +30,7 @@ const PANEL_LABELS: Record<PanelId, string> = {
   'org-affiliations': 'Org Affiliations',
   'release-cadence': 'Release Cadence',
   'security-rollup': 'Security Rollup',
-  governance: 'Governance',
+  governance: 'GOVERNANCE.md Coverage',
   adopters: 'Adopters',
   'project-footprint': 'Project Footprint',
   'activity-rollup': 'Activity Rollup',


### PR DESCRIPTION
## Summary
- Adds the panel-level collapse/expand chevron (matching the pattern shipped in #318 for `StaleAdminsPanel` and `LicenseConsistencyPanel`) to both `MaintainersPanel` and `GovernancePanel`, so every panel in the Governance tab now uses one consistent expand/collapse affordance.
- Renames the inner Governance panel to **"GOVERNANCE.md coverage"** to disambiguate from the tab name "Governance" — the inner panel describes presence of `GOVERNANCE.md` files across repos, a narrower scope than the tab name implies. The Governance tab label is unchanged.
- Updates `PANEL_LABELS` in `components/org-summary/panels/registry.tsx` and in `lib/export/org-summary-markdown-export.ts` to reflect the new inner panel name.
- Adds a **compact summary pill** next to each panel title in the Governance tab, visible in both collapsed and expanded states so the tab is scannable without expanding:
  - **Org admin activity** — `N stale` (rose) + `N unavailable` (amber), or `All active` (emerald) when nothing is flagged.
  - **Maintainers** — `N maintainers · T teams`.
  - **GOVERNANCE.md coverage** — `N of M repos` (emerald when all repos have `GOVERNANCE.md`, slate otherwise).
  - **License consistency** — `N non-OSI` (amber) or `All OSI` (emerald). The duplicate body-level summary line was removed.
- Adds unit tests (`MaintainersPanel.test.tsx`, `GovernancePanel.test.tsx`) covering the chevron toggle behavior, `aria-expanded` / `aria-label` flip, and summary-pill formatting — these were awkward to verify manually.

Closes #336.

## Test plan
- [x] In the Org summary view, open the **Governance** tab. Confirm all four panels (Org admin activity, Maintainers, GOVERNANCE.md coverage, License consistency) render with a chevron toggle on the left of their title.
- [x] Confirm the tab label in the tab bar still reads **Governance** (only the inner panel renamed).
- [x] Confirm dark mode shows the chevron buttons with correct hover/text colors on both panels.
- [x] Export the org summary as Markdown — the corresponding section heading reads **GOVERNANCE.md Coverage**.
- [x] With the Governance tab collapsed, confirm each panel header shows its summary pill with the correct stats and colors (stale/unavailable rose/amber, maintainers slate, all-present emerald, non-OSI amber, all-OSI emerald).
- [ ] Expand each panel and confirm the summary pill remains visible in the header (not only when collapsed).
- [x] Confirm the License consistency body no longer shows the duplicate "N use non-OSI-approved licenses" / "All use OSI-approved licenses" line (moved to the header).

> Chevron expand/collapse round-trip and `aria-expanded` / `aria-label` semantics are covered by unit tests in `MaintainersPanel.test.tsx` and `GovernancePanel.test.tsx` rather than manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)