### PR TITLE
Add org-level 2FA enforcement detection (#286)

### DIFF
--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -113,7 +113,7 @@ describe('GET /api/auth/login', () => {
     expect(scope).toBe('public_repo')
   })
 
-  it('adds read:org scope when ?elevated=1 is passed', async () => {
+  it('adds read:org scope when ?elevated=1 is passed (legacy alias for scope_tier=read-org)', async () => {
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?elevated=1'))
     const location = response.headers.get('location') ?? ''
     const scopeMatch = location.match(/scope=([^&]+)/)
@@ -127,6 +127,34 @@ describe('GET /api/auth/login', () => {
     const location = response.headers.get('location') ?? ''
     const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
     expect(scope).toBe('public_repo')
+  })
+
+  it('adds read:org scope when ?scope_tier=read-org is passed', async () => {
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=read-org'))
+    const location = response.headers.get('location') ?? ''
+    const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
+    expect(scope).toBe('public_repo read:org')
+  })
+
+  it('adds admin:org scope when ?scope_tier=admin-org is passed (no need to also include read:org — admin:org is a superset)', async () => {
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=admin-org'))
+    const location = response.headers.get('location') ?? ''
+    const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
+    expect(scope).toBe('public_repo admin:org')
+  })
+
+  it('treats ?scope_tier=baseline as baseline', async () => {
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=baseline'))
+    const location = response.headers.get('location') ?? ''
+    const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
+    expect(scope).toBe('public_repo')
+  })
+
+  it('prefers scope_tier over the legacy elevated flag when both are present', async () => {
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?elevated=1&scope_tier=admin-org'))
+    const location = response.headers.get('location') ?? ''
+    const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
+    expect(scope).toBe('public_repo admin:org')
   })
 
   it('dev-PAT short-circuit also encodes scope on the redirect fragment', async () => {

--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -157,21 +157,68 @@ describe('GET /api/auth/login', () => {
     expect(scope).toBe('public_repo admin:org')
   })
 
-  it('dev-PAT short-circuit also encodes scope on the redirect fragment', async () => {
+  it('dev-PAT session reports the PAT\'s real scopes from X-OAuth-Scopes, not the requested tier', async () => {
     vi.stubEnv('DEV_GITHUB_PAT', 'ghp_devtesttoken')
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
         new Response(JSON.stringify({ login: 'dev-user' }), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            // PAT actually has only public_repo + read:org, even though the
+            // user asked for admin-org below — the session should reflect
+            // reality, not the request.
+            'x-oauth-scopes': 'public_repo, read:org',
+          },
         }),
       ),
     )
 
-    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?elevated=1'))
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=admin-org'))
     const location = response.headers.get('location') ?? ''
-    expect(location).toContain('scopes=')
+    const decoded = decodeURIComponent(location)
+    expect(decoded).toContain('scopes=public_repo read:org')
+    expect(decoded).not.toContain('admin:org')
+  })
+
+  it('dev-PAT falls back to the requested tier when X-OAuth-Scopes is absent (fine-grained PATs do not report it)', async () => {
+    vi.stubEnv('DEV_GITHUB_PAT', 'github_pat_finegrained')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ login: 'dev-user' }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            // No x-oauth-scopes header — fine-grained PATs omit it.
+          },
+        }),
+      ),
+    )
+
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=admin-org'))
+    const location = response.headers.get('location') ?? ''
+    expect(decodeURIComponent(location)).toContain('scopes=public_repo admin:org')
+  })
+
+  it('dev-PAT treats an empty X-OAuth-Scopes header (legacy GitHub responses) as absent', async () => {
+    vi.stubEnv('DEV_GITHUB_PAT', 'ghp_test')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ login: 'dev-user' }), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'x-oauth-scopes': '',
+          },
+        }),
+      ),
+    )
+
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=read-org'))
+    const location = response.headers.get('location') ?? ''
     expect(decodeURIComponent(location)).toContain('scopes=public_repo read:org')
   })
 })

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -38,10 +38,14 @@ export async function GET(request: Request) {
   // without requiring OAuth App reconfiguration.
   const devPat = getDevPat()
   if (devPat) {
-    const username = await fetchGithubUsername(devPat)
-    if (username) {
+    const probe = await probeDevPat(devPat)
+    if (probe) {
+      // The user's tier selection is only a request; in dev, the PAT's *actual*
+      // scopes are what the session can do. Surface those (not the request),
+      // so the UI doesn't misrepresent the access rights.
+      const effectiveScopes = probe.actualScopes ?? scope
       const base = new URL('/', request.url)
-      const fragment = `token=${encodeURIComponent(devPat)}&username=${encodeURIComponent(username)}&scopes=${encodeURIComponent(scope)}`
+      const fragment = `token=${encodeURIComponent(devPat)}&username=${encodeURIComponent(probe.username)}&scopes=${encodeURIComponent(effectiveScopes)}`
       return Response.redirect(`${base.toString()}#${fragment}`, 302)
     }
     return Response.json(
@@ -76,7 +80,19 @@ export async function GET(request: Request) {
   return Response.redirect(`https://github.com/login/oauth/authorize?${params.toString()}`, 302)
 }
 
-async function fetchGithubUsername(token: string): Promise<string | null> {
+interface DevPatProbe {
+  username: string
+  /**
+   * Space-separated scope list reflecting what the PAT actually carries.
+   * Null if GitHub did not return X-OAuth-Scopes (fine-grained PATs omit it).
+   * When null, callers should fall back to the requested tier — the session
+   * is then optimistic and individual API calls will fail honestly if the
+   * fine-grained PAT lacks the needed permission.
+   */
+  actualScopes: string | null
+}
+
+async function probeDevPat(token: string): Promise<DevPatProbe | null> {
   try {
     const res = await fetch('https://api.github.com/user', {
       headers: {
@@ -86,8 +102,26 @@ async function fetchGithubUsername(token: string): Promise<string | null> {
     })
     if (!res.ok) return null
     const body = (await res.json()) as { login?: string }
-    return body.login ?? null
+    if (!body.login) return null
+
+    const scopesHeader = res.headers.get('x-oauth-scopes')
+    const actualScopes = normalizeScopesHeader(scopesHeader)
+
+    return { username: body.login, actualScopes }
   } catch {
     return null
   }
+}
+
+function normalizeScopesHeader(header: string | null): string | null {
+  if (!header) return null
+  const trimmed = header.trim()
+  if (!trimmed) return null
+  // GitHub returns comma-separated; we store space-separated for parity with
+  // OAuth responses.
+  return trimmed
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join(' ')
 }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -5,14 +5,33 @@ export const runtime = 'nodejs'
 
 const OAUTH_STATE_COOKIE = 'repo_pulse_oauth_state'
 
-export function buildOAuthScope(elevated: boolean): string {
-  return elevated ? 'public_repo read:org' : 'public_repo'
+export type ScopeTier = 'baseline' | 'read-org' | 'admin-org'
+
+export function buildOAuthScope(tier: ScopeTier): string {
+  switch (tier) {
+    case 'admin-org':
+      return 'public_repo admin:org'
+    case 'read-org':
+      return 'public_repo read:org'
+    default:
+      return 'public_repo'
+  }
+}
+
+export function resolveScopeTier(url: URL): ScopeTier {
+  const explicit = url.searchParams.get('scope_tier')
+  if (explicit === 'admin-org') return 'admin-org'
+  if (explicit === 'read-org') return 'read-org'
+  if (explicit === 'baseline') return 'baseline'
+  // Legacy: ?elevated=1 maps to read-org
+  if (url.searchParams.get('elevated') === '1') return 'read-org'
+  return 'baseline'
 }
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
-  const elevated = url.searchParams.get('elevated') === '1'
-  const scope = buildOAuthScope(elevated)
+  const tier = resolveScopeTier(url)
+  const scope = buildOAuthScope(tier)
 
   // Dev-only short-circuit (#207): bypass GitHub OAuth when DEV_GITHUB_PAT is
   // set in `next dev`. Resolves the multi-worktree port-mismatch problem

--- a/app/api/org/two-factor/route.test.ts
+++ b/app/api/org/two-factor/route.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GET } from './route'
+
+function buildReq(query: string, headers: Record<string, string> = { authorization: 'Bearer t' }) {
+  return new Request(`http://localhost/api/org/two-factor${query}`, { headers })
+}
+
+function json(status: number, body: unknown, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  })
+}
+
+describe('GET /api/org/two-factor', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns 400 when org is missing', async () => {
+    const res = await GET(buildReq(''))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const res = await GET(buildReq('?org=k8s', {}))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns not-applicable-non-org immediately for User ownerType without any API calls', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await GET(buildReq('?org=arun-gupta&ownerType=User'))
+    const body = (await res.json()) as {
+      section: { applicability: string; status: string | null }
+    }
+
+    expect(body.section.applicability).toBe('not-applicable-non-org')
+    expect(body.section.status).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns applicable + enforced when GitHub reports the flag as true', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => json(200, { login: 'acme', two_factor_requirement_enabled: true })),
+    )
+
+    const res = await GET(buildReq('?org=acme&ownerType=Organization'))
+    const body = (await res.json()) as {
+      section: { applicability: string; status: string | null }
+    }
+
+    expect(body.section.applicability).toBe('applicable')
+    expect(body.section.status).toBe('enforced')
+  })
+
+  it('returns applicable + not-enforced when GitHub reports the flag as false', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => json(200, { login: 'acme', two_factor_requirement_enabled: false })),
+    )
+
+    const res = await GET(buildReq('?org=acme&ownerType=Organization'))
+    const body = (await res.json()) as {
+      section: { applicability: string; status: string | null }
+    }
+
+    expect(body.section.applicability).toBe('applicable')
+    expect(body.section.status).toBe('not-enforced')
+  })
+
+  it('returns applicable + unknown when the field is absent (insufficient scope)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => json(200, { login: 'acme' })))
+
+    const res = await GET(buildReq('?org=acme&ownerType=Organization'))
+    const body = (await res.json()) as {
+      section: { applicability: string; status: string | null }
+    }
+
+    expect(body.section.applicability).toBe('applicable')
+    expect(body.section.status).toBe('unknown')
+  })
+
+  it('returns org-lookup-unavailable with mapped reason when rate-limited', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('', { status: 403, headers: { 'X-RateLimit-Remaining': '0' } })),
+    )
+
+    const res = await GET(buildReq('?org=acme&ownerType=Organization'))
+    const body = (await res.json()) as {
+      section: { applicability: string; lookupUnavailableReason?: string; status: string | null }
+    }
+
+    expect(body.section.applicability).toBe('org-lookup-unavailable')
+    expect(body.section.status).toBeNull()
+    expect(body.section.lookupUnavailableReason).toBe('rate-limited')
+  })
+
+  it('returns org-lookup-unavailable with reason not-found when the org is 404', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })))
+
+    const res = await GET(buildReq('?org=nope&ownerType=Organization'))
+    const body = (await res.json()) as {
+      section: { applicability: string; lookupUnavailableReason?: string }
+    }
+
+    expect(body.section.applicability).toBe('org-lookup-unavailable')
+    expect(body.section.lookupUnavailableReason).toBe('not-found')
+  })
+
+  it('returns org-lookup-unavailable with reason auth-failed on 401', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 401 })))
+
+    const res = await GET(buildReq('?org=acme&ownerType=Organization'))
+    const body = (await res.json()) as {
+      section: { applicability: string; lookupUnavailableReason?: string }
+    }
+
+    expect(body.section.applicability).toBe('org-lookup-unavailable')
+    expect(body.section.lookupUnavailableReason).toBe('auth-failed')
+  })
+})

