### PR TITLE
Support alternate good-first-issue labels

### DIFF
--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -225,6 +225,9 @@ interface RepoActivityCountsResponse {
   staleIssues180: SearchCount
   staleIssues365: SearchCount
   goodFirstIssues?: SearchCount
+  goodFirstIssuesHyphenated?: SearchCount
+  goodFirstIssuesBeginner?: SearchCount
+  goodFirstIssuesStarter?: SearchCount
   recentMergedPullRequests: {
     nodes: Array<{
       createdAt: string
@@ -502,7 +505,7 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
         staleIssues90Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore90),
         staleIssues180Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore180),
         staleIssues365Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore365),
-        goodFirstIssueQuery: buildGoodFirstIssueQuery(repoSearch),
+        ...buildGoodFirstIssueQueries(repoSearch),
       }
 
       let activityCounts: RepoActivityCountsResponse
@@ -1295,7 +1298,14 @@ interface OnboardingSignalSet {
 
 export function extractOnboardingSignals(
   repo: RepoOverviewResponse['repository'],
-  activityCounts: Pick<RepoActivityCountsResponse, 'goodFirstIssues' | 'recentMergedPullRequests'> | null,
+  activityCounts: Pick<
+    RepoActivityCountsResponse,
+    | 'goodFirstIssues'
+    | 'goodFirstIssuesHyphenated'
+    | 'goodFirstIssuesBeginner'
+    | 'goodFirstIssuesStarter'
+    | 'recentMergedPullRequests'
+  > | null,
 ): OnboardingSignalSet {
   if (!repo) {
     return {
@@ -1318,9 +1328,15 @@ export function extractOnboardingSignals(
   const gitpodPresent: boolean = repo.onbGitpod != null
 
   // goodFirstIssueCount
+  const goodFirstIssueBuckets = [
+    activityCounts?.goodFirstIssues,
+    activityCounts?.goodFirstIssuesHyphenated,
+    activityCounts?.goodFirstIssuesBeginner,
+    activityCounts?.goodFirstIssuesStarter,
+  ]
   const goodFirstIssueCount: number | Unavailable =
-    activityCounts?.goodFirstIssues != null
-      ? activityCounts.goodFirstIssues.issueCount
+    goodFirstIssueBuckets.some((bucket) => bucket != null)
+      ? goodFirstIssueBuckets.reduce((total, bucket) => total + (bucket?.issueCount ?? 0), 0)
       : 'unavailable'
 
   // newContributorPRAcceptanceRate: first-time merged / first-time total
@@ -1442,11 +1458,24 @@ function buildOpenPullRequestsOlderThanQuery(repoSearch: string, before: Date) {
   return `repo:${repoSearch} is:pr is:open created:<${before.toISOString().slice(0, 10)}`
 }
 
-export function buildGoodFirstIssueQuery(repoSearch: string): string {
-  // GitHub's GraphQL search does not scope `repo:` across OR branches, so
-  // OR variants would produce incorrect counts. We use only the canonical
-  // GitHub-recommended label; hyphenated and other variants are tracked in #382.
-  return `repo:${repoSearch} is:issue is:open label:"good first issue"`
+function buildExclusiveIssueLabelQuery(repoSearch: string, label: string, excludedLabels: string[] = []): string {
+  const exclusions = excludedLabels.map((excludedLabel) => `-label:"${excludedLabel}"`).join(' ')
+  return `repo:${repoSearch} is:issue is:open label:"${label}"${exclusions ? ` ${exclusions}` : ''}`
+}
+
+export function buildGoodFirstIssueQueries(repoSearch: string): Record<
+  | 'goodFirstIssueQuery'
+  | 'goodFirstIssueHyphenatedQuery'
+  | 'goodFirstIssueBeginnerQuery'
+  | 'goodFirstIssueStarterQuery',
+  string
+> {
+  return {
+    goodFirstIssueQuery: buildExclusiveIssueLabelQuery(repoSearch, 'good first issue'),
+    goodFirstIssueHyphenatedQuery: buildExclusiveIssueLabelQuery(repoSearch, 'good-first-issue', ['good first issue']),
+    goodFirstIssueBeginnerQuery: buildExclusiveIssueLabelQuery(repoSearch, 'beginner', ['good first issue', 'good-first-issue']),
+    goodFirstIssueStarterQuery: buildExclusiveIssueLabelQuery(repoSearch, 'starter', ['good first issue', 'good-first-issue', 'beginner']),
+  }
 }
 
 // ─── Two-pass responsiveness fetch ───────────────────────────────────────────
@@ -2504,6 +2533,9 @@ function buildUnavailableActivityCounts(): RepoActivityCountsResponse {
     issuesClosed30: unavailable, issuesClosed60: unavailable, issuesClosed90: unavailable, issuesClosed180: unavailable, issuesClosed365: unavailable,
     staleIssues30: unavailable, staleIssues60: unavailable, staleIssues90: unavailable, staleIssues180: unavailable, staleIssues365: unavailable,
     goodFirstIssues: unavailable,
+    goodFirstIssuesHyphenated: unavailable,
+    goodFirstIssuesBeginner: unavailable,
+    goodFirstIssuesStarter: unavailable,
     recentMergedPullRequests: { nodes: [] },
     recentClosedIssues: { nodes: [] },
   }

--- a/lib/analyzer/onboarding-signals.test.ts
+++ b/lib/analyzer/onboarding-signals.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { extractOnboardingSignals, buildGoodFirstIssueQuery } from './analyze'
+import { buildGoodFirstIssueQueries, extractOnboardingSignals } from './analyze'
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function overviewFixture(overrides: Record<string, unknown>): any {
+interface OnboardingPullRequestNode {
+  createdAt: string
+  mergedAt: string | null
+  authorAssociation?: string | null
+}
+
+function overviewFixture(overrides: Record<string, unknown>) {
   return {
     name: 'test', description: '', createdAt: '', primaryLanguage: null,
     stargazerCount: 0, forkCount: 0, watchers: { totalCount: 0 },
@@ -11,10 +16,15 @@ function overviewFixture(overrides: Record<string, unknown>): any {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function activityFixture(mergedPRNodes: any[], goodFirstIssueCount?: number): any {
+function activityFixture(
+  mergedPRNodes: OnboardingPullRequestNode[],
+  goodFirstIssueCounts?: Partial<Record<'goodFirstIssues' | 'goodFirstIssuesHyphenated' | 'goodFirstIssuesBeginner' | 'goodFirstIssuesStarter', number>>,
+){
   return {
-    goodFirstIssues: goodFirstIssueCount !== undefined ? { issueCount: goodFirstIssueCount } : undefined,
+    goodFirstIssues: goodFirstIssueCounts?.goodFirstIssues !== undefined ? { issueCount: goodFirstIssueCounts.goodFirstIssues } : undefined,
+    goodFirstIssuesHyphenated: goodFirstIssueCounts?.goodFirstIssuesHyphenated !== undefined ? { issueCount: goodFirstIssueCounts.goodFirstIssuesHyphenated } : undefined,
+    goodFirstIssuesBeginner: goodFirstIssueCounts?.goodFirstIssuesBeginner !== undefined ? { issueCount: goodFirstIssueCounts.goodFirstIssuesBeginner } : undefined,
+    goodFirstIssuesStarter: goodFirstIssueCounts?.goodFirstIssuesStarter !== undefined ? { issueCount: goodFirstIssueCounts.goodFirstIssuesStarter } : undefined,
     recentMergedPullRequests: { nodes: mergedPRNodes },
   }
 }
@@ -95,14 +105,27 @@ describe('extractOnboardingSignals — goodFirstIssueCount', () => {
   it('returns count when > 0', () => {
     const result = extractOnboardingSignals(
       overviewFixture({}),
-      activityFixture([], 7),
+      activityFixture([], { goodFirstIssues: 7 }),
     )
     expect(result.goodFirstIssueCount).toBe(7)
   })
 
   it('returns 0 when count is 0 (not unavailable)', () => {
-    const result = extractOnboardingSignals(overviewFixture({}), activityFixture([], 0))
+    const result = extractOnboardingSignals(overviewFixture({}), activityFixture([], { goodFirstIssues: 0 }))
     expect(result.goodFirstIssueCount).toBe(0)
+  })
+
+  it('sums mutually exclusive alternate label counts', () => {
+    const result = extractOnboardingSignals(
+      overviewFixture({}),
+      activityFixture([], {
+        goodFirstIssues: 2,
+        goodFirstIssuesHyphenated: 3,
+        goodFirstIssuesBeginner: 4,
+        goodFirstIssuesStarter: 1,
+      }),
+    )
+    expect(result.goodFirstIssueCount).toBe(10)
   })
 
   it('returns unavailable when goodFirstIssues field is missing from activity', () => {
@@ -181,10 +204,17 @@ describe('extractOnboardingSignals — newContributorPRAcceptanceRate', () => {
   })
 })
 
-describe('buildGoodFirstIssueQuery', () => {
-  it('includes common onboarding labels', () => {
-    const q = buildGoodFirstIssueQuery('owner/repo')
-    expect(q).toContain('repo:owner/repo')
-    expect(q).toContain('good first issue')
+describe('buildGoodFirstIssueQueries', () => {
+  it('builds mutually exclusive queries for supported onboarding labels', () => {
+    const queries = buildGoodFirstIssueQueries('owner/repo')
+    expect(queries.goodFirstIssueQuery).toContain('repo:owner/repo')
+    expect(queries.goodFirstIssueQuery).toContain('label:"good first issue"')
+    expect(queries.goodFirstIssueHyphenatedQuery).toContain('label:"good-first-issue"')
+    expect(queries.goodFirstIssueHyphenatedQuery).toContain('-label:"good first issue"')
+    expect(queries.goodFirstIssueBeginnerQuery).toContain('label:"beginner"')
+    expect(queries.goodFirstIssueBeginnerQuery).toContain('-label:"good-first-issue"')
+    expect(queries.goodFirstIssueStarterQuery).toContain('label:"starter"')
+    expect(queries.goodFirstIssueStarterQuery).toContain('-label:"beginner"')
+    expect(Object.values(queries).join(' ')).not.toContain('help wanted')
   })
 })

--- a/lib/analyzer/queries.ts
+++ b/lib/analyzer/queries.ts
@@ -266,6 +266,9 @@ export const REPO_ACTIVITY_COUNTS_QUERY = `
     $staleIssues180Query: String!
     $staleIssues365Query: String!
     $goodFirstIssueQuery: String!
+    $goodFirstIssueHyphenatedQuery: String!
+    $goodFirstIssueBeginnerQuery: String!
+    $goodFirstIssueStarterQuery: String!
   ) {
     prsOpened30: search(query: $prsOpened30Query, type: ISSUE) {
       issueCount
@@ -343,6 +346,15 @@ export const REPO_ACTIVITY_COUNTS_QUERY = `
       issueCount
     }
     goodFirstIssues: search(query: $goodFirstIssueQuery, type: ISSUE) {
+      issueCount
+    }
+    goodFirstIssuesHyphenated: search(query: $goodFirstIssueHyphenatedQuery, type: ISSUE) {
+      issueCount
+    }
+    goodFirstIssuesBeginner: search(query: $goodFirstIssueBeginnerQuery, type: ISSUE) {
+      issueCount
+    }
+    goodFirstIssuesStarter: search(query: $goodFirstIssueStarterQuery, type: ISSUE) {
       issueCount
     }
     recentMergedPullRequests: search(query: $prsMerged365Query, type: ISSUE, first: 100) {

--- a/lib/comparison/sections.ts
+++ b/lib/comparison/sections.ts
@@ -343,7 +343,7 @@ export const COMPARISON_SECTIONS: ComparisonSectionDefinition[] = [
         id: 'good-first-issues-count',
         sectionId: 'contributors',
         label: 'Good first issues',
-        helpText: 'Open issues labeled as good first issues, beginner, or starter.',
+        helpText: 'Open issues labeled as good first issue, good-first-issue, beginner, or starter.',
         direction: 'higher-is-better',
         valueType: 'number',
         getValue: (result) => result.goodFirstIssueCount ?? 'unavailable',


### PR DESCRIPTION
Closes #382

## Summary
- support alternate onboarding label variants: `good-first-issue`, `beginner`, and `starter`
- keep `help wanted` out of the good-first-issue metric
- avoid double-counting by making the per-label GraphQL searches mutually exclusive before summing

## Notes
- Repo-wide lint currently has one unrelated existing warning in `components/org-summary/OrgBucketContent.tsx`, tracked in #393.
- `dod-verifier` flagged the older onboarding spec as mentioning `help wanted`; this PR follows issue #382 and the current bug-fix scope.

## Test plan
- [x] `npx vitest run lib/analyzer/onboarding-signals.test.ts`
- [x] `npm run lint` *(current repo baseline: 1 unrelated warning, tracked in #393)*
- [x] `npm test`
- [x] `DEV_GITHUB_PAT= npm run build`