### PR TITLE
Fix Contributors-pane filter leaking every row under unknown tags

### DIFF
--- a/components/contributors/ContributorsScorePane.tsx
+++ b/components/contributors/ContributorsScorePane.tsx
@@ -110,7 +110,10 @@ export function ContributorsScorePane({ section, activeTag: externalTag, onTagCh
             if (!activeTag) return true
             if (activeTag === 'governance') return GOVERNANCE_CONTRIBUTORS_METRICS.has(metric.label)
             if (activeTag === 'community') return COMMUNITY_CONTRIBUTORS_METRICS.has(metric.label)
-            return true
+            // Unknown tags (e.g., release-health, supply-chain, quick-win) have
+            // no contributors-tab items, so filter everything out rather than
+            // leaking every row through. Fixes #69 follow-up.
+            return false
           })
           .map((metric) => {
             const isGov = GOVERNANCE_CONTRIBUTORS_METRICS.has(metric.label)


### PR DESCRIPTION
## Summary

Follow-up to #333 (Release Health Scoring, #69). When clicking the new `release-health` lens pill, the Contributors pane leaked every metric row through the tag filter because the filter callback had `return true` as its fallback for any unknown tag. The governance and community branches filter to their specific Sets; the fallback should too — not pass everything through.

One-line change, one-file change. Same bug would apply to any future lens tag the Contributors pane doesn't know about (supply-chain, quick-win, etc.).

## Test plan

- [x] `npm test` — passes locally
- [x] Manual check (repo: `facebook/react`): click the `release-health` pill on the Activity tab, then open Contributors tab — metric grid is now empty (Maintainer count, Types of contributions, Funding disclosure all hidden), only the unfiltered header context (weighted factors pills, "Filtering by release-health" banner) remains
- [x] Manual check (repo: `facebook/react`): governance filter shows only Maintainer count; community filter shows Maintainer count + Funding disclosure; release-health filter shows empty grid — no regression on the existing governance / community filter branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)