--- a/app/api/org/two-factor/route.ts
+++ b/app/api/org/two-factor/route.ts
@@ -1,0 +1,84 @@
+import {
+  fetchOrgTwoFactorRequirement,
+  type OrgTwoFactorRequirementResult,
+} from '@/lib/analyzer/github-rest'
+import {
+  classifyTwoFactorRequirement,
+  type OrgLookupUnavailableReason,
+  type TwoFactorEnforcementSection,
+} from '@/lib/governance/two-factor'
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const org = url.searchParams.get('org')?.trim()
+  const ownerType = (url.searchParams.get('ownerType') ?? 'Organization').trim()
+
+  if (!org) {
+    return Response.json(
+      { error: { message: 'Organization is required.', code: 'INVALID_ORG' } },
+      { status: 400 },
+    )
+  }
+
+  const token = getBearerToken(request)
+  if (!token) {
+    return Response.json(
+      { error: { message: 'Authentication required.', code: 'UNAUTHENTICATED' } },
+      { status: 401 },
+    )
+  }
+
+  const resolvedAt = new Date().toISOString()
+
+  if (ownerType !== 'Organization') {
+    const section: TwoFactorEnforcementSection = {
+      kind: 'two-factor-enforcement',
+      applicability: 'not-applicable-non-org',
+      status: null,
+      resolvedAt,
+    }
+    return Response.json({ section })
+  }
+
+  const lookup = await fetchOrgTwoFactorRequirement(token, org)
+  if (lookup.kind !== 'ok') {
+    const section: TwoFactorEnforcementSection = {
+      kind: 'two-factor-enforcement',
+      applicability: 'org-lookup-unavailable',
+      status: null,
+      lookupUnavailableReason: mapLookupReason(lookup),
+      resolvedAt,
+    }
+    return Response.json({ section })
+  }
+
+  const section: TwoFactorEnforcementSection = {
+    kind: 'two-factor-enforcement',
+    applicability: 'applicable',
+    status: classifyTwoFactorRequirement(lookup.twoFactorRequirementEnabled),
+    resolvedAt,
+  }
+  return Response.json({ section })
+}
+
+function mapLookupReason(result: OrgTwoFactorRequirementResult): OrgLookupUnavailableReason {
+  switch (result.kind) {
+    case 'rate-limited':
+      return 'rate-limited'
+    case 'auth-failed':
+      return 'auth-failed'
+    case 'not-found':
+      return 'not-found'
+    case 'network':
+      return 'network'
+    default:
+      return 'unknown'
+  }
+}
+
+function getBearerToken(request: Request): string | null {
+  const authorization = request.headers.get('authorization')
+  if (!authorization) return null
+  const match = authorization.match(/^Bearer\s+(.+)$/i)
+  return match?.[1]?.trim() || null
+}

--- a/components/auth/AuthGate.test.tsx
+++ b/components/auth/AuthGate.test.tsx
@@ -58,7 +58,7 @@ describe('AuthGate', () => {
     expect(screen.getByRole('link', { name: /sign in with github/i })).toBeInTheDocument()
   })
 
