### PR TITLE
Fix #367: show sign-in dialog for demo org analyze buttons

### DIFF
--- a/components/demo/DemoOrganizationClient.tsx
+++ b/components/demo/DemoOrganizationClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
+import { DemoSignInDialog } from '@/components/demo/DemoSignInDialog'
 import { ResultsShell } from '@/components/app-shell/ResultsShell'
 import { OrgInventoryView } from '@/components/org-inventory/OrgInventoryView'
 import { OrgBucketContent } from '@/components/org-summary/OrgBucketContent'
@@ -105,6 +106,7 @@ export function DemoOrganizationClient({ response, governance, topReposAnalyzed 
   const [domTotalMatches, setDomTotalMatches] = useState(0)
   const [domMatchedTabCount, setDomMatchedTabCount] = useState(0)
   const [orgWindow, setOrgWindow] = useState<ContributorDiversityWindow>(90)
+  const [signInDialogRepos, setSignInDialogRepos] = useState<string[] | null>(null)
 
   useEffect(() => {
     const timeout = setTimeout(() => {
@@ -164,6 +166,12 @@ export function DemoOrganizationClient({ response, governance, topReposAnalyzed 
 
   return (
     <SearchProvider query={debouncedQuery}>
+      {signInDialogRepos !== null && (
+        <DemoSignInDialog
+          repos={signInDialogRepos}
+          onDismiss={() => setSignInDialogRepos(null)}
+        />
+      )}
       <ResultsShell
         initialActiveTab="overview"
         analysisPanel={<DemoOrgAnalysisPanel org={response.org} topCount={topReposAnalyzed.length} />}
@@ -187,12 +195,9 @@ export function DemoOrganizationClient({ response, governance, topReposAnalyzed 
             summary={response.summary}
             results={response.results}
             rateLimit={response.rateLimit}
-            onAnalyzeRepo={() => {
-              // No-op: analyzing fresh repositories requires sign-in.
-            }}
-            onAnalyzeSelected={() => {
-              // No-op: analyzing fresh repositories requires sign-in.
-            }}
+            onAnalyzeRepo={(repo) => setSignInDialogRepos([repo])}
+            onAnalyzeSelected={(repos) => setSignInDialogRepos(repos)}
+            onAnalyzeAllActive={(repos) => setSignInDialogRepos(repos)}
           />
         }
         contributors={view ? withNote(

--- a/components/demo/DemoSignInDialog.test.tsx
+++ b/components/demo/DemoSignInDialog.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DemoSignInDialog } from './DemoSignInDialog'
+
+describe('DemoSignInDialog', () => {
+  it('renders with role="dialog" and aria-modal', () => {
+    render(<DemoSignInDialog repos={['facebook/react']} onDismiss={vi.fn()} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('shows single repo name in heading', () => {
+    render(<DemoSignInDialog repos={['facebook/react']} onDismiss={vi.fn()} />)
+    expect(screen.getByRole('heading')).toHaveTextContent('Sign in with GitHub to analyze facebook/react')
+  })
+
+  it('shows repo count in heading for multiple repos', () => {
+    const repos = ['a/b', 'c/d', 'e/f', 'g/h', 'i/j', 'k/l', 'm/n']
+    render(<DemoSignInDialog repos={repos} onDismiss={vi.fn()} />)
+    expect(screen.getByRole('heading')).toHaveTextContent('Sign in with GitHub to analyze these 7 repositories')
+  })
+
+  it('primary CTA links to /', () => {
+    render(<DemoSignInDialog repos={['a/b']} onDismiss={vi.fn()} />)
+    const link = screen.getByRole('link', { name: /sign in with github/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+
+  it('calls onDismiss when "Stay in demo" is clicked', () => {
+    const onDismiss = vi.fn()
+    render(<DemoSignInDialog repos={['a/b']} onDismiss={onDismiss} />)
+    fireEvent.click(screen.getByRole('button', { name: /stay in demo/i }))
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it('calls onDismiss when Escape key is pressed', () => {
+    const onDismiss = vi.fn()
+    render(<DemoSignInDialog repos={['a/b']} onDismiss={onDismiss} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/components/demo/DemoSignInDialog.tsx
+++ b/components/demo/DemoSignInDialog.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import Link from 'next/link'
+
+export interface DemoSignInDialogProps {
+  repos: string[]
+  onDismiss: () => void
+}
+
+export function DemoSignInDialog({ repos, onDismiss }: DemoSignInDialogProps) {
+  const dismissRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    dismissRef.current?.focus()
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onDismiss()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onDismiss])
+
+  const repoCount = repos.length
+  const heading =
+    repoCount === 1
+      ? `Sign in with GitHub to analyze ${repos[0]}`
+      : `Sign in with GitHub to analyze these ${repoCount} repositories`
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="demo-signin-dialog-heading"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="mx-4 w-full max-w-md rounded-lg border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+        <h2
+          id="demo-signin-dialog-heading"
+          className="text-lg font-semibold text-slate-900 dark:text-slate-100"
+        >
+          {heading}
+        </h2>
+
+        <div className="mt-3 space-y-2 text-sm text-slate-700 dark:text-slate-300">
+          <p>
+            Demo data is pre-analyzed from fixtures. Fresh analysis requires a signed-in GitHub
+            session so RepoPulse can query the GitHub API on your behalf.
+          </p>
+          <p>
+            After signing in, you can paste or select the same repositories and run a live
+            analysis — your selection here isn&apos;t lost work.
+          </p>
+        </div>
+
+        <div className="mt-5 flex items-center justify-end gap-3">
+          <button
+            ref={dismissRef}
+            type="button"
+            onClick={onDismiss}
+            className="rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+          >
+            Stay in demo
+          </button>
+          <Link
+            href="/"
+            className="rounded border border-sky-500 bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-700 dark:border-sky-400 dark:bg-sky-500 dark:hover:bg-sky-600"
+          >
+            Sign in with GitHub →
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/e2e/demo-org-analyze.spec.ts
+++ b/e2e/demo-org-analyze.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+// Issue #367 — clicking "Analyze selected (N)" / "Analyze all (N)" in
+// /demo/organization must open the DemoSignInDialog instead of silently no-op'ing.
+// Lightweight DOM assertions only — no visual snapshots.
+
+test.describe('Demo org analyze sign-in dialog (#367)', () => {
+  test('clicking "Analyze selected" opens the sign-in dialog with count in heading', async ({ page }) => {
+    await page.goto('/demo/organization')
+
+    // Select at least one row by clicking the first checkbox in the table.
+    const firstCheckbox = page.locator('table input[type="checkbox"]').first()
+    await firstCheckbox.waitFor({ state: 'visible' })
+    await firstCheckbox.check()
+
+    // The "Analyze selected" button should now be enabled.
+    const analyzeSelected = page.getByRole('button', { name: /analyze selected/i })
+    await expect(analyzeSelected).toBeEnabled()
+    await analyzeSelected.click()
+
+    // Dialog must be visible with the correct heading.
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByRole('heading')).toContainText(/sign in with github to analyze/i)
+
+    // Primary CTA must link to sign-in root.
+    const cta = dialog.getByRole('link', { name: /sign in with github/i })
+    await expect(cta).toHaveAttribute('href', '/')
+
+    // "Stay in demo" dismisses the dialog.
+    await dialog.getByRole('button', { name: /stay in demo/i }).click()
+    await expect(dialog).not.toBeVisible()
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
     trace: 'on-first-retry',
   },
   projects: [
@@ -18,7 +18,7 @@ export default defineConfig({
   ],
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3000',
+    url: process.env.BASE_URL ?? 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
   },
 })


### PR DESCRIPTION
## Summary

- Adds `DemoSignInDialog` component under `components/demo/` that opens when any inventory analyze action fires in demo mode
- Replaces the three silent no-op callbacks in `DemoOrganizationClient` (`onAnalyzeRepo`, `onAnalyzeSelected`, `onAnalyzeAllActive`) with handlers that open the dialog seeded with the repo list
- Dialog heading is specific: single-repo → repo name; multi-repo → "these N repositories"
- Primary CTA links to `/` (sign-in landing); secondary "Stay in demo" button dismisses; ESC also closes

Closes #367

## Test plan

- [x] Unit: `npx vitest run components/demo/DemoSignInDialog.test.tsx` — 6 tests pass
- [x] Playwright: `npx playwright test e2e/demo-org-analyze.spec.ts` — select row, click "Analyze selected", assert dialog heading + CTA href + dismiss
- [x] Manual: visit `/demo/organization`, select rows, click "Analyze selected (N)" — dialog appears with correct count
- [x] Manual: click per-row "Analyze" button — dialog appears with that repo's name
- [x] Manual: click "Analyze all (N)" — dialog appears
- [x] Manual: ESC key closes the dialog
- [x] Manual: "Stay in demo" button closes the dialog
- [x] Manual: "Sign in with GitHub →" link navigates to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)