### PR TITLE
Add Development Cadence panel to Activity

### DIFF
--- a/components/activity/ActivityView.test.tsx
+++ b/components/activity/ActivityView.test.tsx
@@ -2,7 +2,15 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { ActivityView } from './ActivityView'
-import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { AnalysisResult, TrendComparisonMetrics } from '@/lib/analyzer/analysis-result'
+
+function createTrendComparisons(overrides: Partial<Record<'month' | 'week' | 'day', Partial<TrendComparisonMetrics>>> = {}) {
+  return {
+    month: { currentPeriodCommitCount: 3, previousPeriodCommitCount: 2, delta: 0.5, direction: 'accelerating', ...overrides.month },
+    week: { currentPeriodCommitCount: 2, previousPeriodCommitCount: 1, delta: 1, direction: 'accelerating', ...overrides.week },
+    day: { currentPeriodCommitCount: 1, previousPeriodCommitCount: 0, delta: 1, direction: 'accelerating', ...overrides.day },
+  }
+}
 
 function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
   return {
@@ -50,6 +58,71 @@ function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
       metadataChecks: [],
     },
     securityResult: 'unavailable',
+    activityCadenceByWindow: {
+      30: {
+        totalWeeks: 5,
+        weeklyCommitCounts: [1, 0, 1, 0, 1],
+        activeWeeksRatio: 0.6,
+        commitRegularity: 0.4,
+        longestGapDays: 12,
+        weekendToWeekdayRatio: 0.5,
+        weekendCommitCount: 2,
+        weekdayCommitCount: 4,
+        trendComparisons: createTrendComparisons(),
+      },
+      60: {
+        totalWeeks: 9,
+        weeklyCommitCounts: [1, 1, 0, 1, 0, 1, 2, 0, 1],
+        activeWeeksRatio: 0.67,
+        commitRegularity: 0.5,
+        longestGapDays: 18,
+        weekendToWeekdayRatio: 0.5,
+        weekendCommitCount: 3,
+        weekdayCommitCount: 6,
+        trendComparisons: createTrendComparisons({
+          month: { currentPeriodCommitCount: 3, previousPeriodCommitCount: 4, delta: -0.25, direction: 'decelerating' },
+        }),
+      },
+      90: {
+        totalWeeks: 13,
+        weeklyCommitCounts: [1, 0, 1, 0, 1, 1, 0, 2, 0, 2, 1, 0, 1],
+        activeWeeksRatio: 0.62,
+        commitRegularity: 0.58,
+        longestGapDays: 21,
+        weekendToWeekdayRatio: 0.6,
+        weekendCommitCount: 6,
+        weekdayCommitCount: 10,
+        trendComparisons: createTrendComparisons({
+          month: { currentPeriodCommitCount: 6, previousPeriodCommitCount: 4, delta: 0.5, direction: 'accelerating' },
+        }),
+      },
+      180: {
+        totalWeeks: 26,
+        weeklyCommitCounts: Array.from({ length: 26 }, (_, index) => (index % 4 === 0 ? 2 : index % 3 === 0 ? 1 : 0)),
+        activeWeeksRatio: 0.5,
+        commitRegularity: 0.75,
+        longestGapDays: 34,
+        weekendToWeekdayRatio: 0.7,
+        weekendCommitCount: 9,
+        weekdayCommitCount: 13,
+        trendComparisons: createTrendComparisons({
+          month: { currentPeriodCommitCount: 6, previousPeriodCommitCount: 4, delta: 0.5, direction: 'accelerating' },
+        }),
+      },
+      365: {
+        totalWeeks: 53,
+        weeklyCommitCounts: Array.from({ length: 53 }, (_, index) => (index % 5 === 0 ? 2 : index % 3 === 0 ? 1 : 0)),
+        activeWeeksRatio: 0.55,
+        commitRegularity: 0.82,
+        longestGapDays: 41,
+        weekendToWeekdayRatio: 0.8,
+        weekendCommitCount: 16,
+        weekdayCommitCount: 20,
+        trendComparisons: createTrendComparisons({
+          month: { currentPeriodCommitCount: 6, previousPeriodCommitCount: 4, delta: 0.5, direction: 'accelerating' },
+        }),
+      },
+    },
     missingFields: [],
     ...overrides,
   }
