### PR TITLE
Fix lowercase license file detection

### DIFF
--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -89,9 +89,13 @@ interface RepoOverviewResponse {
     licenseInfo?: { spdxId: string | null; name: string | null } | null
     rootTree?: { entries: Array<{ name: string; type: string }> } | null
     docLicense?: DocBlob | null
+    docLicenseLower?: DocBlob | null
     docLicenseMd?: DocBlob | null
+    docLicenseMdLower?: DocBlob | null
     docLicenseTxt?: DocBlob | null
+    docLicenseTxtLower?: DocBlob | null
     docCopying?: DocBlob | null
+    docCopyingLower?: DocBlob | null
     docLicenseMit?: DocBlob | null
     docLicenseApache?: DocBlob | null
     docLicenseBsd?: DocBlob | null
@@ -109,6 +113,7 @@ interface RepoOverviewResponse {
     docCodeOfConductDocs?: DocBlob | null
     docCodeOfConductGithub?: DocBlob | null
     docLicenseRst?: DocBlob | null
+    docLicenseRstLower?: DocBlob | null
     docSecurity?: DocBlob | null
     docSecurityLower?: DocBlob | null
     docSecurityRst?: DocBlob | null
@@ -796,8 +801,11 @@ function buildAnalysisResult(
           const repo = overview.repository
           // Collect license file content for SPDX expression parsing
           const licenseFileContent =
-            repo.docLicense?.text ?? repo.docLicenseMd?.text ?? repo.docLicenseTxt?.text ??
-            repo.docLicenseRst?.text ?? repo.docCopying?.text ?? null
+            repo.docLicense?.text ?? repo.docLicenseLower?.text ??
+            repo.docLicenseMd?.text ?? repo.docLicenseMdLower?.text ??
+            repo.docLicenseTxt?.text ?? repo.docLicenseTxtLower?.text ??
+            repo.docLicenseRst?.text ?? repo.docLicenseRstLower?.text ??
+            repo.docCopying?.text ?? repo.docCopyingLower?.text ?? null
           // Collect additional license files (LICENSE-MIT, LICENSE-APACHE, etc.)
           const additionalLicenseFiles: LicenseFileInfo[] = [
             { suffix: 'MIT', content: repo.docLicenseMit?.text ?? null },
@@ -870,7 +878,21 @@ export function extractDocumentationResult(
   const findFirst = (...aliases: (DocBlob | null | undefined)[]): DocBlob | null =>
     aliases.find((a) => a != null) ?? null
 
-  const licenseBlob = findFirst(repo.docLicense, repo.docLicenseMd, repo.docLicenseTxt, repo.docLicenseRst, repo.docCopying, repo.docLicenseMit, repo.docLicenseApache, repo.docLicenseBsd)
+  const licenseBlob = findFirst(
+    repo.docLicense,
+    repo.docLicenseLower,
+    repo.docLicenseMd,
+    repo.docLicenseMdLower,
+    repo.docLicenseTxt,
+    repo.docLicenseTxtLower,
+    repo.docLicenseRst,
+    repo.docLicenseRstLower,
+    repo.docCopying,
+    repo.docCopyingLower,
+    repo.docLicenseMit,
+    repo.docLicenseApache,
+    repo.docLicenseBsd,
+  )
   const contributingBlob = findFirst(repo.docContributing, repo.docContributingRst, repo.docContributingTxt, repo.docContributingLower, repo.docContributingDocs, repo.docContributingGithub)
   const codeOfConductBlob = findFirst(repo.docCodeOfConduct, repo.docCodeOfConductRst, repo.docCodeOfConductTxt, repo.docCodeOfConductHyphenLower, repo.docCodeOfConductUnderscoreLower, repo.docCodeOfConductDocs, repo.docCodeOfConductGithub)
   const securityBlob = findFirst(
@@ -891,7 +913,11 @@ export function extractDocumentationResult(
   })()
 
   const licensePathMap: [string, DocBlob | null | undefined][] = [
-    ['LICENSE', repo.docLicense], ['LICENSE.md', repo.docLicenseMd], ['LICENSE.txt', repo.docLicenseTxt], ['LICENSE.rst', repo.docLicenseRst], ['COPYING', repo.docCopying],
+    ['LICENSE', repo.docLicense], ['license', repo.docLicenseLower],
+    ['LICENSE.md', repo.docLicenseMd], ['license.md', repo.docLicenseMdLower],
+    ['LICENSE.txt', repo.docLicenseTxt], ['license.txt', repo.docLicenseTxtLower],
+    ['LICENSE.rst', repo.docLicenseRst], ['license.rst', repo.docLicenseRstLower],
+    ['COPYING', repo.docCopying], ['copying', repo.docCopyingLower],
     ['LICENSE-MIT', repo.docLicenseMit], ['LICENSE-APACHE', repo.docLicenseApache], ['LICENSE-BSD', repo.docLicenseBsd],
   ]
   const contributingPathMap: [string, DocBlob | null | undefined][] = [

--- a/lib/analyzer/documentation-extraction.test.ts
+++ b/lib/analyzer/documentation-extraction.test.ts
@@ -23,6 +23,33 @@ function check(
 }
 
 describe('extractDocumentationResult — non-security governance variants', () => {
+  describe('license', () => {
+    it.each([
+      ['LICENSE', 'docLicense'],
+      ['license', 'docLicenseLower'],
+      ['LICENSE.md', 'docLicenseMd'],
+      ['license.md', 'docLicenseMdLower'],
+      ['LICENSE.txt', 'docLicenseTxt'],
+      ['license.txt', 'docLicenseTxtLower'],
+      ['LICENSE.rst', 'docLicenseRst'],
+      ['license.rst', 'docLicenseRstLower'],
+      ['COPYING', 'docCopying'],
+      ['copying', 'docCopyingLower'],
+    ])('resolves as present when %s exists', (path, field) => {
+      const result = extractDocumentationResult(repoFixture({ [field]: { oid: 'abc' } }))
+      const license = check(result, 'license')
+      expect(license.found).toBe(true)
+      expect(license.path).toBe(path)
+    })
+
+    it('resolves as absent when no license variant exists', () => {
+      const result = extractDocumentationResult(repoFixture({}))
+      const license = check(result, 'license')
+      expect(license.found).toBe(false)
+      expect(license.path).toBeNull()
+    })
+  })
+
   describe('code_of_conduct', () => {
     it.each([
       ['CODE_OF_CONDUCT.md', 'docCodeOfConduct'],

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -41,9 +41,13 @@ export const REPO_OVERVIEW_QUERY = `
         }
       }
       docLicense: object(expression: "HEAD:LICENSE") { ... on Blob { oid text } }
+      docLicenseLower: object(expression: "HEAD:license") { ... on Blob { oid text } }
       docLicenseMd: object(expression: "HEAD:LICENSE.md") { ... on Blob { oid text } }
+      docLicenseMdLower: object(expression: "HEAD:license.md") { ... on Blob { oid text } }
       docLicenseTxt: object(expression: "HEAD:LICENSE.txt") { ... on Blob { oid text } }
+      docLicenseTxtLower: object(expression: "HEAD:license.txt") { ... on Blob { oid text } }
       docCopying: object(expression: "HEAD:COPYING") { ... on Blob { oid text } }
+      docCopyingLower: object(expression: "HEAD:copying") { ... on Blob { oid text } }
       docLicenseMit: object(expression: "HEAD:LICENSE-MIT") { ... on Blob { oid text } }
       docLicenseApache: object(expression: "HEAD:LICENSE-APACHE") { ... on Blob { oid text } }
       docLicenseBsd: object(expression: "HEAD:LICENSE-BSD") { ... on Blob { oid text } }
@@ -61,6 +65,7 @@ export const REPO_OVERVIEW_QUERY = `
       docCodeOfConductDocs: object(expression: "HEAD:docs/CODE_OF_CONDUCT.md") { ... on Blob { oid } }
       docCodeOfConductGithub: object(expression: "HEAD:.github/CODE_OF_CONDUCT.md") { ... on Blob { oid } }
       docLicenseRst: object(expression: "HEAD:LICENSE.rst") { ... on Blob { oid text } }
+      docLicenseRstLower: object(expression: "HEAD:license.rst") { ... on Blob { oid text } }
       docSecurity: object(expression: "HEAD:SECURITY.md") { ... on Blob { oid } }
       docSecurityLower: object(expression: "HEAD:security.md") { ... on Blob { oid } }
       docSecurityRst: object(expression: "HEAD:SECURITY.rst") { ... on Blob { oid } }

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -46,6 +46,8 @@ export const REPO_OVERVIEW_QUERY = `
       docLicenseMdLower: object(expression: "HEAD:license.md") { ... on Blob { oid text } }
       docLicenseTxt: object(expression: "HEAD:LICENSE.txt") { ... on Blob { oid text } }
       docLicenseTxtLower: object(expression: "HEAD:license.txt") { ... on Blob { oid text } }
+      docLicenseRst: object(expression: "HEAD:LICENSE.rst") { ... on Blob { oid text } }
+      docLicenseRstLower: object(expression: "HEAD:license.rst") { ... on Blob { oid text } }
       docCopying: object(expression: "HEAD:COPYING") { ... on Blob { oid text } }
       docCopyingLower: object(expression: "HEAD:copying") { ... on Blob { oid text } }
       docLicenseMit: object(expression: "HEAD:LICENSE-MIT") { ... on Blob { oid text } }
@@ -64,8 +66,6 @@ export const REPO_OVERVIEW_QUERY = `
       docCodeOfConductUnderscoreLower: object(expression: "HEAD:code_of_conduct.md") { ... on Blob { oid } }
       docCodeOfConductDocs: object(expression: "HEAD:docs/CODE_OF_CONDUCT.md") { ... on Blob { oid } }
       docCodeOfConductGithub: object(expression: "HEAD:.github/CODE_OF_CONDUCT.md") { ... on Blob { oid } }
-      docLicenseRst: object(expression: "HEAD:LICENSE.rst") { ... on Blob { oid text } }
-      docLicenseRstLower: object(expression: "HEAD:license.rst") { ... on Blob { oid text } }
       docSecurity: object(expression: "HEAD:SECURITY.md") { ... on Blob { oid } }
       docSecurityLower: object(expression: "HEAD:security.md") { ... on Blob { oid } }
       docSecurityRst: object(expression: "HEAD:SECURITY.rst") { ... on Blob { oid } }


### PR DESCRIPTION
## Summary
- detect lowercase root license filename variants such as `license.md` and `copying` in the overview query
- use those variants consistently for both Documentation file presence and licensing-content extraction
- add regression coverage so lowercase license files are treated as present

## Test plan
- [x] `npx vitest run lib/analyzer/documentation-extraction.test.ts __tests__/licensing/extract-licensing.test.ts lib/documentation/score-config.test.ts`
- [x] `npx eslint lib/analyzer/analyze.ts lib/analyzer/queries.ts lib/analyzer/documentation-extraction.test.ts`

## Related
- Fixes #371