### PR TITLE
Fix React Compiler purity error in StaleAdminsPanel

### DIFF
--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -559,6 +559,7 @@ function RowDetail({
   admin: StaleAdminRecord
   nextAutoRetryAt: string | null
 }) {
+  const [now] = useState(() => Date.now())
   if (admin.lastActivityAt) {
     return (
       <span className="inline-flex items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
@@ -592,7 +593,7 @@ function RowDetail({
     // When neither is available (ladder exhausted, terminal reason), no
     // countdown is shown and the copy points at Retry.
     const retryAt =
-      admin.retryAvailableAt && Date.parse(admin.retryAvailableAt) > Date.now()
+      admin.retryAvailableAt && Date.parse(admin.retryAvailableAt) > now
         ? admin.retryAvailableAt
         : null
     const countdownAt = retryAt ?? nextAutoRetryAt


### PR DESCRIPTION
## Summary
- Fixes the pre-existing `react-compiler` lint error in `StaleAdminsPanel.tsx` that was blocking `npm run lint` for unrelated PRs (surfaced in #376)
- `Date.now()` was called directly during render in `RowDetail`, violating the React Compiler's purity requirement
- Fix: use `useState(() => Date.now())` lazy initializer to snapshot the current timestamp once on mount — this satisfies the linter since the initializer is not called on every render

Closes #377

## Test plan
- [x] `npm run lint` exits with 0 errors
- [x] Manual: stale-admins panel with an `unavailable` admin still shows the retry countdown correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)