@@ -65,6 +138,7 @@ describe('ActivityView', () => {
     expect(within(activityView).getAllByText(/^commits$/i)).toHaveLength(2)
     expect(within(activityView).getAllByText(/^pull requests$/i)).toHaveLength(2)
     expect(within(activityView).getAllByText(/^issues$/i)).toHaveLength(2)
+    expect(within(activityView).getAllByText(/development cadence/i)).toHaveLength(2)
     expect(within(activityView).getAllByText(/^merge rate$/i)).toHaveLength(2)
     expect(within(activityView).getAllByText(/^ranking$/i)).toHaveLength(2)
     expect(within(activityView).getAllByText(/^closure rate$/i)).toHaveLength(2)
@@ -118,13 +192,15 @@ describe('ActivityView', () => {
     const activityView = screen.getByRole('region', { name: /activity view/i })
     expect(within(activityView).getByText(/^commits$/i)).toBeInTheDocument()
     expect(within(activityView).getByText('18')).toBeInTheDocument()
+    expect(within(activityView).getByText(/development cadence/i)).toBeInTheDocument()
     expect(within(activityView).getAllByText(/\d+\w{2} percentile/i).length).toBeGreaterThan(0)
 
     await userEvent.click(screen.getByRole('button', { name: '30d' }))
 
     expect(screen.getByRole('button', { name: '30d' })).toHaveAttribute('aria-pressed', 'true')
     expect(within(activityView).getByText(/^commits$/i)).toBeInTheDocument()
-    expect(within(activityView).getByText('3')).toBeInTheDocument()
+    expect(within(activityView).getAllByText('3').length).toBeGreaterThan(0)
+    expect(within(activityView).getByText('60%')).toBeInTheDocument()
     expect(within(activityView).getByText('20.0%')).toBeInTheDocument()
     expect(within(activityView).getAllByText(/\d+\w{2} percentile/i).length).toBeGreaterThan(0)
     expect(within(activityView).getByText(/prs are not reaching merge/i)).toBeInTheDocument()
@@ -136,7 +212,7 @@ describe('ActivityView', () => {
 
     expect(screen.getByRole('button', { name: '12 months' })).toHaveAttribute('aria-pressed', 'true')
     expect(within(activityView).getByText(/^releases$/i)).toBeInTheDocument()
-    expect(within(activityView).getByText('6')).toBeInTheDocument()
+    expect(within(activityView).getAllByText('6').length).toBeGreaterThan(0)
     expect(within(activityView).getByText('75.0%')).toBeInTheDocument()
     expect(within(activityView).getAllByText(/\d+\w{2} percentile/i).length).toBeGreaterThan(0)
     expect(within(activityView).getByText('4.0d')).toBeInTheDocument()

--- a/components/activity/ActivityView.tsx
+++ b/components/activity/ActivityView.tsx
@@ -12,6 +12,7 @@ import { buildActivitySections, getActivityWindowOptions } from '@/lib/activity/
 import { CONTRIB_EX_ACTIVITY_CARDS } from '@/lib/tags/tag-mappings'
 import { ActivityScoreHelp } from './ActivityScoreHelp'
 import { DiscussionsCard } from './DiscussionsCard'
+import { DevelopmentCadenceCard } from './DevelopmentCadenceCard'
 import { ReleaseCadenceCard } from './ReleaseCadenceCard'
 
 interface ActivityViewProps {
@@ -150,6 +151,7 @@ export function ActivityView({ results, activeTag: externalTag, onTagChange }: A
                   {!activeTag || activeTag === 'community' ? (
                     <DiscussionsCard result={result} activeTag={activeTag} onTagClick={handleTagClick} windowDays={windowDays} />
                   ) : null}
+                  <DevelopmentCadenceCard result={result} windowDays={windowDays} />
                   {!activeTag || activeTag === 'release-health' ? (
                     <ReleaseCadenceCard result={result} activeTag={activeTag} onTagClick={handleTagClick} />
                   ) : null}

--- a/components/activity/DevelopmentCadenceCard.test.tsx
+++ b/components/activity/DevelopmentCadenceCard.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult, TrendComparisonMetrics } from '@/lib/analyzer/analysis-result'
+import { DevelopmentCadenceCard } from './DevelopmentCadenceCard'
+
+function createTrendComparisons(overrides: Partial<Record<'month' | 'week' | 'day', Partial<TrendComparisonMetrics>>> = {}) {
+  return {
+    month: { currentPeriodCommitCount: 6, previousPeriodCommitCount: 3, delta: 1, direction: 'accelerating', ...overrides.month },
+    week: { currentPeriodCommitCount: 3, previousPeriodCommitCount: 6, delta: -0.5, direction: 'decelerating', ...overrides.week },
+    day: { currentPeriodCommitCount: 1, previousPeriodCommitCount: 0, delta: 1, direction: 'accelerating', ...overrides.day },
+  }
+}
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'A UI library',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 25,
+    watchers: 10,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 6,
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+describe('DevelopmentCadenceCard', () => {
+  it('renders cadence metrics with a unified default month-over-month trend module', () => {
+    render(
+      <DevelopmentCadenceCard
+        result={buildResult({
+          activityCadenceByWindow: {
+            30: {
+              totalWeeks: 5,
+              weeklyCommitCounts: [1, 0, 1, 2, 0],
+              activeWeeksRatio: 0.6,
+              commitRegularity: 0.4,
+              longestGapDays: 52,
+              weekendToWeekdayRatio: 0.5,
+              weekendCommitCount: 2,
+              weekdayCommitCount: 4,
+              trendComparisons: createTrendComparisons(),
+            },
+          },
+        })}
+        windowDays={30}
+      />,
+    )
+
+    expect(screen.getByRole('region', { name: /development cadence for facebook\/react/i })).toHaveClass('md:col-span-2', 'xl:col-span-2')
+    expect(screen.getByText(/development cadence/i)).toBeInTheDocument()
+    expect(screen.getByText(/based on commit history from the default branch \(main\)/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/weekly commit rhythm/i)).toBeInTheDocument()
+    expect(screen.getByText(/high consistency|moderate consistency|bursty/i)).toBeInTheDocument()
+    expect(screen.getByText('60%')).toBeInTheDocument()
+    expect(screen.getByLabelText(/an active week is any week/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/3 of 5 weeks/i)).toBeInTheDocument()
+    expect(screen.getByText('52 days')).toBeInTheDocument()
+    expect(screen.getByText('Weekend Flow')).toBeInTheDocument()
+    expect(screen.getByText('33% weekend')).toBeInTheDocument()
+    expect(screen.getByLabelText(/2 weekend commits and 4 weekday commits/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/weekend activity made up 33% of all commits/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/0.50x/i)).toBeInTheDocument()
+    expect(screen.getByTitle(/W4 \(.+ to .+\): 2 commits/)).toBeInTheDocument()
+    expect(screen.getByText(/W1 starts .+ The chart runs left-to-right from oldest to most recent week/i)).toBeInTheDocument()
+    expect(screen.getByText(/The selected window currently spans .+ to .+\./i)).toBeInTheDocument()
+    expect(screen.getByText('Month over month')).toBeInTheDocument()
+    expect(screen.getByText(/compares the latest 30 days with the 30 days immediately before them/i)).toBeInTheDocument()
+    expect(screen.getByText('Days 31-60 ago')).toBeInTheDocument()
+    expect(screen.getByText('Last 30 days')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Month' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.queryByRole('button', { name: /zoom in/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /zoom out/i })).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Trend: Accelerating (+100%)')).toBeInTheDocument()
+    expect(screen.getByText('+100%')).toBeInTheDocument()
+  })
+
+  it('returns null when cadence data is absent', () => {
+    const { container } = render(<DevelopmentCadenceCard result={buildResult()} windowDays={30} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('preserves chart zoom affordances on longer windows', async () => {
+    render(
+      <DevelopmentCadenceCard
+        result={buildResult({
+          activityCadenceByWindow: {
+            365: {
+              totalWeeks: 13,
+              weeklyCommitCounts: [2, 1, 1, 2, 2, 3, 1, 2, 1, 1, 2, 3, 1],
+              activeWeeksRatio: 1,
+              commitRegularity: 0.4,
+              longestGapDays: 2,
+              weekendToWeekdayRatio: 0.1,
+              weekendCommitCount: 122,
+              weekdayCommitCount: 1279,
+              trendComparisons: createTrendComparisons({
+                month: { currentPeriodCommitCount: 411, previousPeriodCommitCount: 525, delta: -0.22, direction: 'decelerating' },
+              }),
+            },
+          },
+        })}
+        windowDays={365}
+      />,
+    )
+
+    expect(screen.getByText('W1')).toBeVisible()
+    expect(screen.queryByText('W2')).not.toBeInTheDocument()
+    expect(screen.getByText('W4')).toBeVisible()
+    expect(screen.getByText('W7')).toBeVisible()
+    expect(screen.getByText('W13')).toBeVisible()
+    expect(screen.getByRole('button', { name: /zoom in/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /zoom out/i })).toBeDisabled()
+    expect(screen.getByLabelText('Trend: Decelerating (-22%)')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /zoom in/i }))
+
+    expect(screen.getByText(/Scroll horizontally to move through the timeline\./i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /zoom out/i })).toBeEnabled()
+  })
+
+  it('shows readable commit counts when toggled on', async () => {
+    render(
+      <DevelopmentCadenceCard
+        result={buildResult({
+          activityCadenceByWindow: {
+            30: {
+              totalWeeks: 5,
+              weeklyCommitCounts: [1, 0, 1, 2, 0],
+              activeWeeksRatio: 0.6,
+              commitRegularity: 0.4,
+              longestGapDays: 52,
+              weekendToWeekdayRatio: 0.5,
+              weekendCommitCount: 2,
+              weekdayCommitCount: 4,
+              trendComparisons: createTrendComparisons(),
+            },
+          },
+        })}
+        windowDays={30}
+      />,
+    )
+
+    expect(screen.queryByText('W4: 2')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /show commit counts/i }))
+
+    expect(screen.getByRole('button', { name: /hide commit counts/i })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('W1: 1')).toBeInTheDocument()
+    expect(screen.getByText('W2: 0')).toBeInTheDocument()
+    expect(screen.getByText('W4: 2')).toBeInTheDocument()
+  })
+
+  it('switches trend modes locally and keeps labels, values, and helper copy in sync', async () => {
+    render(
+      <DevelopmentCadenceCard
+        result={buildResult({
+          activityCadenceByWindow: {
+            30: {
+              totalWeeks: 5,
+              weeklyCommitCounts: [1, 0, 1, 2, 0],
+              activeWeeksRatio: 0.6,
+              commitRegularity: 0.4,
+              longestGapDays: 52,
+              weekendToWeekdayRatio: 0.5,
+              weekendCommitCount: 2,
+              weekdayCommitCount: 4,
+              trendComparisons: createTrendComparisons({
+                day: {
+                  currentPeriodCommitCount: 0,
+                  previousPeriodCommitCount: 0,
+                  delta: 'unavailable',
+                  direction: 'unavailable',
+                },
+              }),
+            },
+          },
+        })}
+        windowDays={30}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Week' }))
+
+    expect(screen.getByRole('button', { name: 'Week' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('Week over week')).toBeInTheDocument()
+    expect(screen.getByText(/compares the latest 7 days with the 7 days immediately before them/i)).toBeInTheDocument()
+    expect(screen.getByText('Days 8-14 ago')).toBeInTheDocument()
+    expect(screen.getByText('Last 7 days')).toBeInTheDocument()
+    expect(screen.getByLabelText('Trend: Decelerating (-50%)')).toBeInTheDocument()
+    expect(screen.getByText('-50%')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Day' }))
+
+    expect(screen.getByRole('button', { name: 'Day' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText('Day over day')).toBeInTheDocument()
+    expect(screen.getByText(/compares the most recent complete UTC day with the previous complete UTC day/i)).toBeInTheDocument()
+    expect(screen.getByText('Previous full day')).toBeInTheDocument()
+    expect(screen.getByText('Most recent full day')).toBeInTheDocument()
+    expect(screen.getByLabelText('Trend: Insufficient verified public data')).toBeInTheDocument()
+  })
+})

--- a/components/activity/DevelopmentCadenceCard.tsx
+++ b/components/activity/DevelopmentCadenceCard.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import { useState } from 'react'
+import { HelpLabel } from '@/components/shared/HelpLabel'
+import { MetricValue } from '@/components/shared/MetricValue'
+import type { ActivityWindowDays, AnalysisResult, TrendComparisonMode } from '@/lib/analyzer/analysis-result'
+import { buildDevelopmentCadenceCard } from '@/lib/activity/view-model'
+import { DevelopmentCadenceChart } from './development-cadence-chart'
+
+interface DevelopmentCadenceCardProps {
+  result: AnalysisResult
+  windowDays: ActivityWindowDays
+}
+
+export function DevelopmentCadenceCard({ result, windowDays }: DevelopmentCadenceCardProps) {
+  const card = buildDevelopmentCadenceCard(result, windowDays)
+  const [showCommitCounts, setShowCommitCounts] = useState(false)
+  const [selectedTrendMode, setSelectedTrendMode] = useState<TrendComparisonMode>('month')
+
+  if (!card) return null
+  const cadence = result.activityCadenceByWindow?.[windowDays]
+  const activeTrend = card.trendModes[selectedTrendMode] ?? card.trendModes[card.defaultTrendMode]
+  const defaultBranchLabel =
+    typeof result.defaultBranchName === 'string' && result.defaultBranchName !== 'unavailable'
+      ? `the default branch (${result.defaultBranchName})`
+      : 'the default branch'
+
+  const activeWeeksTooltip =
+    cadence &&
+    typeof cadence.totalWeeks === 'number' &&
+    Array.isArray(cadence.weeklyCommitCounts)
+      ? `An active week is any week in the selected ${windowDays === 365 ? '12 months' : `${windowDays}d`} window with at least 1 verified commit. This value is calculated as active weeks divided by total weeks: ${cadence.weeklyCommitCounts.filter((count) => count > 0).length} of ${cadence.totalWeeks} weeks.`
+      : `An active week is any week in the selected ${windowDays === 365 ? '12 months' : `${windowDays}d`} window with at least 1 verified commit. This value is calculated as active weeks divided by total weeks in that window.`
+  const weekendWeekdayTooltip =
+    cadence &&
+    typeof cadence.weekendCommitCount === 'number' &&
+    typeof cadence.weekdayCommitCount === 'number' &&
+    typeof cadence.weekendToWeekdayRatio === 'number'
+      ? `In the selected ${windowDays === 365 ? '12 months' : `${windowDays}d`} window, this repo had ${new Intl.NumberFormat('en-US').format(cadence.weekendCommitCount)} weekend commits and ${new Intl.NumberFormat('en-US').format(cadence.weekdayCommitCount)} weekday commits. Weekend activity made up ${new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format((cadence.weekendCommitCount / Math.max(1, cadence.weekendCommitCount + cadence.weekdayCommitCount)) * 100)}% of all commits. The weekend-to-weekday ratio was ${cadence.weekendToWeekdayRatio.toFixed(2)}x, which means weekend activity was ${cadence.weekendToWeekdayRatio < 1 ? 'lower than' : cadence.weekendToWeekdayRatio > 1 ? 'higher than' : 'equal to'} weekday activity. This is descriptive only and is not treated as inherently better or worse.`
+      : `Weekend commits divided by weekday commits in the selected ${windowDays === 365 ? '12 months' : `${windowDays}d`} window. Values below 1.0x mean activity happened more often on weekdays; values above 1.0x mean activity happened more often on weekends. This describes work rhythm only and is not treated as inherently better or worse.`
+
+  return (
+    <section
+      aria-label={`Development cadence for ${card.repo}`}
+      className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 md:col-span-2 xl:col-span-2 dark:border-slate-700 dark:bg-slate-800/60"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Development cadence</p>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">Weekly rhythm, consistency, weekend share, and recent momentum.</p>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            Based on commit history from {defaultBranchLabel}.
+          </p>
+        </div>
+        <div className="sm:text-right">
+          <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">{card.regularityLabel}</p>
+          {card.regularityPercentileLabel ? (
+            <p className="text-xs text-slate-500 dark:text-slate-400">{card.regularityPercentileLabel}</p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <DevelopmentCadenceChart bars={card.chartBars} windowDays={windowDays} showCommitCounts={showCommitCounts} />
+        <div className="mt-2 flex justify-end">
+          <button
+            type="button"
+            aria-pressed={showCommitCounts}
+            onClick={() => setShowCommitCounts((current) => !current)}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+              showCommitCounts
+                ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900'
+                : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white'
+            }`}
+          >
+            {showCommitCounts ? 'Hide commit counts' : 'Show commit counts'}
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        <MetricBlock
+          label="Active weeks"
+          labelHelpText={activeWeeksTooltip}
+          value={card.activeWeeksValue}
+          detail={card.activeWeeksPercentileLabel}
+        />
+        <MetricBlock label="Longest gap" value={card.longestGapValue} detail={card.longestGapHighlighted ? 'Unusually long gap' : null} highlight={card.longestGapHighlighted} />
+        <MetricBlock
+          label="Weekend Flow"
+          labelHelpText={weekendWeekdayTooltip}
+          value={card.weekendWeekdayValue}
+          detail="Informational only"
+        />
+      </div>
+
+      <TrendModule
+        className="mt-4"
+        selectedMode={selectedTrendMode}
+        onSelectMode={setSelectedTrendMode}
+        trend={activeTrend}
+      />
+    </section>
+  )
+}
+
+function MetricBlock({
+  label,
+  labelHelpText,
+  value,
+  detail,
+  highlight = false,
+}: {
+  label: string
+  labelHelpText?: string
+  value: string
+  detail?: string | null
+  highlight?: boolean
+}) {
+  return (
+    <div className={`min-w-0 rounded-xl border px-3 py-3 ${highlight ? 'border-amber-300 bg-amber-50 dark:border-amber-700/60 dark:bg-amber-950/20' : 'border-slate-200 bg-white/70 dark:border-slate-700 dark:bg-slate-900/40'}`}>
+      <p className="text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500">
+        {labelHelpText ? <HelpLabel label={label} helpText={labelHelpText} /> : label}
+      </p>
+      <p className="mt-1 break-words text-base leading-tight"><MetricValue value={value} /></p>
+      {detail ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{detail}</p> : null}
+    </div>
+  )
+}
+
+function TrendModule({
+  className,
+  selectedMode,
+  onSelectMode,
+  trend,
+}: {
+  className?: string
+  selectedMode: TrendComparisonMode
+  onSelectMode: (mode: TrendComparisonMode) => void
+  trend: {
+    label: string
+    helperText: string
+    trendLabel: 'Accelerating' | 'Decelerating' | 'Flat' | 'Insufficient verified public data'
+    trendDeltaValue: string | null
+    currentPeriodLabel: string
+    currentPeriodValue: string
+    previousPeriodLabel: string
+    previousPeriodValue: string
+  }
+}) {
+  const { symbol, className: trendClassName } = getTrendPresentation(trend.trendLabel)
+  const trendAriaLabel = `Trend: ${trend.trendLabel}${trend.trendDeltaValue ? ` (${trend.trendDeltaValue})` : ''}`
+
+  return (
+    <div className={`rounded-xl border border-slate-200 bg-white/70 px-3 py-3 dark:border-slate-700 dark:bg-slate-900/40 ${className ?? ''}`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500">
+            <HelpLabel label="Trend" helpText={trend.helperText} />
+          </p>
+          <p className="mt-1 text-sm font-semibold text-slate-900 dark:text-slate-100">{trend.label}</p>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{trend.helperText}</p>
+        </div>
+        <div className="flex items-center gap-2 self-start">
+          {(['month', 'week', 'day'] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              aria-pressed={selectedMode === mode}
+              onClick={() => onSelectMode(mode)}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                selectedMode === mode
+                  ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900'
+                  : 'border-slate-300 text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:border-slate-500 dark:hover:text-white'
+              }`}
+            >
+              {mode === 'month' ? 'Month' : mode === 'week' ? 'Week' : 'Day'}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr),minmax(0,2fr)] lg:items-center">
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-900/60">
+          <div aria-label={trendAriaLabel} className={`text-2xl leading-none ${trendClassName}`}>
+            <span aria-hidden="true">{symbol}</span>
+          </div>
+          <p className="mt-2 text-sm font-semibold text-slate-900 dark:text-slate-100">{trend.trendLabel}</p>
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            <MetricValue value={trend.trendDeltaValue ?? '—'} />
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <TrendColumn label={trend.previousPeriodLabel} value={trend.previousPeriodValue} />
+          <TrendColumn label={trend.currentPeriodLabel} value={trend.currentPeriodValue} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function getTrendPresentation(trend: 'Accelerating' | 'Decelerating' | 'Flat' | 'Insufficient verified public data') {
+  switch (trend) {
+    case 'Accelerating':
+      return { symbol: '↗', className: 'text-emerald-600 dark:text-emerald-400' }
+    case 'Decelerating':
+      return { symbol: '↘', className: 'text-amber-600 dark:text-amber-400' }
+    case 'Flat':
+      return { symbol: '→', className: 'text-slate-600 dark:text-slate-300' }
+    default:
+      return { symbol: '—', className: 'text-slate-400 dark:text-slate-500' }
+  }
+}
+
+function TrendColumn({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-wide text-slate-400 dark:text-slate-500">{label}</p>
+      <p className="mt-1 text-base"><MetricValue value={value} /></p>
+    </div>
+  )
+}

--- a/components/activity/development-cadence-chart.tsx
+++ b/components/activity/development-cadence-chart.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { ActivityWindowDays } from '@/lib/analyzer/analysis-result'
+import type { WeeklyCommitBar } from '@/lib/activity/view-model'
+
+interface DevelopmentCadenceChartProps {
+  bars: WeeklyCommitBar[] | null
+  windowDays: ActivityWindowDays
+  showCommitCounts?: boolean
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export function DevelopmentCadenceChart({ bars, windowDays, showCommitCounts = false }: DevelopmentCadenceChartProps) {
+  const [zoomIndex, setZoomIndex] = useState(0)
+  const now = useMemo(() => new Date(), [])
+  const barCount = bars?.length ?? 0
+  const zoomWidths = useMemo(() => getZoomWidths(barCount), [barCount])
+
+  if (!bars || bars.length === 0) {
+    return <div className="rounded-xl border border-dashed border-slate-200 px-3 py-4 text-xs text-slate-500 dark:border-slate-700 dark:text-slate-400">No cadence data</div>
+  }
+
+  const clampedZoomIndex = Math.min(zoomIndex, zoomWidths.length - 1)
+  const zoomWidth = zoomWidths[clampedZoomIndex] ?? 0
+  const isZoomedIn = zoomWidth > 0
+  const max = Math.max(...bars.map((bar) => bar.commitCount), 1)
+  const tickIndexes = getTickIndexes(bars.length)
+  const countBars = getCountBars(bars, tickIndexes)
+  const w1StartDate = formatDate(getWeekStartDate(0, windowDays, now))
+  const finalWeek = bars[bars.length - 1]
+  const finalWeekEndDate = finalWeek ? formatDate(getWeekEndDate(getWeekIndex(finalWeek), windowDays, now)) : null
+  const trackStyle = isZoomedIn
+    ? { gridTemplateColumns: `repeat(${bars.length}, ${zoomWidth}px)` }
+    : { gridTemplateColumns: `repeat(${bars.length}, minmax(0, 1fr))` }
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white/70 px-3 py-3 dark:border-slate-700 dark:bg-slate-900/40" aria-label="Weekly commit rhythm">
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-[10px] text-slate-500 dark:text-slate-400">
+          W1 starts {w1StartDate}. The chart runs left-to-right from oldest to most recent week.
+        </p>
+        {zoomWidths.length > 1 ? (
+          <div className="flex items-center gap-2 self-end sm:self-auto">
+            <button
+              type="button"
+              aria-label="Zoom in"
+              onClick={() => setZoomIndex((current) => Math.min(current + 1, zoomWidths.length - 1))}
+              disabled={clampedZoomIndex >= zoomWidths.length - 1}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200"
+            >
+              +
+            </button>
+            <button
+              type="button"
+              aria-label="Zoom out"
+              onClick={() => setZoomIndex((current) => Math.max(current - 1, 0))}
+              disabled={clampedZoomIndex === 0}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-sm font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:text-slate-200"
+            >
+              −
+            </button>
+          </div>
+        ) : null}
+      </div>
+      <div className={isZoomedIn ? 'overflow-x-auto pb-1' : ''}>
+        <div className="grid items-end gap-1" style={trackStyle}>
+          {bars.map((bar) => (
+            <div
+              key={bar.weekLabel}
+              className={`w-full rounded-t-sm ${bar.isActive ? 'bg-slate-900 dark:bg-slate-100' : 'bg-slate-200 dark:bg-slate-700'}`}
+              style={{ height: `${Math.max(8, Math.round((bar.commitCount / max) * 48))}px` }}
+              title={formatBarTooltip(bar, windowDays, now)}
+              aria-label={`${bar.weekLabel}: ${bar.commitCount} commits`}
+            />
+          ))}
+        </div>
+        <div className="mt-2 grid gap-1 text-[10px] text-slate-400 dark:text-slate-500" style={trackStyle}>
+          {bars.map((bar, index) => (
+            <span key={`${bar.weekLabel}-tick`} className="min-w-0 text-center">
+              {tickIndexes.includes(index) ? bar.weekLabel : ''}
+            </span>
+          ))}
+        </div>
+      </div>
+      <p className="mt-2 text-[10px] text-slate-500 dark:text-slate-400">
+        {finalWeekEndDate ? `The selected window currently spans ${w1StartDate} to ${finalWeekEndDate}.` : null}
+        {isZoomedIn ? ' Scroll horizontally to move through the timeline.' : ''}
+      </p>
+      {showCommitCounts ? (
+        <div className="mt-3 flex flex-wrap gap-2 border-t border-slate-200 pt-3 text-[11px] text-slate-600 dark:border-slate-700 dark:text-slate-300">
+          {countBars.map((bar) => (
+            <span
+              key={`${bar.weekLabel}-count`}
+              className="rounded-full border border-slate-200 bg-slate-50 px-2 py-1 dark:border-slate-700 dark:bg-slate-800/60"
+              aria-label={`${bar.weekLabel} count: ${bar.commitCount} ${bar.commitCount === 1 ? 'commit' : 'commits'}`}
+            >
+              {bar.weekLabel}: {bar.commitCount}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function getZoomWidths(barCount: number): number[] {
+  if (barCount <= 8) return [barCount]
+  if (barCount <= 20) return [0, 28]
+  return [0, 18, 28]
+}
+
+function getTickIndexes(barCount: number): number[] {
+  if (barCount <= 6) return Array.from({ length: barCount }, (_, index) => index)
+
+  const tickCount = Math.min(5, barCount)
+  const maxIndex = barCount - 1
+  const indexes = new Set<number>()
+
+  for (let tick = 0; tick < tickCount; tick += 1) {
+    indexes.add(Math.round((maxIndex * tick) / (tickCount - 1)))
+  }
+
+  return Array.from(indexes).sort((a, b) => a - b)
+}
+
+function getCountBars(bars: WeeklyCommitBar[], tickIndexes: number[]): WeeklyCommitBar[] {
+  if (bars.length <= 13) return bars
+  return tickIndexes.map((index) => bars[index]!)
+}
+
+function getWeekIndex(bar: WeeklyCommitBar): number {
+  return Math.max(0, Number.parseInt(bar.weekLabel.replace(/^W/, ''), 10) - 1)
+}
+
+function getWeekStartDate(weekIndex: number, windowDays: ActivityWindowDays, now: Date): Date {
+  return new Date(now.getTime() - windowDays * MS_PER_DAY + weekIndex * 7 * MS_PER_DAY)
+}
+
+function getWeekEndDate(weekIndex: number, windowDays: ActivityWindowDays, now: Date): Date {
+  const weekStart = getWeekStartDate(weekIndex, windowDays, now)
+  return new Date(Math.min(now.getTime(), weekStart.getTime() + 7 * MS_PER_DAY - 1))
+}
+
+function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date)
+}
+
+function formatBarTooltip(bar: WeeklyCommitBar, windowDays: ActivityWindowDays, now: Date): string {
+  const weekIndex = getWeekIndex(bar)
+  const weekStart = formatDate(getWeekStartDate(weekIndex, windowDays, now))
+  const weekEnd = formatDate(getWeekEndDate(weekIndex, windowDays, now))
+  return `${bar.weekLabel} (${weekStart} to ${weekEnd}): ${new Intl.NumberFormat('en-US').format(bar.commitCount)} ${bar.commitCount === 1 ? 'commit' : 'commits'}`
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -262,7 +262,7 @@ Phase 2 adds new scoring buckets to the health score. Requirements specs live in
 | 7 | P2-F06 | Foundation-aware recommendations | #119 | |
 | 8 | P2-F08 | Accessibility & Onboarding | #117 | |
 | 9 | P2-F09 | Release health scoring | #69 | ✅ Done |
-| 10 | P2-F10 | Development cadence | #73 | |
+| 10 | P2-F10 | Development cadence | #73 | ✅ Done |
 | 11 | P2-F11 | Project maturity | #74 | |
 | 12 | P2-F12 | Ecosystem Reach | #118 | |
 | 13 | P2-F01b | Documentation scoring (advanced) | #110, #67 | |

--- a/e2e/activity.spec.ts
+++ b/e2e/activity.spec.ts
@@ -2,100 +2,28 @@ import { expect, test } from '@playwright/test'
 
 test.describe('P1-F08 Activity', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
-
-    if ((await page.getByLabel(/github personal access token/i).count()) > 0) {
-      await page.getByLabel(/github personal access token/i).fill('ghp_example')
-    }
+    await page.goto('/demo/repositories')
   })
 
   test('opens Activity and switches recent activity windows locally', async ({ page }) => {
-    let requestCount = 0
-
-    await page.route('**/api/analyze', async (route) => {
-      requestCount += 1
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          results: [
-            buildResult({
-              activityMetricsByWindow: {
-                30: { commits: 7, prsOpened: 2, prsMerged: 1, issuesOpened: 4, issuesClosed: 3, releases: 1, staleIssueRatio: 0.1, medianTimeToMergeHours: 12, medianTimeToCloseHours: 24 },
-                60: { commits: 12, prsOpened: 3, prsMerged: 2, issuesOpened: 6, issuesClosed: 5, releases: 2, staleIssueRatio: 0.15, medianTimeToMergeHours: 18, medianTimeToCloseHours: 30 },
-                90: { commits: 18, prsOpened: 4, prsMerged: 3, issuesOpened: 8, issuesClosed: 6, releases: 3, staleIssueRatio: 0.2, medianTimeToMergeHours: 24, medianTimeToCloseHours: 36 },
-                180: { commits: 30, prsOpened: 7, prsMerged: 5, issuesOpened: 10, issuesClosed: 8, releases: 4, staleIssueRatio: 0.3, medianTimeToMergeHours: 48, medianTimeToCloseHours: 72 },
-                365: { commits: 55, prsOpened: 12, prsMerged: 9, issuesOpened: 16, issuesClosed: 13, releases: 6, staleIssueRatio: 0.4, medianTimeToMergeHours: 96, medianTimeToCloseHours: 144 },
-              },
-            }),
-          ],
-          failures: [],
-          rateLimit: null,
-        }),
-      })
-    })
-
-    await page.getByRole('textbox', { name: /repository list/i }).fill('facebook/react')
-    await page.getByRole('button', { name: /analyze/i }).click()
-
     await page.getByRole('tab', { name: 'Activity' }).click()
     const activityView = page.getByRole('region', { name: /activity view/i })
-    await expect(activityView).toContainText('Commits')
-    await expect(activityView).toContainText('18')
-    await expect(activityView).toContainText('20.0%')
-    await expect(activityView).toContainText('1.0d')
+    await expect(activityView).toContainText('Development cadence')
+    await expect(activityView).toContainText('Month over month')
+    await expect(activityView).toContainText('Weekend Flow')
 
     await page.getByRole('button', { name: '30d' }).click()
-    await expect(activityView).toContainText('Commits')
-    await expect(activityView).toContainText('7')
-    await expect(activityView).toContainText('10.0%')
-    await expect(activityView).toContainText('12.0h')
+    await expect(activityView).toContainText('60%')
+    await expect(activityView).toContainText('33% weekend')
+    await expect(activityView).toContainText('Last 30 days')
+
+    await activityView.getByRole('button', { name: 'Week', exact: true }).click()
+    await expect(activityView).toContainText('Week over week')
+    await expect(activityView).toContainText('Last 7 days')
+    await expect(activityView).toContainText('Days 8-14 ago')
 
     await page.getByRole('button', { name: '12 months' }).click()
-    await expect(activityView).toContainText('Releases')
-    await expect(activityView).toContainText('6')
-    await expect(activityView).toContainText('40.0%')
-    await expect(activityView).toContainText('4.0d')
-    await expect(activityView).toContainText('6.0d')
-    expect(requestCount).toBe(1)
+    await expect(activityView).toContainText('Development cadence')
+    await expect(activityView).toContainText('Month')
   })
 })
-
-function buildResult(overrides: Record<string, unknown>) {
-  return {
-    repo: 'facebook/react',
-    name: 'react',
-    description: 'A UI library',
-    createdAt: '2013-05-24T16:15:54Z',
-    primaryLanguage: 'TypeScript',
-    stars: 100,
-    forks: 25,
-    watchers: 10,
-    commits30d: 7,
-    commits90d: 18,
-    releases12mo: 6,
-    prsOpened90d: 4,
-    prsMerged90d: 3,
-    issuesOpen: 5,
-    issuesClosed90d: 6,
-    staleIssueRatio: 0.2,
-    medianTimeToMergeHours: 24,
-    medianTimeToCloseHours: 36,
-    uniqueCommitAuthors90d: 'unavailable',
-    totalContributors: 'unavailable',
-    commitCountsByAuthor: 'unavailable',
-    issueFirstResponseTimestamps: 'unavailable',
-    issueCloseTimestamps: 'unavailable',
-    prMergeTimestamps: 'unavailable',
-    documentationResult: 'unavailable',
-    defaultBranchName: 'main',
-    topics: [],
-    inclusiveNamingResult: {
-      defaultBranchName: 'main',
-      branchCheck: { checkType: 'branch', term: 'main', passed: true, tier: null, severity: null, replacements: [], context: null },
-      metadataChecks: [],
-    },
-    missingFields: [],
-    ...overrides,
-  }
-}

--- a/fixtures/demo/repositories.json
+++ b/fixtures/demo/repositories.json
@@ -154,6 +154,83 @@
           "medianTimeToCloseHours": "unavailable"
         }
       },
+      "activityCadenceByWindow": {
+        "30": {
+          "totalWeeks": 5,
+          "weeklyCommitCounts": [1, 0, 1, 2, 0],
+          "activeWeeksRatio": 0.6,
+          "commitRegularity": 0.4,
+          "longestGapDays": 12,
+          "weekendToWeekdayRatio": 0.5,
+          "weekendCommitCount": 2,
+          "weekdayCommitCount": 4,
+          "trendComparisons": {
+            "month": { "currentPeriodCommitCount": 3, "previousPeriodCommitCount": 2, "delta": 0.5, "direction": "accelerating" },
+            "week": { "currentPeriodCommitCount": 2, "previousPeriodCommitCount": 1, "delta": 1, "direction": "accelerating" },
+            "day": { "currentPeriodCommitCount": 1, "previousPeriodCommitCount": 0, "delta": 1, "direction": "accelerating" }
+          }
+        },
+        "60": {
+          "totalWeeks": 9,
+          "weeklyCommitCounts": [1, 1, 0, 1, 0, 1, 2, 0, 1],
+          "activeWeeksRatio": 0.67,
+          "commitRegularity": 0.5,
+          "longestGapDays": 18,
+          "weekendToWeekdayRatio": 0.5,
+          "weekendCommitCount": 3,
+          "weekdayCommitCount": 6,
+          "trendComparisons": {
+            "month": { "currentPeriodCommitCount": 3, "previousPeriodCommitCount": 4, "delta": -0.25, "direction": "decelerating" },
+            "week": { "currentPeriodCommitCount": 1, "previousPeriodCommitCount": 2, "delta": -0.5, "direction": "decelerating" },
+            "day": { "currentPeriodCommitCount": 0, "previousPeriodCommitCount": 1, "delta": -1, "direction": "decelerating" }
+          }
+        },
+        "90": {
+          "totalWeeks": 13,
+          "weeklyCommitCounts": [1, 0, 1, 0, 1, 1, 0, 2, 0, 2, 1, 0, 1],
+          "activeWeeksRatio": 0.62,
+          "commitRegularity": 0.58,
+          "longestGapDays": 21,
+          "weekendToWeekdayRatio": 0.6,
+          "weekendCommitCount": 6,
+          "weekdayCommitCount": 10,
+          "trendComparisons": {
+            "month": { "currentPeriodCommitCount": 6, "previousPeriodCommitCount": 4, "delta": 0.5, "direction": "accelerating" },
+            "week": { "currentPeriodCommitCount": 3, "previousPeriodCommitCount": 2, "delta": 0.5, "direction": "accelerating" },
+            "day": { "currentPeriodCommitCount": 1, "previousPeriodCommitCount": 1, "delta": 0, "direction": "flat" }
+          }
+        },
+        "180": {
+          "totalWeeks": 26,
+          "weeklyCommitCounts": [2, 0, 1, 1, 0, 2, 0, 1, 0, 2, 1, 0, 1, 2, 0, 1, 0, 1, 2, 0, 1, 0, 2, 1, 0, 1],
+          "activeWeeksRatio": 0.58,
+          "commitRegularity": 0.74,
+          "longestGapDays": 34,
+          "weekendToWeekdayRatio": 0.7,
+          "weekendCommitCount": 9,
+          "weekdayCommitCount": 13,
+          "trendComparisons": {
+            "month": { "currentPeriodCommitCount": 6, "previousPeriodCommitCount": 4, "delta": 0.5, "direction": "accelerating" },
+            "week": { "currentPeriodCommitCount": 2, "previousPeriodCommitCount": 1, "delta": 1, "direction": "accelerating" },
+            "day": { "currentPeriodCommitCount": 0, "previousPeriodCommitCount": 0, "delta": "unavailable", "direction": "unavailable" }
+          }
+        },
+        "365": {
+          "totalWeeks": 53,
+          "weeklyCommitCounts": [2, 0, 1, 0, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 1, 0],
+          "activeWeeksRatio": 0.55,
+          "commitRegularity": 0.82,
+          "longestGapDays": 41,
+          "weekendToWeekdayRatio": 0.8,
+          "weekendCommitCount": 16,
+          "weekdayCommitCount": 20,
+          "trendComparisons": {
+            "month": { "currentPeriodCommitCount": 6, "previousPeriodCommitCount": 4, "delta": 0.5, "direction": "accelerating" },
+            "week": { "currentPeriodCommitCount": 2, "previousPeriodCommitCount": 1, "delta": 1, "direction": "accelerating" },
+            "day": { "currentPeriodCommitCount": 0, "previousPeriodCommitCount": 0, "delta": "unavailable", "direction": "unavailable" }
+          }
+        }
+      },
       "responsivenessMetricsByWindow": {
         "30": {
           "issueFirstResponseMedianHours": "unavailable",

--- a/lib/activity/cadence.test.ts
+++ b/lib/activity/cadence.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import { buildActivityCadenceMetrics } from './cadence'
+
+const NOW = new Date('2026-04-20T12:00:00.000Z')
+
+describe('buildActivityCadenceMetrics', () => {
+  it('builds weekly buckets including zero-commit weeks and active weeks ratio', () => {
+    const result = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 30,
+      commitTimestamps: [
+        '2026-04-18T10:00:00.000Z',
+        '2026-04-17T10:00:00.000Z',
+        '2026-04-09T10:00:00.000Z',
+        '2026-03-26T10:00:00.000Z',
+      ],
+    })
+
+    expect(result.totalWeeks).toBe(5)
+    expect(result.weeklyCommitCounts).toEqual([1, 0, 1, 2, 0])
+    expect(result.activeWeeksRatio).toBeCloseTo(0.6, 5)
+  })
+
+  it('marks a steady repo as more regular than a bursty repo', () => {
+    const steady = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 30,
+      commitTimestamps: [
+        '2026-04-18T10:00:00.000Z',
+        '2026-04-12T10:00:00.000Z',
+        '2026-04-05T10:00:00.000Z',
+        '2026-03-30T10:00:00.000Z',
+      ],
+    })
+    const bursty = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 30,
+      commitTimestamps: [
+        '2026-04-18T10:00:00.000Z',
+        '2026-04-18T09:00:00.000Z',
+        '2026-04-18T08:00:00.000Z',
+        '2026-03-30T10:00:00.000Z',
+      ],
+    })
+
+    expect(typeof steady.commitRegularity).toBe('number')
+    expect(typeof bursty.commitRegularity).toBe('number')
+    expect((steady.commitRegularity as number)).toBeLessThan(bursty.commitRegularity as number)
+  })
+
+  it('computes longest gap, weekend ratio, and trend direction', () => {
+    const result = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 90,
+      commitTimestamps: [
+        '2026-04-19T10:00:00.000Z', // Sunday
+        '2026-04-12T10:00:00.000Z', // Sunday
+        '2026-04-01T10:00:00.000Z', // Wednesday
+        '2026-03-11T10:00:00.000Z', // Wednesday
+        '2026-03-09T10:00:00.000Z', // Monday
+        '2026-02-10T10:00:00.000Z', // Tuesday
+      ],
+    })
+
+    expect(result.longestGapDays).toBe(27)
+    expect(result.weekendCommitCount).toBe(2)
+    expect(result.weekdayCommitCount).toBe(4)
+    expect(result.weekendToWeekdayRatio).toBe(0.5)
+    expect(result.trendComparisons).not.toBe('unavailable')
+    expect(result.trendComparisons === 'unavailable' ? null : result.trendComparisons.month.currentPeriodCommitCount).toBe(3)
+    expect(result.trendComparisons === 'unavailable' ? null : result.trendComparisons.month.previousPeriodCommitCount).toBe(2)
+    expect(result.trendComparisons === 'unavailable' ? null : result.trendComparisons.month.direction).toBe('accelerating')
+  })
+
+  it('returns unavailable values when there is not enough verified history', () => {
+    const empty = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 30,
+      commitTimestamps: [],
+    })
+    const single = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 30,
+      commitTimestamps: ['2026-04-18T10:00:00.000Z'],
+    })
+
+    expect(empty.weeklyCommitCounts).toBe('unavailable')
+    expect(empty.activeWeeksRatio).toBe('unavailable')
+    expect(empty.trendComparisons).toBe('unavailable')
+    expect(single.longestGapDays).toBe('unavailable')
+  })
+
+  it('marks small deltas as flat trend', () => {
+    const result = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 90,
+      commitTimestamps: [
+        '2026-04-18T10:00:00.000Z',
+        '2026-04-10T10:00:00.000Z',
+        '2026-03-15T10:00:00.000Z',
+        '2026-03-10T10:00:00.000Z',
+      ],
+    })
+
+    expect(result.trendComparisons).not.toBe('unavailable')
+    expect(result.trendComparisons === 'unavailable' ? null : result.trendComparisons.month.currentPeriodCommitCount).toBe(2)
+    expect(result.trendComparisons === 'unavailable' ? null : result.trendComparisons.month.previousPeriodCommitCount).toBe(2)
+    expect(result.trendComparisons === 'unavailable' ? null : result.trendComparisons.month.direction).toBe('flat')
+    expect(result.trendComparisons === 'unavailable' ? null : result.trendComparisons.month.delta).toBe(0)
+  })
+
+  it('computes week-over-week and day-over-day comparisons from the same commit history', () => {
+    const result = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 90,
+      commitTimestamps: [
+        '2026-04-19T10:00:00.000Z',
+        '2026-04-18T10:00:00.000Z',
+        '2026-04-17T10:00:00.000Z',
+        '2026-04-16T10:00:00.000Z',
+        '2026-04-15T10:00:00.000Z',
+        '2026-04-14T10:00:00.000Z',
+        '2026-04-13T10:00:00.000Z',
+        '2026-04-12T10:00:00.000Z',
+        '2026-04-11T10:00:00.000Z',
+      ],
+    })
+
+    expect(result.trendComparisons).not.toBe('unavailable')
+    if (result.trendComparisons === 'unavailable') return
+
+    expect(result.trendComparisons.week.currentPeriodCommitCount).toBe(6)
+    expect(result.trendComparisons.week.previousPeriodCommitCount).toBe(3)
+    expect(result.trendComparisons.week.direction).toBe('accelerating')
+    expect(result.trendComparisons.day.currentPeriodCommitCount).toBe(1)
+    expect(result.trendComparisons.day.previousPeriodCommitCount).toBe(1)
+    expect(result.trendComparisons.day.direction).toBe('flat')
+  })
+
+  it('uses complete UTC days for day-over-day comparisons and keeps unavailable modes explicit', () => {
+    const result = buildActivityCadenceMetrics({
+      now: NOW,
+      windowDays: 90,
+      commitTimestamps: [
+        '2026-04-10T08:00:00.000Z',
+        '2026-04-05T08:00:00.000Z',
+      ],
+    })
+
+    expect(result.trendComparisons).not.toBe('unavailable')
+    if (result.trendComparisons === 'unavailable') return
+
+    expect(result.trendComparisons.day.currentPeriodCommitCount).toBe(0)
+    expect(result.trendComparisons.day.previousPeriodCommitCount).toBe(0)
+    expect(result.trendComparisons.day.delta).toBe('unavailable')
+    expect(result.trendComparisons.day.direction).toBe('unavailable')
+    expect(result.trendComparisons.week.direction).toBe('decelerating')
+  })
+})

