### PR TITLE
Split rate-limited from commit-search-failed in Stale Admins panel (#364)

### DIFF
--- a/app/api/org/stale-admins/route.test.ts
+++ b/app/api/org/stale-admins/route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { GET } from './route'
+import { GET, retryUnavailableAdminsSerially } from './route'
+import type { StaleAdminRecord } from '@/lib/governance/stale-admins'
 
 type FetchArgs = Parameters<typeof fetch>
 
@@ -189,6 +190,121 @@ describe('GET /api/org/stale-admins', () => {
     expect(
       fetchMock.mock.calls.some((call) => String(call[0]).includes('/user/memberships/orgs/')),
     ).toBe(false)
+  })
+
+  it('auto-retries rate-limited admins server-side after the first fan-out', async () => {
+    const now = new Date('2026-04-16T00:00:00Z')
+    vi.setSystemTime(now)
+
+    // stale-bob's events are empty → falls through to commit-search.
+    // First commit-search call returns rate-limited; second returns a real
+    // commit date. With the server-side retry pass, stale-bob should land
+    // as classified (stale) rather than unavailable.
+    let commitCall = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (...args: FetchArgs) => {
+        const url = String(args[0])
+        if (url.includes('/orgs/acme/members')) {
+          return json(200, [{ login: 'stale-bob' }])
+        }
+        if (url.includes('/users/stale-bob/events/public')) {
+          return json(200, [])
+        }
+        if (url.includes('/search/commits') && url.includes('author%3Astale-bob')) {
+          commitCall++
+          if (commitCall === 1) {
+            return new Response('', {
+              status: 403,
+              headers: { 'X-RateLimit-Remaining': '0' },
+            })
+          }
+          return json(200, {
+            total_count: 1,
+            items: [{ commit: { author: { date: '2025-09-01T00:00:00Z' } } }],
+          })
+        }
+        return json(404, {})
+      }),
+    )
+
+    const res = await GET(buildReq('?org=acme&ownerType=Organization'))
+    const body = (await res.json()) as {
+      section: { admins: Array<{ username: string; classification: string }> }
+    }
+
+    expect(body.section.admins[0]).toMatchObject({
+      username: 'stale-bob',
+      classification: 'stale',
+    })
+
+    vi.useRealTimers()
+  })
+
+  it('retryUnavailableAdminsSerially is a no-op when there are no retryable admins', async () => {
+    const admins: StaleAdminRecord[] = [
+      {
+        username: 'active-alice',
+        classification: 'active',
+        lastActivityAt: '2026-04-10T00:00:00Z',
+        lastActivitySource: 'public-events',
+        unavailableReason: null,
+      },
+      {
+        username: 'ghost',
+        classification: 'unavailable',
+        lastActivityAt: null,
+        lastActivitySource: null,
+        unavailableReason: 'admin-account-404',
+      },
+    ]
+    const sleep = vi.fn(async () => {})
+    const result = await retryUnavailableAdminsSerially(admins, 't', 'acme', '2026-04-16T00:00:00Z', {
+      sleep,
+    })
+    expect(result).toBe(admins)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('retryUnavailableAdminsSerially stops once the deadline is exceeded', async () => {
+    const admins: StaleAdminRecord[] = [
+      {
+        username: 'u1',
+        classification: 'unavailable',
+        lastActivityAt: null,
+        lastActivitySource: null,
+        unavailableReason: 'rate-limited',
+      },
+      {
+        username: 'u2',
+        classification: 'unavailable',
+        lastActivityAt: null,
+        lastActivitySource: null,
+        unavailableReason: 'rate-limited',
+      },
+    ]
+    // fetch should be called at most once: after the first admin, the clock
+    // jumps past the 10s budget and the loop exits.
+    const fetchMock = vi.fn(async () =>
+      new Response('', { status: 403, headers: { 'X-RateLimit-Remaining': '0' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    let clock = 0
+    const now = () => clock
+    const sleep = vi.fn(async () => {
+      clock += 60_000
+    })
+
+    await retryUnavailableAdminsSerially(admins, 't', 'acme', '2026-04-16T00:00:00Z', {
+      now,
+      sleep,
+    })
+    // First admin consumed: events fetch + commit search (1 call after maxRetries=0).
+    // After processing, sleep advances clock past the 10s deadline, so u2 is skipped.
+    const usernames = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(usernames.some((u) => u.includes('/users/u1/events/public'))).toBe(true)
+    expect(usernames.some((u) => u.includes('/users/u2/events/public'))).toBe(false)
   })
 
   it('surfaces threshold 90 as default in the response', async () => {

--- a/app/api/org/stale-admins/route.test.ts
+++ b/app/api/org/stale-admins/route.test.ts
@@ -249,6 +249,7 @@ describe('GET /api/org/stale-admins', () => {
         lastActivityAt: '2026-04-10T00:00:00Z',
         lastActivitySource: 'public-events',
         unavailableReason: null,
+        retryAvailableAt: null,
       },
       {
         username: 'ghost',
@@ -256,6 +257,7 @@ describe('GET /api/org/stale-admins', () => {
         lastActivityAt: null,
         lastActivitySource: null,
         unavailableReason: 'admin-account-404',
+        retryAvailableAt: null,
       },
     ]
     const sleep = vi.fn(async () => {})
@@ -274,6 +276,7 @@ describe('GET /api/org/stale-admins', () => {
         lastActivityAt: null,
         lastActivitySource: null,
         unavailableReason: 'rate-limited',
+        retryAvailableAt: null,
       },
       {
         username: 'u2',
@@ -281,11 +284,12 @@ describe('GET /api/org/stale-admins', () => {
         lastActivityAt: null,
         lastActivitySource: null,
         unavailableReason: 'rate-limited',
+        retryAvailableAt: null,
       },
     ]
     // fetch should be called at most once: after the first admin, the clock
     // jumps past the 10s budget and the loop exits.
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (..._args: FetchArgs) =>
       new Response('', { status: 403, headers: { 'X-RateLimit-Remaining': '0' } }),
     )
     vi.stubGlobal('fetch', fetchMock)

--- a/app/api/org/stale-admins/route.ts
+++ b/app/api/org/stale-admins/route.ts
@@ -3,6 +3,7 @@ import {
   fetchUserLatestOrgCommit,
   fetchUserOrgMembership,
   fetchUserPublicEvents,
+  type FetchUserLatestOrgCommitOptions,
   type OrgAdminListResult,
 } from '@/lib/analyzer/github-rest'
 import { STALE_ADMIN_THRESHOLD_DAYS } from '@/lib/config/governance'
@@ -17,6 +18,20 @@ import {
 } from '@/lib/governance/stale-admins'
 
 const PER_ADMIN_CONCURRENCY = 5
+
+// Unavailable reasons we will auto-retry server-side after the first fan-out.
+// `admin-account-404` is terminal (deleted user) and excluded.
+const AUTO_RETRYABLE_REASONS: ReadonlySet<StaleAdminUnavailableReason> = new Set([
+  'rate-limited',
+  'commit-search-failed',
+  'events-fetch-failed',
+])
+
+// Second-pass budget and spacing. Bounded hard so we never blow the
+// serverless function timeout — remaining items simply stay Unavailable and
+// the client's Retry button becomes the fallback.
+const AUTO_RETRY_BUDGET_MS = 10_000
+const AUTO_RETRY_SPACING_MS = 500
 
 export async function GET(request: Request) {
   const url = new URL(request.url)
@@ -74,12 +89,13 @@ export async function GET(request: Request) {
       : 'elevated-ineffective'
     : 'baseline'
 
-  const admins = await resolveAllAdminsWithConcurrency(
+  const firstPass = await resolveAllAdminsWithConcurrency(
     adminListResult.admins.map((a) => a.login),
     token,
     org,
     resolvedAt,
   )
+  const admins = await retryUnavailableAdminsSerially(firstPass, token, org, resolvedAt)
 
   const section: StaleAdminsSection = {
     kind: 'stale-admins',
@@ -98,6 +114,7 @@ async function resolveAdmin(
   token: string,
   org: string,
   resolvedAt: string,
+  commitSearchOptions: FetchUserLatestOrgCommitOptions = {},
 ): Promise<StaleAdminRecord> {
   const eventsResult = await fetchUserPublicEvents(token, username)
 
@@ -114,7 +131,7 @@ async function resolveAdmin(
     error = 'rate-limited'
   } else {
     // events-fetch-failed OR ok-but-empty → fall through to commit search
-    const commitResult = await fetchUserLatestOrgCommit(token, username, org)
+    const commitResult = await fetchUserLatestOrgCommit(token, username, org, commitSearchOptions)
     if (commitResult.kind === 'ok' && commitResult.lastActivityAt) {
       lastActivityAt = commitResult.lastActivityAt
       lastActivitySource = 'org-commit-search'
@@ -165,6 +182,56 @@ async function resolveAllAdminsWithConcurrency(
   const workerCount = Math.min(PER_ADMIN_CONCURRENCY, usernames.length)
   await Promise.all(Array.from({ length: workerCount }, () => worker()))
   return results
+}
+
+// Auto-retry pass: after the concurrent fan-out, walk still-unavailable admins
+// serially with small inter-request spacing. Serializing keeps us well under
+// the Search Commits 30 req/min quota, and the delay gives GitHub's rate-limit
+// window time to slide. Bounded by a hard deadline so we never extend the
+// response beyond the budget — admins still Unavailable after the deadline
+// remain Unavailable for the client's Retry button to handle.
+export async function retryUnavailableAdminsSerially(
+  admins: StaleAdminRecord[],
+  token: string,
+  org: string,
+  resolvedAt: string,
+  opts: { now?: () => number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<StaleAdminRecord[]> {
+  const now = opts.now ?? Date.now
+  const sleep = opts.sleep ?? defaultSleep
+
+  const retryable = admins
+    .map((admin, index) => ({ admin, index }))
+    .filter(
+      ({ admin }) =>
+        admin.classification === 'unavailable' &&
+        admin.unavailableReason !== null &&
+        AUTO_RETRYABLE_REASONS.has(admin.unavailableReason),
+    )
+  if (retryable.length === 0) return admins
+
+  const deadline = now() + AUTO_RETRY_BUDGET_MS
+  const next = [...admins]
+
+  for (const { admin, index } of retryable) {
+    if (now() >= deadline) break
+    try {
+      // maxRetries=0 disables fetchUserLatestOrgCommit's in-function retry —
+      // this pass IS the retry, and the inter-request spacing is our backoff.
+      next[index] = await resolveAdmin(admin.username, token, org, resolvedAt, {
+        maxRetries: 0,
+      })
+    } catch {
+      // Keep the original unavailable record on unexpected throw.
+    }
+    if (now() < deadline) await sleep(AUTO_RETRY_SPACING_MS)
+  }
+
+  return next
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function mapAdminListReason(result: OrgAdminListResult): AdminListUnavailableReason {

--- a/app/api/org/stale-admins/route.ts
+++ b/app/api/org/stale-admins/route.ts
@@ -63,6 +63,7 @@ export async function GET(request: Request) {
       mode: 'baseline',
       thresholdDays: STALE_ADMIN_THRESHOLD_DAYS,
       admins: [],
+      earliestRetryAvailableAt: null,
       resolvedAt,
     }
     return Response.json({ section })
@@ -77,6 +78,7 @@ export async function GET(request: Request) {
       thresholdDays: STALE_ADMIN_THRESHOLD_DAYS,
       admins: [],
       adminListUnavailableReason: mapAdminListReason(adminListResult),
+      earliestRetryAvailableAt: null,
       resolvedAt,
     }
     return Response.json({ section })
@@ -103,10 +105,23 @@ export async function GET(request: Request) {
     mode,
     thresholdDays: STALE_ADMIN_THRESHOLD_DAYS,
     admins,
+    earliestRetryAvailableAt: computeEarliestRetryAvailableAt(admins),
     resolvedAt,
   }
 
   return Response.json({ section })
+}
+
+function computeEarliestRetryAvailableAt(admins: StaleAdminRecord[]): string | null {
+  let earliest: number | null = null
+  for (const admin of admins) {
+    if (admin.classification !== 'unavailable') continue
+    if (!admin.retryAvailableAt) continue
+    const ms = Date.parse(admin.retryAvailableAt)
+    if (!Number.isFinite(ms)) continue
+    if (earliest === null || ms < earliest) earliest = ms
+  }
+  return earliest !== null ? new Date(earliest).toISOString() : null
 }
 
 async function resolveAdmin(
@@ -119,6 +134,7 @@ async function resolveAdmin(
   const eventsResult = await fetchUserPublicEvents(token, username)
 
   let error: StaleAdminUnavailableReason | null = null
+  let retryAvailableAt: string | null = null
   let lastActivityAt: string | null = null
   let lastActivitySource: AdminActivityInput['lastActivitySource'] = null
 
@@ -129,6 +145,7 @@ async function resolveAdmin(
     error = 'admin-account-404'
   } else if (eventsResult.kind === 'rate-limited') {
     error = 'rate-limited'
+    retryAvailableAt = eventsResult.retryAvailableAt
   } else {
     // events-fetch-failed OR ok-but-empty → fall through to commit search
     const commitResult = await fetchUserLatestOrgCommit(token, username, org, commitSearchOptions)
@@ -137,6 +154,7 @@ async function resolveAdmin(
       lastActivitySource = 'org-commit-search'
     } else if (commitResult.kind === 'rate-limited') {
       error = 'rate-limited'
+      retryAvailableAt = commitResult.retryAvailableAt
     } else if (commitResult.kind === 'commit-search-failed') {
       // If events also errored (not just empty), propagate that first
       error = eventsResult.kind === 'events-fetch-failed' ? 'events-fetch-failed' : 'commit-search-failed'
@@ -145,7 +163,7 @@ async function resolveAdmin(
   }
 
   return classifyAdmin(
-    { username, lastActivityAt, lastActivitySource, error },
+    { username, lastActivityAt, lastActivitySource, error, retryAvailableAt },
     STALE_ADMIN_THRESHOLD_DAYS,
     new Date(resolvedAt),
   )
@@ -174,6 +192,7 @@ async function resolveAllAdminsWithConcurrency(
           lastActivityAt: null,
           lastActivitySource: null,
           unavailableReason: 'events-fetch-failed',
+          retryAvailableAt: null,
         }
       }
     }

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -24,6 +24,7 @@ function makeSection(override: Partial<StaleAdminsSection> = {}): StaleAdminsSec
     mode: 'baseline',
     thresholdDays: 90,
     admins: [],
+    earliestRetryAvailableAt: null,
     resolvedAt: '2026-04-16T00:00:00Z',
     ...override,
   }
@@ -39,6 +40,7 @@ describe('StaleAdminsPanel — baseline rendering', () => {
           lastActivityAt: '2026-04-10T00:00:00Z',
           lastActivitySource: 'public-events',
           unavailableReason: null,
+          retryAvailableAt: null,
         },
         {
           username: 'bob',
@@ -46,6 +48,7 @@ describe('StaleAdminsPanel — baseline rendering', () => {
           lastActivityAt: '2025-09-01T00:00:00Z',
           lastActivitySource: 'org-commit-search',
           unavailableReason: null,
+          retryAvailableAt: null,
         },
       ],
     })
@@ -159,6 +162,7 @@ describe('StaleAdminsPanel — baseline rendering', () => {
           lastActivityAt: '2026-04-10T00:00:00Z',
           lastActivitySource: 'public-events',
           unavailableReason: null,
+          retryAvailableAt: null,
         },
         {
           username: 'bob',
@@ -166,6 +170,7 @@ describe('StaleAdminsPanel — baseline rendering', () => {
           lastActivityAt: '2025-09-01T00:00:00Z',
           lastActivitySource: 'org-commit-search',
           unavailableReason: null,
+          retryAvailableAt: null,
         },
       ],
     })
@@ -375,6 +380,30 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     expect(screen.queryByTestId('stale-admins-unavailable-reasons')).not.toBeInTheDocument()
   })
 
+  it('renders a countdown for rate-limited rows with a known retryAvailableAt', () => {
+    vi.setSystemTime(new Date('2026-04-20T12:00:00Z'))
+    const availableAt = new Date('2026-04-20T12:00:37Z').toISOString()
+    const section = makeSection({
+      admins: [mkUnavailable('u1', 'rate-limited', availableAt)],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+
+    const countdown = screen.getByTestId('retry-countdown')
+    expect(countdown.textContent).toMatch(/37s/)
+    vi.useRealTimers()
+  })
+
+  it('renders "Ready to retry" when the countdown has elapsed', () => {
+    vi.setSystemTime(new Date('2026-04-20T12:01:00Z'))
+    const elapsed = new Date('2026-04-20T12:00:00Z').toISOString()
+    const section = makeSection({
+      admins: [mkUnavailable('u1', 'rate-limited', elapsed)],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+    expect(screen.getByTestId('retry-countdown-ready')).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
   it('keeps the section visible during refresh (stale-while-revalidate) and swaps the Retry button to Retrying…', () => {
     const section = makeSection({
       admins: [mkAdmin('a', 'active'), mkUnavailable('u', 'rate-limited')],
@@ -414,7 +443,14 @@ function mkAdmin(
   classification: 'active' | 'stale' | 'no-public-activity' | 'unavailable',
 ) {
   if (classification === 'no-public-activity') {
-    return { username, classification, lastActivityAt: null, lastActivitySource: null, unavailableReason: null }
+    return {
+      username,
+      classification,
+      lastActivityAt: null,
+      lastActivitySource: null,
+      unavailableReason: null,
+      retryAvailableAt: null,
+    }
   }
   if (classification === 'unavailable') {
     return {
@@ -423,6 +459,7 @@ function mkAdmin(
       lastActivityAt: null,
       lastActivitySource: null,
       unavailableReason: 'rate-limited' as const,
+      retryAvailableAt: null,
     }
   }
   return {
@@ -431,12 +468,14 @@ function mkAdmin(
     lastActivityAt: classification === 'stale' ? '2025-09-01T00:00:00Z' : '2026-04-10T00:00:00Z',
     lastActivitySource: 'public-events' as const,
     unavailableReason: null,
+    retryAvailableAt: null,
   }
 }
 
 function mkUnavailable(
   username: string,
   reason: 'rate-limited' | 'commit-search-failed' | 'events-fetch-failed' | 'admin-account-404',
+  retryAvailableAt: string | null = null,
 ) {
   return {
     username,
@@ -444,5 +483,6 @@ function mkUnavailable(
     lastActivityAt: null,
     lastActivitySource: null,
     unavailableReason: reason,
+    retryAvailableAt,
   }
 }

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -353,7 +353,7 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     expect(screen.queryByTestId('stale-admins-unavailable-retry')).not.toBeInTheDocument()
   })
 
-  it('renders humanized row text for each unavailable reason (no enum names)', () => {
+  it('renders humanized, non-app-error row text for each unavailable reason', () => {
     const section = makeSection({
       admins: [
         mkUnavailable('u1', 'rate-limited'),
@@ -364,12 +364,28 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
 
     const unavailable = screen.getByTestId('stale-admins-group-unavailable')
-    expect(within(unavailable).getByText(/GitHub rate limit hit/i)).toBeInTheDocument()
-    expect(within(unavailable).getByText(/GitHub commit search is temporarily unavailable/i)).toBeInTheDocument()
+    // Row copy is framed around what GitHub returned, not our implementation.
+    expect(within(unavailable).getByText(/GitHub rate limit — retry in about a minute/i)).toBeInTheDocument()
+    expect(within(unavailable).getByText(/GitHub didn’t return activity data/i)).toBeInTheDocument()
     expect(within(unavailable).getByText(/GitHub account not found/i)).toBeInTheDocument()
-    // Make sure raw enum values no longer leak into row copy.
+    // Our implementation names and debug asides must not leak into user copy.
+    expect(within(unavailable).queryByText(/commit search/i)).not.toBeInTheDocument()
+    expect(within(unavailable).queryByText(/events feed/i)).not.toBeInTheDocument()
+    expect(within(unavailable).queryByText(/\(often a burst rate-limit\)/i)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/commit-search-failed/)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/rate-limited\)/)).not.toBeInTheDocument()
+  })
+
+  it('when a countdown is present, the row lead is tight and defers the "when" to the timer', () => {
+    vi.setSystemTime(new Date('2026-04-20T12:00:00Z'))
+    const section = makeSection({
+      admins: [mkUnavailable('u1', 'rate-limited', '2026-04-20T12:00:30Z')],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+    // Concise lead (no "retry in about a minute" — countdown carries the signal).
+    expect(screen.getByText('GitHub rate limit.')).toBeInTheDocument()
+    expect(screen.getByTestId('retry-countdown').textContent).toMatch(/Retry available in \d+s/)
+    vi.useRealTimers()
   })
 
   it('omits the sub-breakdown strip on non-unavailable groups', () => {

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -312,19 +312,19 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     ).toMatch(/2 rate-limited/i)
     expect(
       within(strip).getByTestId('stale-admins-unavailable-reason-commit-search-failed').textContent,
-    ).toMatch(/1 commit search failed/i)
+    ).toMatch(/1 search unavailable/i)
   })
 
-  it('shows a Retry button when at least one admin is rate-limited, hidden otherwise', () => {
+  it('shows a Retry button for any retryable unavailable reason, hidden when only terminal reasons remain', () => {
     const onRetry = vi.fn()
-    const sectionWithRL = makeSection({
-      admins: [mkUnavailable('u1', 'rate-limited'), mkUnavailable('u2', 'commit-search-failed')],
+    const retryable = makeSection({
+      admins: [mkUnavailable('u1', 'commit-search-failed')],
     })
     const { rerender } = renderWithSession(
       <StaleAdminsPanel
         org="acme"
         ownerType="Organization"
-        sectionOverride={sectionWithRL}
+        sectionOverride={retryable}
         onRetryOverride={onRetry}
       />,
     )
@@ -339,7 +339,7 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
           org="acme"
           ownerType="Organization"
           sectionOverride={makeSection({
-            admins: [mkUnavailable('u1', 'commit-search-failed')],
+            admins: [mkUnavailable('u1', 'admin-account-404')],
           })}
           onRetryOverride={onRetry}
         />
@@ -348,12 +348,53 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     expect(screen.queryByTestId('stale-admins-unavailable-retry')).not.toBeInTheDocument()
   })
 
+  it('renders humanized row text for each unavailable reason (no enum names)', () => {
+    const section = makeSection({
+      admins: [
+        mkUnavailable('u1', 'rate-limited'),
+        mkUnavailable('u2', 'commit-search-failed'),
+        mkUnavailable('u3', 'admin-account-404'),
+      ],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+
+    const unavailable = screen.getByTestId('stale-admins-group-unavailable')
+    expect(within(unavailable).getByText(/GitHub rate limit hit/i)).toBeInTheDocument()
+    expect(within(unavailable).getByText(/GitHub commit search is temporarily unavailable/i)).toBeInTheDocument()
+    expect(within(unavailable).getByText(/GitHub account not found/i)).toBeInTheDocument()
+    // Make sure raw enum values no longer leak into row copy.
+    expect(within(unavailable).queryByText(/commit-search-failed/)).not.toBeInTheDocument()
+    expect(within(unavailable).queryByText(/rate-limited\)/)).not.toBeInTheDocument()
+  })
+
   it('omits the sub-breakdown strip on non-unavailable groups', () => {
     const section = makeSection({
       admins: [mkAdmin('s', 'stale'), mkAdmin('a', 'active')],
     })
     renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
     expect(screen.queryByTestId('stale-admins-unavailable-reasons')).not.toBeInTheDocument()
+  })
+
+  it('keeps the section visible during refresh (stale-while-revalidate) and swaps the Retry button to Retrying…', () => {
+    const section = makeSection({
+      admins: [mkAdmin('a', 'active'), mkUnavailable('u', 'rate-limited')],
+    })
+    renderWithSession(
+      <StaleAdminsPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={section}
+        loadingOverride={true}
+      />,
+    )
+    // Section content is still rendered (no blank "Loading admin activity..." takeover).
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('u')).toBeInTheDocument()
+    expect(screen.queryByText(/Loading admin activity/i)).not.toBeInTheDocument()
+
+    const retry = screen.getByTestId('stale-admins-unavailable-retry')
+    expect(retry.textContent).toMatch(/Retrying/i)
+    expect(retry).toBeDisabled()
   })
 })
 

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -353,7 +353,7 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     expect(screen.queryByTestId('stale-admins-unavailable-retry')).not.toBeInTheDocument()
   })
 
-  it('renders humanized, non-app-error row text for each unavailable reason', () => {
+  it('renders humanized, non-app-error row text for each unavailable reason (ladder exhausted → "click Retry")', () => {
     const section = makeSection({
       admins: [
         mkUnavailable('u1', 'rate-limited'),
@@ -361,30 +361,74 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
         mkUnavailable('u3', 'admin-account-404'),
       ],
     })
-    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+    // nextAutoRetryAtOverride=null simulates the ladder-exhausted state.
+    renderWithSession(
+      <StaleAdminsPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={section}
+        nextAutoRetryAtOverride={null}
+      />,
+    )
 
     const unavailable = screen.getByTestId('stale-admins-group-unavailable')
-    // Row copy is framed around what GitHub returned, not our implementation.
-    expect(within(unavailable).getByText(/GitHub rate limit — retry in about a minute/i)).toBeInTheDocument()
-    expect(within(unavailable).getByText(/GitHub didn’t return activity data/i)).toBeInTheDocument()
+    expect(within(unavailable).getByText(/GitHub rate limit — click Retry to try again/i)).toBeInTheDocument()
+    expect(within(unavailable).getByText(/GitHub didn’t return activity data — click Retry to try again/i)).toBeInTheDocument()
     expect(within(unavailable).getByText(/GitHub account not found/i)).toBeInTheDocument()
-    // Our implementation names and debug asides must not leak into user copy.
+    // Our implementation names, debug asides, and lying time-promises must not appear.
     expect(within(unavailable).queryByText(/commit search/i)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/events feed/i)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/\(often a burst rate-limit\)/i)).not.toBeInTheDocument()
+    expect(within(unavailable).queryByText(/about a minute/i)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/commit-search-failed/)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/rate-limited\)/)).not.toBeInTheDocument()
   })
 
-  it('when a countdown is present, the row lead is tight and defers the "when" to the timer', () => {
+  it('every unavailable row shows a countdown when a background retry is scheduled, regardless of whether GitHub disclosed a reset', () => {
     vi.setSystemTime(new Date('2026-04-20T12:00:00Z'))
     const section = makeSection({
-      admins: [mkUnavailable('u1', 'rate-limited', '2026-04-20T12:00:30Z')],
+      admins: [
+        // u1 has its own GitHub-disclosed reset (should win over nextAutoRetryAt).
+        mkUnavailable('u1', 'rate-limited', '2026-04-20T12:00:15Z'),
+        // u2 has none — should fall back to the hook's nextAutoRetryAt.
+        mkUnavailable('u2', 'commit-search-failed'),
+      ],
     })
-    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
-    // Concise lead (no "retry in about a minute" — countdown carries the signal).
-    expect(screen.getByText('GitHub rate limit.')).toBeInTheDocument()
-    expect(screen.getByTestId('retry-countdown').textContent).toMatch(/Retry available in \d+s/)
+    renderWithSession(
+      <StaleAdminsPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={section}
+        nextAutoRetryAtOverride={'2026-04-20T12:00:30Z'}
+      />,
+    )
+
+    const countdowns = screen.getAllByTestId('retry-countdown')
+    expect(countdowns).toHaveLength(2)
+    // u1 uses its own reset (≈15s), u2 falls back to nextAutoRetryAt (≈30s).
+    expect(countdowns[0]!.textContent).toMatch(/15s/)
+    expect(countdowns[1]!.textContent).toMatch(/30s/)
+    vi.useRealTimers()
+  })
+
+  it('section-level Retry button shows the auto-retry countdown and disables while waiting', () => {
+    vi.setSystemTime(new Date('2026-04-20T12:00:00Z'))
+    const onRetry = vi.fn()
+    const section = makeSection({
+      admins: [mkUnavailable('u1', 'commit-search-failed')],
+    })
+    renderWithSession(
+      <StaleAdminsPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={section}
+        onRetryOverride={onRetry}
+        nextAutoRetryAtOverride={'2026-04-20T12:00:25Z'}
+      />,
+    )
+    const retry = screen.getByTestId('stale-admins-unavailable-retry')
+    expect(retry.textContent).toMatch(/Auto-retry in \d+s/)
+    expect(retry).toBeDisabled()
     vi.useRealTimers()
   })
 

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -353,7 +353,7 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     expect(screen.queryByTestId('stale-admins-unavailable-retry')).not.toBeInTheDocument()
   })
 
-  it('renders humanized, non-app-error row text for each unavailable reason (ladder exhausted → "click Retry")', () => {
+  it('renders a unified retryable-row message — rate-limit and search-unavailable share the same copy', () => {
     const section = makeSection({
       admins: [
         mkUnavailable('u1', 'rate-limited'),
@@ -361,7 +361,7 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
         mkUnavailable('u3', 'admin-account-404'),
       ],
     })
-    // nextAutoRetryAtOverride=null simulates the ladder-exhausted state.
+    // nextAutoRetryAtOverride=null simulates the ladder-paused state.
     renderWithSession(
       <StaleAdminsPanel
         org="acme"
@@ -372,16 +372,21 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     )
 
     const unavailable = screen.getByTestId('stale-admins-group-unavailable')
-    expect(within(unavailable).getByText(/GitHub rate limit — click Retry to try again/i)).toBeInTheDocument()
-    expect(within(unavailable).getByText(/GitHub didn’t return activity data — click Retry to try again/i)).toBeInTheDocument()
+    // Retryable rows (both rate-limited and commit-search-failed) share one message.
+    const retryableRows = within(unavailable).getAllByText(
+      /GitHub didn’t return activity data — click Retry to try again/i,
+    )
+    expect(retryableRows.length).toBe(2)
+    // Terminal reason keeps its distinct (non-retryable) copy.
     expect(within(unavailable).getByText(/GitHub account not found/i)).toBeInTheDocument()
     // Our implementation names, debug asides, and lying time-promises must not appear.
     expect(within(unavailable).queryByText(/commit search/i)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/events feed/i)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/\(often a burst rate-limit\)/i)).not.toBeInTheDocument()
     expect(within(unavailable).queryByText(/about a minute/i)).not.toBeInTheDocument()
-    expect(within(unavailable).queryByText(/commit-search-failed/)).not.toBeInTheDocument()
-    expect(within(unavailable).queryByText(/rate-limited\)/)).not.toBeInTheDocument()
+    // No per-reason rate-limit lead leaking into a row — the distinction
+    // lives in the sub-pill strip above the rows, not in each row's copy.
+    expect(within(unavailable).queryByText(/^GitHub rate limit/i)).not.toBeInTheDocument()
   })
 
   it('every unavailable row shows a countdown when a background retry is scheduled, regardless of whether GitHub disclosed a reset', () => {

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -458,14 +458,17 @@ describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
     vi.useRealTimers()
   })
 
-  it('renders "Ready to retry" when the countdown has elapsed', () => {
+  it('shows "click Retry" copy (not a stale countdown) when retryAvailableAt is in the past and ladder is exhausted', () => {
     vi.setSystemTime(new Date('2026-04-20T12:01:00Z'))
     const elapsed = new Date('2026-04-20T12:00:00Z').toISOString()
     const section = makeSection({
       admins: [mkUnavailable('u1', 'rate-limited', elapsed)],
     })
     renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
-    expect(screen.getByTestId('retry-countdown-ready')).toBeInTheDocument()
+    // Past retryAvailableAt with no nextAutoRetryAt: ladder exhausted, no countdown pinned.
+    expect(screen.queryByTestId('retry-countdown-ready')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('retry-countdown')).not.toBeInTheDocument()
+    expect(screen.getByText(/click Retry to try again/)).toBeInTheDocument()
     vi.useRealTimers()
   })
 

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -294,6 +294,69 @@ describe('StaleAdminsPanel — US3 mode indicators', () => {
   })
 })
 
+describe('StaleAdminsPanel — Unavailable bucket split (issue #364)', () => {
+  it('renders sub-breakdown pills for rate-limited vs commit-search-failed inside the Unavailable group', () => {
+    const section = makeSection({
+      admins: [
+        mkUnavailable('u1', 'rate-limited'),
+        mkUnavailable('u2', 'rate-limited'),
+        mkUnavailable('u3', 'commit-search-failed'),
+      ],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+
+    const unavailable = screen.getByTestId('stale-admins-group-unavailable')
+    const strip = within(unavailable).getByTestId('stale-admins-unavailable-reasons')
+    expect(
+      within(strip).getByTestId('stale-admins-unavailable-reason-rate-limited').textContent,
+    ).toMatch(/2 rate-limited/i)
+    expect(
+      within(strip).getByTestId('stale-admins-unavailable-reason-commit-search-failed').textContent,
+    ).toMatch(/1 commit search failed/i)
+  })
+
+  it('shows a Retry button when at least one admin is rate-limited, hidden otherwise', () => {
+    const onRetry = vi.fn()
+    const sectionWithRL = makeSection({
+      admins: [mkUnavailable('u1', 'rate-limited'), mkUnavailable('u2', 'commit-search-failed')],
+    })
+    const { rerender } = renderWithSession(
+      <StaleAdminsPanel
+        org="acme"
+        ownerType="Organization"
+        sectionOverride={sectionWithRL}
+        onRetryOverride={onRetry}
+      />,
+    )
+
+    const retry = screen.getByTestId('stale-admins-unavailable-retry')
+    fireEvent.click(retry)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <AuthProvider initialSession={{ token: 't', username: 'u', scopes: ['public_repo'] }}>
+        <StaleAdminsPanel
+          org="acme"
+          ownerType="Organization"
+          sectionOverride={makeSection({
+            admins: [mkUnavailable('u1', 'commit-search-failed')],
+          })}
+          onRetryOverride={onRetry}
+        />
+      </AuthProvider>,
+    )
+    expect(screen.queryByTestId('stale-admins-unavailable-retry')).not.toBeInTheDocument()
+  })
+
+  it('omits the sub-breakdown strip on non-unavailable groups', () => {
+    const section = makeSection({
+      admins: [mkAdmin('s', 'stale'), mkAdmin('a', 'active')],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+    expect(screen.queryByTestId('stale-admins-unavailable-reasons')).not.toBeInTheDocument()
+  })
+})
+
 describe('StaleAdminsPanel — US5 freshness disclosure', () => {
   it('reads the threshold value from the config and discloses public-only + eventual consistency', () => {
     const section = makeSection()
@@ -327,5 +390,18 @@ function mkAdmin(
     lastActivityAt: classification === 'stale' ? '2025-09-01T00:00:00Z' : '2026-04-10T00:00:00Z',
     lastActivitySource: 'public-events' as const,
     unavailableReason: null,
+  }
+}
+
+function mkUnavailable(
+  username: string,
+  reason: 'rate-limited' | 'commit-search-failed' | 'events-fetch-failed' | 'admin-account-404',
+) {
+  return {
+    username,
+    classification: 'unavailable' as const,
+    lastActivityAt: null,
+    lastActivitySource: null,
+    unavailableReason: reason,
   }
 }

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -139,8 +139,12 @@ export function StaleAdminsPanel({
 
       {expanded ? (
         <>
-          {loading ? <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p> : null}
-          {!loading && section ? <SectionBody section={section} onRetry={onRetry} /> : null}
+          {loading && !section ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p>
+          ) : null}
+          {section ? (
+            <SectionBody section={section} onRetry={onRetry} refreshing={loading} />
+          ) : null}
         </>
       ) : null}
     </section>
@@ -242,9 +246,11 @@ function ScoringHelp({ section }: { section: StaleAdminsSection | null }) {
 function SectionBody({
   section,
   onRetry,
+  refreshing,
 }: {
   section: StaleAdminsSection
   onRetry: () => void
+  refreshing: boolean
 }) {
   if (section.applicability === 'not-applicable-non-org') {
     return (
@@ -283,6 +289,7 @@ function SectionBody({
           admins={grouped[classification]}
           defaultOpen={DEFAULT_OPEN[classification]}
           onRetry={onRetry}
+          refreshing={refreshing}
         />
       ))}
     </div>
@@ -294,16 +301,20 @@ function GroupSection({
   admins,
   defaultOpen,
   onRetry,
+  refreshing,
 }: {
   classification: StaleAdminClassification
   admins: StaleAdminRecord[]
   defaultOpen: boolean
   onRetry: () => void
+  refreshing: boolean
 }) {
   const config = GROUP_CONFIG[classification]
   const isUnavailable = classification === 'unavailable'
   const reasonCounts = isUnavailable ? countByUnavailableReason(admins) : null
-  const rateLimitedCount = reasonCounts?.['rate-limited'] ?? 0
+  const retryableCount = reasonCounts
+    ? reasonCounts['rate-limited'] + reasonCounts['commit-search-failed'] + reasonCounts['events-fetch-failed']
+    : 0
   return (
     <details
       open={defaultOpen}
@@ -325,7 +336,8 @@ function GroupSection({
         <UnavailableReasonStrip
           counts={reasonCounts}
           onRetry={onRetry}
-          showRetry={rateLimitedCount > 0}
+          showRetry={retryableCount > 0}
+          refreshing={refreshing}
         />
       ) : null}
       <ul role="list" className="divide-y divide-slate-200 px-3 pb-1.5 dark:divide-slate-700">
@@ -339,19 +351,35 @@ function GroupSection({
 
 const UNAVAILABLE_REASON_LABEL: Record<StaleAdminUnavailableReason, string> = {
   'rate-limited': 'Rate-limited',
-  'commit-search-failed': 'Commit search failed',
-  'events-fetch-failed': 'Events fetch failed',
+  'commit-search-failed': 'Search unavailable',
+  'events-fetch-failed': 'Events unavailable',
   'admin-account-404': 'Account not found',
+}
+
+// Row-level humanized copy. Distinguishes retryable transient GitHub-side
+// issues ("try again in a moment") from terminal conditions ("account not
+// found"). `commit-search-failed` and `events-fetch-failed` are grouped with
+// retryable because in practice they often mask a disguised rate-limit or
+// abuse-detection block whose response didn't carry our expected headers.
+const UNAVAILABLE_REASON_ROW_TEXT: Record<StaleAdminUnavailableReason, string> = {
+  'rate-limited': 'GitHub rate limit hit — try Retry in a moment.',
+  'commit-search-failed':
+    'GitHub commit search is temporarily unavailable (often a burst rate-limit). Try Retry in a moment.',
+  'events-fetch-failed':
+    'GitHub events feed is temporarily unavailable. Try Retry in a moment.',
+  'admin-account-404': 'GitHub account not found or deleted.',
 }
 
 function UnavailableReasonStrip({
   counts,
   onRetry,
   showRetry,
+  refreshing,
 }: {
   counts: Record<StaleAdminUnavailableReason | 'unknown', number>
   onRetry: () => void
   showRetry: boolean
+  refreshing: boolean
 }) {
   const entries = (Object.keys(UNAVAILABLE_REASON_LABEL) as StaleAdminUnavailableReason[])
     .filter((r) => counts[r] > 0)
@@ -378,10 +406,11 @@ function UnavailableReasonStrip({
         <button
           type="button"
           onClick={onRetry}
+          disabled={refreshing}
           data-testid="stale-admins-unavailable-retry"
-          className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-50 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-300 dark:hover:bg-slate-800"
+          className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-50 disabled:cursor-wait disabled:opacity-60 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-300 dark:hover:bg-slate-800"
         >
-          Retry rate-limited
+          {refreshing ? 'Retrying…' : 'Retry unavailable'}
         </button>
       ) : null}
     </div>
@@ -469,11 +498,12 @@ function RowDetail({ admin }: { admin: StaleAdminRecord }) {
     )
   }
   if (admin.classification === 'unavailable') {
-    return (
-      <span className="text-xs text-slate-500 dark:text-slate-400">
-        Activity could not be retrieved ({admin.unavailableReason ?? 'unknown'}).
-      </span>
-    )
+    const reason = admin.unavailableReason
+    const text =
+      reason && reason in UNAVAILABLE_REASON_ROW_TEXT
+        ? UNAVAILABLE_REASON_ROW_TEXT[reason]
+        : 'Activity could not be retrieved.'
+    return <span className="text-xs text-slate-500 dark:text-slate-400">{text}</span>
   }
   return null
 }

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -360,18 +360,26 @@ const UNAVAILABLE_REASON_LABEL: Record<StaleAdminUnavailableReason, string> = {
   'admin-account-404': 'Account not found',
 }
 
-// Row-level humanized copy. Distinguishes retryable transient GitHub-side
-// issues ("try again in a moment") from terminal conditions ("account not
-// found"). `commit-search-failed` and `events-fetch-failed` are grouped with
-// retryable because in practice they often mask a disguised rate-limit or
-// abuse-detection block whose response didn't carry our expected headers.
-const UNAVAILABLE_REASON_ROW_TEXT: Record<StaleAdminUnavailableReason, string> = {
-  'rate-limited': 'GitHub rate limit hit — try Retry in a moment.',
-  'commit-search-failed':
-    'GitHub commit search is temporarily unavailable (often a burst rate-limit). Try Retry in a moment.',
-  'events-fetch-failed':
-    'GitHub events feed is temporarily unavailable. Try Retry in a moment.',
-  'admin-account-404': 'GitHub account not found or deleted.',
+// Row-level humanized copy. Framed around what GitHub returned (or didn't),
+// not our implementation (`/search/commits`, `/events/public`). Avoids
+// parenthetical technical asides — those read as app-error / debug output.
+// Terminal conditions (`admin-account-404`) are distinct from retryable
+// throttling; commit-search / events failures are grouped under the same
+// user-facing copy because in practice they share a root cause (GitHub-side
+// throttling we can't observe directly) and a single recourse (retry later).
+function unavailableReasonRowText(reason: StaleAdminUnavailableReason | null, hasCountdown: boolean): string {
+  switch (reason) {
+    case 'rate-limited':
+      // When a countdown follows, the timer carries the "when"; keep the lead tight.
+      return hasCountdown ? 'GitHub rate limit.' : 'GitHub rate limit — retry in about a minute.'
+    case 'commit-search-failed':
+    case 'events-fetch-failed':
+      return 'GitHub didn’t return activity data — retry may work in about a minute.'
+    case 'admin-account-404':
+      return 'GitHub account not found or deleted.'
+    default:
+      return 'Activity could not be retrieved.'
+  }
 }
 
 function UnavailableReasonStrip({
@@ -541,14 +549,10 @@ function RowDetail({ admin }: { admin: StaleAdminRecord }) {
     )
   }
   if (admin.classification === 'unavailable') {
-    const reason = admin.unavailableReason
-    const text =
-      reason && reason in UNAVAILABLE_REASON_ROW_TEXT
-        ? UNAVAILABLE_REASON_ROW_TEXT[reason]
-        : 'Activity could not be retrieved.'
+    const hasCountdown = Boolean(admin.retryAvailableAt)
     return (
       <span className="text-xs text-slate-500 dark:text-slate-400">
-        {text}
+        {unavailableReasonRowText(admin.unavailableReason, hasCountdown)}
         {admin.retryAvailableAt ? (
           <>
             {' '}

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -21,6 +21,8 @@ interface Props {
   loadingOverride?: boolean
   /** Override for tests. */
   onRetryOverride?: () => void
+  /** Override for tests. */
+  nextAutoRetryAtOverride?: string | null
 }
 
 // Risk-first ordering: the user's attention should go to Stale and Unavailable
@@ -79,6 +81,7 @@ export function StaleAdminsPanel({
   sectionOverride,
   loadingOverride,
   onRetryOverride,
+  nextAutoRetryAtOverride,
 }: Props) {
   const { session, hasScope } = useAuth()
   // admin:org is a strict superset of read:org — treat either as "elevated"
@@ -96,6 +99,12 @@ export function StaleAdminsPanel({
   const section = hasOverride ? sectionOverride : hookState.section
   const loading = loadingOverride ?? (hasOverride ? false : hookState.loading)
   const onRetry = onRetryOverride ?? hookState.refetch
+  const nextAutoRetryAt =
+    nextAutoRetryAtOverride !== undefined
+      ? nextAutoRetryAtOverride
+      : hasOverride
+        ? null
+        : hookState.nextAutoRetryAt
   const [expanded, setExpanded] = useState(true)
 
   return (
@@ -143,7 +152,12 @@ export function StaleAdminsPanel({
             <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p>
           ) : null}
           {section ? (
-            <SectionBody section={section} onRetry={onRetry} refreshing={loading} />
+            <SectionBody
+              section={section}
+              onRetry={onRetry}
+              refreshing={loading}
+              nextAutoRetryAt={nextAutoRetryAt}
+            />
           ) : null}
         </>
       ) : null}
@@ -247,10 +261,12 @@ function SectionBody({
   section,
   onRetry,
   refreshing,
+  nextAutoRetryAt,
 }: {
   section: StaleAdminsSection
   onRetry: () => void
   refreshing: boolean
+  nextAutoRetryAt: string | null
 }) {
   if (section.applicability === 'not-applicable-non-org') {
     return (
@@ -290,7 +306,7 @@ function SectionBody({
           defaultOpen={DEFAULT_OPEN[classification]}
           onRetry={onRetry}
           refreshing={refreshing}
-          earliestRetryAvailableAt={section.earliestRetryAvailableAt ?? null}
+          nextAutoRetryAt={nextAutoRetryAt}
         />
       ))}
     </div>
@@ -303,14 +319,14 @@ function GroupSection({
   defaultOpen,
   onRetry,
   refreshing,
-  earliestRetryAvailableAt,
+  nextAutoRetryAt,
 }: {
   classification: StaleAdminClassification
   admins: StaleAdminRecord[]
   defaultOpen: boolean
   onRetry: () => void
   refreshing: boolean
-  earliestRetryAvailableAt: string | null
+  nextAutoRetryAt: string | null
 }) {
   const config = GROUP_CONFIG[classification]
   const isUnavailable = classification === 'unavailable'
@@ -341,12 +357,12 @@ function GroupSection({
           onRetry={onRetry}
           showRetry={retryableCount > 0}
           refreshing={refreshing}
-          earliestRetryAvailableAt={earliestRetryAvailableAt}
+          nextAutoRetryAt={nextAutoRetryAt}
         />
       ) : null}
       <ul role="list" className="divide-y divide-slate-200 px-3 pb-1.5 dark:divide-slate-700">
         {admins.map((admin) => (
-          <AdminRow key={admin.username} admin={admin} />
+          <AdminRow key={admin.username} admin={admin} nextAutoRetryAt={nextAutoRetryAt} />
         ))}
       </ul>
     </details>
@@ -363,18 +379,23 @@ const UNAVAILABLE_REASON_LABEL: Record<StaleAdminUnavailableReason, string> = {
 // Row-level humanized copy. Framed around what GitHub returned (or didn't),
 // not our implementation (`/search/commits`, `/events/public`). Avoids
 // parenthetical technical asides — those read as app-error / debug output.
-// Terminal conditions (`admin-account-404`) are distinct from retryable
-// throttling; commit-search / events failures are grouped under the same
-// user-facing copy because in practice they share a root cause (GitHub-side
-// throttling we can't observe directly) and a single recourse (retry later).
+//
+// Two rendering modes, driven by `hasCountdown`:
+//   - With countdown: a live timer follows the lead and carries the "when".
+//     Keep the lead tight; no promises about time live in the text.
+//   - Without countdown: the background retry ladder is exhausted, so the
+//     text points at the Retry button instead of lying about a time.
+//
+// Terminal conditions (`admin-account-404`) don't vary — they're terminal.
 function unavailableReasonRowText(reason: StaleAdminUnavailableReason | null, hasCountdown: boolean): string {
   switch (reason) {
     case 'rate-limited':
-      // When a countdown follows, the timer carries the "when"; keep the lead tight.
-      return hasCountdown ? 'GitHub rate limit.' : 'GitHub rate limit — retry in about a minute.'
+      return hasCountdown ? 'GitHub rate limit.' : 'GitHub rate limit — click Retry to try again.'
     case 'commit-search-failed':
     case 'events-fetch-failed':
-      return 'GitHub didn’t return activity data — retry may work in about a minute.'
+      return hasCountdown
+        ? 'GitHub didn’t return activity data.'
+        : 'GitHub didn’t return activity data — click Retry to try again.'
     case 'admin-account-404':
       return 'GitHub account not found or deleted.'
     default:
@@ -387,13 +408,13 @@ function UnavailableReasonStrip({
   onRetry,
   showRetry,
   refreshing,
-  earliestRetryAvailableAt,
+  nextAutoRetryAt,
 }: {
   counts: Record<StaleAdminUnavailableReason | 'unknown', number>
   onRetry: () => void
   showRetry: boolean
   refreshing: boolean
-  earliestRetryAvailableAt: string | null
+  nextAutoRetryAt: string | null
 }) {
   const entries = (Object.keys(UNAVAILABLE_REASON_LABEL) as StaleAdminUnavailableReason[])
     .filter((r) => counts[r] > 0)
@@ -420,7 +441,7 @@ function UnavailableReasonStrip({
         <RetryButton
           onRetry={onRetry}
           refreshing={refreshing}
-          earliestRetryAvailableAt={earliestRetryAvailableAt}
+          nextAutoRetryAt={nextAutoRetryAt}
         />
       ) : null}
     </div>
@@ -430,13 +451,13 @@ function UnavailableReasonStrip({
 function RetryButton({
   onRetry,
   refreshing,
-  earliestRetryAvailableAt,
+  nextAutoRetryAt,
 }: {
   onRetry: () => void
   refreshing: boolean
-  earliestRetryAvailableAt: string | null
+  nextAutoRetryAt: string | null
 }) {
-  const target = earliestRetryAvailableAt ? Date.parse(earliestRetryAvailableAt) : NaN
+  const target = nextAutoRetryAt ? Date.parse(nextAutoRetryAt) : NaN
   const hasKnownTarget = Number.isFinite(target)
   const [nowMs, setNowMs] = useState(() => Date.now())
   useEffect(() => {
@@ -448,12 +469,15 @@ function RetryButton({
   const remainingMs = hasKnownTarget ? Math.max(0, target - nowMs) : 0
   const seconds = Math.ceil(remainingMs / 1000)
   const waiting = hasKnownTarget && remainingMs > 0
+  // When a background auto-retry is pending, users should not fire their
+  // own on top of it (doubles the rate-limit pressure). Disable until the
+  // timer is up OR the ladder is exhausted (nextAutoRetryAt = null).
   const disabled = refreshing || waiting
   const label = refreshing
     ? 'Retrying…'
     : waiting
-      ? `Retry in ${seconds}s`
-      : 'Retry unavailable'
+      ? `Auto-retry in ${seconds}s`
+      : 'Retry'
 
   return (
     <button
@@ -504,7 +528,13 @@ function GroupChevron() {
   )
 }
 
-function AdminRow({ admin }: { admin: StaleAdminRecord }) {
+function AdminRow({
+  admin,
+  nextAutoRetryAt,
+}: {
+  admin: StaleAdminRecord
+  nextAutoRetryAt: string | null
+}) {
   return (
     <li
       className="flex flex-wrap items-baseline justify-between gap-2 py-1"
@@ -518,12 +548,18 @@ function AdminRow({ admin }: { admin: StaleAdminRecord }) {
       >
         {admin.username}
       </a>
-      <RowDetail admin={admin} />
+      <RowDetail admin={admin} nextAutoRetryAt={nextAutoRetryAt} />
     </li>
   )
 }
 
-function RowDetail({ admin }: { admin: StaleAdminRecord }) {
+function RowDetail({
+  admin,
+  nextAutoRetryAt,
+}: {
+  admin: StaleAdminRecord
+  nextAutoRetryAt: string | null
+}) {
   if (admin.lastActivityAt) {
     return (
       <span className="inline-flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
@@ -549,14 +585,21 @@ function RowDetail({ admin }: { admin: StaleAdminRecord }) {
     )
   }
   if (admin.classification === 'unavailable') {
-    const hasCountdown = Boolean(admin.retryAvailableAt)
+    // Unified countdown source: prefer this admin's own GitHub-disclosed
+    // reset (`retryAvailableAt`), fall back to the hook's next scheduled
+    // background retry (`nextAutoRetryAt`). Either way, every unavailable
+    // row shows a live countdown — no "about a minute" copy that never
+    // updates. When neither is available (ladder exhausted, terminal
+    // reason), no countdown is shown and the copy points at Retry.
+    const countdownAt = admin.retryAvailableAt ?? nextAutoRetryAt
+    const hasCountdown = Boolean(countdownAt)
     return (
       <span className="text-xs text-slate-500 dark:text-slate-400">
         {unavailableReasonRowText(admin.unavailableReason, hasCountdown)}
-        {admin.retryAvailableAt ? (
+        {countdownAt ? (
           <>
             {' '}
-            <RetryCountdown availableAt={admin.retryAvailableAt} />
+            <RetryCountdown availableAt={countdownAt} />
           </>
         ) : null}
       </span>

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAuth } from '@/components/auth/AuthContext'
 import { STALE_ADMIN_THRESHOLD_DAYS } from '@/lib/config/governance'
 import { useStaleAdmins, type OwnerType } from '@/components/shared/hooks/useStaleAdmins'
@@ -290,6 +290,7 @@ function SectionBody({
           defaultOpen={DEFAULT_OPEN[classification]}
           onRetry={onRetry}
           refreshing={refreshing}
+          earliestRetryAvailableAt={section.earliestRetryAvailableAt ?? null}
         />
       ))}
     </div>
@@ -302,12 +303,14 @@ function GroupSection({
   defaultOpen,
   onRetry,
   refreshing,
+  earliestRetryAvailableAt,
 }: {
   classification: StaleAdminClassification
   admins: StaleAdminRecord[]
   defaultOpen: boolean
   onRetry: () => void
   refreshing: boolean
+  earliestRetryAvailableAt: string | null
 }) {
   const config = GROUP_CONFIG[classification]
   const isUnavailable = classification === 'unavailable'
@@ -338,6 +341,7 @@ function GroupSection({
           onRetry={onRetry}
           showRetry={retryableCount > 0}
           refreshing={refreshing}
+          earliestRetryAvailableAt={earliestRetryAvailableAt}
         />
       ) : null}
       <ul role="list" className="divide-y divide-slate-200 px-3 pb-1.5 dark:divide-slate-700">
@@ -375,11 +379,13 @@ function UnavailableReasonStrip({
   onRetry,
   showRetry,
   refreshing,
+  earliestRetryAvailableAt,
 }: {
   counts: Record<StaleAdminUnavailableReason | 'unknown', number>
   onRetry: () => void
   showRetry: boolean
   refreshing: boolean
+  earliestRetryAvailableAt: string | null
 }) {
   const entries = (Object.keys(UNAVAILABLE_REASON_LABEL) as StaleAdminUnavailableReason[])
     .filter((r) => counts[r] > 0)
@@ -403,17 +409,54 @@ function UnavailableReasonStrip({
         </span>
       ))}
       {showRetry ? (
-        <button
-          type="button"
-          onClick={onRetry}
-          disabled={refreshing}
-          data-testid="stale-admins-unavailable-retry"
-          className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-50 disabled:cursor-wait disabled:opacity-60 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-300 dark:hover:bg-slate-800"
-        >
-          {refreshing ? 'Retrying…' : 'Retry unavailable'}
-        </button>
+        <RetryButton
+          onRetry={onRetry}
+          refreshing={refreshing}
+          earliestRetryAvailableAt={earliestRetryAvailableAt}
+        />
       ) : null}
     </div>
+  )
+}
+
+function RetryButton({
+  onRetry,
+  refreshing,
+  earliestRetryAvailableAt,
+}: {
+  onRetry: () => void
+  refreshing: boolean
+  earliestRetryAvailableAt: string | null
+}) {
+  const target = earliestRetryAvailableAt ? Date.parse(earliestRetryAvailableAt) : NaN
+  const hasKnownTarget = Number.isFinite(target)
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  useEffect(() => {
+    if (!hasKnownTarget) return
+    const id = setInterval(() => setNowMs(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [hasKnownTarget])
+
+  const remainingMs = hasKnownTarget ? Math.max(0, target - nowMs) : 0
+  const seconds = Math.ceil(remainingMs / 1000)
+  const waiting = hasKnownTarget && remainingMs > 0
+  const disabled = refreshing || waiting
+  const label = refreshing
+    ? 'Retrying…'
+    : waiting
+      ? `Retry in ${seconds}s`
+      : 'Retry unavailable'
+
+  return (
+    <button
+      type="button"
+      onClick={onRetry}
+      disabled={disabled}
+      data-testid="stale-admins-unavailable-retry"
+      className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-50 disabled:cursor-wait disabled:opacity-60 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-300 dark:hover:bg-slate-800"
+    >
+      {label}
+    </button>
   )
 }
 
@@ -503,9 +546,50 @@ function RowDetail({ admin }: { admin: StaleAdminRecord }) {
       reason && reason in UNAVAILABLE_REASON_ROW_TEXT
         ? UNAVAILABLE_REASON_ROW_TEXT[reason]
         : 'Activity could not be retrieved.'
-    return <span className="text-xs text-slate-500 dark:text-slate-400">{text}</span>
+    return (
+      <span className="text-xs text-slate-500 dark:text-slate-400">
+        {text}
+        {admin.retryAvailableAt ? (
+          <>
+            {' '}
+            <RetryCountdown availableAt={admin.retryAvailableAt} />
+          </>
+        ) : null}
+      </span>
+    )
   }
   return null
+}
+
+function RetryCountdown({ availableAt }: { availableAt: string }) {
+  const target = Date.parse(availableAt)
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  useEffect(() => {
+    if (!Number.isFinite(target)) return
+    const id = setInterval(() => setNowMs(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [target])
+  if (!Number.isFinite(target)) return null
+  const remainingMs = target - nowMs
+  if (remainingMs <= 0) {
+    return (
+      <span
+        data-testid="retry-countdown-ready"
+        className="font-medium text-emerald-700 dark:text-emerald-400"
+      >
+        Ready to retry.
+      </span>
+    )
+  }
+  const seconds = Math.ceil(remainingMs / 1000)
+  return (
+    <span
+      data-testid="retry-countdown"
+      className="font-medium text-amber-700 dark:text-amber-400"
+    >
+      Retry available in {seconds}s.
+    </span>
+  )
 }
 
 function ModeBadge({ mode }: { mode: StaleAdminMode }) {

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -245,11 +245,11 @@ function ScoringHelp({ section }: { section: StaleAdminsSection | null }) {
     <details className="relative" data-testid="stale-admins-scoring-help">
       <summary
         aria-label="How is this scored?"
-        className="inline-flex h-4 w-4 cursor-pointer select-none items-center justify-center rounded-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-500 list-none hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200 [&::-webkit-details-marker]:hidden dark:bg-slate-900"
+        className="inline-flex h-4 w-4 cursor-pointer select-none items-center justify-center rounded-full border border-slate-300 bg-white text-[10px] font-semibold text-slate-500 list-none hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200 [&::-webkit-details-marker]:hidden"
       >
         ?
       </summary>
-      <div className="absolute left-0 top-6 z-10 w-72 rounded-md border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:bg-slate-900">
+      <div className="absolute left-0 top-6 z-10 w-72 rounded-md border border-slate-200 bg-white p-3 text-xs text-slate-600 shadow-md dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
         <p className="mb-1 font-medium text-slate-700 dark:text-slate-200">How is this scored?</p>
         <ThresholdDisclosure section={section} />
       </div>
@@ -279,7 +279,7 @@ function SectionBody({
 
   if (section.applicability === 'admin-list-unavailable') {
     return (
-      <p className="text-sm text-rose-700 dark:text-rose-400 dark:text-rose-300" data-testid="stale-admins-unavailable">
+      <p className="text-sm text-rose-700 dark:text-rose-300" data-testid="stale-admins-unavailable">
         Admin list could not be retrieved —{' '}
         <span className="font-medium">{section.adminListUnavailableReason ?? 'unknown'}</span>.
       </p>
@@ -337,7 +337,7 @@ function GroupSection({
   return (
     <details
       open={defaultOpen}
-      className={`group rounded-md bg-slate-50 dark:bg-slate-800/40 ${config.headerBorderClassName} dark:bg-slate-800/60 `}
+      className={`group rounded-md bg-slate-50 dark:bg-slate-800/60 ${config.headerBorderClassName}`}
       data-testid={`stale-admins-group-${classification}`}
     >
       <summary

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -380,27 +380,26 @@ const UNAVAILABLE_REASON_LABEL: Record<StaleAdminUnavailableReason, string> = {
 // not our implementation (`/search/commits`, `/events/public`). Avoids
 // parenthetical technical asides — those read as app-error / debug output.
 //
+// All retryable reasons (rate-limited, commit-search-failed,
+// events-fetch-failed) share a single message so rows read consistently;
+// the per-reason split is already visible at a glance via the sub-pill
+// strip above the rows ("3 rate-limited · 18 search unavailable"), which
+// is where users who care about the distinction can find it.
+//
 // Two rendering modes, driven by `hasCountdown`:
 //   - With countdown: a live timer follows the lead and carries the "when".
-//     Keep the lead tight; no promises about time live in the text.
-//   - Without countdown: the background retry ladder is exhausted, so the
-//     text points at the Retry button instead of lying about a time.
-//
-// Terminal conditions (`admin-account-404`) don't vary — they're terminal.
+//   - Without countdown: the background retry ladder is paused, so the
+//     text points at the Retry button instead of promising a time.
 function unavailableReasonRowText(reason: StaleAdminUnavailableReason | null, hasCountdown: boolean): string {
-  switch (reason) {
-    case 'rate-limited':
-      return hasCountdown ? 'GitHub rate limit.' : 'GitHub rate limit — click Retry to try again.'
-    case 'commit-search-failed':
-    case 'events-fetch-failed':
-      return hasCountdown
-        ? 'GitHub didn’t return activity data.'
-        : 'GitHub didn’t return activity data — click Retry to try again.'
-    case 'admin-account-404':
-      return 'GitHub account not found or deleted.'
-    default:
-      return 'Activity could not be retrieved.'
+  if (reason === 'admin-account-404') {
+    return 'GitHub account not found or deleted.'
   }
+  if (reason === null) {
+    return 'Activity could not be retrieved.'
+  }
+  return hasCountdown
+    ? 'GitHub didn’t return activity data.'
+    : 'GitHub didn’t return activity data — click Retry to try again.'
 }
 
 function UnavailableReasonStrip({

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -9,6 +9,7 @@ import type {
   StaleAdminMode,
   StaleAdminRecord,
   StaleAdminsSection,
+  StaleAdminUnavailableReason,
 } from '@/lib/governance/stale-admins'
 
 interface Props {
@@ -18,6 +19,8 @@ interface Props {
   sectionOverride?: StaleAdminsSection | null
   /** Override for tests. */
   loadingOverride?: boolean
+  /** Override for tests. */
+  onRetryOverride?: () => void
 }
 
 // Risk-first ordering: the user's attention should go to Stale and Unavailable
@@ -70,7 +73,13 @@ const GROUP_CONFIG: Record<
   },
 }
 
-export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverride }: Props) {
+export function StaleAdminsPanel({
+  org,
+  ownerType,
+  sectionOverride,
+  loadingOverride,
+  onRetryOverride,
+}: Props) {
   const { session, hasScope } = useAuth()
   // admin:org is a strict superset of read:org — treat either as "elevated"
   // for the concealed-admins view.
@@ -86,6 +95,7 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
 
   const section = hasOverride ? sectionOverride : hookState.section
   const loading = loadingOverride ?? (hasOverride ? false : hookState.loading)
+  const onRetry = onRetryOverride ?? hookState.refetch
   const [expanded, setExpanded] = useState(true)
 
   return (
@@ -130,7 +140,7 @@ export function StaleAdminsPanel({ org, ownerType, sectionOverride, loadingOverr
       {expanded ? (
         <>
           {loading ? <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p> : null}
-          {!loading && section ? <SectionBody section={section} /> : null}
+          {!loading && section ? <SectionBody section={section} onRetry={onRetry} /> : null}
         </>
       ) : null}
     </section>
@@ -229,7 +239,13 @@ function ScoringHelp({ section }: { section: StaleAdminsSection | null }) {
   )
 }
 
-function SectionBody({ section }: { section: StaleAdminsSection }) {
+function SectionBody({
+  section,
+  onRetry,
+}: {
+  section: StaleAdminsSection
+  onRetry: () => void
+}) {
   if (section.applicability === 'not-applicable-non-org') {
     return (
       <p className="text-sm text-slate-600 dark:text-slate-300" data-testid="stale-admins-na">
@@ -266,6 +282,7 @@ function SectionBody({ section }: { section: StaleAdminsSection }) {
           classification={classification}
           admins={grouped[classification]}
           defaultOpen={DEFAULT_OPEN[classification]}
+          onRetry={onRetry}
         />
       ))}
     </div>
@@ -276,12 +293,17 @@ function GroupSection({
   classification,
   admins,
   defaultOpen,
+  onRetry,
 }: {
   classification: StaleAdminClassification
   admins: StaleAdminRecord[]
   defaultOpen: boolean
+  onRetry: () => void
 }) {
   const config = GROUP_CONFIG[classification]
+  const isUnavailable = classification === 'unavailable'
+  const reasonCounts = isUnavailable ? countByUnavailableReason(admins) : null
+  const rateLimitedCount = reasonCounts?.['rate-limited'] ?? 0
   return (
     <details
       open={defaultOpen}
@@ -299,6 +321,13 @@ function GroupSection({
           {admins.length}
         </span>
       </summary>
+      {isUnavailable && reasonCounts ? (
+        <UnavailableReasonStrip
+          counts={reasonCounts}
+          onRetry={onRetry}
+          showRetry={rateLimitedCount > 0}
+        />
+      ) : null}
       <ul role="list" className="divide-y divide-slate-200 px-3 pb-1.5 dark:divide-slate-700">
         {admins.map((admin) => (
           <AdminRow key={admin.username} admin={admin} />
@@ -306,6 +335,75 @@ function GroupSection({
       </ul>
     </details>
   )
+}
+
+const UNAVAILABLE_REASON_LABEL: Record<StaleAdminUnavailableReason, string> = {
+  'rate-limited': 'Rate-limited',
+  'commit-search-failed': 'Commit search failed',
+  'events-fetch-failed': 'Events fetch failed',
+  'admin-account-404': 'Account not found',
+}
+
+function UnavailableReasonStrip({
+  counts,
+  onRetry,
+  showRetry,
+}: {
+  counts: Record<StaleAdminUnavailableReason | 'unknown', number>
+  onRetry: () => void
+  showRetry: boolean
+}) {
+  const entries = (Object.keys(UNAVAILABLE_REASON_LABEL) as StaleAdminUnavailableReason[])
+    .filter((r) => counts[r] > 0)
+    .map((r) => ({ reason: r, count: counts[r], label: UNAVAILABLE_REASON_LABEL[r] }))
+  if (counts.unknown > 0) {
+    entries.push({ reason: 'unknown' as never, count: counts.unknown, label: 'Unknown' })
+  }
+  if (entries.length === 0) return null
+  return (
+    <div
+      className="mx-3 mb-1 flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-amber-200 pb-1.5 text-xs dark:border-amber-900/60"
+      data-testid="stale-admins-unavailable-reasons"
+    >
+      {entries.map(({ reason, count, label }) => (
+        <span
+          key={reason}
+          className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+          data-testid={`stale-admins-unavailable-reason-${reason}`}
+        >
+          {count} {label.toLowerCase()}
+        </span>
+      ))}
+      {showRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          data-testid="stale-admins-unavailable-retry"
+          className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-0.5 text-xs font-medium text-amber-800 hover:bg-amber-50 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-300 dark:hover:bg-slate-800"
+        >
+          Retry rate-limited
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+function countByUnavailableReason(
+  admins: StaleAdminRecord[],
+): Record<StaleAdminUnavailableReason | 'unknown', number> {
+  const counts: Record<StaleAdminUnavailableReason | 'unknown', number> = {
+    'rate-limited': 0,
+    'commit-search-failed': 0,
+    'events-fetch-failed': 0,
+    'admin-account-404': 0,
+    unknown: 0,
+  }
+  for (const a of admins) {
+    const r = a.unavailableReason
+    if (r && r in counts) counts[r]++
+    else counts.unknown++
+  }
+  return counts
 }
 
 function GroupChevron() {

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -585,12 +585,17 @@ function RowDetail({
   }
   if (admin.classification === 'unavailable') {
     // Unified countdown source: prefer this admin's own GitHub-disclosed
-    // reset (`retryAvailableAt`), fall back to the hook's next scheduled
-    // background retry (`nextAutoRetryAt`). Either way, every unavailable
-    // row shows a live countdown — no "about a minute" copy that never
-    // updates. When neither is available (ladder exhausted, terminal
-    // reason), no countdown is shown and the copy points at Retry.
-    const countdownAt = admin.retryAvailableAt ?? nextAutoRetryAt
+    // reset (`retryAvailableAt`) only while it's still in the future —
+    // a past timestamp means the window has passed and shouldn't keep
+    // "Ready to retry." pinned after the ladder is exhausted. Fall back
+    // to the hook's next scheduled background retry (`nextAutoRetryAt`).
+    // When neither is available (ladder exhausted, terminal reason), no
+    // countdown is shown and the copy points at Retry.
+    const retryAt =
+      admin.retryAvailableAt && Date.parse(admin.retryAvailableAt) > Date.now()
+        ? admin.retryAvailableAt
+        : null
+    const countdownAt = retryAt ?? nextAutoRetryAt
     const hasCountdown = Boolean(countdownAt)
     return (
       <span className="text-xs text-slate-500 dark:text-slate-400">

--- a/components/shared/hooks/useStaleAdmins.ts
+++ b/components/shared/hooks/useStaleAdmins.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { StaleAdminsSection } from '@/lib/governance/stale-admins'
 
 export type OwnerType = 'Organization' | 'User'
@@ -20,12 +20,27 @@ export interface UseStaleAdminsState {
   refetch: () => void
 }
 
+// Bounded background auto-retry ladder. Hybrid strategy:
+//   - If the section carries `earliestRetryAvailableAt`, schedule the next
+//     retry right after that timestamp (header-driven, accurate).
+//   - Otherwise, fall back to this fixed ladder for cases where GitHub did
+//     not disclose a reset time (secondary rate limits, 5xx, etc).
+// Capped at 3 attempts. A manual `refetch()` resets the ladder so the user
+// can always trigger a fresh cycle.
+const BG_RETRY_LADDER_MS = [10_000, 30_000, 60_000]
+const BG_RETRY_MAX_DELAY_MS = 60_000
+const BG_RETRY_JITTER_MS = 500
+
 export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsState {
   const { org, ownerType, token, elevated } = options
   const fetchFn = options.fetchFn ?? fetch
 
   const [retryCount, setRetryCount] = useState(0)
-  const refetch = useCallback(() => setRetryCount((n) => n + 1), [])
+  const [ladderStep, setLadderStep] = useState(0)
+  const refetch = useCallback(() => {
+    setLadderStep(0)
+    setRetryCount((n) => n + 1)
+  }, [])
   const [state, setState] = useState<Omit<UseStaleAdminsState, 'refetch'>>(() => ({
     loading: Boolean(org && token),
     section: null,
@@ -88,5 +103,56 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
     }
   }, [org, ownerType, token, elevated, fetchFn, retryCount])
 
+  // Reset the ladder whenever the caller options change (nav, sign-out, etc).
+  const ladderResetKey = `${org}|${ownerType}|${token}|${elevated}`
+  const lastResetKeyRef = useRef(ladderResetKey)
+  useEffect(() => {
+    if (lastResetKeyRef.current === ladderResetKey) return
+    lastResetKeyRef.current = ladderResetKey
+    // Defer the state update out of the effect body to avoid cascading renders
+    // (eslint react-hooks/set-state-in-effect).
+    queueMicrotask(() => setLadderStep(0))
+  }, [ladderResetKey])
+
+  // Schedule a background auto-retry after each fetch completes, when there
+  // are still retryable-unavailable admins. Cancelled on new fetch / option
+  // change / unmount. The ladder advances per fire; once exhausted, the
+  // user's Retry button is the fallback.
+  useEffect(() => {
+    if (state.loading) return
+    if (!state.section) return
+    if (ladderStep >= BG_RETRY_LADDER_MS.length) return
+    if (!sectionHasRetryableUnavailable(state.section)) return
+
+    const fallbackDelay = BG_RETRY_LADDER_MS[ladderStep]!
+    const earliestAt = state.section.earliestRetryAvailableAt
+    let delay = fallbackDelay
+    if (earliestAt) {
+      const untilReset = Date.parse(earliestAt) - Date.now()
+      if (Number.isFinite(untilReset)) {
+        delay = Math.min(
+          Math.max(untilReset + BG_RETRY_JITTER_MS, 1000),
+          BG_RETRY_MAX_DELAY_MS,
+        )
+      }
+    }
+
+    const id = setTimeout(() => {
+      setLadderStep((s) => s + 1)
+      setRetryCount((n) => n + 1)
+    }, delay)
+    return () => clearTimeout(id)
+  }, [state.loading, state.section, ladderStep])
+
   return { ...state, refetch }
+}
+
+function sectionHasRetryableUnavailable(section: StaleAdminsSection): boolean {
+  if (section.applicability !== 'applicable') return false
+  return section.admins.some(
+    (admin) =>
+      admin.classification === 'unavailable' &&
+      admin.unavailableReason !== null &&
+      admin.unavailableReason !== 'admin-account-404',
+  )
 }

--- a/components/shared/hooks/useStaleAdmins.ts
+++ b/components/shared/hooks/useStaleAdmins.ts
@@ -28,14 +28,19 @@ export interface UseStaleAdminsState {
   nextAutoRetryAt: string | null
 }
 
-// Bounded background auto-retry ladder. Hybrid strategy:
+// Bounded background auto-retry. Hybrid strategy:
 //   - If the section carries `earliestRetryAvailableAt`, schedule the next
 //     retry right after that timestamp (header-driven, accurate).
-//   - Otherwise, fall back to this fixed ladder for cases where GitHub did
-//     not disclose a reset time (secondary rate limits, 5xx, etc).
-// Capped at 3 attempts. A manual `refetch()` resets the ladder so the user
-// can always trigger a fresh cycle.
-const BG_RETRY_LADDER_MS = [10_000, 30_000, 60_000]
+//   - Otherwise, use a fixed 30s interval for the case where GitHub did not
+//     disclose a reset (secondary rate limits, 5xx, etc). 30s is long
+//     enough for the Search-Commits 1-minute window to mostly slide and
+//     short enough that the user does not feel abandoned.
+//
+// Capped at 3 attempts. After that the ladder pauses and the user must
+// click Retry to start a fresh cycle — preventing an idle tab from
+// hammering GitHub forever.
+const BG_RETRY_INTERVAL_MS = 30_000
+const BG_RETRY_MAX_ATTEMPTS = 3
 const BG_RETRY_MAX_DELAY_MS = 60_000
 const BG_RETRY_JITTER_MS = 500
 
@@ -132,7 +137,7 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
     const canSchedule =
       !state.loading &&
       state.section !== null &&
-      ladderStep < BG_RETRY_LADDER_MS.length &&
+      ladderStep < BG_RETRY_MAX_ATTEMPTS &&
       sectionHasRetryableUnavailable(state.section)
 
     if (!canSchedule) {
@@ -140,9 +145,8 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
       return
     }
 
-    const fallbackDelay = BG_RETRY_LADDER_MS[ladderStep]!
     const earliestAt = state.section!.earliestRetryAvailableAt
-    let delay = fallbackDelay
+    let delay = BG_RETRY_INTERVAL_MS
     if (earliestAt) {
       const untilReset = Date.parse(earliestAt) - Date.now()
       if (Number.isFinite(untilReset)) {

--- a/components/shared/hooks/useStaleAdmins.ts
+++ b/components/shared/hooks/useStaleAdmins.ts
@@ -51,9 +51,12 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
     }
 
     let cancelled = false
+    // Stale-while-revalidate: keep any previous `section` in place during a
+    // refetch so the panel does not blank out. Only `loading` and `error`
+    // flip; `section` is cleared only on options change (caller-driven).
     queueMicrotask(() => {
       if (cancelled) return
-      setState((prev) => (prev.loading ? prev : { loading: true, section: null, error: null }))
+      setState((prev) => (prev.loading ? prev : { ...prev, loading: true, error: null }))
     })
 
     const params = new URLSearchParams({ org, ownerType })
@@ -65,7 +68,7 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
       .then(async (res) => {
         if (cancelled) return
         if (!res.ok) {
-          setState({ loading: false, section: null, error: `HTTP ${res.status}` })
+          setState((prev) => ({ ...prev, loading: false, error: `HTTP ${res.status}` }))
           return
         }
         const body = (await res.json()) as { section?: StaleAdminsSection }
@@ -73,11 +76,11 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
       })
       .catch((err: unknown) => {
         if (cancelled) return
-        setState({
+        setState((prev) => ({
+          ...prev,
           loading: false,
-          section: null,
           error: err instanceof Error ? err.message : 'stale-admin fetch failed',
-        })
+        }))
       })
 
     return () => {

--- a/components/shared/hooks/useStaleAdmins.ts
+++ b/components/shared/hooks/useStaleAdmins.ts
@@ -18,6 +18,14 @@ export interface UseStaleAdminsState {
   section: StaleAdminsSection | null
   error: string | null
   refetch: () => void
+  /**
+   * ISO timestamp of the next scheduled background auto-retry, or null
+   * when none is scheduled (ladder exhausted, loading, nothing retryable,
+   * or section absent). Used by the panel to drive a unified countdown
+   * across all unavailable rows so the user sees one consistent signal
+   * instead of a mix of exact counters and vague "about a minute" copy.
+   */
+  nextAutoRetryAt: string | null
 }
 
 // Bounded background auto-retry ladder. Hybrid strategy:
@@ -37,11 +45,12 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
 
   const [retryCount, setRetryCount] = useState(0)
   const [ladderStep, setLadderStep] = useState(0)
+  const [nextAutoRetryAt, setNextAutoRetryAt] = useState<string | null>(null)
   const refetch = useCallback(() => {
     setLadderStep(0)
     setRetryCount((n) => n + 1)
   }, [])
-  const [state, setState] = useState<Omit<UseStaleAdminsState, 'refetch'>>(() => ({
+  const [state, setState] = useState<Omit<UseStaleAdminsState, 'refetch' | 'nextAutoRetryAt'>>(() => ({
     loading: Boolean(org && token),
     section: null,
     error: null,
@@ -117,15 +126,22 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
   // Schedule a background auto-retry after each fetch completes, when there
   // are still retryable-unavailable admins. Cancelled on new fetch / option
   // change / unmount. The ladder advances per fire; once exhausted, the
-  // user's Retry button is the fallback.
+  // user's Retry button is the fallback. `nextAutoRetryAt` tracks the fire
+  // time so the UI can render one unified countdown across all rows.
   useEffect(() => {
-    if (state.loading) return
-    if (!state.section) return
-    if (ladderStep >= BG_RETRY_LADDER_MS.length) return
-    if (!sectionHasRetryableUnavailable(state.section)) return
+    const canSchedule =
+      !state.loading &&
+      state.section !== null &&
+      ladderStep < BG_RETRY_LADDER_MS.length &&
+      sectionHasRetryableUnavailable(state.section)
+
+    if (!canSchedule) {
+      queueMicrotask(() => setNextAutoRetryAt(null))
+      return
+    }
 
     const fallbackDelay = BG_RETRY_LADDER_MS[ladderStep]!
-    const earliestAt = state.section.earliestRetryAvailableAt
+    const earliestAt = state.section!.earliestRetryAvailableAt
     let delay = fallbackDelay
     if (earliestAt) {
       const untilReset = Date.parse(earliestAt) - Date.now()
@@ -137,6 +153,8 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
       }
     }
 
+    const fireAt = new Date(Date.now() + delay).toISOString()
+    queueMicrotask(() => setNextAutoRetryAt(fireAt))
     const id = setTimeout(() => {
       setLadderStep((s) => s + 1)
       setRetryCount((n) => n + 1)
@@ -144,7 +162,7 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
     return () => clearTimeout(id)
   }, [state.loading, state.section, ladderStep])
 
-  return { ...state, refetch }
+  return { ...state, refetch, nextAutoRetryAt }
 }
 
 function sectionHasRetryableUnavailable(section: StaleAdminsSection): boolean {

--- a/components/shared/hooks/useStaleAdmins.ts
+++ b/components/shared/hooks/useStaleAdmins.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { StaleAdminsSection } from '@/lib/governance/stale-admins'
 
 export type OwnerType = 'Organization' | 'User'
@@ -17,13 +17,16 @@ export interface UseStaleAdminsState {
   loading: boolean
   section: StaleAdminsSection | null
   error: string | null
+  refetch: () => void
 }
 
 export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsState {
   const { org, ownerType, token, elevated } = options
   const fetchFn = options.fetchFn ?? fetch
 
-  const [state, setState] = useState<UseStaleAdminsState>(() => ({
+  const [retryCount, setRetryCount] = useState(0)
+  const refetch = useCallback(() => setRetryCount((n) => n + 1), [])
+  const [state, setState] = useState<Omit<UseStaleAdminsState, 'refetch'>>(() => ({
     loading: Boolean(org && token),
     section: null,
     error: null,
@@ -80,7 +83,7 @@ export function useStaleAdmins(options: UseStaleAdminsOptions): UseStaleAdminsSt
     return () => {
       cancelled = true
     }
-  }, [org, ownerType, token, elevated, fetchFn])
+  }, [org, ownerType, token, elevated, fetchFn, retryCount])
 
-  return state
+  return { ...state, refetch }
 }

--- a/lib/analyzer/github-rest.test.ts
+++ b/lib/analyzer/github-rest.test.ts
@@ -161,9 +161,9 @@ describe('fetchOrgAdmins', () => {
     if (result.kind === 'ok') {
       expect(result.admins.map((a) => a.login)).toEqual(['alice'])
     }
-    const callArgs = fetchMock.mock.calls[0]
+    const callArgs = fetchMock.mock.calls[0] as unknown[]
     expect(callArgs).toBeDefined()
-    const init = callArgs![1] as RequestInit | undefined
+    const init = callArgs[1] as RequestInit | undefined
     expect(init?.headers).toMatchObject({ Authorization: 'Bearer ghp_test' })
   })
 
@@ -465,7 +465,7 @@ describe('fetchOrgTwoFactorRequirement', () => {
     const result = await fetchOrgTwoFactorRequirement('ghp_test', 'kubernetes')
 
     expect(result).toEqual({ kind: 'ok', twoFactorRequirementEnabled: true })
-    const init = fetchMock.mock.calls[0]![1] as RequestInit | undefined
+    const init = (fetchMock.mock.calls[0] as unknown[])[1] as RequestInit | undefined
     expect(init?.headers).toMatchObject({ Authorization: 'Bearer ghp_test' })
   })
 

--- a/lib/analyzer/github-rest.test.ts
+++ b/lib/analyzer/github-rest.test.ts
@@ -371,6 +371,57 @@ describe('fetchUserLatestOrgCommit', () => {
     expect(sleep).toHaveBeenCalledWith(3000)
   })
 
+  it('populates retryAvailableAt from Retry-After when rate-limited', async () => {
+    const nowMs = Date.parse('2026-04-16T00:00:00Z')
+    vi.setSystemTime(new Date(nowMs))
+
+    const fetchMock = vi.fn(async () =>
+      new Response('', {
+        status: 403,
+        headers: { 'X-RateLimit-Remaining': '0', 'Retry-After': '45' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep: async () => {} })
+    expect(result.kind).toBe('rate-limited')
+    if (result.kind === 'rate-limited') {
+      expect(result.retryAvailableAt).toBe(new Date(nowMs + 45_000).toISOString())
+    }
+
+    vi.useRealTimers()
+  })
+
+  it('falls back to X-RateLimit-Reset when Retry-After is absent', async () => {
+    const resetEpoch = Math.floor(Date.parse('2026-04-16T00:05:00Z') / 1000)
+    const fetchMock = vi.fn(async () =>
+      new Response('', {
+        status: 403,
+        headers: { 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': String(resetEpoch) },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep: async () => {} })
+    expect(result.kind).toBe('rate-limited')
+    if (result.kind === 'rate-limited') {
+      expect(result.retryAvailableAt).toBe(new Date(resetEpoch * 1000).toISOString())
+    }
+  })
+
+  it('returns retryAvailableAt=null when neither header is present', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response('', { status: 403, headers: { 'X-RateLimit-Remaining': '0' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep: async () => {} })
+    expect(result.kind).toBe('rate-limited')
+    if (result.kind === 'rate-limited') {
+      expect(result.retryAvailableAt).toBeNull()
+    }
+  })
+
   it('detects secondary rate-limit by body message when headers do not match', async () => {
     const fetchMock = vi.fn(async () =>
       new Response(

--- a/lib/analyzer/github-rest.test.ts
+++ b/lib/analyzer/github-rest.test.ts
@@ -310,14 +310,93 @@ describe('fetchUserLatestOrgCommit', () => {
     }
   })
 
-  it('maps 403+rate-limit to rate-limited', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => buildRateLimitedResponse()))
-    expect((await fetchUserLatestOrgCommit('t', 'alice', 'x')).kind).toBe('rate-limited')
+  it('maps 403+rate-limit to rate-limited after one retry', async () => {
+    const fetchMock = vi.fn(async () => buildRateLimitedResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+    expect(result.kind).toBe('rate-limited')
+    // One initial attempt + one retry attempt = 2 fetches, 1 sleep.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledTimes(1)
   })
 
-  it('maps other failures to commit-search-failed', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 422 })))
-    expect((await fetchUserLatestOrgCommit('t', 'alice', 'x')).kind).toBe('commit-search-failed')
+  it('retries after a transient rate-limit and succeeds on the second attempt', async () => {
+    let call = 0
+    const fetchMock = vi.fn(async () => {
+      call++
+      if (call === 1) return buildRateLimitedResponse()
+      return buildPageResponse({
+        total_count: 1,
+        items: [{ commit: { author: { date: '2026-01-01T00:00:00Z' } } }],
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+
+    expect(result).toEqual({ kind: 'ok', lastActivityAt: '2026-01-01T00:00:00Z' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats 403 with Retry-After header (no X-RateLimit-Remaining: 0) as rate-limited', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response('', {
+        status: 403,
+        headers: { 'Retry-After': '1' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+    expect(result.kind).toBe('rate-limited')
+    // Retry-After=1 second → bounded ≤3000ms.
+    expect(sleep).toHaveBeenCalledWith(1000)
+  })
+
+  it('caps the retry wait at 3000ms even when Retry-After is larger', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response('', {
+        status: 403,
+        headers: { 'Retry-After': '60' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+
+    await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+    expect(sleep).toHaveBeenCalledWith(3000)
+  })
+
+  it('detects secondary rate-limit by body message when headers do not match', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          message: 'You have exceeded a secondary rate limit. Please wait a few minutes.',
+        }),
+        { status: 403, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+    expect(result.kind).toBe('rate-limited')
+    expect(sleep).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps true 4xx/5xx errors to commit-search-failed without retrying', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 422 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+    expect(result.kind).toBe('commit-search-failed')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
   })
 })
 

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -277,13 +277,20 @@ export type UserLatestOrgCommitResult =
 const COMMIT_SEARCH_RETRY_MAX_WAIT_MS = 3000
 const COMMIT_SEARCH_DEFAULT_RETRY_MS = 1500
 
+export interface FetchUserLatestOrgCommitOptions {
+  sleep?: (ms: number) => Promise<void>
+  /** Max in-function retries on rate-limit. Default 1 (two total attempts). */
+  maxRetries?: number
+}
+
 export async function fetchUserLatestOrgCommit(
   token: string,
   username: string,
   org: string,
-  options: { sleep?: (ms: number) => Promise<void> } = {},
+  options: FetchUserLatestOrgCommitOptions = {},
 ): Promise<UserLatestOrgCommitResult> {
   const sleep = options.sleep ?? defaultSleep
+  const maxRetries = options.maxRetries ?? 1
   let attempt = 0
 
   while (true) {
@@ -303,7 +310,7 @@ export async function fetchUserLatestOrgCommit(
       if (response.status === 403) {
         const rateLimited = isRateLimited(response) || (await hasSecondaryRateLimitBody(response))
         if (rateLimited) {
-          if (attempt < 1) {
+          if (attempt < maxRetries) {
             const wait = Math.min(
               parseRetryAfterMs(response) ?? COMMIT_SEARCH_DEFAULT_RETRY_MS,
               COMMIT_SEARCH_RETRY_MAX_WAIT_MS,

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -229,7 +229,7 @@ export async function fetchOrgTwoFactorRequirement(
 export type UserPublicEventsResult =
   | { kind: 'ok'; lastActivityAt: string | null }
   | { kind: 'admin-account-404' }
-  | { kind: 'rate-limited' }
+  | { kind: 'rate-limited'; retryAvailableAt: string | null }
   | { kind: 'events-fetch-failed' }
 
 export async function fetchUserPublicEvents(
@@ -249,7 +249,9 @@ export async function fetchUserPublicEvents(
     )
 
     if (response.status === 404) return { kind: 'admin-account-404' }
-    if (response.status === 403 && isRateLimited(response)) return { kind: 'rate-limited' }
+    if (response.status === 403 && isRateLimited(response)) {
+      return { kind: 'rate-limited', retryAvailableAt: parseRetryAvailableAt(response) }
+    }
     if (!response.ok) return { kind: 'events-fetch-failed' }
 
     const payload = (await response.json()) as Array<{ created_at?: unknown }>
@@ -268,7 +270,7 @@ export async function fetchUserPublicEvents(
 
 export type UserLatestOrgCommitResult =
   | { kind: 'ok'; lastActivityAt: string | null }
-  | { kind: 'rate-limited' }
+  | { kind: 'rate-limited'; retryAvailableAt: string | null }
   | { kind: 'commit-search-failed' }
 
 // Search Commits has a 30 req/min quota — roughly 10x tighter than core REST.
@@ -319,7 +321,7 @@ export async function fetchUserLatestOrgCommit(
             attempt++
             continue
           }
-          return { kind: 'rate-limited' }
+          return { kind: 'rate-limited', retryAvailableAt: parseRetryAvailableAt(response) }
         }
       }
       if (!response.ok) return { kind: 'commit-search-failed' }
@@ -361,6 +363,21 @@ function parseRetryAfterMs(response: Response): number | null {
   const seconds = Number(header)
   if (!Number.isFinite(seconds) || seconds < 0) return null
   return seconds * 1000
+}
+
+// Prefer Retry-After (relative, usually shorter) over X-RateLimit-Reset
+// (absolute, usually further out). Returns an ISO timestamp at which the
+// next request is expected to succeed, or null when GitHub gave us neither
+// signal (secondary rate limits sometimes omit both).
+export function parseRetryAvailableAt(response: Response, nowMs: number = Date.now()): string | null {
+  const retryAfterMs = parseRetryAfterMs(response)
+  if (retryAfterMs !== null) return new Date(nowMs + retryAfterMs).toISOString()
+  const reset = response.headers.get('X-RateLimit-Reset')
+  if (reset) {
+    const secs = Number(reset)
+    if (Number.isFinite(secs) && secs > 0) return new Date(secs * 1000).toISOString()
+  }
+  return null
 }
 
 function defaultSleep(ms: number): Promise<void> {

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -271,41 +271,93 @@ export type UserLatestOrgCommitResult =
   | { kind: 'rate-limited' }
   | { kind: 'commit-search-failed' }
 
+// Search Commits has a 30 req/min quota — roughly 10x tighter than core REST.
+// In admin-resolution bursts this cap is routinely hit; a single short retry
+// recovers most near-boundary cases without serializing the whole fan-out.
+const COMMIT_SEARCH_RETRY_MAX_WAIT_MS = 3000
+const COMMIT_SEARCH_DEFAULT_RETRY_MS = 1500
+
 export async function fetchUserLatestOrgCommit(
   token: string,
   username: string,
   org: string,
+  options: { sleep?: (ms: number) => Promise<void> } = {},
 ): Promise<UserLatestOrgCommitResult> {
-  try {
-    const q = `author:${username}+org:${org}`
-    const response = await fetch(
-      `https://api.github.com/search/commits?q=${encodeURIComponent(q)}&sort=author-date&order=desc&per_page=1`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
+  const sleep = options.sleep ?? defaultSleep
+  let attempt = 0
+
+  while (true) {
+    try {
+      const q = `author:${username}+org:${org}`
+      const response = await fetch(
+        `https://api.github.com/search/commits?q=${encodeURIComponent(q)}&sort=author-date&order=desc&per_page=1`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
         },
-      },
-    )
+      )
 
-    if (response.status === 403 && isRateLimited(response)) return { kind: 'rate-limited' }
-    if (!response.ok) return { kind: 'commit-search-failed' }
+      if (response.status === 403) {
+        const rateLimited = isRateLimited(response) || (await hasSecondaryRateLimitBody(response))
+        if (rateLimited) {
+          if (attempt < 1) {
+            const wait = Math.min(
+              parseRetryAfterMs(response) ?? COMMIT_SEARCH_DEFAULT_RETRY_MS,
+              COMMIT_SEARCH_RETRY_MAX_WAIT_MS,
+            )
+            await sleep(wait)
+            attempt++
+            continue
+          }
+          return { kind: 'rate-limited' }
+        }
+      }
+      if (!response.ok) return { kind: 'commit-search-failed' }
 
-    const payload = (await response.json()) as {
-      total_count?: number
-      items?: Array<{ commit?: { author?: { date?: unknown } } }>
+      const payload = (await response.json()) as {
+        total_count?: number
+        items?: Array<{ commit?: { author?: { date?: unknown } } }>
+      }
+      if (!payload || typeof payload.total_count !== 'number' || payload.total_count === 0) {
+        return { kind: 'ok', lastActivityAt: null }
+      }
+      const first = payload.items?.[0]
+      const date = first?.commit?.author?.date
+      if (typeof date !== 'string') return { kind: 'ok', lastActivityAt: null }
+      return { kind: 'ok', lastActivityAt: date }
+    } catch {
+      return { kind: 'commit-search-failed' }
     }
-    if (!payload || typeof payload.total_count !== 'number' || payload.total_count === 0) {
-      return { kind: 'ok', lastActivityAt: null }
-    }
-    const first = payload.items?.[0]
-    const date = first?.commit?.author?.date
-    if (typeof date !== 'string') return { kind: 'ok', lastActivityAt: null }
-    return { kind: 'ok', lastActivityAt: date }
-  } catch {
-    return { kind: 'commit-search-failed' }
   }
+}
+
+async function hasSecondaryRateLimitBody(response: Response): Promise<boolean> {
+  try {
+    const body = (await response.clone().json()) as { message?: unknown }
+    const message = typeof body.message === 'string' ? body.message.toLowerCase() : ''
+    return (
+      message.includes('secondary rate limit') ||
+      message.includes('abuse detection') ||
+      message.includes('api rate limit exceeded')
+    )
+  } catch {
+    return false
+  }
+}
+
+function parseRetryAfterMs(response: Response): number | null {
+  const header = response.headers.get('Retry-After')
+  if (!header) return null
+  const seconds = Number(header)
+  if (!Number.isFinite(seconds) || seconds < 0) return null
+  return seconds * 1000
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 export interface UserOrgMembershipResult {
@@ -348,7 +400,12 @@ function classifyRestStatus(response: Response): 'ok' | OrgAdminListResult {
 }
 
 function isRateLimited(response: Response): boolean {
-  return response.headers.get('X-RateLimit-Remaining') === '0'
+  if (response.headers.get('X-RateLimit-Remaining') === '0') return true
+  // Secondary rate limits surface as 403 with Retry-After but without the
+  // `X-RateLimit-Remaining: 0` header. Present Retry-After is GitHub telling
+  // the caller to back off — classify as rate-limited.
+  if (response.headers.get('Retry-After')) return true
+  return false
 }
 
 function parseNextLink(linkHeader: string | null): string | null {

--- a/lib/governance/stale-admins.test.ts
+++ b/lib/governance/stale-admins.test.ts
@@ -139,7 +139,7 @@ describe('classifyAdmin', () => {
     }
   })
 
-  it.each([30, 60, 90, 180, 365])('respects the configured threshold window of %i days', (threshold) => {
+  it.each([30, 60, 90, 180, 365] as const)('respects the configured threshold window of %i days', (threshold) => {
     const justInside: AdminActivityInput = {
       username: 'inside',
       lastActivityAt: iso(NOW_MS - (threshold - 1) * DAY_MS),

--- a/lib/governance/stale-admins.ts
+++ b/lib/governance/stale-admins.ts
@@ -25,6 +25,13 @@ export interface StaleAdminRecord {
   lastActivityAt: string | null
   lastActivitySource: StaleAdminActivitySource | null
   unavailableReason: StaleAdminUnavailableReason | null
+  /**
+   * For unavailable admins where GitHub disclosed a rate-limit reset
+   * (via `Retry-After` or `X-RateLimit-Reset`), the ISO timestamp at
+   * which a retry is expected to succeed. Null when GitHub gave no
+   * reset signal (e.g. secondary rate limits, generic 5xx).
+   */
+  retryAvailableAt: string | null
 }
 
 export type StaleAdminsApplicability =
@@ -46,6 +53,12 @@ export interface StaleAdminsSection {
   thresholdDays: StaleAdminThresholdDays
   admins: StaleAdminRecord[]
   adminListUnavailableReason?: AdminListUnavailableReason
+  /**
+   * Earliest `retryAvailableAt` across all unavailable admins, used by the
+   * client to schedule a reset-aware background auto-retry. Null when no
+   * unavailable admin carries a known reset time.
+   */
+  earliestRetryAvailableAt: string | null
   resolvedAt: string
 }
 
@@ -54,6 +67,7 @@ export interface AdminActivityInput {
   lastActivityAt: string | null
   lastActivitySource: StaleAdminActivitySource | null
   error: StaleAdminUnavailableReason | null
+  retryAvailableAt?: string | null
 }
 
 const DAY_MS = 86_400_000
@@ -70,6 +84,7 @@ export function classifyAdmin(
       lastActivityAt: null,
       lastActivitySource: null,
       unavailableReason: input.error,
+      retryAvailableAt: input.retryAvailableAt ?? null,
     }
   }
 
@@ -80,6 +95,7 @@ export function classifyAdmin(
       lastActivityAt: null,
       lastActivitySource: null,
       unavailableReason: null,
+      retryAvailableAt: null,
     }
   }
 
@@ -94,5 +110,6 @@ export function classifyAdmin(
     lastActivityAt: input.lastActivityAt,
     lastActivitySource: input.lastActivitySource,
     unavailableReason: null,
+    retryAvailableAt: null,
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5129,7 +5129,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Fixes #364.

## Summary
- Broaden `isRateLimited()` to also treat `403 + Retry-After` as rate-limited; secondary rate-limit responses that lack `X-RateLimit-Remaining: 0` are no longer mis-bucketed as generic errors.
- Inside `fetchUserLatestOrgCommit`: sniff 403 bodies for `"secondary rate limit"` / `"abuse detection"` messages, then retry once with a bounded wait (≤3s, honoring `Retry-After` when present). Most near-boundary hits of the 30 req/min Search quota now recover transparently.
- Split the **Unavailable** UI bucket inside `StaleAdminsPanel` into per-reason sub-pills (e.g. `13 rate-limited`, `8 commit search failed`) and add a **Retry rate-limited** button that triggers a full refetch via a new `refetch` returned from `useStaleAdmins`.

## Test plan
- [x] `npx vitest run lib/analyzer/github-rest.test.ts lib/governance/stale-admins.test.ts app/api/org/stale-admins/route.test.ts components/org-summary/panels/StaleAdminsPanel.test.tsx` — all pass (78 total, 11 new)
- [x] `npm run lint` — no errors introduced
- [x] `npx tsc --noEmit` — no new errors from touched files (pre-existing errors in unrelated test files unchanged at 70)
- [x] `DEV_GITHUB_PAT= npm run build` — production build succeeds
- [x] Manual: analyze a large org (e.g. `nvidia`) → Org Summary → Governance → Stale Admins → expand Unavailable; verify sub-pills show counts per reason and Retry button appears when ≥1 admin is rate-limited
- [x] Manual: click Retry rate-limited → section refetches, rate-limited count visibly drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)