### PR TITLE
Make Sign in with GitHub button visible in dark mode (#344)

### DIFF
--- a/components/auth/SignInButton.tsx
+++ b/components/auth/SignInButton.tsx
@@ -19,7 +19,7 @@ export function SignInButton({ tier = 'baseline' }: { tier?: ScopeTier }) {
     <a
       href={href}
       onClick={handleClick}
-      className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700"
+      className="inline-flex items-center gap-2 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
     >
       <svg height="16" viewBox="0 0 16 16" width="16" aria-hidden="true" fill="currentColor">
         <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />

--- a/e2e/dark-mode.spec.ts
+++ b/e2e/dark-mode.spec.ts
@@ -191,6 +191,65 @@ test.describe('#340 theme toggle exposes System option', () => {
   })
 })
 
+test.describe('#344 sign-in button is visible in dark mode', () => {
+  // Regression guard: in dark mode the landing-page "Sign in with GitHub" button
+  // used to render as a near-black pill on a near-black page, making the primary
+  // CTA almost invisible. Assert the button background is light in dark mode and
+  // dark in light mode — a computed-style check that will fail if a future edit
+  // drops the dark: variant. Uses a canvas round-trip so the check is robust to
+  // modern color spaces (lab/oklch) used by Tailwind 4.
+
+  async function buttonRelativeLuminance(link: Locator): Promise<number> {
+    return link.evaluate((el) => {
+      const bg = getComputedStyle(el).backgroundColor
+      const c = document.createElement('canvas')
+      c.width = 1
+      c.height = 1
+      const ctx = c.getContext('2d')!
+      ctx.fillStyle = bg
+      ctx.fillRect(0, 0, 1, 1)
+      const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
+      // Perceptual relative luminance in [0, 1] (Rec. 709 coefficients).
+      const lin = (v: number) => {
+        const s = v / 255
+        return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+      }
+      return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+    })
+  }
+
+  test.describe('with prefers-color-scheme: dark', () => {
+    test.use({ colorScheme: 'dark' })
+
+    test('sign-in button has a light background that contrasts the dark page', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.locator('html')).toHaveClass(/(^|\s)dark(\s|$)/)
+
+      const link = page.getByRole('link', { name: /sign in with github/i })
+      await expect(link).toBeVisible()
+      const luminance = await buttonRelativeLuminance(link)
+      // In dark mode the button must be a light surface — well above the dark
+      // slate family (slate-900 luminance ≈ 0.009). 0.5 is the standard midpoint.
+      expect(luminance).toBeGreaterThan(0.5)
+    })
+  })
+
+  test.describe('with prefers-color-scheme: light', () => {
+    test.use({ colorScheme: 'light' })
+
+    test('sign-in button keeps a dark background in light mode (no regression)', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.locator('html')).not.toHaveClass(/(^|\s)dark(\s|$)/)
+
+      const link = page.getByRole('link', { name: /sign in with github/i })
+      await expect(link).toBeVisible()
+      const luminance = await buttonRelativeLuminance(link)
+      // In light mode the button must stay dark — well below midpoint.
+      expect(luminance).toBeLessThan(0.2)
+    })
+  })
+})
+
 test.describe('#326 dark mode surfaces', () => {
   test('Overview top-bar controls render on dark surfaces', async ({ page }) => {
     await setupAnalyzed(page)


### PR DESCRIPTION
## Summary

- Adds `dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white` to the landing-page **Sign in with GitHub** button so the primary CTA inverts in dark mode — light pill on the dark page background — instead of rendering as a near-black pill on a near-black surface.
- Reuses the same inversion pattern already used by the RepoInputForm mode pills (`bg-slate-900 → dark:bg-slate-100`).
- Adds a lightweight Playwright regression guard in `e2e/dark-mode.spec.ts` (lightness via canvas round-trip → robust to `lab()` / `oklch()` color spaces used by Tailwind 4) that asserts the button is a light surface in dark mode and stays a dark surface in light mode.

Fixes #344.

## Test plan

- [x] `npx vitest run components/auth` — all auth unit tests pass
- [x] `npx playwright test e2e/dark-mode.spec.ts -g "#344"` — both dark and light regression assertions pass
- [x] `npm run lint` — no new errors
- [x] Manual: landing page in dark mode — Sign in with GitHub button is clearly visible at a glance, text contrast is crisp
- [x] Manual: landing page in light mode — button still renders as the existing dark pill (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)