--- a/lib/activity/cadence.ts
+++ b/lib/activity/cadence.ts
@@ -1,0 +1,153 @@
+import type { ActivityCadenceMetrics, ActivityWindowDays, TrendComparisonMetrics, TrendComparisonMode, Unavailable } from '@/lib/analyzer/analysis-result'
+
+export interface BuildCadenceInput {
+  commitTimestamps: string[]
+  now: Date
+  windowDays: ActivityWindowDays
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+const TREND_FLAT_DELTA = 0.05
+const TREND_MODE_DAYS: Record<Exclude<TrendComparisonMode, 'day'>, number> = {
+  month: 30,
+  week: 7,
+}
+
+export function buildActivityCadenceMetrics({ commitTimestamps, now, windowDays }: BuildCadenceInput): ActivityCadenceMetrics {
+  const allTimestamps = commitTimestamps
+    .map((value) => Date.parse(value))
+    .filter((value) => Number.isFinite(value) && value <= now.getTime())
+    .sort((a, b) => a - b)
+  const windowStart = new Date(now.getTime() - windowDays * MS_PER_DAY)
+  const timestamps = allTimestamps.filter((value) => value >= windowStart.getTime())
+
+  if (timestamps.length === 0) {
+    return unavailableCadence()
+  }
+
+  const totalWeeks = Math.ceil(windowDays / 7)
+  const weeklyCommitCounts = Array.from({ length: totalWeeks }, () => 0)
+  const weekendCommitCount = timestamps.filter((value) => isWeekend(value)).length
+  const weekdayCommitCount = timestamps.length - weekendCommitCount
+
+  for (const timestamp of timestamps) {
+    const bucket = Math.min(totalWeeks - 1, Math.floor((timestamp - windowStart.getTime()) / (7 * MS_PER_DAY)))
+    weeklyCommitCounts[Math.max(0, bucket)] += 1
+  }
+
+  const activeWeekCount = weeklyCommitCounts.filter((count) => count > 0).length
+  const activeWeeksRatio = activeWeekCount / totalWeeks
+  const commitRegularity = computeCoefficientOfVariation(weeklyCommitCounts)
+  const longestGapDays = timestamps.length >= 2 ? computeLongestGapDays(timestamps) : 'unavailable'
+  const weekendToWeekdayRatio =
+    weekdayCommitCount > 0 ? weekendCommitCount / weekdayCommitCount : weekendCommitCount > 0 ? weekendCommitCount : 'unavailable'
+
+  return {
+    totalWeeks,
+    weeklyCommitCounts,
+    activeWeeksRatio,
+    commitRegularity,
+    longestGapDays,
+    weekendToWeekdayRatio,
+    weekendCommitCount,
+    weekdayCommitCount,
+    trendComparisons: buildTrendComparisons(allTimestamps, now),
+  }
+}
+
+function unavailableCadence(): ActivityCadenceMetrics {
+  return {
+    totalWeeks: 'unavailable',
+    weeklyCommitCounts: 'unavailable',
+    activeWeeksRatio: 'unavailable',
+    commitRegularity: 'unavailable',
+    longestGapDays: 'unavailable',
+    weekendToWeekdayRatio: 'unavailable',
+    weekendCommitCount: 'unavailable',
+    weekdayCommitCount: 'unavailable',
+    trendComparisons: 'unavailable',
+  }
+}
+
+function computeCoefficientOfVariation(values: number[]): number | Unavailable {
+  if (values.length === 0) return 'unavailable'
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length
+  if (mean <= 0) return 'unavailable'
+  const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / values.length
+  return Math.sqrt(variance) / mean
+}
+
+function computeLongestGapDays(timestamps: number[]): number {
+  let longest = 0
+  for (let index = 1; index < timestamps.length; index += 1) {
+    const gap = Math.round((timestamps[index]! - timestamps[index - 1]!) / MS_PER_DAY)
+    if (gap > longest) longest = gap
+  }
+  return longest
+}
+
+function buildTrendComparisons(
+  timestamps: number[],
+  now: Date,
+): Record<TrendComparisonMode, TrendComparisonMetrics> {
+  return {
+    month: buildRollingTrendComparison(timestamps, now, TREND_MODE_DAYS.month),
+    week: buildRollingTrendComparison(timestamps, now, TREND_MODE_DAYS.week),
+    day: buildDayTrendComparison(timestamps, now),
+  }
+}
+
+function buildRollingTrendComparison(
+  timestamps: number[],
+  now: Date,
+  periodDays: number,
+): TrendComparisonMetrics {
+  const currentStart = now.getTime() - periodDays * MS_PER_DAY
+  const previousStart = now.getTime() - periodDays * 2 * MS_PER_DAY
+  const currentPeriodCommitCount = countCommitsInRange(timestamps, currentStart, now.getTime() + 1)
+  const previousPeriodCommitCount = countCommitsInRange(timestamps, previousStart, currentStart)
+  return buildTrendComparisonMetrics(currentPeriodCommitCount, previousPeriodCommitCount)
+}
+
+function buildDayTrendComparison(timestamps: number[], now: Date): TrendComparisonMetrics {
+  const currentDayEnd = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const currentDayStart = currentDayEnd - MS_PER_DAY
+  const previousDayStart = currentDayStart - MS_PER_DAY
+  const currentPeriodCommitCount = countCommitsInRange(timestamps, currentDayStart, currentDayEnd)
+  const previousPeriodCommitCount = countCommitsInRange(timestamps, previousDayStart, currentDayStart)
+  return buildTrendComparisonMetrics(currentPeriodCommitCount, previousPeriodCommitCount)
+}
+
+function countCommitsInRange(timestamps: number[], startInclusive: number, endExclusive: number): number {
+  return timestamps.filter((timestamp) => timestamp >= startInclusive && timestamp < endExclusive).length
+}
+
+function buildTrendComparisonMetrics(
+  currentPeriodCommitCount: number,
+  previousPeriodCommitCount: number,
+): TrendComparisonMetrics {
+  const delta = computeTrendDelta(currentPeriodCommitCount, previousPeriodCommitCount)
+  return {
+    currentPeriodCommitCount,
+    previousPeriodCommitCount,
+    delta,
+    direction: computeTrendDirection(delta),
+  }
+}
+
+function computeTrendDelta(current: number, previous: number): number | Unavailable {
+  if (current === 0 && previous === 0) return 'unavailable'
+  if (previous === 0) return current > 0 ? 1 : 'unavailable'
+  return (current - previous) / previous
+}
+
+function computeTrendDirection(delta: number | Unavailable): TrendComparisonMetrics['direction'] {
+  if (delta === 'unavailable') return 'unavailable'
+  if (Math.abs(delta) <= TREND_FLAT_DELTA) return 'flat'
+  return delta > 0 ? 'accelerating' : 'decelerating'
+}
+
+function isWeekend(timestamp: number): boolean {
+  const day = new Date(timestamp).getUTCDay()
+  return day === 0 || day === 6
+}

--- a/lib/activity/view-model.test.ts
+++ b/lib/activity/view-model.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { buildDevelopmentCadenceCard } from './view-model'
+
+function buildResult(overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo: 'facebook/react',
+    name: 'react',
+    description: 'A UI library',
+    createdAt: '2013-05-24T16:15:54Z',
+    primaryLanguage: 'TypeScript',
+    stars: 100,
+    forks: 25,
+    watchers: 10,
+    commits30d: 7,
+    commits90d: 18,
+    releases12mo: 6,
+    prsOpened90d: 4,
+    prsMerged90d: 3,
+    issuesOpen: 5,
+    issuesClosed90d: 6,
+    uniqueCommitAuthors90d: 'unavailable',
+    totalContributors: 'unavailable',
+    maintainerCount: 'unavailable',
+    commitCountsByAuthor: 'unavailable',
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    issueFirstResponseTimestamps: 'unavailable',
+    issueCloseTimestamps: 'unavailable',
+    prMergeTimestamps: 'unavailable',
+    documentationResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}
+
+describe('buildDevelopmentCadenceCard', () => {
+  it('formats cadence metrics for the activity card', () => {
+    const card = buildDevelopmentCadenceCard(
+      buildResult({
+        activityCadenceByWindow: {
+          30: {
+            totalWeeks: 5,
+            weeklyCommitCounts: [1, 0, 1, 2, 0],
+            activeWeeksRatio: 0.6,
+            commitRegularity: 0.4,
+            longestGapDays: 52,
+            weekendToWeekdayRatio: 0.5,
+            weekendCommitCount: 2,
+            weekdayCommitCount: 4,
+            trendComparisons: {
+              month: { currentPeriodCommitCount: 6, previousPeriodCommitCount: 3, delta: 1, direction: 'accelerating' },
+              week: { currentPeriodCommitCount: 4, previousPeriodCommitCount: 2, delta: 1, direction: 'accelerating' },
+              day: { currentPeriodCommitCount: 1, previousPeriodCommitCount: 0, delta: 1, direction: 'accelerating' },
+            },
+          },
+        },
+      }),
+      30,
+    )
+
+    expect(card?.chartBars).toHaveLength(5)
+    expect(card?.activeWeeksValue).toBe('60%')
+    expect(card?.longestGapValue).toBe('52 days')
+    expect(card?.longestGapHighlighted).toBe(true)
+    expect(card?.weekendWeekdayValue).toBe('33% weekend')
+    expect(card?.defaultTrendMode).toBe('month')
+    expect(card?.trendModes.month.label).toBe('Month over month')
+    expect(card?.trendModes.month.trendLabel).toBe('Accelerating')
+    expect(card?.trendModes.month.trendDeltaValue).toBe('+100%')
+    expect(card?.trendModes.month.currentPeriodValue).toBe('6')
+    expect(card?.trendModes.month.previousPeriodValue).toBe('3')
+  })
+
+  it('returns null when cadence data is absent', () => {
+    expect(buildDevelopmentCadenceCard(buildResult(), 30)).toBeNull()
+  })
+})

--- a/lib/activity/view-model.ts
+++ b/lib/activity/view-model.ts
@@ -1,6 +1,14 @@
-import { type ActivityWindowDays, ACTIVITY_WINDOW_DAYS, type AnalysisResult, type Unavailable } from '@/lib/analyzer/analysis-result'
+import {
+  type ActivityCadenceMetrics,
+  type ActivityWindowDays,
+  ACTIVITY_WINDOW_DAYS,
+  type AnalysisResult,
+  type TrendComparisonMetrics,
+  type TrendComparisonMode,
+  type Unavailable,
+} from '@/lib/analyzer/analysis-result'
 import { getMergeRateGuidance } from './merge-rate-guidance'
-import { formatPercentileLabel, getCalibrationForStars, interpolatePercentile } from '@/lib/scoring/config-loader'
+import { ACTIVITY_LONG_GAP_ALERT_DAYS, formatPercentileLabel, getCalibrationForStars, interpolatePercentile } from '@/lib/scoring/config-loader'
 
 export interface ActivityCardLine {
   label: string
@@ -18,6 +26,38 @@ export interface ActivitySectionViewModel {
   repo: string
   cards: ActivityCardViewModel[]
   metrics: ReturnType<typeof getWindowMetrics>
+  cadence: DevelopmentCadenceCardViewModel | null
+}
+
+export interface WeeklyCommitBar {
+  weekLabel: string
+  commitCount: number
+  isActive: boolean
+}
+
+export interface DevelopmentCadenceCardViewModel {
+  repo: string
+  chartBars: WeeklyCommitBar[] | null
+  regularityLabel: 'High consistency' | 'Moderate consistency' | 'Bursty' | 'Insufficient verified public data'
+  regularityPercentileLabel: string | null
+  activeWeeksValue: string
+  activeWeeksPercentileLabel: string | null
+  longestGapValue: string
+  longestGapHighlighted: boolean
+  weekendWeekdayValue: string
+  defaultTrendMode: TrendComparisonMode
+  trendModes: Record<TrendComparisonMode, TrendComparisonViewModel>
+}
+
+export interface TrendComparisonViewModel {
+  label: string
+  helperText: string
+  trendLabel: 'Accelerating' | 'Decelerating' | 'Flat' | 'Insufficient verified public data'
+  trendDeltaValue: string | null
+  currentPeriodLabel: string
+  currentPeriodValue: string
+  previousPeriodLabel: string
+  previousPeriodValue: string
 }
 
 export function getActivityWindowOptions() {
@@ -35,8 +75,47 @@ export function buildActivitySections(results: AnalysisResult[], windowDays: Act
       repo: result.repo,
       cards: buildCards(metrics, result.stars),
       metrics,
+      cadence: buildDevelopmentCadenceCard(result, windowDays),
     }
   })
+}
+
+export function buildDevelopmentCadenceCard(
+  result: AnalysisResult,
+  windowDays: ActivityWindowDays,
+): DevelopmentCadenceCardViewModel | null {
+  const cadence = result.activityCadenceByWindow?.[windowDays]
+  if (!cadence) return null
+
+  const calibration = getCalibrationForStars(result.stars)
+  const activeWeeksPercentile =
+    typeof cadence.activeWeeksRatio === 'number' && calibration.activeWeeksRatio
+      ? interpolatePercentile(cadence.activeWeeksRatio, calibration.activeWeeksRatio)
+      : null
+  const regularityPercentile =
+    typeof cadence.commitRegularity === 'number' && calibration.commitRegularity
+      ? interpolatePercentile(cadence.commitRegularity, calibration.commitRegularity, true)
+      : null
+
+  return {
+    repo: result.repo,
+    chartBars: Array.isArray(cadence.weeklyCommitCounts)
+      ? cadence.weeklyCommitCounts.map((commitCount, index) => ({
+          weekLabel: `W${index + 1}`,
+          commitCount,
+          isActive: commitCount > 0,
+        }))
+      : null,
+    regularityLabel: formatRegularityLabel(regularityPercentile, cadence.commitRegularity),
+    regularityPercentileLabel: regularityPercentile === null ? null : formatPercentileLabel(regularityPercentile),
+    activeWeeksValue: formatPercent(cadence.activeWeeksRatio),
+    activeWeeksPercentileLabel: activeWeeksPercentile === null ? null : formatPercentileLabel(activeWeeksPercentile),
+    longestGapValue: formatDays(cadence.longestGapDays),
+    longestGapHighlighted: typeof cadence.longestGapDays === 'number' && cadence.longestGapDays >= ACTIVITY_LONG_GAP_ALERT_DAYS,
+    weekendWeekdayValue: formatWeekendWeekday(cadence.weekendCommitCount, cadence.weekdayCommitCount, cadence.weekendToWeekdayRatio),
+    defaultTrendMode: 'month',
+    trendModes: buildTrendModes(cadence.trendComparisons),
+  }
 }
 
 function buildCards(metrics: ReturnType<typeof getWindowMetrics>, stars: number | import('@/lib/analyzer/analysis-result').Unavailable = 'unavailable'): ActivityCardViewModel[] {
@@ -130,3 +209,105 @@ function formatClosureRateWithPercentile(closed: number | Unavailable, opened: n
   return `${raw} (${formatPercentileLabel(p)})`
 }
 
+function formatRegularityLabel(
+  percentile: number | null,
+  rawRegularity: number | Unavailable,
+): DevelopmentCadenceCardViewModel['regularityLabel'] {
+  if (percentile !== null) {
+    if (percentile >= 75) return 'High consistency'
+    if (percentile >= 40) return 'Moderate consistency'
+    return 'Bursty'
+  }
+  if (typeof rawRegularity !== 'number') return 'Insufficient verified public data'
+  if (rawRegularity <= 0.5) return 'High consistency'
+  if (rawRegularity <= 1) return 'Moderate consistency'
+  return 'Bursty'
+}
+
+function formatPercent(value: number | Unavailable): string {
+  if (typeof value !== 'number') return '—'
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value * 100)}%`
+}
+
+function formatDays(value: number | Unavailable): string {
+  if (typeof value !== 'number') return '—'
+  return value === 1 ? '1 day' : `${value} days`
+}
+
+function formatWeekendWeekday(
+  weekendCount: number | Unavailable,
+  weekdayCount: number | Unavailable,
+  ratio: number | Unavailable,
+): string {
+  if (typeof weekendCount !== 'number' || typeof weekdayCount !== 'number' || typeof ratio !== 'number') return '—'
+  const totalCount = weekendCount + weekdayCount
+  if (totalCount <= 0) return '—'
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format((weekendCount / totalCount) * 100)}% weekend`
+}
+
+function formatTrendLabel(value: TrendComparisonMetrics['direction']): TrendComparisonViewModel['trendLabel'] {
+  if (value === 'accelerating') return 'Accelerating'
+  if (value === 'decelerating') return 'Decelerating'
+  if (value === 'flat') return 'Flat'
+  return 'Insufficient verified public data'
+}
+
+function formatTrendDelta(value: number | Unavailable): string | null {
+  if (typeof value !== 'number') return null
+  if (value === 1) return '+100%'
+  return `${value > 0 ? '+' : ''}${Math.round(value * 100)}%`
+}
+
+function buildTrendModes(
+  trendComparisons: ActivityCadenceMetrics['trendComparisons'],
+): Record<TrendComparisonMode, TrendComparisonViewModel> {
+  const fallback: TrendComparisonMetrics = {
+    currentPeriodCommitCount: 'unavailable',
+    previousPeriodCommitCount: 'unavailable',
+    delta: 'unavailable',
+    direction: 'unavailable',
+  }
+
+  return {
+    month: buildTrendModeViewModel(
+      'Month over month',
+      'Compares the latest 30 days with the 30 days immediately before them.',
+      'Last 30 days',
+      'Days 31-60 ago',
+      trendComparisons === 'unavailable' ? fallback : trendComparisons.month,
+    ),
+    week: buildTrendModeViewModel(
+      'Week over week',
+      'Compares the latest 7 days with the 7 days immediately before them.',
+      'Last 7 days',
+      'Days 8-14 ago',
+      trendComparisons === 'unavailable' ? fallback : trendComparisons.week,
+    ),
+    day: buildTrendModeViewModel(
+      'Day over day',
+      'Compares the most recent complete UTC day with the previous complete UTC day.',
+      'Most recent full day',
+      'Previous full day',
+      trendComparisons === 'unavailable' ? fallback : trendComparisons.day,
+    ),
+  }
+}
+
+function buildTrendModeViewModel(
+  label: string,
+  helperText: string,
+  currentPeriodLabel: string,
+  previousPeriodLabel: string,
+  metrics: TrendComparisonMetrics,
+): TrendComparisonViewModel {
+  return {
+    label,
+    helperText,
+    trendLabel: formatTrendLabel(metrics.direction),
+    trendDeltaValue: formatTrendDelta(metrics.delta),
+    currentPeriodLabel,
+    currentPeriodValue: formatMetric(metrics.currentPeriodCommitCount),
+    previousPeriodLabel,
+    previousPeriodValue: formatMetric(metrics.previousPeriodCommitCount),
+  }
+}

