### PR TITLE
fix: detect secondary rate limits on /search/commits and /events

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -288,7 +288,7 @@ Phase 2 adds new scoring buckets to the health score. Requirements specs live in
 | 4 | P2-F07 | Security scoring | #68 | ✅ Done |
 | 5 | P2-F04 | Governance & Transparency | #116 | ✅ Done |
 | 6 | P2-F05 | Community scoring | #70 | ✅ Done |
-| 7 | P2-F06a | CNCF foundation support | #398 (#157, #210, #211, #399) | |
+| 7 | P2-F06a | CNCF foundation support | #398 (#399, #400, #157, #210, #211) | |
 | 8 | P2-F06b | Foundation-aware recommendations (Apache, LF, others) | #119 | |
 | 9 | P2-F08 | Accessibility & Onboarding | #117 | ✅ Done |
 | 10 | P2-F09 | Release health scoring | #69 | ✅ Done |

--- a/lib/analyzer/github-rest.test.ts
+++ b/lib/analyzer/github-rest.test.ts
@@ -275,6 +275,24 @@ describe('fetchUserPublicEvents', () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 500 })))
     expect((await fetchUserPublicEvents('t', 'alice')).kind).toBe('events-fetch-failed')
   })
+
+  it('maps 429 to rate-limited', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 429 })))
+    expect((await fetchUserPublicEvents('t', 'alice')).kind).toBe('rate-limited')
+  })
+
+  it('maps 403 with secondary rate-limit body to rate-limited when headers are absent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({ message: 'You have exceeded a secondary rate limit.' }),
+          { status: 403, headers: { 'Content-Type': 'application/json' } },
+        ),
+      ),
+    )
+    expect((await fetchUserPublicEvents('t', 'alice')).kind).toBe('rate-limited')
+  })
 })
 
 describe('fetchUserLatestOrgCommit', () => {
@@ -450,6 +468,30 @@ describe('fetchUserLatestOrgCommit', () => {
     expect(result.kind).toBe('commit-search-failed')
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('maps 429 to rate-limited (newer GitHub secondary rate limit signal)', async () => {
+    const fetchMock = vi.fn(async () => new Response('', { status: 429, headers: { 'Retry-After': '30' } }))
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+    expect(result.kind).toBe('rate-limited')
+    expect(sleep).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps 403 + X-RateLimit-Resource: search to rate-limited', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response('', {
+        status: 403,
+        headers: { 'X-RateLimit-Resource': 'search', 'X-RateLimit-Remaining': '5' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const sleep = vi.fn(async () => {})
+
+    const result = await fetchUserLatestOrgCommit('t', 'alice', 'x', { sleep })
+    expect(result.kind).toBe('rate-limited')
   })
 })
 

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -336,7 +336,10 @@ export async function fetchUserPublicEvents(
     )
 
     if (response.status === 404) return { kind: 'admin-account-404' }
-    if (response.status === 403 && isRateLimited(response)) {
+    if (
+      response.status === 429 ||
+      (response.status === 403 && (isRateLimited(response) || (await hasSecondaryRateLimitBody(response))))
+    ) {
       return { kind: 'rate-limited', retryAvailableAt: parseRetryAvailableAt(response) }
     }
     if (!response.ok) return { kind: 'events-fetch-failed' }
@@ -396,8 +399,9 @@ export async function fetchUserLatestOrgCommit(
         },
       )
 
-      if (response.status === 403) {
-        const rateLimited = isRateLimited(response) || (await hasSecondaryRateLimitBody(response))
+      if (response.status === 403 || response.status === 429) {
+        const rateLimited =
+          response.status === 429 || isRateLimited(response) || (await hasSecondaryRateLimitBody(response))
         if (rateLimited) {
           if (attempt < maxRetries) {
             const wait = Math.min(
@@ -516,6 +520,9 @@ function isRateLimited(response: Response): boolean {
   // `X-RateLimit-Remaining: 0` header. Present Retry-After is GitHub telling
   // the caller to back off — classify as rate-limited.
   if (response.headers.get('Retry-After')) return true
+  // Search has a separate 30 req/min quota; a 403 with X-RateLimit-Resource:
+  // search means that quota was hit even when X-RateLimit-Remaining is not 0.
+  if (response.headers.get('X-RateLimit-Resource') === 'search') return true
   return false
 }
 


### PR DESCRIPTION
Closes #343

## Summary

- `isRateLimited()` now returns true for `X-RateLimit-Resource: search` (search has a separate 30 req/min quota; a 403 with this header means that quota was hit even when `X-RateLimit-Remaining` is non-zero)
- `fetchUserLatestOrgCommit` now handles **429** in addition to 403, routing it through the same retry-then-rate-limited path
- `fetchUserPublicEvents` now handles 429 and 403-with-secondary-body, matching the classification logic already in `fetchUserLatestOrgCommit`

## What was broken

- 429 responses in both callers fell through to `!response.ok` → `commit-search-failed` / `events-fetch-failed`
- 403 with only a body containing `"secondary rate limit"` in `fetchUserPublicEvents` fell through to `events-fetch-failed` (body detection was only wired in `fetchUserLatestOrgCommit`)
- `X-RateLimit-Resource: search` without `X-RateLimit-Remaining: 0` was not detected by `isRateLimited()`

## Test plan

- [x] `npx vitest run lib/analyzer/github-rest.test.ts` — all 52 tests pass
- [x] [429 → `rate-limited` for `fetchUserLatestOrgCommit`](https://github.com/arun-gupta/repo-pulse/blob/343-detect-secondary-rate-limits-on-search-c/lib/analyzer/github-rest.test.ts#L473)
- [x] [403 + `X-RateLimit-Resource: search` → `rate-limited` for `fetchUserLatestOrgCommit`](https://github.com/arun-gupta/repo-pulse/blob/343-detect-secondary-rate-limits-on-search-c/lib/analyzer/github-rest.test.ts#L483)
- [x] [429 → `rate-limited` for `fetchUserPublicEvents`](https://github.com/arun-gupta/repo-pulse/blob/343-detect-secondary-rate-limits-on-search-c/lib/analyzer/github-rest.test.ts#L279)
- [x] [403 + secondary rate-limit body → `rate-limited` for `fetchUserPublicEvents`](https://github.com/arun-gupta/repo-pulse/blob/343-detect-secondary-rate-limits-on-search-c/lib/analyzer/github-rest.test.ts#L284)
- [x] [Existing primary rate-limit tests still pass](https://github.com/arun-gupta/repo-pulse/blob/343-detect-secondary-rate-limits-on-search-c/lib/analyzer/github-rest.test.ts#L333) (no behavior change for `X-RateLimit-Remaining: 0` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)