### PR TITLE
Auto-trigger analysis from ?repos= query parameter (closes #91)

### DIFF
--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -643,4 +643,51 @@ describe('RepoInputClient — shareable URL pre-population', () => {
     renderWithAuth(<RepoInputClient />)
     expect(screen.getByRole('textbox', { name: /repository list/i })).toHaveValue('')
   })
+
+  it('auto-triggers analysis when ?repos= query param contains valid repos', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('repos=facebook%2Freact%2Cvercel%2Fnext.js'))
+    const onAnalyze = vi.fn().mockResolvedValue({
+      results: [buildAnalysisResult('facebook/react'), buildAnalysisResult('vercel/next.js')],
+      failures: [],
+      rateLimit: null,
+    })
+
+    renderWithAuth(<RepoInputClient onAnalyze={onAnalyze} />)
+
+    await vi.waitFor(() => {
+      expect(onAnalyze).toHaveBeenCalledWith(['facebook/react', 'vercel/next.js'], 'gho_test_token')
+    })
+    expect(onAnalyze).toHaveBeenCalledTimes(1)
+    mockUseSearchParams.mockReturnValue(new URLSearchParams())
+  })
+
+  it('does not auto-trigger analysis when the param contains an invalid slug', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('repos=facebook%2Freact%2Cnot-a-slug'))
+    const onAnalyze = vi.fn()
+
+    renderWithAuth(<RepoInputClient onAnalyze={onAnalyze} />)
+
+    // Textarea pre-populates even with the malformed entry.
+    const textarea = screen.getByRole('textbox', { name: /repository list/i })
+    expect(textarea).toHaveValue('facebook/react\nnot-a-slug')
+
+    // Give the mount effect a chance to run — it should not dispatch.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onAnalyze).not.toHaveBeenCalled()
+
+    // Clicking Analyze surfaces the validation error inline.
+    await userEvent.click(screen.getByRole('button', { name: /^analyze$/i }))
+    expect(screen.getByTestId('repo-error')).toHaveTextContent(/not a valid owner\/repo slug/i)
+    mockUseSearchParams.mockReturnValue(new URLSearchParams())
+  })
+
+  it('does not auto-trigger analysis when no ?repos= param is present', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams())
+    const onAnalyze = vi.fn()
+
+    renderWithAuth(<RepoInputClient onAnalyze={onAnalyze} />)
+
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onAnalyze).not.toHaveBeenCalled()
+  })
 })

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -30,6 +30,7 @@ import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import { decodeRepos } from '@/lib/export/shareable-url'
+import { parseRepos } from '@/lib/parse-repos'
 import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
 import { RepoInputForm } from './RepoInputForm'
 
@@ -41,7 +42,9 @@ interface RepoInputClientProps {
 export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProps) {
   const { session } = useAuth()
   const searchParams = useSearchParams()
-  const initialRepoValue = decodeRepos(searchParams.toString()).join('\n')
+  const initialRepos = decodeRepos(searchParams.toString())
+  const initialRepoValue = initialRepos.join('\n')
+  const autoTriggeredRef = useRef(false)
   const [analysisResponse, setAnalysisResponse] = useState<AnalyzeResponse | null>(null)
   const [analyzedRepos, setAnalyzedRepos] = useState<string[]>([])
   const [orgInventoryResponse, setOrgInventoryResponse] = useState<OrgInventoryResponse | null>(null)
@@ -262,6 +265,18 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       })
     }
   }, [analysisResponse])
+
+  useEffect(() => {
+    if (autoTriggeredRef.current) return
+    if (!session?.token) return
+    if (initialRepos.length === 0) return
+
+    autoTriggeredRef.current = true
+    const parsed = parseRepos(initialRepoValue)
+    if (!parsed.valid) return
+    void handleSubmit(parsed.repos)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.token])
 
   async function handleSubmit(repos: string[]) {
     if (!session?.token) return


### PR DESCRIPTION
## Summary

- Completes the shareable-URL round-trip for issue #91: opening `/?repos=facebook/react,vercel/next.js` now pre-fills the textarea **and** auto-dispatches the analysis on mount.
- The pre-fill half was already wired (`RepoInputClient` reads `searchParams` and passes `initialRepoValue` down). This PR adds the on-mount auto-trigger, guarded by an `autoTriggeredRef` latch so it fires exactly once per page load.
- Invalid slugs are left pre-populated in the textarea and the inline validation error surfaces only when the user clicks **Analyze** — matching the acceptance criterion "shown in input but flagged on analysis."

## Why it works for signed-out users

`AuthGate` already preserves `window.location.search` across the OAuth redirect via `sessionStorage('oauth_return_search')` (see `components/auth/SignInButton.tsx:9` → `components/auth/AuthGate.tsx:38`). So a signed-out visitor who opens `/?repos=...` authenticates, returns to the same URL, and the auto-trigger fires on the first render where `session.token` is available.

## Key change

`components/repo-input/RepoInputClient.tsx`:

```ts
useEffect(() => {
  if (autoTriggeredRef.current) return
  if (!session?.token) return
  if (initialRepos.length === 0) return

  autoTriggeredRef.current = true
  const parsed = parseRepos(initialRepoValue)
  if (!parsed.valid) return
  void handleSubmit(parsed.repos)
}, [session?.token])
```

## Test plan

- [x] `npm test -- components/repo-input` — all 35 tests pass, including 3 new cases:
  - auto-triggers when `?repos=facebook/react,vercel/next.js`
  - does **not** auto-trigger when param contains an invalid slug (e.g. `not-a-slug`) and the textarea still shows the malformed text
  - does **not** auto-trigger when no `?repos=` param is present
- [x] `npm run lint -- components/repo-input` — no new warnings (the pre-existing `emptyQuoteIndex` warning is untouched)
- [x] `npx tsc --noEmit` — no new TypeScript errors introduced by this change (pre-existing errors on `main` are unrelated)
- [x] Manual browser check: open `/?repos=facebook/react,vercel/next.js` while signed in → analysis kicks off on load without clicking Analyze
- [x] Manual browser check: open `/?repos=facebook/react,not-a-slug` while signed in → textarea shows both entries, no analysis starts, clicking **Analyze** shows the `"not-a-slug" is not a valid owner/repo slug.` error
- [x] Manual browser check: open `/?repos=facebook/react` while signed **out** → land on sign-in, authenticate, return to `/?repos=facebook/react`, analysis auto-starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)