--- a/lib/analyzer/analysis-result.ts
+++ b/lib/analyzer/analysis-result.ts
@@ -28,6 +28,27 @@ export interface ActivityWindowMetrics {
   medianTimeToCloseHours: number | Unavailable
 }
 
+export type TrendComparisonMode = 'month' | 'week' | 'day'
+
+export interface TrendComparisonMetrics {
+  currentPeriodCommitCount: number | Unavailable
+  previousPeriodCommitCount: number | Unavailable
+  delta: number | Unavailable
+  direction: 'accelerating' | 'decelerating' | 'flat' | Unavailable
+}
+
+export interface ActivityCadenceMetrics {
+  totalWeeks: number | Unavailable
+  weeklyCommitCounts: number[] | Unavailable
+  activeWeeksRatio: number | Unavailable
+  commitRegularity: number | Unavailable
+  longestGapDays: number | Unavailable
+  weekendToWeekdayRatio: number | Unavailable
+  weekendCommitCount: number | Unavailable
+  weekdayCommitCount: number | Unavailable
+  trendComparisons: Record<TrendComparisonMode, TrendComparisonMetrics> | Unavailable
+}
+
 export interface ResponsivenessMetrics {
   issueFirstResponseMedianHours: number | Unavailable
   issueFirstResponseP90Hours: number | Unavailable
@@ -159,6 +180,8 @@ export interface AnalysisResult {
   experimentalUnattributedAuthors90d: number | Unavailable
   contributorMetricsByWindow?: Record<ContributorWindowDays, ContributorWindowMetrics>
   activityMetricsByWindow?: Record<ActivityWindowDays, ActivityWindowMetrics>
+  activityCadenceByWindow?: Record<ActivityWindowDays, ActivityCadenceMetrics>
+  commitTimestamps365d?: string[] | Unavailable
   responsivenessMetricsByWindow?: Record<ActivityWindowDays, ResponsivenessMetrics>
   responsivenessMetrics?: ResponsivenessMetrics
   staleIssueRatio?: number | Unavailable

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityCadenceMetrics,
   ActivityWindowDays,
   ActivityWindowMetrics,
   AnalysisDiagnostic,
@@ -15,12 +16,13 @@ import type {
   RepositoryFetchFailure,
   Unavailable,
 } from './analysis-result'
-import { CONTRIBUTOR_WINDOW_DAYS } from './analysis-result'
+import { ACTIVITY_WINDOW_DAYS, CONTRIBUTOR_WINDOW_DAYS } from './analysis-result'
 import { queryGitHubGraphQL } from './github-graphql'
 import { fetchContributorCount, fetchMaintainerCount, fetchPublicUserOrganizations, type MaintainerToken } from './github-rest'
 import { REPO_COMMIT_AND_RELEASES_QUERY, REPO_ACTIVITY_COUNTS_QUERY, REPO_COMMIT_HISTORY_PAGE_QUERY, REPO_DISCUSSIONS_PAGE_QUERY, REPO_OVERVIEW_QUERY, REPO_README_BLOB_QUERY, REPO_RESPONSIVENESS_METADATA_QUERY, buildResponsivenessDetailQuery } from './queries'
 import { extractLicensingResult, type LicenseFileInfo } from './extract-licensing'
 import { extractInclusiveNamingResult } from '@/lib/inclusive-naming/checker'
+import { buildActivityCadenceMetrics } from '@/lib/activity/cadence'
 import { detectReleaseHealth } from '@/lib/release-health/detect'
 import type { SecurityResult, DirectSecurityCheck } from '@/lib/security/analysis-result'
 import { fetchScorecardData } from '@/lib/security/scorecard-client'
@@ -582,6 +584,10 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
         commitHistory.nodes,
         overview.data.repository?.issues.totalCount,
       )
+      const commitTimestamps365d = commitHistory.nodes.length > 0
+        ? commitHistory.nodes.map((node) => node.authoredDate)
+        : 'unavailable'
+      const activityCadenceByWindow = buildActivityCadenceByWindow(commitTimestamps365d, now)
       const experimentalOrgAttribution = await buildExperimentalOrganizationCommitCountsByWindow(input.token, commitHistory.nodes, now)
       latestRateLimit = experimentalOrgAttribution.rateLimit ?? latestRateLimit
 
@@ -600,6 +606,8 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
         responsiveness.data,
         contributorMetricsByWindow,
         activityMetricsByWindow,
+        activityCadenceByWindow,
+        commitTimestamps365d,
         contributorCount.data,
         maintainers.data.count,
         maintainers.data.tokens,
@@ -672,6 +680,8 @@ function buildAnalysisResult(
   responsiveness: RepoResponsivenessResponse,
   contributorMetricsByWindow: Record<ContributorWindowDays, ContributorWindowMetrics>,
   activityMetricsByWindow: Record<ActivityWindowDays, ActivityWindowMetrics>,
+  activityCadenceByWindow: Record<ActivityWindowDays, ActivityCadenceMetrics> | undefined,
+  commitTimestamps365d: string[] | Unavailable,
   totalContributorCount: number | Unavailable,
   maintainerCount: number | Unavailable,
   maintainerTokens: MaintainerToken[] | Unavailable,
@@ -790,6 +800,8 @@ function buildAnalysisResult(
       ]),
     ) as Record<ContributorWindowDays, ContributorWindowMetrics>,
     activityMetricsByWindow,
