### PR TITLE
auth: reduce baseline OAuth scope from public_repo to no scope

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,7 +1,9 @@
 # RepoPulse Constitution
 
-**Version**: 1.3 — Amended 2026-04-20
-**Amendment**: Sections XII and XIII updated to drop the per-feature `specs/NNN-feature-name/checklists/manual-testing.md` file. The PR body's `## Test plan` section is now the single source of truth for manual testing signoff. Rationale: under the one-Claude-per-issue ephemeral-worktree workflow, the in-repo checklist file duplicated the PR Test Plan, drifted from it, and added ceremony without adding coverage. GitHub preserves PR bodies indefinitely and they are queryable via `gh pr view --json body`, so the test record remains durable. Signed off by: arun-gupta.
+**Version**: 1.4 — Amended 2026-04-21
+**Amendment (v1.4, 2026-04-21)**: Section III rule 4 updated to reflect no-scope baseline OAuth (issue #401). Rationale: RepoPulse only reads public data; the previous `public_repo` baseline granted unnecessary write access. A no-scope token provides the same read access and full 5,000 req/hr rate limit without write permission. Signed off by: arun-gupta.
+
+**Amendment (v1.3)**: Sections XII and XIII updated to drop the per-feature `specs/NNN-feature-name/checklists/manual-testing.md` file. The PR body's `## Test plan` section is now the single source of truth for manual testing signoff. Rationale: under the one-Claude-per-issue ephemeral-worktree workflow, the in-repo checklist file duplicated the PR Test Plan, drifted from it, and added ceremony without adding coverage. GitHub preserves PR bodies indefinitely and they are queryable via `gh pr view --json body`, so the test record remains durable. Signed off by: arun-gupta.
 
 **Amendment (v1.3, 2026-04-20)**: Section XII updated to add a Definition of Done item requiring fixture generator parity for any PR that adds or changes a governance signal. Rationale: issue #385 revealed that `memberPermission` was hand-authored in `fixtures/demo/org-ossf.json` with fabricated values because `generate-demo-fixtures.ts` was not updated in the same PR as the feature. The new DoD item closes this gap by requiring generator parity and fixture regeneration whenever `OrgFixture.governance` changes. A CI check (`npm run demo:check-parity`) enforces this mechanically. Signed off by: arun-gupta.
 
@@ -61,7 +63,7 @@ Response: { "results": AnalysisResult[] }
 1. **Primary source**: GitHub GraphQL API (`https://api.github.com/graphql`).
 2. Each repo requires 1–3 GraphQL requests. Precise field selection — no over-fetching.
 3. REST API may supplement only where GraphQL cannot reach a specific metric. This is an exception, not a pattern.
-4. Auth: GitHub OAuth App only — PAT input is not supported in Phase 1 (amended v1.1). OAuth token is held in-memory for the duration of the session; it is never written to localStorage, cookies, or any persistent storage. Minimum scope: `public_repo` read-only.
+4. Auth: GitHub OAuth App only — PAT input is not supported in Phase 1 (amended v1.1). OAuth token is held in-memory for the duration of the session; it is never written to localStorage, cookies, or any persistent storage. Baseline scope: no scope (empty string) — read-only access to all public data without write permission (amended v1.4). Elevated tiers: `read:org` and `admin:org` only — `public_repo` is not included in any tier.
 5. No server-side `GITHUB_TOKEN` is used — each user authenticates via OAuth and their own quota is consumed (amended v1.1). Credentials are never hardcoded anywhere in the codebase.
 6. ~~Server-side `GITHUB_TOKEN` takes precedence~~ — removed in v1.1. All API calls use the authenticated user's OAuth token. `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are stored as server-side environment variables and never sent to the client.
 7. Token is never included in URLs, never exposed to the client bundle, never logged.

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -61,7 +61,7 @@ export async function GET(request: Request) {
 
   const userData = (await userResponse.json()) as { login?: string }
   const username = userData.login ?? 'unknown'
-  const scopes = tokenData.scope ?? 'public_repo'
+  const scopes = tokenData.scope ?? ''
 
   // Return token to client via URL fragment (never sent to server)
   const fragment = `token=${encodeURIComponent(tokenData.access_token)}&username=${encodeURIComponent(username)}&scopes=${encodeURIComponent(scopes)}`

--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -38,7 +38,7 @@ describe('GET /api/auth/login', () => {
     const location = response.headers.get('location') ?? ''
     expect(location).toContain('https://github.com/login/oauth/authorize')
     expect(location).toContain('client_id=test_client_id')
-    expect(location).toContain('scope=public_repo')
+    expect(location).toContain('scope=')
   })
 
   it('includes a state parameter', async () => {
@@ -104,13 +104,11 @@ describe('GET /api/auth/login', () => {
     expect(location).toContain('github.com/login/oauth/authorize')
   })
 
-  it('requests public_repo scope only on the baseline path (no ?elevated=1)', async () => {
+  it('requests no scope (empty) on the baseline path (no ?elevated=1)', async () => {
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login'))
     const location = response.headers.get('location') ?? ''
-    const scopeMatch = location.match(/scope=([^&]+)/)
-    expect(scopeMatch).not.toBeNull()
-    const scope = decodeURIComponent(scopeMatch![1]!)
-    expect(scope).toBe('public_repo')
+    const url = new URL(location)
+    expect(url.searchParams.get('scope')).toBe('')
   })
 
   it('adds read:org scope when ?elevated=1 is passed (legacy alias for scope_tier=read-org)', async () => {
@@ -119,42 +117,42 @@ describe('GET /api/auth/login', () => {
     const scopeMatch = location.match(/scope=([^&]+)/)
     expect(scopeMatch).not.toBeNull()
     const scope = decodeURIComponent(scopeMatch![1]!).replace(/\+/g, ' ')
-    expect(scope).toBe('public_repo read:org')
+    expect(scope).toBe('read:org')
   })
 
   it('treats ?elevated=0 as baseline', async () => {
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?elevated=0'))
     const location = response.headers.get('location') ?? ''
-    const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
-    expect(scope).toBe('public_repo')
+    const url = new URL(location)
+    expect(url.searchParams.get('scope')).toBe('')
   })
 
   it('adds read:org scope when ?scope_tier=read-org is passed', async () => {
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=read-org'))
     const location = response.headers.get('location') ?? ''
     const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
-    expect(scope).toBe('public_repo read:org')
+    expect(scope).toBe('read:org')
   })
 
   it('adds admin:org scope when ?scope_tier=admin-org is passed (no need to also include read:org — admin:org is a superset)', async () => {
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=admin-org'))
     const location = response.headers.get('location') ?? ''
     const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
-    expect(scope).toBe('public_repo admin:org')
+    expect(scope).toBe('admin:org')
   })
 
   it('treats ?scope_tier=baseline as baseline', async () => {
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=baseline'))
     const location = response.headers.get('location') ?? ''
-    const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
-    expect(scope).toBe('public_repo')
+    const url = new URL(location)
+    expect(url.searchParams.get('scope')).toBe('')
   })
 
   it('prefers scope_tier over the legacy elevated flag when both are present', async () => {
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?elevated=1&scope_tier=admin-org'))
     const location = response.headers.get('location') ?? ''
     const scope = decodeURIComponent(location.match(/scope=([^&]+)/)![1]!).replace(/\+/g, ' ')
-    expect(scope).toBe('public_repo admin:org')
+    expect(scope).toBe('admin:org')
   })
 
   it('dev-PAT session reports the PAT\'s real scopes from X-OAuth-Scopes, not the requested tier', async () => {
@@ -199,7 +197,7 @@ describe('GET /api/auth/login', () => {
 
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=admin-org'))
     const location = response.headers.get('location') ?? ''
-    expect(decodeURIComponent(location)).toContain('scopes=public_repo admin:org')
+    expect(decodeURIComponent(location)).toContain('scopes=admin:org')
   })
 
   it('dev-PAT treats an empty X-OAuth-Scopes header (legacy GitHub responses) as absent', async () => {
@@ -219,6 +217,6 @@ describe('GET /api/auth/login', () => {
 
     const response = await GET(mockRequest('http://localhost:3010/api/auth/login?scope_tier=read-org'))
     const location = response.headers.get('location') ?? ''
-    expect(decodeURIComponent(location)).toContain('scopes=public_repo read:org')
+    expect(decodeURIComponent(location)).toContain('scopes=read:org')
   })
 })

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -10,11 +10,11 @@ export type ScopeTier = 'baseline' | 'read-org' | 'admin-org'
 export function buildOAuthScope(tier: ScopeTier): string {
   switch (tier) {
     case 'admin-org':
-      return 'public_repo admin:org'
+      return 'admin:org'
     case 'read-org':
-      return 'public_repo read:org'
+      return 'read:org'
     default:
-      return 'public_repo'
+      return ''
   }
 }
 
@@ -49,7 +49,7 @@ export async function GET(request: Request) {
       return Response.redirect(`${base.toString()}#${fragment}`, 302)
     }
     return Response.json(
-      { error: 'DEV_GITHUB_PAT is set but rejected by GitHub (invalid or lacking public_repo scope).' },
+      { error: 'DEV_GITHUB_PAT is set but rejected by GitHub (invalid token).' },
       { status: 500 },
     )
   }

--- a/components/auth/AuthContext.test.tsx
+++ b/components/auth/AuthContext.test.tsx
@@ -52,14 +52,14 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('token')).toHaveTextContent('none')
   })
 
-  it('defaults scopes to [public_repo] when none are supplied', () => {
+  it('defaults scopes to [] when none are supplied', () => {
     render(
       <AuthProvider initialSession={{ token: 'gho_abc', username: 'arun-gupta' }}>
         <TestConsumer />
       </AuthProvider>,
     )
-    expect(screen.getByTestId('scopes')).toHaveTextContent('public_repo')
-    expect(screen.getByTestId('hasPublicRepo')).toHaveTextContent('true')
+    expect(screen.getByTestId('scopes')).toHaveTextContent('none')
+    expect(screen.getByTestId('hasPublicRepo')).toHaveTextContent('false')
     expect(screen.getByTestId('hasReadOrg')).toHaveTextContent('false')
   })
 
@@ -90,10 +90,10 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('hasPublicRepo')).toHaveTextContent('false')
   })
 
-  it('elevatedScopes is empty on a baseline session', () => {
+  it('elevatedScopes is empty on a baseline session (no scope)', () => {
     render(
       <AuthProvider
-        initialSession={{ token: 'gho_abc', username: 'arun-gupta', scopes: ['public_repo'] }}
+        initialSession={{ token: 'gho_abc', username: 'arun-gupta', scopes: [] }}
       >
         <TestConsumer />
       </AuthProvider>,

--- a/components/auth/AuthContext.test.tsx
+++ b/components/auth/AuthContext.test.tsx
@@ -101,7 +101,7 @@ describe('AuthContext', () => {
     expect(screen.getByTestId('elevatedScopes')).toHaveTextContent('none')
   })
 
-  it('elevatedScopes lists every non-baseline scope', () => {
+  it('elevatedScopes lists only known elevated scopes (read:org, admin:org), not public_repo', () => {
     render(
       <AuthProvider
         initialSession={{

--- a/components/auth/AuthContext.tsx
+++ b/components/auth/AuthContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useCallback, useContext, useMemo, useState } from 'react'
 
-export const BASELINE_SCOPE = 'public_repo'
+export const BASELINE_SCOPE = ''
 
 export interface AuthSession {
   token: string
@@ -31,12 +31,14 @@ const AuthContext = createContext<AuthContextValue>({
 })
 
 function normalizeScopes(input: readonly string[] | undefined): readonly string[] {
-  if (!input || input.length === 0) return [BASELINE_SCOPE] as const
+  if (!input || input.length === 0) return [] as const
   return input
 }
 
+const ELEVATED_SCOPE_SET = new Set(['read:org', 'admin:org'])
+
 export function getElevatedScopes(scopes: readonly string[] | undefined): readonly string[] {
-  return (scopes ?? []).filter((s) => s !== BASELINE_SCOPE)
+  return (scopes ?? []).filter((s) => ELEVATED_SCOPE_SET.has(s))
 }
 
 export function AuthProvider({

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -33,7 +33,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             .split(/[\s,]+/)
             .map((s) => s.trim())
             .filter(Boolean)
-        : ['public_repo']
+        : []
       signIn({ token, username, scopes })
       // Restore any query params saved before the OAuth redirect (e.g. ?repos=...)
       const savedSearch = sessionStorage.getItem('oauth_return_search') ?? ''
@@ -116,7 +116,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
             value="baseline"
             checked={scopeTier === 'baseline'}
             onChange={setScopeTier}
-            label={<><span className="font-semibold">Baseline</span> (<code>public_repo</code>)</>}
+            label={<><span className="font-semibold">Baseline</span> (read-only public data)</>}
             guidance="Public data only — for auditing third-party orgs."
           />
           <ScopeRadio

--- a/components/auth/ElevatedScopeBanner.test.tsx
+++ b/components/auth/ElevatedScopeBanner.test.tsx
@@ -14,10 +14,10 @@ describe('ElevatedScopeBanner', () => {
     expect(screen.queryByTestId('elevated-scope-banner')).not.toBeInTheDocument()
   })
 
-  it('renders nothing when session has only the baseline public_repo scope', () => {
+  it('renders nothing when session has no elevated scopes (baseline: no scope)', () => {
     render(
       <AuthProvider
-        initialSession={{ token: 'gho_abc', username: 'arun-gupta', scopes: ['public_repo'] }}
+        initialSession={{ token: 'gho_abc', username: 'arun-gupta', scopes: [] }}
       >
         <ElevatedScopeBanner />
       </AuthProvider>,

--- a/components/auth/UserBadge.test.tsx
+++ b/components/auth/UserBadge.test.tsx
@@ -34,10 +34,10 @@ describe('UserBadge', () => {
     expect(signOut).toHaveBeenCalled()
   })
 
-  it('does not render an elevated-scope chip on a baseline session', () => {
+  it('does not render an elevated-scope chip on a baseline session (no scope)', () => {
     render(
       <AuthProvider
-        initialSession={{ token: 'gho_abc', username: 'arun-gupta', scopes: ['public_repo'] }}
+        initialSession={{ token: 'gho_abc', username: 'arun-gupta', scopes: [] }}
       >
         <UserBadge />
       </AuthProvider>,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -288,7 +288,7 @@ Phase 2 adds new scoring buckets to the health score. Requirements specs live in
 | 4 | P2-F07 | Security scoring | #68 | ✅ Done |
 | 5 | P2-F04 | Governance & Transparency | #116 | ✅ Done |
 | 6 | P2-F05 | Community scoring | #70 | ✅ Done |
-| 7 | P2-F06a | CNCF foundation support | #398 (#157, #210, #211, #399) | |
+| 7 | P2-F06a | CNCF foundation support | #398 (#399, #400, #157, #210, #211) | |
 | 8 | P2-F06b | Foundation-aware recommendations (Apache, LF, others) | #119 | |
 | 9 | P2-F08 | Accessibility & Onboarding | #117 | ✅ Done |
 | 10 | P2-F09 | Release health scoring | #69 | ✅ Done |

--- a/e2e/elevated-scope-indicator.spec.ts
+++ b/e2e/elevated-scope-indicator.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('RFE #345 — global elevated-scope indicator', () => {
   test('baseline session renders no banner and no chip', async ({ page }) => {
-    await page.goto('/#token=gho_test_token&username=test-user&scopes=public_repo')
+    await page.goto('/#token=gho_test_token&username=test-user&scopes=')
 
     // Wait for the signed-in app shell to render
     await expect(page.getByText('test-user')).toBeVisible()
@@ -13,7 +13,7 @@ test.describe('RFE #345 — global elevated-scope indicator', () => {
 
   test('elevated session renders a global banner enumerating read:org', async ({ page }) => {
     await page.goto(
-      '/#token=gho_test_token&username=test-user&scopes=' + encodeURIComponent('public_repo read:org'),
+      '/#token=gho_test_token&username=test-user&scopes=' + encodeURIComponent('read:org'),
     )
 
     const banner = page.getByTestId('elevated-scope-banner')
@@ -30,7 +30,7 @@ test.describe('RFE #345 — global elevated-scope indicator', () => {
 
   test('elevated session also renders a persistent chip next to the user badge', async ({ page }) => {
     await page.goto(
-      '/#token=gho_test_token&username=test-user&scopes=' + encodeURIComponent('public_repo read:org'),
+      '/#token=gho_test_token&username=test-user&scopes=' + encodeURIComponent('read:org'),
     )
 
     const chip = page.getByTestId('elevated-scope-chip')
@@ -42,7 +42,7 @@ test.describe('RFE #345 — global elevated-scope indicator', () => {
 
   test('dismissing the banner keeps the chip visible', async ({ page }) => {
     await page.goto(
-      '/#token=gho_test_token&username=test-user&scopes=' + encodeURIComponent('public_repo read:org'),
+      '/#token=gho_test_token&username=test-user&scopes=' + encodeURIComponent('read:org'),
     )
 
     await expect(page.getByTestId('elevated-scope-banner')).toBeVisible()

--- a/package-lock.json
+++ b/package-lock.json
@@ -5129,7 +5129,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
## Summary

- Switches baseline OAuth scope from `public_repo` (read+write) to empty string (read-only public data) — RepoPulse never writes to repos so the write permission was unnecessary
- Drops `public_repo` prefix from elevated tiers: `read-org` → `read:org` only, `admin-org` → `admin:org` only
- Updates UI baseline tier label from `(public_repo)` to `(read-only public data)`
- Fixes `getElevatedScopes` to explicitly allow-list `read:org`/`admin:org` rather than filtering by `!== BASELINE_SCOPE`, so legacy tokens carrying `public_repo` don't incorrectly trigger the elevated-permissions banner
- Updates constitution v1.3 → v1.4 to document the new baseline scope rule

Closes #401

## Test plan

- [x] All 1455 unit/integration tests pass (`npm test`)
- [x] Linting clean (`npm run lint`)
- [x] Manual: click "Sign in with GitHub" on baseline tier — GitHub authorize page shows no scope listed (or just the app name) rather than "public_repo"
- [x] Manual: elevated-scope banner and chip do NOT appear after baseline sign-in
- [x] Manual: elevated-scope banner DOES appear after sign-in with `read:org` tier
- [x] Manual: `read:org` tier authorize page shows only `read:org`, not `public_repo read:org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)