### PR TITLE
fix(#393): remove unused useAuth import from OrgBucketContent

### DIFF
--- a/components/org-summary/OrgBucketContent.tsx
+++ b/components/org-summary/OrgBucketContent.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useAuth } from '@/components/auth/AuthContext'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
 import type { ContributorDiversityWindow } from '@/lib/org-aggregation/aggregators/types'
 import type { TwoFactorEnforcementSection } from '@/lib/governance/two-factor'


### PR DESCRIPTION
## Summary

- Removes the unused `useAuth` import from `components/org-summary/OrgBucketContent.tsx`
- Brings repo-wide lint to **0 warnings / 0 errors**

Fixes #393.

## Test plan

- [x] `npm run lint` reports 0 warnings and 0 errors
- [x] No functional behavior changed (import was unused)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)