-  it('renders an opt-in deeper-permission checkbox on the unauthenticated branch', () => {
+  it('renders three scope-tier radios on the unauthenticated branch, with baseline selected by default', () => {
     render(
       <AuthProvider>
         <AuthGate>
@@ -66,12 +66,16 @@ describe('AuthGate', () => {
         </AuthGate>
       </AuthProvider>,
     )
-    const checkbox = screen.getByRole('checkbox', { name: /deeper github permission/i })
-    expect(checkbox).toBeInTheDocument()
-    expect(checkbox).not.toBeChecked()
+    const baseline = screen.getByRole('radio', { name: /baseline/i })
+    const readOrg = screen.getByRole('radio', { name: /read org membership/i })
+    const adminOrg = screen.getByRole('radio', { name: /org admin \(read\)/i })
+
+    expect(baseline).toBeChecked()
+    expect(readOrg).not.toBeChecked()
+    expect(adminOrg).not.toBeChecked()
   })
 
-  it('sign-in link includes ?elevated=1 when the checkbox is checked, and omits it when unchecked', async () => {
+  it('sign-in link reflects the selected scope tier', async () => {
     const userEvent = (await import('@testing-library/user-event')).default
     render(
       <AuthProvider>
@@ -83,10 +87,26 @@ describe('AuthGate', () => {
     const link = screen.getByRole('link', { name: /sign in with github/i })
     expect(link.getAttribute('href')).toBe('/api/auth/login')
 
-    await userEvent.click(screen.getByRole('checkbox', { name: /deeper github permission/i }))
-    expect(link.getAttribute('href')).toBe('/api/auth/login?elevated=1')
+    await userEvent.click(screen.getByRole('radio', { name: /read org membership/i }))
+    expect(link.getAttribute('href')).toBe('/api/auth/login?scope_tier=read-org')
 
-    await userEvent.click(screen.getByRole('checkbox', { name: /deeper github permission/i }))
+    await userEvent.click(screen.getByRole('radio', { name: /org admin \(read\)/i }))
+    expect(link.getAttribute('href')).toBe('/api/auth/login?scope_tier=admin-org')
+
+    await userEvent.click(screen.getByRole('radio', { name: /baseline/i }))
     expect(link.getAttribute('href')).toBe('/api/auth/login')
+  })
+
+  it('each scope tier carries a brief guidance line to help the user decide', () => {
+    render(
+      <AuthProvider>
+        <AuthGate>
+          <p>Protected content</p>
+        </AuthGate>
+      </AuthProvider>,
+    )
+    expect(screen.getByText(/public data only/i)).toBeInTheDocument()
+    expect(screen.getByText(/concealed admins/i)).toBeInTheDocument()
+    expect(screen.getByText(/owner-only org settings/i)).toBeInTheDocument()
   })
 })

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from './AuthContext'
-import { SignInButton } from './SignInButton'
+import { SignInButton, type ScopeTier } from './SignInButton'
 
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const { session, signIn } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
   const authError = searchParams.get('auth_error')
-  const [elevatedOptIn, setElevatedOptIn] = useState(false)
+  const [scopeTier, setScopeTier] = useState<ScopeTier>('baseline')
 
   useEffect(() => {
     // Remove stale PAT key left by the pre-OAuth token-storage implementation
@@ -88,21 +88,37 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
           </div>
         </div>
 
-        <SignInButton elevated={elevatedOptIn} />
+        <SignInButton tier={scopeTier} />
 
-        <label className="flex max-w-md cursor-pointer items-start gap-2 px-4 text-left text-xs text-slate-600 dark:text-slate-300">
-          <input
-            type="checkbox"
-            checked={elevatedOptIn}
-            onChange={(e) => setElevatedOptIn(e.target.checked)}
-            className="mt-0.5 h-3.5 w-3.5 rounded border-slate-300 dark:border-slate-600"
+        <fieldset
+          className="max-w-md space-y-2 px-4 text-left text-xs text-slate-600 dark:text-slate-300"
+          aria-label="GitHub permission scope"
+        >
+          <legend className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            GitHub permission
+          </legend>
+          <ScopeRadio
+            value="baseline"
+            checked={scopeTier === 'baseline'}
+            onChange={setScopeTier}
+            label={<><span className="font-semibold">Baseline</span> (<code>public_repo</code>)</>}
+            guidance="Public data only. Recommended for read-only audits of third-party orgs."
           />
-          <span>
-            Request a <span className="font-semibold">deeper GitHub permission</span> (<code>read:org</code>)
-            to see concealed admins of orgs you belong to. Unlocks the full Stale Admin panel for
-            your own orgs. Default: off.
-          </span>
-        </label>
+          <ScopeRadio
+            value="read-org"
+            checked={scopeTier === 'read-org'}
+            onChange={setScopeTier}
+            label={<><span className="font-semibold">Read org membership</span> (<code>read:org</code>)</>}
+            guidance="See concealed admins of orgs you belong to. Choose this if you want the full Stale Admin panel for your own orgs."
+          />
+          <ScopeRadio
+            value="admin-org"
+            checked={scopeTier === 'admin-org'}
+            onChange={setScopeTier}
+            label={<><span className="font-semibold">Org admin (read)</span> (<code>admin:org</code>)</>}
+            guidance="Includes everything above, plus owner-only org settings like 2FA enforcement. Broadest scope — choose only if you own the orgs you plan to audit."
+          />
+        </fieldset>
 
         <div className="max-w-md space-y-2 text-center">
           <p className="text-xs italic text-slate-400 dark:text-slate-500">
@@ -117,4 +133,35 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
   return <>{children}</>
 
+}
+
+function ScopeRadio({
+  value,
+  checked,
+  onChange,
+  label,
+  guidance,
+}: {
+  value: ScopeTier
+  checked: boolean
+  onChange: (t: ScopeTier) => void
+  label: React.ReactNode
+  guidance: string
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-2">
+      <input
+        type="radio"
+        name="scope-tier"
+        value={value}
+        checked={checked}
+        onChange={() => onChange(value)}
+        className="mt-0.5 h-3.5 w-3.5 border-slate-300 dark:border-slate-600"
+      />
+      <span className="min-w-0">
+        <span className="block">{label}</span>
+        <span className="block text-[11px] text-slate-500 dark:text-slate-400">{guidance}</span>
+      </span>
+    </label>
+  )
 }

--- a/components/auth/SignInButton.tsx
+++ b/components/auth/SignInButton.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-export function SignInButton({ elevated = false }: { elevated?: boolean }) {
+export type ScopeTier = 'baseline' | 'read-org' | 'admin-org'
+
+export function SignInButton({ tier = 'baseline' }: { tier?: ScopeTier }) {
   function handleClick() {
     if (typeof window === 'undefined') return
     if (window.location.search) {
@@ -10,7 +12,8 @@ export function SignInButton({ elevated = false }: { elevated?: boolean }) {
     }
   }
 
-  const href = elevated ? '/api/auth/login?elevated=1' : '/api/auth/login'
+  const href =
+    tier === 'baseline' ? '/api/auth/login' : `/api/auth/login?scope_tier=${tier}`
 
   return (
     <a

--- a/components/org-summary/OrgBucketContent.test.tsx
+++ b/components/org-summary/OrgBucketContent.test.tsx
@@ -91,6 +91,41 @@ describe('OrgBucketContent — StaleAdminsPanel migration (#303)', () => {
   })
 })
 
+describe('OrgBucketContent — TwoFactorEnforcementPanel wiring (#286)', () => {
+  it('does NOT render TwoFactorEnforcementPanel when bucketId is documentation', () => {
+    renderWithSession(<OrgBucketContent bucketId="documentation" view={emptyView()} org="acme" />)
+    expect(screen.queryByTestId('two-factor-panel')).not.toBeInTheDocument()
+  })
+
+  it('renders TwoFactorEnforcementPanel when bucketId is governance and ownerType is Organization', () => {
+    renderWithSession(<OrgBucketContent bucketId="governance" view={emptyView()} org="acme" />)
+    expect(screen.getByTestId('two-factor-panel')).toBeInTheDocument()
+  })
+
+  it('renders TwoFactorEnforcementPanel even when ownerType is User (org=null) — its own N/A rendering is its responsibility', () => {
+    renderWithSession(<OrgBucketContent bucketId="governance" view={emptyView()} org={null} />)
+    expect(screen.getByTestId('two-factor-panel')).toBeInTheDocument()
+  })
+
+  it('does NOT render TwoFactorEnforcementPanel under any non-governance bucket', () => {
+    for (const bucketId of ['contributors', 'activity', 'responsiveness', 'documentation', 'security'] as const) {
+      const { unmount } = renderWithSession(<OrgBucketContent bucketId={bucketId} view={emptyView()} org="acme" />)
+      expect(screen.queryByTestId('two-factor-panel')).not.toBeInTheDocument()
+      unmount()
+    }
+  })
+
+  it('renders TwoFactorEnforcementPanel BEFORE StaleAdminsPanel so both org-level signals sit at the top of Governance', () => {
+    renderWithSession(<OrgBucketContent bucketId="governance" view={emptyView()} org="acme" />)
+
+    const twoFactorNode = screen.getByTestId('two-factor-panel')
+    const staleAdminsNode = screen.getByTestId('stale-admins-panel')
+
+    const positionRelation = twoFactorNode.compareDocumentPosition(staleAdminsNode)
+    expect(positionRelation & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})
+
 describe('OrgBucketContent — risk-first panel order in Governance (#303 US3)', () => {
   it('renders StaleAdminsPanel BEFORE registry-driven panels', () => {
     renderWithSession(<OrgBucketContent bucketId="governance" view={viewWithGovernancePanels()} org="acme" />)

--- a/components/org-summary/OrgBucketContent.test.tsx
+++ b/components/org-summary/OrgBucketContent.test.tsx
@@ -91,6 +91,26 @@ describe('OrgBucketContent — StaleAdminsPanel migration (#303)', () => {
   })
 })
 
+describe('OrgBucketContent — pre-analysis governance rendering (#286)', () => {
+  it('renders TwoFactorEnforcementPanel and StaleAdminsPanel when view is null — org-level panels self-fetch', () => {
+    renderWithSession(<OrgBucketContent bucketId="governance" view={null} org="acme" />)
+    expect(screen.getByTestId('two-factor-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('stale-admins-panel')).toBeInTheDocument()
+  })
+
+  it('renders no rollup panels when view is null (nothing to aggregate yet)', () => {
+    renderWithSession(<OrgBucketContent bucketId="governance" view={null} org="acme" />)
+    // Registry-driven rollup panels rely on view.panels — none should appear.
+    expect(screen.queryByTestId('mock-panel-maintainers')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mock-panel-license-consistency')).not.toBeInTheDocument()
+  })
+
+  it('renders the empty-state hint when view is null and bucket has no extra panels (e.g. activity)', () => {
+    renderWithSession(<OrgBucketContent bucketId="activity" view={null} org="acme" />)
+    expect(screen.getByText(/no data available/i)).toBeInTheDocument()
+  })
+})
+
 describe('OrgBucketContent — TwoFactorEnforcementPanel wiring (#286)', () => {
   it('does NOT render TwoFactorEnforcementPanel when bucketId is documentation', () => {
     renderWithSession(<OrgBucketContent bucketId="documentation" view={emptyView()} org="acme" />)

--- a/components/org-summary/OrgBucketContent.tsx
+++ b/components/org-summary/OrgBucketContent.tsx
@@ -8,7 +8,7 @@ import { TwoFactorEnforcementPanel } from './panels/TwoFactorEnforcementPanel'
 
 interface Props {
   bucketId: PanelBucketId
-  view: OrgSummaryViewModel
+  view: OrgSummaryViewModel | null
   selectedWindow?: ContributorDiversityWindow
   org?: string | null
 }
@@ -17,11 +17,13 @@ export function OrgBucketContent({ bucketId, view, selectedWindow, org }: Props)
   const bucket = PANEL_BUCKETS.find((b) => b.id === bucketId)
   if (!bucket) return null
 
-  const bucketPanels = bucket.panels
-    .map((panelId) => ({ panelId, panel: view.panels[panelId] }))
-    .filter((x): x is { panelId: typeof x.panelId; panel: NonNullable<typeof x.panel> } =>
-      Boolean(x.panel) && isRealPanel(x.panelId)
-    )
+  const bucketPanels = view
+    ? bucket.panels
+        .map((panelId) => ({ panelId, panel: view.panels[panelId] }))
+        .filter((x): x is { panelId: typeof x.panelId; panel: NonNullable<typeof x.panel> } =>
+          Boolean(x.panel) && isRealPanel(x.panelId),
+        )
+    : []
 
   const extraPanels =
     bucketId === 'governance' ? (

--- a/components/org-summary/OrgBucketContent.tsx
+++ b/components/org-summary/OrgBucketContent.tsx
@@ -4,6 +4,7 @@ import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
 import type { ContributorDiversityWindow } from '@/lib/org-aggregation/aggregators/types'
 import { PANEL_BUCKETS, isRealPanel, renderPanel, type PanelBucketId } from './panels/registry'
 import { StaleAdminsPanel } from './panels/StaleAdminsPanel'
+import { TwoFactorEnforcementPanel } from './panels/TwoFactorEnforcementPanel'
 
 interface Props {
   bucketId: PanelBucketId
@@ -24,7 +25,10 @@ export function OrgBucketContent({ bucketId, view, selectedWindow, org }: Props)
 
   const extraPanels =
     bucketId === 'governance' ? (
-      <StaleAdminsPanel org={org ?? null} ownerType={org ? 'Organization' : 'User'} />
+      <>
+        <TwoFactorEnforcementPanel org={org ?? null} ownerType={org ? 'Organization' : 'User'} />
+        <StaleAdminsPanel org={org ?? null} ownerType={org ? 'Organization' : 'User'} />
+      </>
     ) : null
 
   if (bucketPanels.length === 0 && !extraPanels) {

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -124,7 +124,7 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     expect(within(strip).getByTestId('stale-admins-count-active').textContent).toMatch(/2 active/i)
   })
 
-  it('hides the description, summary strip, and group list when the panel is collapsed', () => {
+  it('hides the description and group list when the panel is collapsed, keeps the summary count strip visible', () => {
     const section = makeSection({
       admins: [mkAdmin('s1', 'stale'), mkAdmin('a1', 'active')],
     })
@@ -138,9 +138,9 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     fireEvent.click(toggle)
 
     expect(screen.queryByTestId('stale-admins-group-stale')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('stale-admins-count-strip')).not.toBeInTheDocument()
     expect(screen.queryByText(/stale admin detection/i)).not.toBeInTheDocument()
-    // Title stays visible.
+    // Summary strip and title stay visible so the signal is still readable at a glance.
+    expect(screen.getByTestId('stale-admins-count-strip')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /org admin activity/i })).toBeInTheDocument()
   })
 

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -122,7 +122,7 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
           </div>
           {section ? <ModeBadge mode={section.mode} /> : null}
         </div>
-        {expanded && section ? <HeaderCountStrip section={section} /> : null}
+        {section ? <HeaderCountStrip section={section} /> : null}
       </header>
 
       {expanded ? (

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -72,7 +72,9 @@ const GROUP_CONFIG: Record<
 
 export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverride }: Props) {
   const { session, hasScope } = useAuth()
-  const elevated = hasScope('read:org')
+  // admin:org is a strict superset of read:org — treat either as "elevated"
+  // for the concealed-admins view.
+  const elevated = hasScope('read:org') || hasScope('admin:org')
   const hasOverride = sectionOverride !== undefined
 
   const hookState = useStaleAdmins({

--- a/components/org-summary/panels/TwoFactorEnforcementPanel.test.tsx
+++ b/components/org-summary/panels/TwoFactorEnforcementPanel.test.tsx
@@ -72,6 +72,20 @@ describe('TwoFactorEnforcementPanel — applicable states', () => {
     expect(explain.textContent).toMatch(/not the same as not enforced/i)
     expect(explain.textContent).toMatch(/organization owner/i)
   })
+
+  it('tells owners how to read the flag — hint at the elevated-scope landing-page checkbox', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={makeSection({ status: 'unknown' })}
+      />,
+    )
+    const explain = screen.getByTestId('two-factor-unknown-explain')
+    expect(explain.textContent).toMatch(/read:org/)
+    expect(explain.textContent).toMatch(/deeper GitHub permission/i)
+    expect(explain.textContent).toMatch(/public_repo/)
+  })
 })
 
 describe('TwoFactorEnforcementPanel — N/A for non-org targets', () => {

--- a/components/org-summary/panels/TwoFactorEnforcementPanel.test.tsx
+++ b/components/org-summary/panels/TwoFactorEnforcementPanel.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { AuthProvider } from '@/components/auth/AuthContext'
+import { TwoFactorEnforcementPanel } from './TwoFactorEnforcementPanel'
+import type { TwoFactorEnforcementSection } from '@/lib/governance/two-factor'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+function renderWithSession(ui: React.ReactElement) {
+  return render(
+    <AuthProvider initialSession={{ token: 't', username: 'u', scopes: ['public_repo'] }}>
+      {ui}
+    </AuthProvider>,
+  )
+}
+
+function makeSection(override: Partial<TwoFactorEnforcementSection> = {}): TwoFactorEnforcementSection {
+  return {
+    kind: 'two-factor-enforcement',
+    applicability: 'applicable',
+    status: 'enforced',
+    resolvedAt: '2026-04-16T00:00:00Z',
+    ...override,
+  }
+}
+
+describe('TwoFactorEnforcementPanel — applicable states', () => {
+  it('renders an "enforced" badge with distinct affirmative styling when status is enforced', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={makeSection({ status: 'enforced' })}
+      />,
+    )
+    const badge = screen.getByTestId('two-factor-status-enforced')
+    expect(badge.textContent).toMatch(/enforced/i)
+    expect(badge.className).toMatch(/emerald/)
+  })
+
+  it('renders a "not enforced" badge with distinct warning styling when status is not-enforced', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={makeSection({ status: 'not-enforced' })}
+      />,
+    )
+    const badge = screen.getByTestId('two-factor-status-not-enforced')
+    expect(badge.textContent).toMatch(/not enforced/i)
+    expect(badge.className).toMatch(/rose/)
+  })
+
+  it('renders an "unknown" badge distinct from "not enforced" and explicitly disambiguates the two', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={makeSection({ status: 'unknown' })}
+      />,
+    )
+    const badge = screen.getByTestId('two-factor-status-unknown')
+    expect(badge.textContent).toMatch(/unknown/i)
+    expect(badge.textContent).not.toMatch(/not enforced/i)
+
+    // The "unknown" explanation must call out that unknown ≠ not-enforced
+    // (acceptance criterion from issue #286).
+    const explain = screen.getByTestId('two-factor-unknown-explain')
+    expect(explain.textContent).toMatch(/not the same as not enforced/i)
+    expect(explain.textContent).toMatch(/organization owner/i)
+  })
+})
+
+describe('TwoFactorEnforcementPanel — N/A for non-org targets', () => {
+  it('renders an explicit N/A state and no status badge when applicability is not-applicable-non-org', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org={null}
+        ownerType="User"
+        sectionOverride={makeSection({
+          applicability: 'not-applicable-non-org',
+          status: null,
+        })}
+      />,
+    )
+    expect(screen.getByTestId('two-factor-na')).toBeInTheDocument()
+    expect(screen.queryByTestId(/two-factor-status-/)).not.toBeInTheDocument()
+  })
+})
+
+describe('TwoFactorEnforcementPanel — org-lookup-unavailable', () => {
+  it('renders a labeled unavailable state with the reason', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={makeSection({
+          applicability: 'org-lookup-unavailable',
+          status: null,
+          lookupUnavailableReason: 'rate-limited',
+        })}
+      />,
+    )
+    const el = screen.getByTestId('two-factor-unavailable')
+    expect(el.textContent).toMatch(/could not be retrieved/i)
+    expect(el.textContent).toMatch(/rate-limited/)
+    expect(screen.queryByTestId(/two-factor-status-/)).not.toBeInTheDocument()
+  })
+})
+
+describe('TwoFactorEnforcementPanel — collapse/expand', () => {
+  it('hides description and body when collapsed, keeps the title and status badge visible', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={makeSection({ status: 'enforced' })}
+      />,
+    )
+
+    expect(screen.getByText(/whether this organization requires/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('two-factor-panel-toggle'))
+
+    expect(screen.queryByText(/whether this organization requires/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /org 2fa enforcement/i })).toBeInTheDocument()
+    // Status badge remains visible in collapsed state so the signal is still
+    // readable at a glance — matches the pattern in StaleAdminsPanel.
+    expect(screen.getByTestId('two-factor-status-enforced')).toBeInTheDocument()
+  })
+})
+
+describe('TwoFactorEnforcementPanel — scoring help', () => {
+  it('discloses that the value is read from GitHub and requires org-owner scope', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={makeSection({ status: 'unknown' })}
+      />,
+    )
+    const help = screen.getByTestId('two-factor-scoring-help')
+    expect(help.textContent).toMatch(/two_factor_requirement_enabled/)
+    expect(help.textContent).toMatch(/organization owner/i)
+    expect(help.textContent).toMatch(/observation-only/i)
+  })
+})
+
+describe('TwoFactorEnforcementPanel — loading override', () => {
+  it('shows a loading hint while override says loading', () => {
+    renderWithSession(
+      <TwoFactorEnforcementPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={null}
+        loadingOverride={true}
+      />,
+    )
+    expect(screen.getByText(/loading 2fa status/i)).toBeInTheDocument()
+  })
+})

--- a/components/org-summary/panels/TwoFactorEnforcementPanel.test.tsx
+++ b/components/org-summary/panels/TwoFactorEnforcementPanel.test.tsx
@@ -82,8 +82,8 @@ describe('TwoFactorEnforcementPanel — applicable states', () => {
       />,
     )
     const explain = screen.getByTestId('two-factor-unknown-explain')
-    expect(explain.textContent).toMatch(/read:org/)
-    expect(explain.textContent).toMatch(/deeper GitHub permission/i)
+    expect(explain.textContent).toMatch(/admin:org/)
+    expect(explain.textContent).toMatch(/Organization administration: Read/i)
     expect(explain.textContent).toMatch(/public_repo/)
   })
 })

--- a/components/org-summary/panels/TwoFactorEnforcementPanel.tsx
+++ b/components/org-summary/panels/TwoFactorEnforcementPanel.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useState } from 'react'
+import { useAuth } from '@/components/auth/AuthContext'
+import {
+  useTwoFactorEnforcement,
+  type OwnerType,
+} from '@/components/shared/hooks/useTwoFactorEnforcement'
+import type {
+  TwoFactorEnforcementSection,
+  TwoFactorEnforcementStatus,
+} from '@/lib/governance/two-factor'
+
+interface Props {
+  org: string | null
+  ownerType: OwnerType
+  /** Override for tests. */
+  sectionOverride?: TwoFactorEnforcementSection | null
+  /** Override for tests. */
+  loadingOverride?: boolean
+}
+
+const STATUS_CONFIG: Record<
+  TwoFactorEnforcementStatus,
+  { label: string; icon: string; badgeClassName: string; ariaLabel: string }
+> = {
+  enforced: {
+    label: '2FA enforced',
+    icon: '✓',
+    badgeClassName:
+      'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400',
+    ariaLabel: '2FA enforced for all organization members',
+  },
+  'not-enforced': {
+    label: '2FA not enforced',
+    icon: '⚠',
+    badgeClassName: 'bg-rose-50 text-rose-700 dark:bg-rose-950 dark:text-rose-400',
+    ariaLabel: '2FA is not enforced for organization members',
+  },
+  unknown: {
+    label: '2FA status unknown',
+    icon: '?',
+    badgeClassName: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+    ariaLabel: '2FA enforcement status could not be determined',
+  },
+}
+
+export function TwoFactorEnforcementPanel({
+  org,
+  ownerType,
+  sectionOverride,
+  loadingOverride,
+}: Props) {
+  const { session } = useAuth()
+  const hasOverride = sectionOverride !== undefined
+
+  const hookState = useTwoFactorEnforcement({
+    org: hasOverride ? null : org,
+    ownerType,
+    token: hasOverride ? null : session?.token ?? null,
+  })
+
+  const section = hasOverride ? sectionOverride : hookState.section
+  const loading = loadingOverride ?? (hasOverride ? false : hookState.loading)
+  const [expanded, setExpanded] = useState(true)
+
+  return (
+    <section
+      aria-label="Org 2FA enforcement"
+      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+      data-testid="two-factor-panel"
+    >
+      <header className={expanded ? 'mb-3' : ''}>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="flex min-w-0 items-start gap-2">
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              aria-label={expanded ? 'Collapse Org 2FA enforcement' : 'Expand Org 2FA enforcement'}
+              aria-expanded={expanded}
+              title={expanded ? 'Collapse' : 'Expand'}
+              data-testid="two-factor-panel-toggle"
+              className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+            >
+              <PanelChevron expanded={expanded} />
+            </button>
+            <div className="min-w-0">
+              <div className="flex items-center gap-1.5">
+                <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  Org 2FA enforcement
+                </h3>
+                <ScoringHelp />
+              </div>
+              {expanded ? (
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Whether this organization requires two-factor authentication for all members.
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {section && section.applicability === 'applicable' && section.status ? (
+            <StatusBadge status={section.status} />
+          ) : null}
+        </div>
+      </header>
+
+      {expanded ? (
+        <>
+          {loading ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">Loading 2FA status…</p>
+          ) : null}
+          {!loading && section ? <SectionBody section={section} /> : null}
+        </>
+      ) : null}
+    </section>
+  )
+}
+
+function PanelChevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`h-4 w-4 transition-transform ${expanded ? '' : '-rotate-90'}`}
+    >
+      <path d="M4 6l4 4 4-4" />
+    </svg>
+  )
+}
+
+function StatusBadge({ status }: { status: TwoFactorEnforcementStatus }) {
+  const config = STATUS_CONFIG[status]
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium ${config.badgeClassName}`}
+      data-testid={`two-factor-status-${status}`}
+      aria-label={config.ariaLabel}
+    >
+      <span aria-hidden="true">{config.icon}</span>
+      <span>{config.label}</span>
+    </span>
+  )
+}
+
+function SectionBody({ section }: { section: TwoFactorEnforcementSection }) {
+  if (section.applicability === 'not-applicable-non-org') {
+    return (
+      <p
+        className="text-sm text-slate-600 dark:text-slate-300"
+        data-testid="two-factor-na"
+      >
+        Not applicable for non-organization targets. 2FA enforcement is an organization-level
+        setting; this analysis targets a user-owned repository.
+      </p>
+    )
+  }
+
+  if (section.applicability === 'org-lookup-unavailable') {
+    return (
+      <p
+        className="text-sm text-rose-700 dark:text-rose-400"
+        data-testid="two-factor-unavailable"
+      >
+        Organization lookup could not be retrieved —{' '}
+        <span className="font-medium">{section.lookupUnavailableReason ?? 'unknown'}</span>.
+      </p>
+    )
+  }
+
+  if (section.status === 'unknown') {
+    return (
+      <p
+        className="text-sm text-slate-600 dark:text-slate-300"
+        data-testid="two-factor-unknown-explain"
+      >
+        GitHub does not expose the <code className="font-mono text-xs">two_factor_requirement_enabled</code>{' '}
+        field to this session. Unknown is <span className="font-medium">not the same as not enforced</span> —
+        only an organization owner can read this flag.
+      </p>
+    )
+  }
+
+  if (section.status === 'enforced') {
+    return (
+      <p className="text-sm text-slate-600 dark:text-slate-300">
+        All members of this organization are required to enable two-factor authentication.
+      </p>
+    )
+  }
+
+  if (section.status === 'not-enforced') {
+    return (
+      <p className="text-sm text-slate-600 dark:text-slate-300">
+        This organization does not require members to enable two-factor authentication. Enabling
+        the requirement reduces the blast radius of credential compromise.
+      </p>
+    )
+  }
+
+  return null
+}
+
+function ScoringHelp() {
+  return (
+    <details className="relative" data-testid="two-factor-scoring-help">
+      <summary
+        aria-label="How is this scored?"
+        className="inline-flex h-4 w-4 cursor-pointer select-none items-center justify-center rounded-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-500 list-none hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200 [&::-webkit-details-marker]:hidden"
+      >
+        ?
+      </summary>
+      <div className="absolute left-0 top-6 z-10 w-72 rounded-md border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <p className="mb-1 font-medium text-slate-700 dark:text-slate-200">How is this scored?</p>
+        <p className="mb-1.5">
+          Value is read from GitHub&apos;s{' '}
+          <code className="font-mono text-[11px]">two_factor_requirement_enabled</code> field on{' '}
+          <code className="font-mono text-[11px]">GET /orgs/&#123;org&#125;</code>.
+        </p>
+        <p className="mb-1.5">
+          The field is only populated for authenticated <span className="font-medium">organization owners</span>. Other sessions
+          receive <span className="font-medium">null</span>, which we surface as{' '}
+          <span className="font-medium">unknown</span> — never confused with{' '}
+          <span className="font-medium">not enforced</span>.
+        </p>
+        <p>This signal is observation-only and does not feed the composite OSS Health Score.</p>
+      </div>
+    </details>
+  )
+}

--- a/components/org-summary/panels/TwoFactorEnforcementPanel.tsx
+++ b/components/org-summary/panels/TwoFactorEnforcementPanel.tsx
@@ -174,14 +174,20 @@ function SectionBody({ section }: { section: TwoFactorEnforcementSection }) {
 
   if (section.status === 'unknown') {
     return (
-      <p
-        className="text-sm text-slate-600 dark:text-slate-300"
-        data-testid="two-factor-unknown-explain"
-      >
-        GitHub does not expose the <code className="font-mono text-xs">two_factor_requirement_enabled</code>{' '}
-        field to this session. Unknown is <span className="font-medium">not the same as not enforced</span> —
-        only an organization owner can read this flag.
-      </p>
+      <div className="space-y-2 text-sm text-slate-600 dark:text-slate-300" data-testid="two-factor-unknown-explain">
+        <p>
+          GitHub does not expose the <code className="font-mono text-xs">two_factor_requirement_enabled</code>{' '}
+          field to this session. Unknown is <span className="font-medium">not the same as not enforced</span> —
+          only an organization owner with the <code className="font-mono text-xs">read:org</code> scope can
+          read this flag.
+        </p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          If you own this org: sign out, check <span className="font-medium">&ldquo;Request deeper GitHub
+          permission&rdquo;</span> on the landing page, and sign back in. Baseline{' '}
+          <code className="font-mono text-[11px]">public_repo</code> scope returns{' '}
+          <code className="font-mono text-[11px]">null</code> for this field even for owners.
+        </p>
+      </div>
     )
   }
 

--- a/components/org-summary/panels/TwoFactorEnforcementPanel.tsx
+++ b/components/org-summary/panels/TwoFactorEnforcementPanel.tsx
@@ -178,14 +178,16 @@ function SectionBody({ section }: { section: TwoFactorEnforcementSection }) {
         <p>
           GitHub does not expose the <code className="font-mono text-xs">two_factor_requirement_enabled</code>{' '}
           field to this session. Unknown is <span className="font-medium">not the same as not enforced</span> —
-          only an organization owner with the <code className="font-mono text-xs">read:org</code> scope can
-          read this flag.
+          only an organization owner whose token has the <code className="font-mono text-xs">admin:org</code>{' '}
+          scope (classic PAT) or the <span className="font-medium">Organization administration: Read</span>{' '}
+          permission (fine-grained PAT) can read this flag.
         </p>
         <p className="text-xs text-slate-500 dark:text-slate-400">
-          If you own this org: sign out, check <span className="font-medium">&ldquo;Request deeper GitHub
-          permission&rdquo;</span> on the landing page, and sign back in. Baseline{' '}
-          <code className="font-mono text-[11px]">public_repo</code> scope returns{' '}
-          <code className="font-mono text-[11px]">null</code> for this field even for owners.
+          Baseline <code className="font-mono text-[11px]">public_repo</code> and{' '}
+          <code className="font-mono text-[11px]">read:org</code> both return{' '}
+          <code className="font-mono text-[11px]">null</code> for this field even for owners — GitHub
+          requires a stricter admin scope than the landing-page &ldquo;deeper permission&rdquo;
+          checkbox currently requests.
         </p>
       </div>
     )
@@ -228,8 +230,10 @@ function ScoringHelp() {
           <code className="font-mono text-[11px]">GET /orgs/&#123;org&#125;</code>.
         </p>
         <p className="mb-1.5">
-          The field is only populated for authenticated <span className="font-medium">organization owners</span>. Other sessions
-          receive <span className="font-medium">null</span>, which we surface as{' '}
+          The field is only populated for authenticated <span className="font-medium">organization owners</span> whose
+          token carries <code className="font-mono text-[11px]">admin:org</code> (classic PAT) or{' '}
+          <span className="font-medium">Organization administration: Read</span> (fine-grained PAT).
+          Other sessions receive <span className="font-medium">null</span>, which we surface as{' '}
           <span className="font-medium">unknown</span> — never confused with{' '}
           <span className="font-medium">not enforced</span>.
         </p>

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -377,9 +377,14 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         { id: 'governance', label: 'Governance', status: 'implemented', description: 'Org-level hygiene and policy — account activity, maintainers, governance files, license consistency.' },
         { id: 'security', label: 'Security', status: 'implemented', description: 'Org-level OpenSSF Scorecard rollup.' },
       ]
-    : [
-        { id: 'overview', label: 'Overview', status: 'implemented', description: 'Organization inventory summary and lightweight public repository metadata.' },
-      ]
+    : orgInventoryResponse?.org
+      ? [
+          { id: 'overview', label: 'Overview', status: 'implemented', description: 'Organization inventory summary and lightweight public repository metadata.' },
+          { id: 'governance', label: 'Governance', status: 'implemented', description: 'Org-level security signals available without analyzing individual repos — 2FA enforcement, admin activity.' },
+        ]
+      : [
+          { id: 'overview', label: 'Overview', status: 'implemented', description: 'Organization inventory summary and lightweight public repository metadata.' },
+        ]
 
   const showOrgWorkspace = inputMode === 'org'
   const successfulRepoCount = analysisResponse?.results.length ?? 0
@@ -656,6 +661,12 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
             view={orgAggregation.view}
             selectedWindow={orgWindow}
             org={orgInventoryResponse?.org ?? null}
+          />
+        ) : inputMode === 'org' && orgInventoryResponse?.org ? (
+          <OrgBucketContent
+            bucketId="governance"
+            view={null}
+            org={orgInventoryResponse.org}
           />
         ) : null
       }

--- a/components/shared/hooks/useTwoFactorEnforcement.ts
+++ b/components/shared/hooks/useTwoFactorEnforcement.ts
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { TwoFactorEnforcementSection } from '@/lib/governance/two-factor'
+
+export type OwnerType = 'Organization' | 'User'
+
+export interface UseTwoFactorEnforcementOptions {
+  org: string | null
+  ownerType: OwnerType
+  token: string | null
+  fetchFn?: typeof fetch
+}
+
+export interface UseTwoFactorEnforcementState {
+  loading: boolean
+  section: TwoFactorEnforcementSection | null
+  error: string | null
+}
+
+export function useTwoFactorEnforcement(
+  options: UseTwoFactorEnforcementOptions,
+): UseTwoFactorEnforcementState {
+  const { org, ownerType, token } = options
+  const fetchFn = options.fetchFn ?? fetch
+
+  const [state, setState] = useState<UseTwoFactorEnforcementState>(() => ({
+    loading: Boolean(org && token),
+    section: null,
+    error: null,
+  }))
+
+  useEffect(() => {
+    if (!org || !token) {
+      let cancelled = false
+      queueMicrotask(() => {
+        if (cancelled) return
+        setState((prev) =>
+          prev.loading || prev.section || prev.error
+            ? { loading: false, section: null, error: null }
+            : prev,
+        )
+      })
+      return () => {
+        cancelled = true
+      }
+    }
+
+    let cancelled = false
+    queueMicrotask(() => {
+      if (cancelled) return
+      setState((prev) => (prev.loading ? prev : { loading: true, section: null, error: null }))
+    })
+
+    const params = new URLSearchParams({ org, ownerType })
+
+    fetchFn(`/api/org/two-factor?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then(async (res) => {
+        if (cancelled) return
+        if (!res.ok) {
+          setState({ loading: false, section: null, error: `HTTP ${res.status}` })
+          return
+        }
+        const body = (await res.json()) as { section?: TwoFactorEnforcementSection }
+        setState({ loading: false, section: body.section ?? null, error: null })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setState({
+          loading: false,
+          section: null,
+          error: err instanceof Error ? err.message : 'two-factor fetch failed',
+        })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [org, ownerType, token, fetchFn])
+
+  return state
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -266,7 +266,7 @@ Phase 2 adds new scoring buckets to the health score. Requirements specs live in
 | 11 | P2-F11 | Project maturity | #74 | |
 | 12 | P2-F12 | Ecosystem Reach | #118 | |
 | 13 | P2-F01b | Documentation scoring (advanced) | #110, #67 | |
-| 14 | P2-F13 | Org governance audit — stale admin detection | #287 (child of #285) | ✅ Done |
+| 14 | P2-F13 | Org governance audit — stale admin detection, 2FA enforcement | #287, #286 (children of #285) | ✅ Done |
 
 ## Phase 3 feature order
 

--- a/lib/analyzer/github-rest.test.ts
+++ b/lib/analyzer/github-rest.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   fetchMaintainerCount,
   fetchOrgAdmins,
+  fetchOrgTwoFactorRequirement,
   fetchUserLatestOrgCommit,
   fetchUserOrgMembership,
   fetchUserPublicEvents,
@@ -317,6 +318,100 @@ describe('fetchUserLatestOrgCommit', () => {
   it('maps other failures to commit-search-failed', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 422 })))
     expect((await fetchUserLatestOrgCommit('t', 'alice', 'x')).kind).toBe('commit-search-failed')
+  })
+})
+
+describe('fetchOrgTwoFactorRequirement', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('sends bearer auth to /orgs/{org} and returns the literal boolean true', async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input)
+      expect(url).toBe('https://api.github.com/orgs/kubernetes')
+      return buildPageResponse({ login: 'kubernetes', two_factor_requirement_enabled: true })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchOrgTwoFactorRequirement('ghp_test', 'kubernetes')
+
+    expect(result).toEqual({ kind: 'ok', twoFactorRequirementEnabled: true })
+    const init = fetchMock.mock.calls[0]![1] as RequestInit | undefined
+    expect(init?.headers).toMatchObject({ Authorization: 'Bearer ghp_test' })
+  })
+
+  it('returns literal false when enforcement is explicitly disabled', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => buildPageResponse({ two_factor_requirement_enabled: false })),
+    )
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result).toEqual({ kind: 'ok', twoFactorRequirementEnabled: false })
+  })
+
+  it('returns null (unknown) when the field is absent — caller lacks org-owner scope', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => buildPageResponse({ login: 'x' })))
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result).toEqual({ kind: 'ok', twoFactorRequirementEnabled: null })
+  })
+
+  it('returns null (unknown) when the field value is literal null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => buildPageResponse({ two_factor_requirement_enabled: null })),
+    )
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result).toEqual({ kind: 'ok', twoFactorRequirementEnabled: null })
+  })
+
+  it('maps 403 + X-RateLimit-Remaining: 0 to kind rate-limited', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => buildRateLimitedResponse()))
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result.kind).toBe('rate-limited')
+  })
+
+  it('maps 401 to kind auth-failed', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 401 })))
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result.kind).toBe('auth-failed')
+  })
+
+  it('maps 404 to kind not-found', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })))
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result.kind).toBe('not-found')
+  })
+
+  it('maps a thrown fetch error to kind network', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('boom')
+      }),
+    )
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result.kind).toBe('network')
+  })
+
+  it('maps an unexpected 500 to kind unknown', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 500 })))
+
+    const result = await fetchOrgTwoFactorRequirement('t', 'x')
+
+    expect(result.kind).toBe('unknown')
   })
 })
 

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -191,6 +191,41 @@ export async function fetchOrgAdmins(token: string, org: string): Promise<OrgAdm
   return { kind: 'ok', admins }
 }
 