+    activityCadenceByWindow,
+    commitTimestamps365d,
     responsivenessMetricsByWindow,
     responsivenessMetrics,
     staleIssueRatio: activityMetricsByWindow[90].staleIssueRatio,
@@ -838,6 +850,26 @@ function buildAnalysisResult(
     releaseHealthResult: extractReleaseHealthResult(activity, now),
     missingFields,
   }
+}
+
+function buildActivityCadenceByWindow(
+  commitTimestamps365d: string[] | Unavailable,
+  now: Date,
+): Record<ActivityWindowDays, ActivityCadenceMetrics> | undefined {
+  if (!Array.isArray(commitTimestamps365d)) {
+    return undefined
+  }
+
+  return Object.fromEntries(
+    ACTIVITY_WINDOW_DAYS.map((windowDays) => [
+      windowDays,
+      buildActivityCadenceMetrics({
+        commitTimestamps: commitTimestamps365d,
+        now,
+        windowDays,
+      }),
+    ]),
+  ) as Record<ActivityWindowDays, ActivityCadenceMetrics>
 }
 
 function extractReleaseHealthResult(

--- a/lib/analyzer/analyzer.test.ts
+++ b/lib/analyzer/analyzer.test.ts
@@ -170,7 +170,15 @@ describe('analyze', () => {
       issueFirstResponseTimestamps: 'unavailable',
       issueCloseTimestamps: 'unavailable',
       prMergeTimestamps: 'unavailable',
+      commitTimestamps365d: [
+        '2026-03-30T12:00:00Z',
+        '2026-03-29T12:00:00Z',
+        '2026-03-28T12:00:00Z',
+      ],
     })
+    expect(result.results[0]?.activityCadenceByWindow?.[30]).toBeDefined()
+    expect(result.results[0]?.activityCadenceByWindow?.[30]?.weeklyCommitCounts).not.toBe('unavailable')
+    expect(result.results[0]?.activityCadenceByWindow?.[30]?.trendComparisons).not.toBe('unavailable')
     expect(result.results[0]?.missingFields).not.toContain('releases12mo')
     expect(result.results[0]?.missingFields).not.toContain('uniqueCommitAuthors90d')
     expect(result.results[0]?.missingFields).not.toContain('totalContributors')

--- a/lib/scoring/config-loader.ts
+++ b/lib/scoring/config-loader.ts
@@ -27,6 +27,7 @@ export const ACTIVITY_CADENCE_RECENCY_WEIGHT = 0.05
 export const DOCUMENTATION_SEMVER_BONUS = 0.03
 export const DOCUMENTATION_NOTES_BONUS = 0.02
 export const DOCUMENTATION_TAG_PROMOTION_BONUS = 0.02
+export const ACTIVITY_LONG_GAP_ALERT_DAYS = 45
 
 export type BracketKey = 'solo-tiny' | 'solo-small' | 'emerging' | 'growing' | 'established' | 'popular'
 
@@ -69,6 +70,8 @@ export interface BracketCalibration {
   issuesClosedWithoutCommentRatio: PercentileSet
   topContributorShare: PercentileSet
   documentationScore?: PercentileSet
+  activeWeeksRatio?: PercentileSet
+  commitRegularity?: PercentileSet
 }
 
 /**

--- a/specs/73-development-cadence/checklists/requirements.md
+++ b/specs/73-development-cadence/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Development Cadence
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec aligns with issue #73 by keeping cadence in the Activity tab, adding a regularity readout, percentile-backed active weeks ratio, longest-gap highlighting, and a unified trend module with month-over-month as the default plus selectable week-over-week and day-over-day views.

--- a/specs/73-development-cadence/contracts/development-cadence.md
+++ b/specs/73-development-cadence/contracts/development-cadence.md
@@ -1,0 +1,178 @@
+# Contract: Development Cadence
+
+**Feature**: P2-F10 — Development Cadence (issue #73)  
+**Branch**: `73-development-cadence`
+
+This contract locks the module interfaces that cross analyzer, scoring, and Activity-tab rendering for the revised cadence panel.
+
+---
+
+## 1. Analyzer output — cadence fields on `AnalysisResult`
+
+```ts
+// lib/analyzer/analysis-result.ts
+export type TrendComparisonMode = 'month' | 'week' | 'day'
+
+export interface TrendComparisonMetrics {
+  currentPeriodCommitCount: number | Unavailable
+  previousPeriodCommitCount: number | Unavailable
+  delta: number | Unavailable
+  direction: 'accelerating' | 'decelerating' | 'flat' | Unavailable
+}
+
+export interface ActivityCadenceMetrics {
+  totalWeeks: number | Unavailable
+  weeklyCommitCounts: number[] | Unavailable
+  activeWeeksRatio: number | Unavailable
+  commitRegularity: number | Unavailable
+  longestGapDays: number | Unavailable
+  weekendToWeekdayRatio: number | Unavailable
+  weekendCommitCount: number | Unavailable
+  weekdayCommitCount: number | Unavailable
+  trendComparisons: Record<TrendComparisonMode, TrendComparisonMetrics> | Unavailable
+}
+
+export interface AnalysisResult {
+  // ...existing fields...
+  commitTimestamps365d?: string[] | Unavailable
+  activityCadenceByWindow?: Record<ActivityWindowDays, ActivityCadenceMetrics>
+}
+```
+
+**Contract**:
+
+- Fresh analyses emit either a cadence object or per-field `'unavailable'`; older fixtures may still leave cadence fields `undefined`.
+- `weeklyCommitCounts` always includes zero-commit weeks when present.
+- `trendComparisons` contains exactly the three approved modes (`month`, `week`, `day`) when present.
+
+---
+
+## 2. Pure cadence derivation — `lib/activity/cadence.ts`
+
+```ts
+export interface BuildCadenceInput {
+  commitTimestamps: string[]
+  now: Date
+  windowDays: ActivityWindowDays
+}
+
+export function buildActivityCadenceMetrics(input: BuildCadenceInput): ActivityCadenceMetrics
+```
+
+**Contract**:
+
+- Pure function: no network, no `Date.now()` reads, no UI dependencies.
+- Input timestamps may be unsorted; implementation normalizes to chronological order.
+- Returns per-field `'unavailable'` when the selected window lacks sufficient verified commits for a cadence metric or trend mode.
+- Day-over-day uses complete UTC days only; the in-progress current day is excluded.
+
+---
+
+## 3. Calibration contract — `lib/scoring/config-loader.ts`
+
+```ts
+export interface BracketCalibration {
+  // ...existing fields...
+  activeWeeksRatio: PercentileSet
+  commitRegularity: PercentileSet
+}
+
+export const ACTIVITY_LONG_GAP_ALERT_DAYS: number
+```
+
+**Contract**:
+
+- `activeWeeksRatio` percentiles are interpreted normally (higher is healthier).
+- `commitRegularity` percentiles are interpreted with `inverted = true` because lower dispersion is healthier.
+- `ACTIVITY_LONG_GAP_ALERT_DAYS` is shared config, not hardcoded in components.
+
+---
+
+## 4. Activity view-model contract — `lib/activity/view-model.ts`
+
+```ts
+export interface TrendComparisonViewModel {
+  label: string
+  helperText: string
+  trendLabel: 'Accelerating' | 'Decelerating' | 'Flat' | 'Insufficient verified public data'
+  trendDeltaValue: string | null
+  currentPeriodLabel: string
+  currentPeriodValue: string
+  previousPeriodLabel: string
+  previousPeriodValue: string
+}
+
+export interface DevelopmentCadenceCardViewModel {
+  repo: string
+  chartBars: WeeklyCommitBar[] | null
+  regularityLabel: string
+  regularityPercentileLabel: string | null
+  activeWeeksValue: string
+  activeWeeksPercentileLabel: string | null
+  longestGapValue: string
+  longestGapHighlighted: boolean
+  weekendWeekdayValue: string
+  defaultTrendMode: TrendComparisonMode
+  trendModes: Record<TrendComparisonMode, TrendComparisonViewModel>
+}
+
+export function buildDevelopmentCadenceCard(
+  result: AnalysisResult,
+  windowDays: ActivityWindowDays,
+): DevelopmentCadenceCardViewModel | null
+```
+
+**Contract**:
+
+- Returns `null` only when the feature is completely absent from the analysis result.
+- Unavailable metric values are preformatted for UI consumption and use the same missing-data conventions as the rest of the Activity tab.
+- The default selected trend mode is `month`.
+
+---
+
+## 5. Activity-tab rendering contract — `components/activity/DevelopmentCadenceCard.tsx`
+
+```ts
+interface DevelopmentCadenceCardProps {
+  result: AnalysisResult
+  windowDays: ActivityWindowDays
+}
+```
+
+**Contract**:
+
+- Renders one main weekly cadence visual and one unified trend module.
+- The unified trend module defaults to month-over-month and allows switching to week-over-week and day-over-day.
+- Does not fetch data or derive cadence formulas itself beyond trivial UI state and formatting.
+- Uses the shared missing-data treatment (`—`) rather than raw `"unavailable"` strings.
+
+---
+
+## 6. Calibration script contract — `scripts/calibrate.ts`
+
+The calibration pipeline must emit percentile anchors for:
+
+```ts
+activeWeeksRatio: number | null
+commitRegularity: number | null
+```
+
+**Contract**:
+
+- Metrics are computed from the same verified commit-history source used by the analyzer.
+- Calibration output updates `lib/scoring/calibration-data.json` with the two percentile sets per bracket.
+- If a sampled repo lacks enough commit history, the metric is `null` and excluded from percentile aggregation.
+
+---
+
+## 7. Constitution compliance
+
+| # | Rule | How this contract upholds it |
+|---|---|---|
+| II | Accuracy | All cadence and trend-mode values derive from verified commit timestamps or direct formulas; unavailable states stay explicit |
+| III | Data Sources | No new source beyond GitHub GraphQL and the existing calibration pipeline |
+| IV | Analyzer Boundary | Cadence and trend-mode derivation stay in shared library code; UI consumes a view model |
+| V | CHAOSS | No new score category; Activity is extended in place |
+| VI | Thresholds | Long-gap alerting and percentile anchors live in shared config/calibration data |
+| IX | YAGNI | Only the three approved comparison modes are modeled; no custom range builder or extra trend surfaces are introduced |
+| XI | Testing | Every pure function and view-model contract remains testable before UI wiring |

--- a/specs/73-development-cadence/data-model.md
+++ b/specs/73-development-cadence/data-model.md
@@ -1,0 +1,164 @@
+# Phase 1 Data Model: Development Cadence
+
+**Feature**: P2-F10 — Development Cadence (issue #73)  
+**Branch**: `73-development-cadence`
+
+Flat, diffable shapes per Constitution §IX.5.
+
+---
+
+## `TrendComparisonMode`
+
+User-selectable momentum lens for the unified trend module.
+
+```ts
+export type TrendComparisonMode = 'month' | 'week' | 'day'
+```
+
+Semantics:
+
+- `month` = latest 30 days versus the immediately preceding 30 days
+- `week` = latest 7 days versus the immediately preceding 7 days
+- `day` = most recent complete UTC day versus the immediately preceding complete UTC day
+
+---
+
+## `TrendComparisonMetrics`
+
+Normalized per-mode trend payload derived from verified commit timestamps.
+
+```ts
+export interface TrendComparisonMetrics {
+  currentPeriodCommitCount: number | Unavailable
+  previousPeriodCommitCount: number | Unavailable
+  delta: number | Unavailable
+  direction: 'accelerating' | 'decelerating' | 'flat' | Unavailable
+}
+```
+
+Rules:
+
+- `delta = (current - previous) / previous` when `previous > 0`
+- `delta = 1` when `previous = 0` and `current > 0`
+- all fields are `unavailable` when the selected mode lacks sufficient verified data
+- `flat` uses the existing cadence tolerance for materially equal periods
+
+---
+
+## `ActivityCadenceMetrics`
+
+Optional field on `AnalysisResult` capturing cadence-specific raw and derived signals for the Activity tab.
+
+```ts
+export type Unavailable = 'unavailable'
+
+export interface ActivityCadenceMetrics {
+  totalWeeks: number | Unavailable
+  weeklyCommitCounts: number[] | Unavailable
+  activeWeeksRatio: number | Unavailable
+  commitRegularity: number | Unavailable
+  longestGapDays: number | Unavailable
+  weekendToWeekdayRatio: number | Unavailable
+  weekendCommitCount: number | Unavailable
+  weekdayCommitCount: number | Unavailable
+  trendComparisons: Record<TrendComparisonMode, TrendComparisonMetrics> | Unavailable
+}
+```
+
+`AnalysisResult` keeps:
+
+```ts
+activityCadenceByWindow?: Record<ActivityWindowDays, ActivityCadenceMetrics>
+commitTimestamps365d?: string[] | Unavailable
+```
+
+- `commitTimestamps365d` remains the verified source of truth for recomputing cadence windows.
+- `trendComparisons` replaces the single 30-day trend summary with mode-specific summaries kept inside each cadence object.
+
+---
+
+## `CadencePercentileSummary`
+
+Derived percentile context attached to the Activity view model rather than stored in raw analyzer output.
+
+```ts
+export interface CadencePercentileSummary {
+  activeWeeksPercentile: number | null
+  regularityPercentile: number | null
+  longestGapOutlier: boolean
+}
+```
+
+Rules:
+
+- `activeWeeksPercentile` uses direct interpolation against bracket calibration
+- `regularityPercentile` uses inverted interpolation because lower dispersion is better
+- `longestGapOutlier` is `true` when `longestGapDays >= ACTIVITY_LONG_GAP_ALERT_DAYS`
+
+---
+
+## `TrendComparisonViewModel`
+
+Presentation-ready summary for one momentum mode.
+
+```ts
+export interface TrendComparisonViewModel {
+  label: string
+  helperText: string
+  trendLabel: 'Accelerating' | 'Decelerating' | 'Flat' | 'Insufficient verified public data'
+  trendDeltaValue: string | null
+  currentPeriodLabel: string
+  currentPeriodValue: string
+  previousPeriodLabel: string
+  previousPeriodValue: string
+}
+```
+
+This keeps mode-specific copy, labels, and formatted values out of the component implementation.
+
+---
+
+## `DevelopmentCadenceCardViewModel`
+
+UI-facing shape consumed by the Activity-tab cadence card.
+
+```ts
+export interface WeeklyCommitBar {
+  weekLabel: string
+  commitCount: number
+  isActive: boolean
+}
+
+export interface DevelopmentCadenceCardViewModel {
+  repo: string
+  chartBars: WeeklyCommitBar[] | null
+  regularityLabel: 'High consistency' | 'Moderate consistency' | 'Bursty' | 'Insufficient verified public data'
+  regularityPercentileLabel: string | null
+  activeWeeksValue: string
+  activeWeeksPercentileLabel: string | null
+  longestGapValue: string
+  longestGapHighlighted: boolean
+  weekendWeekdayValue: string
+  defaultTrendMode: TrendComparisonMode
+  trendModes: Record<TrendComparisonMode, TrendComparisonViewModel>
+}
+```
+
+The card remains presentation-ready, but the trend area now exposes one formatted view model per approved mode plus the default selected mode.
+
+---
+
+## State classification rules
+
+- **Unavailable cadence object**:
+  - no verified commit timestamps in the selected Activity window
+- **Unavailable longest gap**:
+  - fewer than 2 verified commits in the selected window
+- **Unavailable weekend ratio**:
+  - zero verified commits in the selected window
+- **Unavailable trend mode**:
+  - the selected mode has no verifiable commits in either compared period
+- **Flat trend**:
+  - both periods are verifiable and materially equal under the cadence trend tolerance
+- **Insufficient verified public data**:
+  - cadence readout or selected trend mode cannot be computed because the required raw cadence inputs are unavailable

--- a/specs/73-development-cadence/plan.md
+++ b/specs/73-development-cadence/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Development Cadence
+
+**Branch**: `73-development-cadence` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/73-development-cadence/spec.md`
+
+## Summary
+
+Revise the existing Development Cadence panel so the current split trend presentation becomes one unified momentum module. The module will default to month-over-month comparison, expose week-over-week and day-over-day modes from the same verified commit-history source, and keep the analyzer, view-model, and Activity UI aligned without introducing a new navigation surface or speculative abstractions.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18, Next.js App Router  
+**Primary Dependencies**: Next.js, React, Tailwind CSS, Vitest, React Testing Library, Playwright  
+**Storage**: N/A (stateless, derived from verified GitHub commit timestamps already present in analysis results)  
+**Testing**: Vitest, React Testing Library, Playwright  
+**Target Platform**: Web app in modern desktop/mobile browsers  
+**Project Type**: Next.js web application with a framework-agnostic analyzer module  
+**Performance Goals**: Trend mode changes stay local to the rendered analysis result and do not trigger a new analysis request  
+**Constraints**: Verified GitHub data only; unavailable stays explicit; analyzer remains framework-agnostic; no new top-level tab; no hardcoded thresholds in components; keep the design bounded to the three approved comparison modes  
+**Scale/Scope**: One cadence panel per analyzed repository, one weekly rhythm chart, and one unified trend module with month/week/day modes derived from the same recent commit-history window
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **II. Accuracy Policy — PASS**: All planned trend modes derive only from verified commit timestamps already captured for cadence; missing or partial periods remain `unavailable`.
+- **III. Data Source Rules — PASS**: No new source is introduced; the design stays on GitHub GraphQL-derived commit history.
+- **IV. Analyzer Module Boundary — PASS**: Trend comparison derivation remains in shared activity/analyzer code, while the UI consumes formatted view-model output.
+- **VI. Scoring Thresholds — PASS**: Existing long-gap/config behavior remains in shared config; no new inline scoring thresholds are introduced.
+- **IX. Feature Scope / YAGNI — PASS**: The revision is limited to replacing the split trend area with one module and adding only the three spec-approved comparison modes.
+- **XI. Testing — PASS**: The plan keeps TDD at analyzer, view-model, component, and Activity flow layers.
+
+**Post-Design Re-check**: PASS — the Phase 1 artifacts below keep trend-mode logic in the cadence domain model and contracts, with no constitution violations introduced by the revised scope.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/73-development-cadence/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── development-cadence.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+components/
+└── activity/
+    ├── ActivityView.tsx
+    ├── ActivityView.test.tsx
+    ├── DevelopmentCadenceCard.tsx
+    ├── DevelopmentCadenceCard.test.tsx
+    └── development-cadence-chart.tsx
+
+e2e/
+└── activity.spec.ts
+
+lib/
+├── activity/
+│   ├── cadence.ts
+│   ├── cadence.test.ts
+│   ├── view-model.ts
+│   └── view-model.test.ts
+├── analyzer/
+│   └── analysis-result.ts
+└── scoring/
+    └── config-loader.ts
+```
+
+**Structure Decision**: Keep the current single-project Next.js structure. Revise the shared cadence domain files in `lib/activity/` to model selectable trend comparisons, then thread the new view-model shape through `components/activity/` and the existing Activity tests.
+
+## Complexity Tracking
+
+No constitution exceptions or extra complexity waivers are required for this revision.

--- a/specs/73-development-cadence/quickstart.md
+++ b/specs/73-development-cadence/quickstart.md
@@ -1,0 +1,81 @@
+# Quickstart: Development Cadence (P2-F10 / #73)
+
+One-page implementation map for a developer picking up the revised cadence scope mid-flight.
+
+---
+
+## What ships
+
+1. A **Development Cadence** section inside the existing Activity tab.
+2. Five cadence metrics:
+   - commit regularity
+   - active weeks ratio
+   - longest gap
+   - weekend-to-weekday ratio
+   - recent velocity trend
+3. A weekly commit-rhythm visual that makes steady versus bursty development obvious.
+4. One unified trend module that combines:
+   - trend direction
+   - delta
+   - the two compared period totals
+   - selectable comparison modes
+5. Three trend modes:
+   - month-over-month (default)
+   - week-over-week
+   - day-over-day
+6. Calibration-backed percentile context for:
+   - active weeks ratio
+   - cadence regularity
+7. Long-gap highlighting via shared config threshold.
+
+## What does NOT ship
+
+- A new top-level tab
+- A new composite score or CHAOSS category
+- Recommendations driven by cadence signals
+- Custom comparison ranges or arbitrary date pickers
+- Export, comparison, or org-aggregation cadence surfaces in this slice
+- Percentile ranking for weekend-to-weekday ratio
+
+---
+
+## Directory walk (implementation order)
+
+1. `lib/analyzer/analysis-result.ts` — replace the single trend fields with nested per-mode comparison shapes.
+2. `lib/activity/cadence.test.ts` — write red tests for month/week/day comparisons, including complete-day behavior and per-mode unavailable states.
+3. `lib/activity/cadence.ts` — implement shared period-comparison derivation and embed it in each cadence object.
+4. `lib/activity/view-model.test.ts` — write red tests for default mode selection and mode-specific labels/values.
+5. `lib/activity/view-model.ts` — expose a unified trend view-model instead of disconnected trend/count fields.
+6. `components/activity/DevelopmentCadenceCard.test.tsx` — write red UI tests for the merged trend module, selector behavior, and updated copy/tooltips.
+7. `components/activity/DevelopmentCadenceCard.tsx` — replace the split trend area with a single mode-switching module.
+8. `components/activity/ActivityView.test.tsx` — confirm cadence remains wired cleanly inside the Activity tab.
+9. `e2e/activity.spec.ts` — extend Activity coverage for default month mode and local switching between trend modes.
+
+---
+
+## Gotchas
+
+- **Month stays the default**: week/day are alternate lenses, not the opening state.
+- **Day-over-day uses complete UTC days**: do not compare against the in-progress current day.
+- **Mode switching is local UI state**: it should not rerun analysis or interfere with the Activity window selector.
+- **Unavailable stays mode-specific**: one unavailable mode must not borrow counts or deltas from another.
+- **Use the shared missing-data treatment**: UI should render `—`, not raw `"unavailable"`.
+
+---
+
+## Testing rubric
+
+- **Unit (Vitest)**:
+  - `lib/activity/cadence.ts`
+  - `lib/activity/view-model.ts`
+- **Component (Vitest + RTL)**:
+  - `DevelopmentCadenceCard`
+  - `ActivityView`
+- **E2E (Playwright)**:
+  - `e2e/activity.spec.ts` extended to assert the default month view and local mode switching
+
+---
+
+## Release sequencing
+
+This remains one Phase 2 PR on `73-development-cadence`. On completion, `docs/DEVELOPMENT.md` flips `P2-F10` to `✅ Done`.

--- a/specs/73-development-cadence/research.md
+++ b/specs/73-development-cadence/research.md
@@ -1,0 +1,180 @@
+# Phase 0 Research: Development Cadence
+
+**Feature**: P2-F10 — Development Cadence (issue #73)  
+**Branch**: `73-development-cadence`  
+**Date**: 2026-04-20
+
+This document resolves the main design choices required before implementation of the revised trend module.
+
+---
+
+## Q1 — What is the clearest cadence visual for the main rhythm story?
+
+**Context**: The approved spec still requires an at-a-glance rhythm visual that makes steady versus bursty development obvious, even after the trend area is consolidated.
+
+### Decision
+
+**Keep the compact weekly bar-strip visual as the main cadence chart.**
+
+The rhythm chart continues to show one bucket per week across the selected cadence window, while the separate trend area is refactored into a single stronger module rather than overloaded into the weekly chart.
+
+### Rationale
+
+1. **It already answers the right question.** The weekly bars communicate burstiness and consistency better than a line or summary number.
+2. **It avoids chart overload.** The revised feature adds mode selection to the trend module, so the rhythm chart should stay focused on cadence shape.
+3. **It stays aligned with YAGNI.** No new charting system or second full-size chart is needed for the revised scope.
+
+### Alternatives considered
+
+- **Replace the weekly strip with a single momentum chart**: Rejected because it weakens the “steady vs bursty” story required by the cadence spec.
+- **Fold trend modes directly into the weekly chart**: Rejected because mode switching answers a different question than weekly rhythm.
+
+---
+
+## Q2 — How should commit regularity continue to be computed?
+
+**Context**: The revised trend module does not change the regularity requirement, but the plan still needs a stable decision for the core cadence readout.
+
+### Decision
+
+**Keep commit regularity based on the coefficient of variation of weekly commit counts across the selected cadence window.**
+
+### Rationale
+
+1. **It is already spec-aligned and volume-independent.**
+2. **Zero-commit weeks still matter.** They remain essential for distinguishing truly steady work from bursty work.
+3. **No redesign pressure exists here.** The new scope changes trend comparison modes, not regularity semantics.
+
+### Alternatives considered
+
+- **Longest active streak**: Rejected because it hides dispersion across the rest of the window.
+- **Raw standard deviation**: Rejected because it overweights absolute volume.
+
+---
+
+## Q3 — How should the revised trend area be presented?
+
+**Context**: The user wants the existing separate “Trend” tile and adjacent 30-day counts collapsed into one more impactful module.
+
+### Decision
+
+**Replace the split trend tile + comparison block with one unified momentum module.**
+
+The module will present:
+
+- the selected comparison mode,
+- the trend direction cue,
+- the signed delta,
+- the two compared period totals,
+- and explanatory labels/tooltips tied to the current mode.
+
+### Rationale
+
+1. **The current split presentation makes users reconcile two surfaces manually.**
+2. **A single module is easier to scan.** The meaning of the percentage and the underlying counts stay together.
+3. **It naturally supports mode switching.** Month/week/day become alternate views of the same momentum concept.
+
+### Alternatives considered
+
+- **Keep the current split layout and only change labels**: Rejected because it does not address the core comprehension problem.
+- **Show trend only as text and leave counts below**: Rejected because it remains visually fragmented.
+
+---
+
+## Q4 — Which trend modes should ship, and what should be the default?
+
+**Context**: The approved spec revision now explicitly includes selectable month-over-month, week-over-week, and day-over-day modes.
+
+### Decision
+
+**Ship exactly three modes: month-over-month (default), week-over-week, and day-over-day.**
+
+- **Month-over-month** compares the latest 30 days to the immediately preceding 30 days.
+- **Week-over-week** compares the latest 7 days to the immediately preceding 7 days.
+- **Day-over-day** compares the most recent complete UTC day to the immediately preceding complete UTC day.
+
+### Rationale
+
+1. **Month-over-month is the broadest and most stable baseline.**
+2. **Week-over-week provides a shorter-term operational view without excessive noise.**
+3. **Day-over-day is intentionally narrow and should be opt-in rather than default.**
+4. **Limiting the set to three modes keeps the UI and data model bounded to the approved contract.**
+
+### Alternatives considered
+
+- **Custom date ranges**: Rejected as feature expansion beyond the approved revision.
+- **Rolling averages**: Rejected because the spec asks for direct period comparisons.
+- **Default week-over-week**: Rejected because it is more volatile and less representative for many repos.
+
+---
+
+## Q5 — How should day-over-day avoid misleading partial-day comparisons?
+
+**Context**: A same-day comparison would fluctuate as the current day is still in progress, which would undermine the accuracy story.
+
+### Decision
+
+**Define day-over-day using complete UTC days only.**
+
+The comparison uses:
+
+- **Current day window**: the most recently completed UTC day
+- **Prior day window**: the UTC day immediately before it
+
+The in-progress current day is excluded from day-over-day trend calculations.
+
+### Rationale
+
+1. **Avoids partial-day noise and mid-day reversals.**
+2. **Preserves a clear, testable formula grounded in verified timestamps.**
+3. **Matches the repo’s accuracy policy by avoiding implicit normalization or extrapolation.**
+
+### Alternatives considered
+
+- **Use “last 24 hours” versus previous 24 hours**: Rejected because it produces moving-window results that are harder to explain in the UI.
+- **Use the current partial day**: Rejected because it creates misleading comparisons early in the day.
+
+---
+
+## Q6 — Where should multi-mode trend data live?
+
+**Context**: The current cadence object stores only one 30-day trend summary. The revised scope needs three parallel comparisons while keeping the analyzer boundary intact.
+
+### Decision
+
+**Model trend comparisons as a nested record inside each `ActivityCadenceMetrics` object, keyed by comparison mode.**
+
+That keeps all cadence-derived momentum data together and lets the view model choose a default mode plus preformatted labels without recomputing formulas in the component.
+
+### Rationale
+
+1. **Keeps trend logic in the domain layer rather than the UI.**
+2. **Reuses the existing per-window cadence object instead of adding disconnected top-level fields.**
+3. **Supports per-mode unavailable states honestly.**
+
+### Alternatives considered
+
+- **Separate top-level trend fields on `AnalysisResult`**: Rejected because they split cadence logic across multiple shapes.
+- **Derive week/day modes directly in the component**: Rejected by the analyzer-boundary rule and would make testing weaker.
+
+---
+
+## Additional implementation decisions
+
+### R7 — Weekend ratio presentation
+
+**Decision**: Keep weekend activity descriptive only and continue separating the user-facing display choice from the underlying verified counts and ratio. The revised trend work does not make weekend activity a scored signal.
+
+### R8 — Missing-data handling for trend modes
+
+**Decision**:
+
+- if both compared periods for a selected mode contain zero verified commits, that mode is `unavailable`
+- if the prior period is zero and the current period is non-zero, delta is treated as `+100%`
+- if one mode is unavailable, the other modes remain selectable and independent
+
+This preserves Constitution §II without borrowing values across modes.
+
+### R9 — UI interaction scope
+
+**Decision**: Trend mode switching is local to the rendered cadence card and does not change the main Activity window selector or trigger a new repository analysis request.

--- a/specs/73-development-cadence/spec.md
+++ b/specs/73-development-cadence/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Development Cadence
+
+**Feature Branch**: `73-development-cadence`
+**Created**: 2026-04-20
+**Status**: Draft
+**Input**: GitHub issue [#73](https://github.com/arun-gupta/repo-pulse/issues/73) — "Add development cadence and consistency metrics", plus branch feedback to unify the trend area and support selectable comparison modes
+**Phase 2 Feature**: P2-F10
+
+## Overview
+
+Commit totals alone can make a repository look healthier than it is. A project that lands 100 commits in one burst and then goes quiet for months appears active by volume, but its development rhythm is fragile and unpredictable. Maintainers and adopters need to see whether work happens steadily, how often activity goes dark, and whether momentum is improving or fading.
+
+This feature extends the existing Activity surface with a dedicated **Development Cadence** panel, a percentile-backed cadence readout, and a stronger trend module that combines the summary signal with the compared-period totals in one place. It focuses on five cadence signals for this slice: commit regularity, active weeks ratio, longest gap between commits, weekend-to-weekday ratio, and recent velocity trend. Together these signals describe whether development is steady, sporadic, accelerating, or stalled.
+
+### Why this belongs in Activity, not a separate top-level tab
+
+Development cadence is a deeper view into commit behavior, which RepoPulse already treats as part of Activity. Surfacing cadence in the Activity tab keeps throughput and consistency together instead of splitting one concept across multiple places. The feature adds new cadence-specific measurements and percentile context without changing the user's primary navigation model.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Cadence metrics visible in the Activity tab (Priority: P1)
+
+A maintainer reviewing a repository can open the Activity tab and immediately see whether work happens steadily or in bursts. The tab shows cadence metrics alongside an at-a-glance visual of recent commit rhythm so the user does not need to infer consistency from raw commit totals alone.
+
+**Why this priority**: Visibility is the core outcome in the issue acceptance criteria. Without a clear Activity-tab presentation, the cadence signals do not help users.
+
+**Independent Test**: Analyze a repository with enough recent commit history, open the Activity tab, and confirm that Development Cadence metrics are shown with raw values, human-readable labels, and a visual trend that makes bursty vs steady patterns obvious.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with verified recent commit history, **When** the user opens the Activity tab, **Then** a Development Cadence section displays commit regularity, active weeks ratio, longest gap, weekend-to-weekday ratio, recent velocity trend, and a visual representation of commit rhythm across the cadence window.
+2. **Given** a repository whose commit activity is concentrated in a small number of weeks, **When** the user opens the Activity tab, **Then** the cadence section's visual representation makes the burst pattern obvious rather than presenting the repository as merely "active."
+3. **Given** a repository with insufficient verified commit history for one or more cadence metrics, **When** the user opens the Activity tab, **Then** each unavailable field is shown as unavailable rather than hidden or replaced with zero.
+
+---
+
+### User Story 2 — Consistency score and unusual gaps are called out clearly (Priority: P1)
+
+A user wants RepoPulse to summarize whether the repository's recent development rhythm is consistent. Instead of making them interpret raw weekly counts themselves, RepoPulse turns cadence inputs into a regularity readout and highlights unusually long maintenance gaps.
+
+**Why this priority**: The issue explicitly asks for a regularity score and for longest gaps to be highlighted when abnormal. Those are the decision-support pieces, not just extra stats.
+
+**Independent Test**: Compare a steady repository and a bursty repository and confirm that the steady one receives a stronger cadence readout while the bursty one is flagged for irregularity or long gaps.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository whose weekly commit counts are relatively even across the analysis window, **When** cadence is computed, **Then** its regularity readout indicates high consistency.
+2. **Given** a repository with several inactive stretches and one or two heavy commit bursts, **When** cadence is computed, **Then** its regularity readout indicates low consistency.
+3. **Given** a repository whose longest inactive period is unusually long relative to peers, **When** the Activity tab renders, **Then** that gap is visually highlighted as an outlier maintenance pause.
+
+---
+
+### User Story 3 — Percentile context shows how cadence compares to peers (Priority: P2)
+
+A maintainer wants to know not just the raw cadence values, but whether those values are strong or weak compared with similar repositories. RepoPulse provides percentile context for cadence metrics so users can benchmark steadiness, not only volume.
+
+**Why this priority**: The issue calls for percentile ranking on active weeks ratio and for calibration data to include cadence metrics. Without peer context, the raw numbers are harder to interpret.
+
+**Independent Test**: Analyze repositories with different activity rhythms and confirm that active weeks ratio and the cadence readout show percentile context that ranks steadier repositories above more sporadic ones.
+
+**Acceptance Scenarios**:
+
+1. **Given** two repositories with similar commit volume but different week-to-week consistency, **When** the user compares their Activity tabs, **Then** the steadier repository receives a stronger cadence percentile outcome.
+2. **Given** a repository with commits in most weeks of the analysis window, **When** the cadence section renders, **Then** active weeks ratio is shown with both the raw ratio and its percentile ranking.
+3. **Given** calibration data does not support a cadence percentile for a metric, **When** the cadence section renders, **Then** the raw metric is still shown and the percentile label is omitted or marked unavailable rather than fabricated.
+
+---
+
+### User Story 4 — Trend module compares momentum across time scales (Priority: P3)
+
+A user wants to know whether the repository is speeding up or losing momentum without mentally stitching together separate cards. RepoPulse presents one unified trend module that defaults to month-over-month momentum and lets the user switch to week-over-week or day-over-day comparisons when they want a shorter-term view.
+
+**Why this priority**: Trend direction is useful context, but the feature still delivers value without it as long as visibility, consistency scoring, and percentile context are present.
+
+**Independent Test**: Analyze repositories with changing recent commit activity, open the Activity tab, and confirm the unified trend module defaults to month-over-month comparison, updates when the user switches comparison mode, and keeps the summary and compared-period values in sync.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository with verified recent commit history, **When** the user opens the Development Cadence panel, **Then** the trend module defaults to a month-over-month comparison and shows both the trend summary and the two compared month windows together.
+2. **Given** a repository whose most recent comparison period is more active than the immediately preceding period, **When** the selected trend mode is evaluated, **Then** the trend is labeled as accelerating and shown with a visual upward trend cue.
+3. **Given** a repository whose most recent comparison period is less active than the immediately preceding period, **When** the selected trend mode is evaluated, **Then** the trend is labeled as decelerating and shown with a visual downward trend cue.
+4. **Given** a user who wants a shorter-term view of momentum, **When** they switch the trend mode from month-over-month to week-over-week or day-over-day, **Then** the trend summary and compared-period values update together to reflect the newly selected mode.
+5. **Given** a repository that lacks enough verified commit history for one of the shorter-term trend modes, **When** the user selects that mode, **Then** that mode shows unavailable rather than reusing another mode's value.
+
+### Edge Cases
+
+- **Very sparse history**: A repository with fewer than two verified commits in the cadence window cannot produce gap or regularity metrics; those fields render as unavailable and the cadence readout falls back to insufficient verified public data if necessary.
+- **Perfectly steady but low-volume work**: A repository with one commit every week should read as highly regular even if the absolute commit volume is modest.
+- **High-volume burst repo**: A repository with many commits in only a handful of weeks should read as irregular despite high total commit counts.
+- **Weekend-heavy automation or volunteer projects**: Weekend-to-weekday ratio is shown as descriptive context and highlighted in the panel, but it must not be framed as inherently positive or negative by itself.
+- **No commits in one comparison period**: Velocity trend still renders if one of the periods is zero and the other is non-zero; it becomes unavailable only when the selected comparison mode lacks enough verified data to determine direction.
+- **Long dormant repositories**: Longest gap can dominate the cadence story; the UI should still show the other cadence metrics instead of collapsing them into a single warning.
+- **Short-term mode noise**: Day-over-day comparisons can change sharply between adjacent days; the UI should still keep month-over-month as the default view so short-term noise does not replace the broader signal.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Cadence signal derivation
+
+- **FR-001**: The system MUST derive a weekly commit-count series from verified public GitHub commit history over a shared cadence analysis window.
+- **FR-002**: The system MUST compute **commit regularity** from the dispersion of weekly commit counts so that steadier week-to-week commit patterns receive a stronger regularity outcome than burstier patterns with the same total volume.
+- **FR-003**: The system MUST compute **active weeks ratio** as the share of weeks in the analysis window that contain at least one verified commit.
+- **FR-004**: The system MUST compute **longest gap** as the largest number of calendar days between consecutive verified commits within the cadence analysis window.
+- **FR-005**: The system MUST compute **weekend-to-weekday ratio** from verified commit timestamps, distinguishing commits made on weekends from those made on weekdays.
+- **FR-006**: The system MUST compute **recent velocity trend** in month-over-month mode by comparing the verified recent 30-day commit rate with the immediately preceding 30-day commit rate.
+- **FR-006a**: The system MUST compute **recent velocity trend** in week-over-week mode by comparing the verified recent 7-day commit rate with the immediately preceding 7-day commit rate.
+- **FR-006b**: The system MUST compute **recent velocity trend** in day-over-day mode by comparing the most recent complete day with the immediately preceding complete day from verified commit history.
+
+#### Activity-tab presentation
+
+- **FR-007**: The Activity tab MUST display a dedicated Development Cadence section for every successfully analyzed repository.
+- **FR-008**: The Development Cadence section MUST show the raw values for commit regularity, active weeks ratio, longest gap, weekend-to-weekday ratio, and recent velocity trend whenever those values are verifiable.
+- **FR-008a**: The Development Cadence section MUST include a visual representation of recent commit rhythm across the cadence analysis window so users can distinguish steady development from bursty development at a glance.
+- **FR-008b**: The recent velocity trend MUST be presented as one unified module that combines the trend summary with the two compared period totals so users do not have to interpret separate areas of the panel.
+- **FR-008c**: The unified trend module MUST default to month-over-month comparison when the Development Cadence section first renders.
+- **FR-008d**: The unified trend module MUST allow the user to switch between month-over-month, week-over-week, and day-over-day comparison modes within the Development Cadence section.
+- **FR-008e**: When the user changes the comparison mode, the trend direction, trend delta, comparison labels, and compared-period totals MUST all update together to reflect the selected mode.
+- **FR-009**: The Development Cadence section MUST surface a cadence regularity readout that communicates whether development is consistent or bursty using a clear ordered scale.
+- **FR-010**: The longest gap metric MUST be visually highlighted when it exceeds the configured threshold for an unusual maintenance pause or when peer calibration places it in an outlier range.
+- **FR-011**: Weekend-to-weekday ratio MUST be highlighted in the Development Cadence section as part of the repository's work-pattern summary, but the system MUST NOT label weekend-heavy development as inherently better or worse on its own.
+
+#### Peer comparison and percentile context
+
+- **FR-012**: Active weeks ratio MUST be shown with percentile context when sufficient calibration data exists for peer comparison.
+- **FR-013**: The cadence regularity readout MUST use calibration-backed peer comparison so that repositories with steadier development rank above repositories with more sporadic development in the same peer set.
+- **FR-014**: Calibration data for development cadence MUST include, at minimum, the metrics needed to percentile-rank active weeks ratio and cadence regularity.
+- **FR-015**: When calibration data is unavailable for a cadence metric, the system MUST continue to display the verified raw metric and mark the percentile context unavailable rather than inventing a percentile.
+
+#### Missing-data behavior and boundaries
+
+- **FR-016**: Every cadence metric displayed or exported by this feature MUST originate from verified public GitHub data or a direct formula over that data, consistent with the constitution's accuracy policy.
+- **FR-017**: When verified data is insufficient to compute a cadence metric, that metric MUST render as `"unavailable"` and MUST NOT be substituted with another activity signal.
+- **FR-017a**: If one trend comparison mode is unavailable while another is verifiable, the unavailable mode MUST remain unavailable and the verifiable mode MUST remain selectable.
+- **FR-018**: When the cadence regularity readout cannot be computed because the required verified inputs are missing, the system MUST display `"Insufficient verified public data"` rather than a score or label.
+- **FR-019**: Development Cadence MUST extend the existing Activity experience; it MUST NOT require a new top-level navigation tab.
+
+### Key Entities *(include if feature involves data)*
+
+- **Cadence analysis window**: The fixed recent time range over which weekly commit counts, active weeks ratio, longest gap, weekend-to-weekday ratio, and recent velocity trend are derived.
+- **Weekly commit series**: The ordered count of verified commits per week inside the cadence analysis window; used to measure regularity and active weeks ratio.
+- **Development cadence metrics**: The five verified cadence outputs for a repository: commit regularity, active weeks ratio, longest gap, weekend-to-weekday ratio, and recent velocity trend.
+- **Cadence regularity readout**: A percentile-backed interpretation of development consistency derived from the cadence metrics and shown in the Activity tab.
+- **Trend comparison mode**: The user-selectable momentum lens for the unified trend module: month-over-month, week-over-week, or day-over-day.
+- **Trend comparison summary**: The combined trend direction, delta, and paired period totals for the currently selected trend comparison mode.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every successful repository analysis shows a Development Cadence section in the Activity tab.
+- **SC-001a**: The Development Cadence section includes an at-a-glance visual that allows a reviewer to distinguish a steady weekly commit pattern from a bursty one without reading only the numeric metrics.
+- **SC-002**: A repository with steadier week-to-week commit activity ranks higher on cadence regularity than a repository with the same total commits concentrated into bursts.
+- **SC-003**: Active weeks ratio is shown with both a raw ratio and percentile context whenever the calibration dataset supports peer comparison.
+- **SC-004**: Repositories whose longest inactive gap falls into an outlier range are visibly flagged in the Activity tab.
+- **SC-005**: Repositories with insufficient verified commit history show cadence fields as unavailable and never display fabricated percentile or score outputs.
+- **SC-006**: The Development Cadence panel defaults to a month-over-month trend view and shows the trend summary and compared-period totals together in a single module for every repository with sufficient verified recent history.
+- **SC-007**: Users can switch between month-over-month, week-over-week, and day-over-day trend modes without leaving the Development Cadence panel, and each mode updates the visible trend interpretation on the same analysis result.
+- **SC-008**: Recent velocity trend correctly distinguishes accelerating and decelerating repositories when consecutive periods in the selected comparison mode have materially different verified commit rates.
+
+## Assumptions
+
+- **Cadence lives inside Activity**: This feature deepens the Activity tab rather than introducing a separate navigation destination.
+- **Fixed analysis window**: A single recent window is used for cadence calculations so weekly consistency metrics are comparable across repositories.
+- **Percentile coverage is selective**: Active weeks ratio and the overall cadence regularity readout are the required percentile-backed outputs; other cadence metrics may remain raw-value-first unless calibration is added.
+- **Weekend ratio is highlighted but informational**: It should be visible in the Cadence panel because it helps characterize project rhythm, but it does not independently define project quality and should not trigger a recommendation by itself.
+- **Month-over-month remains the default**: The panel should open on the broader month-over-month comparison even when shorter-term views are available.
+- **Shorter trend modes reuse the same analysis result**: Switching between month-over-month, week-over-week, and day-over-day compares different verified recent periods from the same analyzed repository rather than requiring a fresh analysis run.
+- **No custom comparison builder**: Users can switch only among the three predefined trend modes in this feature revision.

--- a/specs/73-development-cadence/tasks.md
+++ b/specs/73-development-cadence/tasks.md
@@ -1,0 +1,209 @@
+# Tasks: Development Cadence
+
+**Input**: Design documents from `/specs/73-development-cadence/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: TDD is required for this repo and the feature spec includes independent test criteria for each story.  
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Align existing feature artifacts and fixtures with the revised trend contract
+
+- [x] T001 Update cadence fixture shapes in `lib/analyzer/analysis-result.ts` to replace single trend fields with per-mode trend comparisons
+- [x] T002 [P] Refresh cadence design docs references in `specs/73-development-cadence/quickstart.md` and `specs/73-development-cadence/contracts/development-cadence.md` if implementation details diverge during coding
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core domain changes that block all user stories
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T003 Write red multi-mode cadence derivation tests in `lib/activity/cadence.test.ts`
+- [x] T004 Implement shared month/week/day trend comparison derivation in `lib/activity/cadence.ts`
+- [x] T005 [P] Write red view-model tests for default month mode, mode labels, and unavailable handling in `lib/activity/view-model.test.ts`
+- [x] T006 Update `lib/activity/view-model.ts` to expose the nested unified trend view model and revised weekend display formatting
+
+**Checkpoint**: Cadence domain and view-model support the revised trend contract
+
+---
+
+## Phase 3: User Story 1 - Cadence metrics visible in the Activity tab (Priority: P1) 🎯 MVP
+
+**Goal**: Show a clearer Development Cadence panel with one unified trend module and a more intuitive weekend metric
+
+**Independent Test**: Open the Activity tab for a repo with cadence data and confirm the cadence panel shows the weekly rhythm chart, the `Weekend Flow` value as weekend share, and a single trend module that defaults to month-over-month with matching summary and counts.
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T007 [P] [US1] Add component coverage for the unified month-over-month trend module and weekend-share display in `components/activity/DevelopmentCadenceCard.test.tsx`
+- [x] T008 [P] [US1] Extend Activity tab integration coverage for the revised cadence card copy in `components/activity/ActivityView.test.tsx`
+- [x] T009 [P] [US1] Extend Activity flow assertions for the default month-over-month trend module in `e2e/activity.spec.ts`
+
+### Implementation for User Story 1
+
+- [x] T010 [US1] Update weekend-flow value formatting and trend labels in `lib/activity/view-model.ts`
+- [x] T011 [US1] Replace the split trend tile and comparison block with a unified default month-over-month module in `components/activity/DevelopmentCadenceCard.tsx`
+- [x] T012 [US1] Adjust trend helper copy, tooltip text, and visible labels in `components/activity/DevelopmentCadenceCard.tsx`
+
+**Checkpoint**: User Story 1 is fully functional and testable independently with month-over-month as the default view
+
+---
+
+## Phase 4: User Story 2 - Consistency score and unusual gaps are called out clearly (Priority: P1)
+
+**Goal**: Preserve the existing cadence rhythm, regularity, and long-gap signals while landing the trend redesign safely
+
+**Independent Test**: Compare steady and bursty cadence fixtures and confirm the regularity label, longest-gap highlighting, and weekly rhythm chart still render correctly alongside the new trend module.
+
+### Tests for User Story 2 ⚠️
+
+- [x] T013 [P] [US2] Expand cadence chart and long-gap regression coverage in `components/activity/DevelopmentCadenceCard.test.tsx`
+- [x] T014 [P] [US2] Add cadence-domain regression cases for unchanged regularity and long-gap behavior in `lib/activity/cadence.test.ts`
+
+### Implementation for User Story 2
+
+- [x] T015 [US2] Reconcile `components/activity/development-cadence-chart.tsx` with the revised cadence card so zoom, count toggles, and timeline copy still behave correctly
+- [x] T016 [US2] Preserve long-gap highlighting and regularity presentation in `components/activity/DevelopmentCadenceCard.tsx` after the trend refactor
+
+**Checkpoint**: User Story 2 remains independently testable and the redesigned panel does not regress regularity or gap behavior
+
+---
+
+## Phase 5: User Story 3 - Percentile context shows how cadence compares to peers (Priority: P2)
+
+**Goal**: Keep active-weeks percentile and cadence regularity percentile intact while the trend data shape changes
+
+**Independent Test**: Render cadence data with calibration-backed values and confirm active-weeks and regularity percentile labels still appear correctly with the redesigned trend module.
+
+### Tests for User Story 3 ⚠️
+
+- [x] T017 [P] [US3] Add view-model assertions that percentile context survives the trend-shape revision in `lib/activity/view-model.test.ts`
+- [x] T018 [P] [US3] Add component assertions that percentile labels still render with the redesigned module in `components/activity/DevelopmentCadenceCard.test.tsx`
+
+### Implementation for User Story 3
+
+- [x] T019 [US3] Thread percentile-backed cadence values through the revised `DevelopmentCadenceCardViewModel` in `lib/activity/view-model.ts`
+- [x] T020 [US3] Keep percentile presentation stable in `components/activity/DevelopmentCadenceCard.tsx`
+
+**Checkpoint**: User Story 3 remains independently testable and peer-comparison context is unchanged
+
+---
+
+## Phase 6: User Story 4 - Trend module compares momentum across time scales (Priority: P3)
+
+**Goal**: Let users switch the unified trend module between month-over-month, week-over-week, and day-over-day views without rerunning analysis
+
+**Independent Test**: Open a cadence card with multi-mode trend data, verify month is selected by default, switch to week and day modes, and confirm the direction, delta, labels, and period totals all update together while unavailable modes remain honest.
+
+### Tests for User Story 4 ⚠️
+
+- [x] T021 [P] [US4] Add component interaction tests for switching month/week/day trend modes in `components/activity/DevelopmentCadenceCard.test.tsx`
+- [x] T022 [P] [US4] Add cadence-domain tests for complete-day handling and per-mode unavailable states in `lib/activity/cadence.test.ts`
+- [x] T023 [P] [US4] Extend Activity E2E coverage for local trend-mode switching in `e2e/activity.spec.ts`
+
+### Implementation for User Story 4
+
+- [x] T024 [US4] Add local trend-mode state and selector UI to `components/activity/DevelopmentCadenceCard.tsx`
+- [x] T025 [US4] Implement mode-specific labels, helper text, and inaccessible-state rendering in `components/activity/DevelopmentCadenceCard.tsx`
+- [x] T026 [US4] Ensure `lib/activity/view-model.ts` emits month/week/day comparison labels and values from `trendComparisons`
+
+**Checkpoint**: All approved trend modes are independently functional inside the cadence panel
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup across stories
+
+- [x] T027 [P] Run focused cadence unit/component checks for `lib/activity/cadence.test.ts`, `lib/activity/view-model.test.ts`, `components/activity/DevelopmentCadenceCard.test.tsx`, and `components/activity/ActivityView.test.tsx`
+- [x] T028 [P] Run `npm run lint` and targeted `e2e/activity.spec.ts` validation for the revised cadence panel
+- [x] T029 Update `docs/DEVELOPMENT.md` when P2-F10 is complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Starts immediately
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational completion
+- **Polish (Phase 7)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Foundational and delivers the MVP cadence-panel redesign
+- **US2 (P1)**: Depends on US1’s card refactor because it preserves chart and long-gap behavior around that redesign
+- **US3 (P2)**: Depends on Foundational and can land after US1; it only preserves percentile behavior in the revised view model
+- **US4 (P3)**: Depends on US1 because it extends the unified trend module with additional modes
+
+### Within Each User Story
+
+- Tests MUST be written and fail before implementation
+- Domain changes before component wiring
+- Component wiring before Activity integration and E2E assertions
+
+### Parallel Opportunities
+
+- `T003` and `T005` can proceed in parallel across cadence domain and view-model tests
+- `T007`, `T008`, and `T009` can be written in parallel once Foundational work is stable
+- `T017` and `T018` can run in parallel for percentile preservation
+- `T021`, `T022`, and `T023` can run in parallel for multi-mode trend coverage
+
+---
+
+## Parallel Example: User Story 4
+
+```bash
+# Launch multi-mode trend tests together:
+Task: "Add component interaction tests for switching month/week/day trend modes in components/activity/DevelopmentCadenceCard.test.tsx"
+Task: "Add cadence-domain tests for complete-day handling and per-mode unavailable states in lib/activity/cadence.test.ts"
+Task: "Extend Activity E2E coverage for local trend-mode switching in e2e/activity.spec.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE** the unified default month-over-month module
+
+### Incremental Delivery
+
+1. Finish domain/view-model groundwork
+2. Ship the clearer default month-over-month module
+3. Preserve regularity, gap, and percentile behaviors
+4. Add week-over-week and day-over-day switching
+5. Finish lint, focused tests, and docs
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. One developer handles domain/view-model (`lib/activity/`)
+2. One developer handles cadence card UI/tests (`components/activity/`)
+3. One developer handles Activity E2E coverage (`e2e/activity.spec.ts`)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- Each user story remains independently testable
+- Keep all trend math grounded in verified commit timestamps
+- Do not add custom date-range controls or extra trend surfaces


### PR DESCRIPTION
## Summary
- add a Development Cadence panel to Activity with a weekly rhythm chart, active weeks, longest gap, and Weekend Flow
- replace the split trend surfaces with one unified trend module that defaults to month-over-month and supports week/day switching
- wire cadence metrics into analyzer output, demo fixtures, specs, and regression coverage for the Activity flow

Closes #73

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [x] `DEV_GITHUB_PAT= npm run build`
- [x] `npx playwright test e2e/activity.spec.ts`
- [x] Manual check on `http://127.0.0.1:3011` — signed off by `arun-gupta`
