### PR TITLE
Tighten landing-page scope-picker copy; drop solo-maintainer footnote

### DIFF
--- a/components/auth/AuthGate.test.tsx
+++ b/components/auth/AuthGate.test.tsx
@@ -107,6 +107,17 @@ describe('AuthGate', () => {
     )
     expect(screen.getByText(/public data only/i)).toBeInTheDocument()
     expect(screen.getByText(/concealed admins/i)).toBeInTheDocument()
-    expect(screen.getByText(/owner-only org settings/i)).toBeInTheDocument()
+    expect(screen.getByText(/2fa enforcement/i)).toBeInTheDocument()
+  })
+
+  it('omits the solo-maintainer footnote that previously sat below the picker', () => {
+    render(
+      <AuthProvider>
+        <AuthGate>
+          <p>Protected content</p>
+        </AuthGate>
+      </AuthProvider>,
+    )
+    expect(screen.queryByText(/solo-maintainer repos are auto-detected/i)).not.toBeInTheDocument()
   })
 })

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -110,31 +110,25 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             checked={scopeTier === 'baseline'}
             onChange={setScopeTier}
             label={<><span className="font-semibold">Baseline</span> (<code>public_repo</code>)</>}
-            guidance="Public data only. Recommended for read-only audits of third-party orgs."
+            guidance="Public data only — for auditing third-party orgs."
           />
           <ScopeRadio
             value="read-org"
             checked={scopeTier === 'read-org'}
             onChange={setScopeTier}
             label={<><span className="font-semibold">Read org membership</span> (<code>read:org</code>)</>}
-            guidance="See concealed admins of orgs you belong to. Choose this if you want the full Stale Admin panel for your own orgs."
+            guidance="Adds concealed admins of orgs you belong to."
           />
           <ScopeRadio
             value="admin-org"
             checked={scopeTier === 'admin-org'}
             onChange={setScopeTier}
             label={<><span className="font-semibold">Org admin (read)</span> (<code>admin:org</code>)</>}
-            guidance="Includes everything above, plus owner-only org settings like 2FA enforcement. Broadest scope — choose only if you own the orgs you plan to audit."
+            guidance="Adds owner-only signals like 2FA enforcement; for orgs you own."
           />
         </fieldset>
 
-        <div className="max-w-md space-y-2 text-center">
-          <p className="text-xs italic text-slate-400 dark:text-slate-500">
-            Built for community-oriented projects. Solo-maintainer repos are auto-detected and
-            scored on Activity, Security, and Documentation instead.
-          </p>
-          <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 transition dark:text-slate-500">View scoring methodology</a>
-        </div>
+        <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 transition hover:text-slate-600 dark:text-slate-500">View scoring methodology</a>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Closes #357. Keeps all three GitHub-permission radios visible on the landing page so the informed-consent posture from #345 stays intact, but compresses each guidance line to one short clause:
  - **Baseline (`public_repo`)**: "Public data only — for auditing third-party orgs."
  - **Read org membership (`read:org`)**: "Adds concealed admins of orgs you belong to."
  - **Org admin (read) (`admin:org`)**: "Adds owner-only signals like 2FA enforcement; for orgs you own."
- Drops the italic solo-maintainer footnote that sat below the picker — that detail belongs on the scoring methodology page, which the existing "View scoring methodology" link still points to.
- Two commits on the branch (intermediate disclosure-based attempt + revision after design discussion); reviewers can squash on merge.

## Why this revision
The first attempt hid the picker behind an "Advanced" `<details>` disclosure. That regressed the principle established in #345: **users should never forget the app's permission surface while using it**, and the original `4d7dc7a` commit deliberately surfaced all three tiers with guidance hints so users could make an informed scope choice without reading external docs. Keeping the picker visible — with shorter copy — addresses #357 without that regression.

## Test plan
- [x] `npx vitest run components/auth` — 5 files, 29 tests, all green
- [x] `npm run lint` — no new errors or warnings introduced
- [x] Manual: load `/` unauthenticated; confirm all three radios are still visible with Baseline pre-selected and the guidance lines are noticeably shorter
- [x] Manual: pick `read:org` and `admin:org` in turn; confirm the Sign-in CTA href updates to `?scope_tier=read-org` and `?scope_tier=admin-org`
- [x] Manual: confirm the italic "Built for community-oriented projects…" footnote is gone, and the "View scoring methodology" link is still present
- [x] Manual: dark mode — confirm the radios, code tags, and methodology link remain legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)