+export type OrgTwoFactorRequirementResult =
+  | { kind: 'ok'; twoFactorRequirementEnabled: boolean | null }
+  | { kind: 'rate-limited' }
+  | { kind: 'auth-failed' }
+  | { kind: 'not-found' }
+  | { kind: 'network' }
+  | { kind: 'unknown' }
+
+export async function fetchOrgTwoFactorRequirement(
+  token: string,
+  org: string,
+): Promise<OrgTwoFactorRequirementResult> {
+  try {
+    const response = await fetch(`https://api.github.com/orgs/${encodeURIComponent(org)}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    })
+
+    if (response.status === 403 && isRateLimited(response)) return { kind: 'rate-limited' }
+    if (response.status === 401) return { kind: 'auth-failed' }
+    if (response.status === 404) return { kind: 'not-found' }
+    if (!response.ok) return { kind: 'unknown' }
+
+    const payload = (await response.json()) as { two_factor_requirement_enabled?: unknown }
+    const raw = payload?.two_factor_requirement_enabled
+    const value: boolean | null = raw === true ? true : raw === false ? false : null
+    return { kind: 'ok', twoFactorRequirementEnabled: value }
+  } catch {
+    return { kind: 'network' }
+  }
+}
+
 export type UserPublicEventsResult =
   | { kind: 'ok'; lastActivityAt: string | null }
   | { kind: 'admin-account-404' }

--- a/lib/governance/two-factor.test.ts
+++ b/lib/governance/two-factor.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { classifyTwoFactorRequirement } from './two-factor'
+
+describe('classifyTwoFactorRequirement', () => {
+  it('returns "enforced" when the flag is literal true', () => {
+    expect(classifyTwoFactorRequirement(true)).toBe('enforced')
+  })
+
+  it('returns "not-enforced" when the flag is literal false', () => {
+    expect(classifyTwoFactorRequirement(false)).toBe('not-enforced')
+  })
+
+  it('returns "unknown" when the flag is null — caller lacks org-owner scope', () => {
+    expect(classifyTwoFactorRequirement(null)).toBe('unknown')
+  })
+
+  it('returns "unknown" when the flag is undefined — field absent', () => {
+    expect(classifyTwoFactorRequirement(undefined)).toBe('unknown')
+  })
+})

--- a/lib/governance/two-factor.ts
+++ b/lib/governance/two-factor.ts
@@ -1,0 +1,29 @@
+export type TwoFactorEnforcementStatus = 'enforced' | 'not-enforced' | 'unknown'
+
+export type TwoFactorApplicability =
+  | 'applicable'
+  | 'not-applicable-non-org'
+  | 'org-lookup-unavailable'
+
+export type OrgLookupUnavailableReason =
+  | 'rate-limited'
+  | 'auth-failed'
+  | 'not-found'
+  | 'network'
+  | 'unknown'
+
+export interface TwoFactorEnforcementSection {
+  kind: 'two-factor-enforcement'
+  applicability: TwoFactorApplicability
+  status: TwoFactorEnforcementStatus | null
+  lookupUnavailableReason?: OrgLookupUnavailableReason
+  resolvedAt: string
+}
+
+export function classifyTwoFactorRequirement(
+  twoFactorRequirementEnabled: boolean | null | undefined,
+): TwoFactorEnforcementStatus {
+  if (twoFactorRequirementEnabled === true) return 'enforced'
+  if (twoFactorRequirementEnabled === false) return 'not-enforced'
+  return 'unknown'
+}


### PR DESCRIPTION
Closes #286 (child of #285 — Org-level governance audit).

## Summary

- Surfaces GitHub's `two_factor_requirement_enabled` flag as a new observation-only panel on the Governance bucket of the org summary, classified as **enforced** / **not enforced** / **unknown** with distinct visual treatments.
- When the caller lacks org-owner scope, the flag is `null` on GitHub's side. We surface that as **unknown** with an explicit in-panel disclaimer that unknown is **not the same as not enforced** — the exact UX acceptance criterion from the issue.
- Non-organization targets (user-owned repos) render an explicit **N/A** state; REST errors are labeled (`rate-limited`, `auth-failed`, `not-found`, `network`) rather than silently empty.
- Follows the stale-admins pattern introduced in #287: pure classifier in `lib/governance/two-factor.ts` (zero framework imports), self-fetching React hook + panel, backed by a new `GET /api/org/two-factor` route.
- Signal is **observation-only** and does not feed the composite OSS Health Score, consistent with the parent #285 guidance and the #287 precedent.

## Architecture note

The panel is rendered inline via `OrgBucketContent` alongside `StaleAdminsPanel`, placed first so the two org-level security signals sit at the top of the Governance bucket. Existing per-repo aggregators under `lib/org-aggregation/aggregators/` are pure over `AnalysisResult[]`, but 2FA enforcement is org-level (not per-repo) and requires a REST call with the session token — same rationale as `StaleAdminsPanel`.

## Constitution compliance

- **II Accuracy**: verified-API-only, no inference. `null`/missing field → explicit `unknown`, never silently treated as `not-enforced`.
- **III Data sources**: OAuth only, baseline `public_repo`. No scope widening is attempted for 2FA — we rely on whatever the session already has and surface `unknown` honestly when insufficient.
- **IV Analyzer boundary**: `lib/governance/two-factor.ts` has zero Next.js / React imports.
- **VIII Honesty**: unknown state is visibly disclosed in-panel, not buried in a tooltip.
- **X.5 Per-repo error isolation**: a failed 2FA lookup yields a labeled `org-lookup-unavailable` state; it does not affect other panels.
- **XI TDD**: unit tests cover the pure classifier (4 cases), the REST fetcher across ok/rate-limited/auth-failed/not-found/network/unknown + field-null and field-absent (9 cases), the API route (9 cases including 400/401/N-A/applicable×3/unavailable×3), the panel (8 cases across enforced/not-enforced/unknown/N-A/unavailable/collapse/scoring-help/loading), and the `OrgBucketContent` wiring (5 cases for governance-only rendering + ordering).

## Test plan

Automated checks pass on this branch; the live-path checks require a signed-in session.

- [x] `npm test` — 1136/1137 pass on this branch (1 pre-existing failure in `components/comparison/ComparisonView.test.tsx` confirmed on `main` via `git stash`, unrelated to this change).
- [x] `npm run lint` — 0 errors (warnings pre-existing).
- [x] `DEV_GITHUB_PAT= npm run build` — success; `/api/org/two-factor` appears in the routes manifest.
- [x] API smoke — `curl http://localhost:3011/api/org/two-factor` returns the expected `INVALID_ORG` 400.
- [ ] **Enforced path (live)** — on the org summary for a GitHub org where the signed-in user is an owner and 2FA is required, confirm the green **2FA enforced** badge renders on the Governance tab, with affirmative body copy. *(See deferral comment below.)*
- [ ] **Not-enforced path (live)** — on a GitHub org where the signed-in user is an owner and 2FA is NOT required, confirm the rose **2FA not enforced** badge renders with the body copy explaining the risk. *(See deferral comment below.)*
- [x] **Unknown path (live)** — on any org where the signed-in user is not an owner (e.g. `helix-editor` from a non-member session), confirm the slate **2FA status unknown** badge renders and the body copy explicitly states that unknown ≠ not enforced and only an org owner can read the flag. *(Verified on `kubernetes` — slate badge renders with the disambiguation copy as designed.)*
- [x] **N/A path (live)** — analyze a user-owned repo (e.g. `arun-gupta/repo-pulse`); confirm the Governance tab renders the explicit N/A state with no badge. *(API-verified: `ownerType=User` returns `applicability: 'not-applicable-non-org', status: null` with no GitHub API calls made.)*
- [x] **Unavailable path (live)** — analyze a nonexistent org (e.g. `this-org-does-not-exist-xyz123`); confirm the panel renders a labeled unavailable state with reason `not-found`. *(API-verified: `this-org-does-not-exist-xyz123` returns `applicability: 'org-lookup-unavailable', lookupUnavailableReason: 'not-found'`.)*
- [x] **Panel ordering (visual)** — on the Governance tab for an org, confirm the 2FA panel renders above the Org admin activity panel and both sit above the registry-driven panels. *(Verified on `helix-editor` pre-analysis Governance tab — 2FA panel renders above Org admin activity. Registry-driven panels don't apply in the pre-analysis state.)*
- [x] **Collapse/expand** — click the panel chevron; confirm description and body hide while the title + status badge remain visible.
- [x] **Scope-tier landing-page radios** (added mid-PR) — landing page shows three mutually-exclusive radios (Baseline / read:org / admin:org), each with a one-line guidance hint; selecting each updates the sign-in link's `?scope_tier=...` query param. *(Unit-test coverage in `AuthGate.test.tsx` — 3 new cases — plus the login route test confirming each tier maps to the correct OAuth scope string.)*
- [x] **Dev-PAT scope honesty** (added mid-PR) — dev-mode login probes `X-OAuth-Scopes` and reports the PAT's *real* scopes, falling back to the requested tier only when the header is absent (fine-grained PATs). *(Unit-test coverage in `route.test.ts` — 3 cases for present / absent / empty header.)*
- [x] **Admin count strip persistence on collapse** (added mid-PR) — `Org admin activity` count strip stays visible when the panel is collapsed, matching the status-badge pattern. *(Unit-test coverage in `StaleAdminsPanel.test.tsx` — updated collapse test.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)


