### PR TITLE
fix(#381): hoist repeated "percentile" out of scorecard cells

### DIFF
--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -28,8 +28,9 @@ describe('MetricCard', () => {
     expect(screen.getByText(/20.8% fork rate/i)).toBeInTheDocument()
     expect(screen.getByText(/2.7% watcher rate/i)).toBeInTheDocument()
 
-    // Percentile labels present
-    expect(screen.getAllByText(/\d+\w{2} percentile/).length).toBeGreaterThanOrEqual(3)
+    // Percentile rank header shown once; cells show ordinals only
+    expect(screen.getAllByText('percentile rank').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText(/^\d+\w{2}$/).length).toBeGreaterThanOrEqual(3)
   })
 
   it('shows insufficient data label for scores without data', () => {

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -114,22 +114,29 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
         <p className="text-lg font-bold">{hs.label}</p>
       </div>
 
-      {profileCells.length > 0 ? (
-        <div
-          className={`mt-2 grid grid-cols-1 gap-1.5 sm:grid-cols-3 ${isSolo ? 'opacity-50' : ''}`}
-          title={isSolo ? 'Popularity signals — not health. Dimmed for solo-maintained projects.' : undefined}
-          data-testid={isSolo ? `ecosystem-dimmed-${card.repo}` : undefined}
-        >
-          {profileCells.map((cell) => (
-            <ScorecardCell key={cell.label} {...cell} />
-          ))}
-        </div>
-      ) : null}
-      {scoreCells.length > 0 ? (
-        <div className={`mt-1.5 grid grid-cols-2 gap-1.5 ${SCORECARD_GRID_COLS[scoreCells.length] ?? 'sm:grid-cols-5'}`}>
-          {scoreCells.map((cell) => (
-            <ScorecardCell key={cell.label} {...cell} />
-          ))}
+      {(profileCells.length > 0 || scoreCells.length > 0) ? (
+        <div className="mt-2">
+          <div className="mb-1 flex items-baseline gap-2">
+            <span className="text-[9px] text-slate-400 dark:text-slate-500">percentile rank</span>
+          </div>
+          {profileCells.length > 0 ? (
+            <div
+              className={`grid grid-cols-1 gap-1.5 sm:grid-cols-3 ${isSolo ? 'opacity-50' : ''}`}
+              title={isSolo ? 'Popularity signals — not health. Dimmed for solo-maintained projects.' : undefined}
+              data-testid={isSolo ? `ecosystem-dimmed-${card.repo}` : undefined}
+            >
+              {profileCells.map((cell) => (
+                <ScorecardCell key={cell.label} {...cell} />
+              ))}
+            </div>
+          ) : null}
+          {scoreCells.length > 0 ? (
+            <div className={`mt-1.5 grid grid-cols-2 gap-1.5 ${SCORECARD_GRID_COLS[scoreCells.length] ?? 'sm:grid-cols-5'}`}>
+              {scoreCells.map((cell) => (
+                <ScorecardCell key={cell.label} {...cell} />
+              ))}
+            </div>
+          ) : null}
         </div>
       ) : null}
 
@@ -259,7 +266,7 @@ function ScorecardCell({ label, percentileLabel, detail, tooltip, toneClass, onC
     <>
       <div className="flex items-baseline justify-between gap-1">
         <span className="text-[10px] font-medium uppercase tracking-wide">{label}</span>
-        <span className="text-xs font-semibold">{percentileLabel}</span>
+        <span className="text-xs font-semibold">{percentileLabel.replace(' percentile', '')}</span>
       </div>
       <p className="mt-0.5 text-[10px] opacity-60">{detail ?? '\u00A0'}</p>
     </>


### PR DESCRIPTION
## Summary

- Strips `" percentile"` from each `ScorecardCell` label so cells show ordinals only (e.g. `35th` instead of `35th percentile`)
- Wraps the profile-cells and score-cells grids in a shared section with a single `percentile rank` label above them — consistent with the existing lenses legend (`percentile rank · signals present`)
- Updates the test that previously asserted `\d+\w{2} percentile` in cell text to instead assert the new header and bare ordinals

## Test plan

- [x] All existing `MetricCard` tests pass (`npm run test -- components/metric-cards/MetricCard.test.tsx`)
- [x] No lint errors (`npm run lint -- components/metric-cards/MetricCard.tsx`)
- [x] Scorecard cells show only ordinals ("35th", "91st") — no repeated "percentile" word
- [x] "percentile rank" label appears once above the scorecard grid
- [x] Lenses section still shows its own "percentile rank · signals present" legend unchanged

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)