### PR TITLE
ux(org-panel): overhaul Org member & admin overview for baseline and OAuth-restricted orgs

### DIFF
--- a/app/api/org/member-permissions/route.test.ts
+++ b/app/api/org/member-permissions/route.test.ts
@@ -6,10 +6,10 @@ function buildReq(query: string, headers: Record<string, string> = { authorizati
 }
 
 function memberPage(logins: string[]): Response {
-  return new Response(JSON.stringify(logins.map((login) => ({ login }))), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return new Response(
+    JSON.stringify(logins.map((login) => ({ login, avatar_url: `https://github.com/${login}.png` }))),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
 }
 
 describe('GET /api/org/member-permissions', () => {
@@ -36,13 +36,14 @@ describe('GET /api/org/member-permissions', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('returns applicable with correct adminCount, memberCount (non-admin), and collaboratorCount', async () => {
+  it('returns applicable with correct adminCount, memberCount (non-admin), collaboratorCount, and publicMemberCount', async () => {
     vi.stubGlobal('fetch', vi.fn(async (input: string | URL) => {
       const url = String(input)
-      // role=admin → 2 admins; role=all → 5 total members; outside_collaborators → 1
+      // role=admin → 2 admins; role=all → 5 total members; outside_collaborators → 1; public_members → 3
       if (url.includes('role=admin')) return memberPage(['admin1', 'admin2'])
       if (url.includes('role=all')) return memberPage(['admin1', 'admin2', 'user1', 'user2', 'user3'])
       if (url.includes('outside_collaborators')) return memberPage(['ext1'])
+      if (url.includes('public_members')) return memberPage(['user1', 'user2', 'user3'])
       return new Response('', { status: 404 })
     }))
 
@@ -53,6 +54,8 @@ describe('GET /api/org/member-permissions', () => {
         adminCount: number
         memberCount: number
         outsideCollaboratorCount: number
+        publicMemberCount: number
+        publicMembers: string[]
       }
     }
 
@@ -60,6 +63,12 @@ describe('GET /api/org/member-permissions', () => {
     expect(body.section.adminCount).toBe(2)
     expect(body.section.memberCount).toBe(3) // 5 total - 2 admins
     expect(body.section.outsideCollaboratorCount).toBe(1)
+    expect(body.section.publicMemberCount).toBe(3)
+    expect(body.section.publicMembers).toEqual([
+      { login: 'user1', avatarUrl: 'https://github.com/user1.png' },
+      { login: 'user2', avatarUrl: 'https://github.com/user2.png' },
+      { login: 'user3', avatarUrl: 'https://github.com/user3.png' },
+    ])
   })
 
   it('returns member-list-unavailable when total-member fetch is rate-limited', async () => {

--- a/app/api/org/member-permissions/route.ts
+++ b/app/api/org/member-permissions/route.ts
@@ -1,10 +1,11 @@
 import {
   fetchOrgAdmins,
   fetchOrgMembers,
+  fetchOrgPublicMembers,
   fetchOrgOutsideCollaborators,
   type OrgAdminListResult,
-  type OrgMemberListResult,
   type OrgCollaboratorListResult,
+  type OrgMemberListResult,
 } from '@/lib/analyzer/github-rest'
 import type {
   MemberPermissionDistributionSection,
@@ -39,6 +40,8 @@ export async function GET(request: Request) {
       applicability: 'not-applicable-non-org',
       adminCount: null,
       memberCount: null,
+      publicMemberCount: null,
+      publicMembers: null,
       outsideCollaboratorCount: null,
       unavailableReasons: [],
       resolvedAt,
@@ -46,11 +49,16 @@ export async function GET(request: Request) {
     return Response.json({ section })
   }
 
-  const [adminResult, allMembersResult, collaboratorResult] = await Promise.all([
+  const [adminResult, allMembersResult, publicMembersResult, collaboratorResult] = await Promise.all([
     fetchOrgAdmins(token, org),
     fetchOrgMembers(token, org),
+    fetchOrgPublicMembers(token, org),
     fetchOrgOutsideCollaborators(token, org),
   ])
+
+  // Public members — available without read:org; degrade gracefully
+  const publicMemberCount = publicMembersResult.kind === 'ok' ? publicMembersResult.members.length : null
+  const publicMembers = publicMembersResult.kind === 'ok' ? publicMembersResult.members : null
 
   // Total member fetch failing is a hard blocker — we can't show any counts
   if (allMembersResult.kind !== 'ok') {
@@ -59,6 +67,8 @@ export async function GET(request: Request) {
       applicability: 'member-list-unavailable',
       adminCount: null,
       memberCount: null,
+      publicMemberCount,
+      publicMembers,
       outsideCollaboratorCount: null,
       unavailableReasons: [mapMemberReason(allMembersResult)],
       resolvedAt,
@@ -74,6 +84,16 @@ export async function GET(request: Request) {
     adminCount = adminResult.admins.length
   } else {
     unavailableReasons.push(mapAdminReason(adminResult))
+  }
+
+  // Detect OAuth app restriction: when an org restricts third-party OAuth apps,
+  // role=admin and role=all return the same set of visible public members.
+  // Signal: adminCount equals total visible members (memberCount would be 0).
+  // In this case the admin count is unreliable — null it out so the UI doesn't
+  // display "86 (100%)" when the org simply has OAuth restrictions active.
+  if (adminCount !== null && adminCount > 0 && adminCount === allMembersResult.members.length) {
+    adminCount = null
+    unavailableReasons.push('admin-list-possibly-oauth-restricted')
   }
 
   // Non-admin members = all org members − admins (only when both are available)
@@ -94,6 +114,8 @@ export async function GET(request: Request) {
     applicability,
     adminCount,
     memberCount,
+    publicMemberCount,
+    publicMembers,
     outsideCollaboratorCount,
     unavailableReasons,
     resolvedAt,

--- a/components/auth/AuthContext.tsx
+++ b/components/auth/AuthContext.tsx
@@ -8,6 +8,7 @@ export interface AuthSession {
   token: string
   username: string
   scopes?: readonly string[]
+  isPAT?: boolean
 }
 
 interface AuthContextValue {

--- a/components/auth/AuthGate.test.tsx
+++ b/components/auth/AuthGate.test.tsx
@@ -58,25 +58,7 @@ describe('AuthGate', () => {
     expect(screen.getByRole('link', { name: /sign in with github/i })).toBeInTheDocument()
   })
 
-  it('renders three scope-tier radios on the unauthenticated branch, with baseline selected by default', () => {
-    render(
-      <AuthProvider>
-        <AuthGate>
-          <p>Protected content</p>
-        </AuthGate>
-      </AuthProvider>,
-    )
-    const baseline = screen.getByRole('radio', { name: /baseline/i })
-    const readOrg = screen.getByRole('radio', { name: /read org membership/i })
-    const adminOrg = screen.getByRole('radio', { name: /org admin \(read\)/i })
-
-    expect(baseline).toBeChecked()
-    expect(readOrg).not.toBeChecked()
-    expect(adminOrg).not.toBeChecked()
-  })
-
-  it('sign-in link reflects the selected scope tier', async () => {
-    const userEvent = (await import('@testing-library/user-event')).default
+  it('sign-in link always uses baseline scope (no scope-tier picker on sign-in page)', () => {
     render(
       <AuthProvider>
         <AuthGate>
@@ -86,38 +68,6 @@ describe('AuthGate', () => {
     )
     const link = screen.getByRole('link', { name: /sign in with github/i })
     expect(link.getAttribute('href')).toBe('/api/auth/login')
-
-    await userEvent.click(screen.getByRole('radio', { name: /read org membership/i }))
-    expect(link.getAttribute('href')).toBe('/api/auth/login?scope_tier=read-org')
-
-    await userEvent.click(screen.getByRole('radio', { name: /org admin \(read\)/i }))
-    expect(link.getAttribute('href')).toBe('/api/auth/login?scope_tier=admin-org')
-
-    await userEvent.click(screen.getByRole('radio', { name: /baseline/i }))
-    expect(link.getAttribute('href')).toBe('/api/auth/login')
-  })
-
-  it('each scope tier carries a brief guidance line to help the user decide', () => {
-    render(
-      <AuthProvider>
-        <AuthGate>
-          <p>Protected content</p>
-        </AuthGate>
-      </AuthProvider>,
-    )
-    expect(screen.getByText(/public data only/i)).toBeInTheDocument()
-    expect(screen.getByText(/concealed admins/i)).toBeInTheDocument()
-    expect(screen.getByText(/2fa enforcement/i)).toBeInTheDocument()
-  })
-
-  it('omits the solo-maintainer footnote that previously sat below the picker', () => {
-    render(
-      <AuthProvider>
-        <AuthGate>
-          <p>Protected content</p>
-        </AuthGate>
-      </AuthProvider>,
-    )
-    expect(screen.queryByText(/solo-maintainer repos are auto-detected/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
   })
 })

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -1,17 +1,16 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useAuth } from './AuthContext'
-import { SignInButton, type ScopeTier } from './SignInButton'
+import { useAuth, type AuthSession } from './AuthContext'
+import { SignInButton } from './SignInButton'
 
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const { session, signIn } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
   const authError = searchParams.get('auth_error')
-  const [scopeTier, setScopeTier] = useState<ScopeTier>('baseline')
 
   useEffect(() => {
     // Remove stale PAT key left by the pre-OAuth token-storage implementation
@@ -95,7 +94,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
           </div>
         </div>
 
-        <SignInButton tier={scopeTier} />
+        <SignInButton />
 
         <a
           href="/demo"
@@ -105,35 +104,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
           See an example without signing in →
         </a>
 
-        <fieldset
-          className="max-w-md space-y-2 px-4 text-left text-xs text-slate-600 dark:text-slate-300"
-          aria-label="GitHub permission scope"
-        >
-          <legend className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            GitHub permission
-          </legend>
-          <ScopeRadio
-            value="baseline"
-            checked={scopeTier === 'baseline'}
-            onChange={setScopeTier}
-            label={<><span className="font-semibold">Baseline</span> (read-only public data)</>}
-            guidance="Public data only — for auditing third-party orgs."
-          />
-          <ScopeRadio
-            value="read-org"
-            checked={scopeTier === 'read-org'}
-            onChange={setScopeTier}
-            label={<><span className="font-semibold">Read org membership</span> (<code>read:org</code>)</>}
-            guidance="Adds concealed admins of orgs you belong to."
-          />
-          <ScopeRadio
-            value="admin-org"
-            checked={scopeTier === 'admin-org'}
-            onChange={setScopeTier}
-            label={<><span className="font-semibold">Org admin (read)</span> (<code>admin:org</code>)</>}
-            guidance="Adds owner-only signals like 2FA enforcement; for orgs you own."
-          />
-        </fieldset>
+        <PATForm onSuccess={signIn} />
 
         <a href="/baseline" target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 transition hover:text-slate-600 dark:text-slate-500">View scoring methodology</a>
       </div>
@@ -144,33 +115,114 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
 }
 
-function ScopeRadio({
-  value,
-  checked,
-  onChange,
-  label,
-  guidance,
-}: {
-  value: ScopeTier
-  checked: boolean
-  onChange: (t: ScopeTier) => void
-  label: React.ReactNode
-  guidance: string
-}) {
+function PATForm({ onSuccess }: { onSuccess: (session: AuthSession) => void }) {
+  const [open, setOpen] = useState(false)
+  const [pat, setPat] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [errorMsg, setErrorMsg] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function handleToggle() {
+    setOpen((v) => !v)
+    if (!open) setTimeout(() => inputRef.current?.focus(), 50)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = pat.trim()
+    if (!trimmed) return
+    setStatus('loading')
+    setErrorMsg('')
+    try {
+      const res = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${trimmed}`,
+          Accept: 'application/vnd.github+json',
+        },
+      })
+      if (!res.ok) {
+        setStatus('error')
+        setErrorMsg(res.status === 401 ? 'Invalid token — check it and try again.' : `GitHub returned ${res.status}.`)
+        return
+      }
+      const body = (await res.json()) as { login?: string }
+      const username = body.login ?? 'unknown'
+      const scopesHeader = res.headers.get('x-oauth-scopes') ?? ''
+      const scopes = scopesHeader.split(',').map((s) => s.trim()).filter(Boolean)
+      onSuccess({ token: trimmed, username, scopes, isPAT: true })
+    } catch {
+      setStatus('error')
+      setErrorMsg('Network error — check your connection and try again.')
+    }
+  }
+
   return (
-    <label className="flex cursor-pointer items-start gap-2">
-      <input
-        type="radio"
-        name="scope-tier"
-        value={value}
-        checked={checked}
-        onChange={() => onChange(value)}
-        className="mt-0.5 h-3.5 w-3.5 border-slate-300 dark:border-slate-600"
-      />
-      <span className="min-w-0">
-        <span className="block">{label}</span>
-        <span className="block text-[11px] text-slate-500 dark:text-slate-400">{guidance}</span>
+    <div className="w-full max-w-md text-center">
+      <span className="group relative inline-block">
+        <button
+          type="button"
+          onClick={handleToggle}
+          className="text-xs text-slate-500 underline-offset-2 hover:text-slate-700 hover:underline dark:text-slate-400 dark:hover:text-slate-200"
+          data-testid="pat-toggle"
+        >
+          {open ? 'Hide' : 'Use a Personal Access Token instead'}
+        </button>
+        {!open && (
+          <span
+            role="tooltip"
+            className="pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 w-72 -translate-x-1/2 rounded-md border border-slate-200 bg-white px-3 py-2 text-left text-xs text-slate-600 opacity-0 shadow-md transition-opacity group-hover:opacity-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300"
+          >
+            Some GitHub organizations restrict which OAuth apps can access their data. A Personal Access Token bypasses those restrictions and can be granted <code className="font-mono text-[0.7rem]">read:org</code> scope for full member and admin counts.
+          </span>
+        )}
       </span>
-    </label>
+
+      {open && (
+        <form
+          onSubmit={handleSubmit}
+          className="mt-3 space-y-2 rounded-lg border border-slate-200 bg-white p-4 text-left dark:border-slate-700 dark:bg-slate-900"
+          data-testid="pat-form"
+        >
+          <p className="text-xs text-slate-600 dark:text-slate-300">
+            A PAT bypasses org-level OAuth app restrictions — useful when the org hasn&apos;t
+            approved this app. Recommended scope:
+          </p>
+          <ul className="ml-3 space-y-0.5 text-xs text-slate-600 dark:text-slate-300">
+            <li><code className="font-mono text-[11px]">read:org</code> — full member list, concealed admins</li>
+          </ul>
+          <a
+            href="https://github.com/settings/tokens/new?scopes=read%3Aorg&description=RepoPulse"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-xs font-medium text-sky-700 hover:underline dark:text-sky-400"
+          >
+            Create a token on GitHub with these scopes →
+          </a>
+          <input
+            ref={inputRef}
+            type="password"
+            value={pat}
+            onChange={(e) => { setPat(e.target.value); setStatus('idle') }}
+            placeholder="ghp_… or github_pat_…"
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full rounded border border-slate-300 bg-slate-50 px-3 py-1.5 font-mono text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+            data-testid="pat-input"
+          />
+          {status === 'error' && (
+            <p className="text-xs text-rose-600 dark:text-rose-400" data-testid="pat-error">{errorMsg}</p>
+          )}
+          <button
+            type="submit"
+            disabled={!pat.trim() || status === 'loading'}
+            className="w-full rounded bg-slate-800 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-white"
+            data-testid="pat-submit"
+          >
+            {status === 'loading' ? 'Verifying…' : 'Sign in with PAT'}
+          </button>
+        </form>
+      )}
+    </div>
   )
 }
+

--- a/components/auth/ElevatedScopeBanner.test.tsx
+++ b/components/auth/ElevatedScopeBanner.test.tsx
@@ -88,4 +88,53 @@ describe('ElevatedScopeBanner', () => {
     await userEvent.click(screen.getByRole('button', { name: /sign out to revert/i }))
     expect(screen.queryByTestId('elevated-scope-banner')).not.toBeInTheDocument()
   })
+
+  it('shows "Personal Access Token active" heading for PAT sessions', () => {
+    render(
+      <AuthProvider
+        initialSession={{
+          token: 'ghp_abc',
+          username: 'arun-gupta',
+          scopes: ['read:org'],
+          isPAT: true,
+        }}
+      >
+        <ElevatedScopeBanner />
+      </AuthProvider>,
+    )
+    expect(screen.getByTestId('elevated-scope-banner')).toBeInTheDocument()
+    expect(screen.getByText(/personal access token active/i)).toBeInTheDocument()
+  })
+
+  it('shows "Sign out" (not "Sign out to revert") for PAT sessions', () => {
+    render(
+      <AuthProvider
+        initialSession={{
+          token: 'ghp_abc',
+          username: 'arun-gupta',
+          scopes: ['read:org'],
+          isPAT: true,
+        }}
+      >
+        <ElevatedScopeBanner />
+      </AuthProvider>,
+    )
+    expect(screen.getByRole('button', { name: /^sign out$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /sign out to revert/i })).not.toBeInTheDocument()
+  })
+
+  it('shows "Sign out to revert" for OAuth elevated sessions', () => {
+    render(
+      <AuthProvider
+        initialSession={{
+          token: 'gho_abc',
+          username: 'arun-gupta',
+          scopes: ['read:org'],
+        }}
+      >
+        <ElevatedScopeBanner />
+      </AuthProvider>,
+    )
+    expect(screen.getByRole('button', { name: /sign out to revert/i })).toBeInTheDocument()
+  })
 })

--- a/components/auth/ElevatedScopeBanner.tsx
+++ b/components/auth/ElevatedScopeBanner.tsx
@@ -8,6 +8,7 @@ export function ElevatedScopeBanner() {
   if (!session || elevatedScopes.length === 0 || bannerDismissed) return null
 
   const scopeList = elevatedScopes.join(', ')
+  const isPAT = session.isPAT === true
 
   return (
     <div
@@ -18,8 +19,17 @@ export function ElevatedScopeBanner() {
     >
       <div className="mx-auto flex max-w-5xl items-start justify-between gap-3 px-4 py-2 text-xs sm:text-sm">
         <p className="min-w-0 flex-1">
-          <span className="font-semibold">Elevated GitHub permissions active</span>
-          {' — this session can see concealed org admins and non-public org membership. Active scopes: '}
+          {isPAT ? (
+            <>
+              <span className="font-semibold">Personal Access Token active</span>
+              {' — bypasses org OAuth app restrictions; can see concealed org admins and non-public org membership. Active scopes: '}
+            </>
+          ) : (
+            <>
+              <span className="font-semibold">Elevated GitHub permissions active</span>
+              {' — this session can see concealed org admins and non-public org membership. Active scopes: '}
+            </>
+          )}
           <code
             data-testid="elevated-scope-banner-scopes"
             className="rounded bg-amber-100 px-1 py-0.5 font-mono text-[0.72rem] text-amber-900 dark:bg-amber-900/40 dark:text-amber-100"
@@ -34,7 +44,7 @@ export function ElevatedScopeBanner() {
             onClick={signOut}
             className="rounded border border-amber-400 bg-white/60 px-2 py-1 text-xs font-medium text-amber-900 transition hover:bg-white dark:border-amber-600 dark:bg-amber-900/40 dark:text-amber-100 dark:hover:bg-amber-900/70"
           >
-            Sign out to revert
+            {isPAT ? 'Sign out' : 'Sign out to revert'}
           </button>
           <button
             type="button"

--- a/components/org-summary/panels/MemberPermissionDistributionPanel.test.tsx
+++ b/components/org-summary/panels/MemberPermissionDistributionPanel.test.tsx
@@ -9,9 +9,10 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }))
 
-function renderWithSession(ui: React.ReactElement) {
+function renderWithSession(ui: React.ReactElement, { elevated = false }: { elevated?: boolean } = {}) {
+  const scopes = elevated ? ['public_repo', 'read:org'] : ['public_repo']
   return render(
-    <AuthProvider initialSession={{ token: 't', username: 'u', scopes: ['public_repo'] }}>
+    <AuthProvider initialSession={{ token: 't', username: 'u', scopes }}>
       {ui}
     </AuthProvider>,
   )
@@ -23,6 +24,14 @@ function makeSection(overrides: Partial<MemberPermissionDistributionSection> = {
     applicability: 'applicable',
     adminCount: 2,
     memberCount: 8,
+    publicMemberCount: 5,
+    publicMembers: [
+      { login: 'alice', avatarUrl: 'https://github.com/alice.png' },
+      { login: 'bob', avatarUrl: 'https://github.com/bob.png' },
+      { login: 'carol', avatarUrl: 'https://github.com/carol.png' },
+      { login: 'dave', avatarUrl: 'https://github.com/dave.png' },
+      { login: 'eve', avatarUrl: 'https://github.com/eve.png' },
+    ],
     outsideCollaboratorCount: 1,
     unavailableReasons: [],
     resolvedAt: '2026-04-20T00:00:00Z',
@@ -48,29 +57,42 @@ describe('Member permission distribution (absorbed into StaleAdminsPanel) — ro
         memberPermissionOverride={makeSection()}
       />,
     )
-    expect(screen.getByText(/org admin.*member overview/i)).toBeTruthy()
+    expect(screen.getByText(/org member.*admin overview/i)).toBeTruthy()
   })
 
-  it('shows admin, member, and outside-collaborator counts', () => {
+  it('shows admin, member, and outside-collaborator counts with elevated scope', () => {
     // adminCount=2, memberCount=8, outsideCollaboratorCount=1
     renderWithSession(
       <StaleAdminsPanel
         {...BASE_PROPS}
         memberPermissionOverride={makeSection()}
       />,
+      { elevated: true },
     )
     expect(screen.getByTestId('perm-admin-count').textContent).toMatch(/2/)
     expect(screen.getByTestId('perm-member-count').textContent).toMatch(/8/)
     expect(screen.getByTestId('perm-collab-count').textContent).toMatch(/1/)
   })
 
-  it('shows admin percentage', () => {
+  it('hides admin count (shows Unavailable) without elevated scope', () => {
+    renderWithSession(
+      <StaleAdminsPanel
+        {...BASE_PROPS}
+        memberPermissionOverride={makeSection()}
+      />,
+    )
+    expect(screen.getByTestId('perm-admin-count').textContent).toBe('Not available')
+    expect(screen.queryByTestId('perm-admin-pct')).toBeNull()
+  })
+
+  it('shows admin percentage with elevated scope', () => {
     // 2 admins in 11 total (2+8+1) = ~18%
     renderWithSession(
       <StaleAdminsPanel
         {...BASE_PROPS}
         memberPermissionOverride={makeSection()}
       />,
+      { elevated: true },
     )
     expect(screen.getByTestId('perm-admin-pct').textContent).toMatch(/18%/)
   })
@@ -94,6 +116,28 @@ describe('Member permission distribution (absorbed into StaleAdminsPanel) — ro
     )
     expect(screen.getByTestId('perm-unavailable')).toBeTruthy()
     expect(screen.queryByTestId('perm-admin-count')).toBeNull()
+  })
+
+  it('renders "Unavailable" (not "0") for member count when memberCount is 0, even with elevated scope', () => {
+    // With read:org but without org membership, GitHub returns only public members.
+    // All public members may be admins, giving memberCount = 0. This should display
+    // as Unavailable rather than "0 (0%)" to avoid implying the org has no members.
+    render(
+      <AuthProvider initialSession={{ token: 't', username: 'u', scopes: ['read:org'] }}>
+        <StaleAdminsPanel
+          {...BASE_PROPS}
+          memberPermissionOverride={makeSection({
+            applicability: 'partial',
+            adminCount: 86,
+            memberCount: 0,
+            outsideCollaboratorCount: null,
+            unavailableReasons: ['collaborator-list-scope-insufficient'],
+          })}
+        />
+      </AuthProvider>,
+    )
+    expect(screen.getByTestId('perm-member-count').textContent).toBe('Not available')
+    expect(screen.queryByTestId('perm-member-pct')).toBeNull()
   })
 
   it('shows loading text while loading', () => {
@@ -175,16 +219,27 @@ describe('Member permission distribution (absorbed into StaleAdminsPanel) — ro
     expect(link.target).toBe('_blank')
   })
 
-  it('renders a link for the member count', () => {
+  it('renders a link for the member count with elevated scope', () => {
+    renderWithSession(
+      <StaleAdminsPanel
+        {...BASE_PROPS}
+        memberPermissionOverride={makeSection()}
+      />,
+      { elevated: true },
+    )
+    const link = screen.getByTestId('perm-member-link') as HTMLAnchorElement
+    expect(link.href).toContain('github.com/orgs/acme/people')
+    expect(link.target).toBe('_blank')
+  })
+
+  it('renders no link for the member count in baseline mode (list shown inline)', () => {
     renderWithSession(
       <StaleAdminsPanel
         {...BASE_PROPS}
         memberPermissionOverride={makeSection()}
       />,
     )
-    const link = screen.getByTestId('perm-member-link') as HTMLAnchorElement
-    expect(link.href).toContain('github.com/orgs/acme/people')
-    expect(link.target).toBe('_blank')
+    expect(screen.queryByTestId('perm-member-link')).toBeNull()
   })
 
   it('renders no links in N/A state', () => {

--- a/components/org-summary/panels/StaleAdminsPanel.test.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.test.tsx
@@ -74,7 +74,7 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
     const badge = screen.getByTestId('stale-admins-mode-baseline')
     expect(badge.textContent).toMatch(/baseline/i)
-    expect(badge.textContent).toMatch(/public admins only/i)
+    expect(badge.textContent).toMatch(/public members only/i)
   })
 
   it('shows per-group count pills matching the number of admins in each group', () => {
@@ -104,8 +104,17 @@ describe('StaleAdminsPanel — baseline rendering', () => {
     expect(within(unavailableSummary).getByText('1')).toBeInTheDocument()
   })
 
-  it('renders a header summary strip with totals across all classifications', () => {
+  it('hides the header summary strip in baseline mode (activity section is hidden)', () => {
     const section = makeSection({
+      admins: [mkAdmin('a1', 'active'), mkAdmin('s1', 'stale'), mkAdmin('u1', 'unavailable')],
+    })
+    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+    expect(screen.queryByTestId('stale-admins-count-strip')).not.toBeInTheDocument()
+  })
+
+  it('renders a header summary strip with totals across all classifications when elevated', () => {
+    const section = makeSection({
+      mode: 'elevated-effective',
       admins: [
         mkAdmin('a1', 'active'),
         mkAdmin('a2', 'active'),
@@ -114,37 +123,41 @@ describe('StaleAdminsPanel — baseline rendering', () => {
         mkAdmin('u1', 'unavailable'),
       ],
     })
-    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+    renderWithSession(
+      <StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />,
+      { scopes: ['public_repo', 'read:org'] },
+    )
 
     const strip = screen.getByTestId('stale-admins-count-strip')
-    expect(strip).toHaveAttribute('aria-label', 'Admin summary — 5 admins')
+    expect(strip).toHaveAttribute('aria-label', 'Admin summary — 5')
     expect(within(strip).getByText('5 admins')).toBeInTheDocument()
     expect(within(strip).getByTestId('stale-admins-count-stale').textContent).toMatch(/1 stale/i)
-    expect(within(strip).getByTestId('stale-admins-count-unavailable').textContent).toMatch(/1 unavailable/i)
-    expect(
-      within(strip).getByTestId('stale-admins-count-no-public-activity').textContent,
-    ).toMatch(/1 no public activity/i)
+    expect(within(strip).getByTestId('stale-admins-count-unavailable').textContent).toMatch(/1 activity unknown/i)
     expect(within(strip).getByTestId('stale-admins-count-active').textContent).toMatch(/2 active/i)
   })
 
-  it('hides the description and group list when the panel is collapsed, keeps the summary count strip visible', () => {
+  it('hides the description and group list when the panel is collapsed', () => {
     const section = makeSection({
+      mode: 'elevated-effective',
       admins: [mkAdmin('s1', 'stale'), mkAdmin('a1', 'active')],
     })
-    renderWithSession(<StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />)
+    renderWithSession(
+      <StaleAdminsPanel org="acme" ownerType="Organization" sectionOverride={section} />,
+      { scopes: ['public_repo', 'read:org'] },
+    )
 
-    // Expanded by default — strip and description are visible.
+    // Expanded by default — strip and activity section are visible.
     expect(screen.getByTestId('stale-admins-count-strip')).toBeInTheDocument()
-    expect(screen.getByText(/member roles and admin activity/i)).toBeInTheDocument()
+    expect(screen.getByTestId('stale-admins-activity-detail')).toBeInTheDocument()
 
     const toggle = screen.getByTestId('stale-admins-panel-toggle')
     fireEvent.click(toggle)
 
+    // After collapse, groups and subtitle are hidden.
     expect(screen.queryByTestId('stale-admins-group-stale')).not.toBeInTheDocument()
-    expect(screen.queryByText(/member roles and admin activity/i)).not.toBeInTheDocument()
-    // Summary strip and title stay visible so the signal is still readable at a glance.
+    // Summary strip and title stay visible.
     expect(screen.getByTestId('stale-admins-count-strip')).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: /org admin.*member overview/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /org member.*admin overview/i })).toBeInTheDocument()
   })
 
   it('omits the header summary strip when applicability is not applicable', () => {

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -364,7 +364,7 @@ function MemberPermissionSummary({
           <span className="font-medium">Personal Access Token</span>
           {' with '}
           <code className="font-mono text-[0.7rem]">read:org</code>
-          {' scope — PATs bypass OAuth app restrictions. You must also be a member of this org to see concealed admins and member counts.'}
+          {' scope — PATs bypass OAuth app restrictions. You must also be a member of this org to see full member details and admin counts.'}
         </p>
       ) : !elevated ? (
         <p className="text-xs text-slate-500 dark:text-slate-400">

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -1162,7 +1162,6 @@ const MODE_CONFIG: Record<StaleAdminMode, { label: string; className: string; to
   'elevated-ineffective': {
     label: 'Elevated grant did not widen this view',
     className: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
-    tooltip: 'The admin list returned the same count as the full member list — this typically means the org restricts third-party OAuth apps. Are you a member of this org? A Personal Access Token with read:org scope bypasses OAuth app restrictions.',
   },
 }
 

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -1128,7 +1128,7 @@ function RetryCountdown({ availableAt }: { availableAt: string }) {
 
 function ModeBadge({ mode }: { mode: StaleAdminMode }) {
   const config = MODE_CONFIG[mode]
-  return (
+  const badge = (
     <span
       className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${config.className}`}
       data-testid={`stale-admins-mode-${mode}`}
@@ -1136,9 +1136,21 @@ function ModeBadge({ mode }: { mode: StaleAdminMode }) {
       {config.label}
     </span>
   )
+  if (!config.tooltip) return badge
+  return (
+    <span className="group relative inline-flex">
+      {badge}
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute bottom-full right-0 z-20 mb-1.5 w-64 rounded-md border border-slate-200 bg-white px-3 py-2 text-left text-xs text-slate-600 opacity-0 shadow-md transition-opacity group-hover:opacity-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300"
+      >
+        {config.tooltip}
+      </span>
+    </span>
+  )
 }
 
-const MODE_CONFIG: Record<StaleAdminMode, { label: string; className: string }> = {
+const MODE_CONFIG: Record<StaleAdminMode, { label: string; className: string; tooltip?: string }> = {
   baseline: {
     label: 'Baseline — public members only',
     className: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
@@ -1150,6 +1162,7 @@ const MODE_CONFIG: Record<StaleAdminMode, { label: string; className: string }> 
   'elevated-ineffective': {
     label: 'Elevated grant did not widen this view',
     className: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+    tooltip: 'The read:org scope was granted but this org restricts third-party OAuth apps — the data returned is the same as without it. Are you a member of this org? A Personal Access Token with read:org scope bypasses OAuth app restrictions.',
   },
 }
 

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -8,6 +8,7 @@ import { useMemberPermissionDistribution } from '@/components/shared/hooks/useMe
 import {
   evaluatePermissionFlag,
   type MemberPermissionDistributionSection,
+  type MemberPermissionUnavailableReason,
   type PermissionFlag,
 } from '@/lib/governance/member-permissions'
 import type {
@@ -61,10 +62,10 @@ const GROUP_CONFIG: Record<
     headerBorderClassName: 'border-l-4 border-rose-500',
   },
   unavailable: {
-    label: 'Unavailable',
+    label: 'Activity unknown',
     icon: '?',
     pillClassName: 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400',
-    groupAriaLabel: 'Admins with unavailable activity',
+    groupAriaLabel: 'Activity could not be retrieved — rate-limited or API error',
     headerBorderClassName: 'border-l-4 border-amber-500',
   },
   'no-public-activity': {
@@ -92,7 +93,8 @@ export function StaleAdminsPanel({
   nextAutoRetryAtOverride,
   memberPermissionOverride,
 }: Props) {
-  const { session, hasScope } = useAuth()
+  const { session, hasScope, signOut } = useAuth()
+  const isPAT = session?.isPAT === true
   // admin:org is a strict superset of read:org — treat either as "elevated"
   // for the concealed-admins view.
   const elevated = hasScope('read:org') || hasScope('admin:org')
@@ -125,6 +127,12 @@ export function StaleAdminsPanel({
   const memberSection = hasMemberOverride ? memberPermissionOverride : memberHookState.section
   const memberLoading = hasMemberOverride ? false : memberHookState.loading
 
+  // OAuth restriction: elevated scope was granted but org blocks the OAuth app.
+  // Detected once memberSection loads; until then, assumes elevated is effective.
+  const oauthRestricted = elevated &&
+    memberSection?.unavailableReasons?.includes('admin-list-possibly-oauth-restricted') === true
+  const effectivelyElevated = elevated && !oauthRestricted
+
   const computedFlag: PermissionFlag | null =
     memberSection && memberSection.applicability === 'applicable' && memberSection.adminCount !== null
       ? (memberSection.flag !== undefined
@@ -141,7 +149,7 @@ export function StaleAdminsPanel({
 
   return (
     <section
-      aria-label="Org admin & member overview"
+      aria-label="Org member & admin overview"
       className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
       data-testid="stale-admins-panel"
     >
@@ -151,7 +159,7 @@ export function StaleAdminsPanel({
             <button
               type="button"
               onClick={() => setExpanded((e) => !e)}
-              aria-label={expanded ? 'Collapse Org admin & member overview' : 'Expand Org admin & member overview'}
+              aria-label={expanded ? 'Collapse Org member & admin overview' : 'Expand Org member & admin overview'}
               aria-expanded={expanded}
               title={expanded ? 'Collapse' : 'Expand'}
               data-testid="stale-admins-panel-toggle"
@@ -162,19 +170,21 @@ export function StaleAdminsPanel({
             <div className="min-w-0">
               <div className="flex items-center gap-1.5">
                 <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-                  Org admin &amp; member overview
+                  Org member &amp; admin overview
                 </h3>
                 <ScoringHelp section={section} />
               </div>
               {expanded ? (
                 <p className="text-xs text-slate-500 dark:text-slate-400">
-                  Member roles and admin activity — who has elevated access and whether they&apos;re active.
+                  {effectivelyElevated
+                    ? 'Member roles and admin activity — who has elevated access and whether they\'re active.'
+                    : 'Public member overview — sign in with a PAT for full admin and member breakdown.'}
                 </p>
               ) : null}
             </div>
           </div>
           <div className="flex items-center gap-2">
-            {!elevated && memberSection?.applicability === 'applicable' ? (
+            {!effectivelyElevated && memberSection?.applicability === 'applicable' ? (
               <span
                 className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 text-xs text-slate-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400"
                 title="Sign in with 'Read org membership' or 'Org admin' permission to see private member counts"
@@ -186,7 +196,7 @@ export function StaleAdminsPanel({
             {section ? <ModeBadge mode={section.mode} /> : null}
           </div>
         </div>
-        {section ? <HeaderCountStrip section={section} /> : null}
+        {section && effectivelyElevated ? <HeaderCountStrip section={section} elevated={effectivelyElevated} /> : null}
       </header>
 
       {expanded ? (
@@ -197,10 +207,13 @@ export function StaleAdminsPanel({
             loading={memberLoading}
             org={org ?? ''}
             elevated={elevated}
+            oauthRestricted={oauthRestricted}
+            isPAT={isPAT}
+            onSignOut={signOut}
           />
 
-          {/* Admin activity detail — collapsible sub-section */}
-          <details open className="group" data-testid="stale-admins-activity-detail">
+          {/* Activity detail — only shown with effective elevated scope (baseline = can't identify admins) */}
+          <details open className="group" data-testid="stale-admins-activity-detail" hidden={!effectivelyElevated}>
             <summary className="flex cursor-pointer select-none items-center gap-1.5 text-xs font-medium text-slate-600 list-none dark:text-slate-300 [&::-webkit-details-marker]:hidden">
               <svg
                 aria-hidden="true"
@@ -214,11 +227,13 @@ export function StaleAdminsPanel({
                   clipRule="evenodd"
                 />
               </svg>
-              Admin activity detail
+              {effectivelyElevated ? 'Admin activity detail' : 'Public member activity'}
             </summary>
             <div className="mt-2">
               {loading && !section ? (
-                <p className="text-sm text-slate-500 dark:text-slate-400">Loading admin activity…</p>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  {effectivelyElevated ? 'Loading admin activity…' : 'Loading public member activity…'}
+                </p>
               ) : null}
               {section ? (
                 <SectionBody
@@ -226,6 +241,7 @@ export function StaleAdminsPanel({
                   onRetry={onRetry}
                   refreshing={loading}
                   nextAutoRetryAt={nextAutoRetryAt}
+                  elevated={effectivelyElevated}
                 />
               ) : null}
             </div>
@@ -243,11 +259,17 @@ function MemberPermissionSummary({
   loading,
   org,
   elevated,
+  oauthRestricted,
+  isPAT,
+  onSignOut,
 }: {
   section: MemberPermissionDistributionSection | null
   loading: boolean
   org: string
   elevated: boolean
+  oauthRestricted: boolean
+  isPAT: boolean
+  onSignOut: () => void
 }) {
   if (loading) {
     return (
@@ -275,15 +297,25 @@ function MemberPermissionSummary({
     )
   }
 
-  const adminVal = section.adminCount ?? 0
-  const effectiveMemberCount =
-    !elevated && section.memberCount === 0 ? null : section.memberCount
+  // "Effectively elevated" = has elevated scope AND it actually widened the view.
+  const effectivelyElevated = elevated && !oauthRestricted
+
+  // Without effective elevated scope GitHub may return unreliable counts — hide admin count.
+  const displayAdminCount = effectivelyElevated ? section.adminCount : null
+  const adminVal = displayAdminCount ?? 0
+  const effectiveMemberCount = section.memberCount === 0 ? null : section.memberCount
   const memberCount = effectiveMemberCount ?? 0
   const collabCount = section.outsideCollaboratorCount ?? 0
   const total = adminVal + memberCount + collabCount
   const adminPct = total > 0 ? Math.round((adminVal / total) * 100) : 0
   const memberPct = total > 0 ? Math.round((memberCount / total) * 100) : 0
   const collabPct = total > 0 ? Math.round((collabCount / total) * 100) : 0
+
+  const publicCount = section.publicMemberCount ?? null
+  const privateMemberCount =
+    effectiveMemberCount !== null && publicCount !== null
+      ? effectiveMemberCount - publicCount
+      : null
 
   const adminUrl = `https://github.com/orgs/${org}/people?query=role%3Aowner`
   const memberUrl = `https://github.com/orgs/${org}/people?query=role%3Amember`
@@ -293,21 +325,24 @@ function MemberPermissionSummary({
       <div className="grid grid-cols-3 gap-2 text-sm">
         <RoleRow
           label="Admins"
-          count={section.adminCount}
+          count={displayAdminCount}
           pct={adminPct}
           countTestId="perm-admin-count"
           pctTestId="perm-admin-pct"
           linkTestId="perm-admin-link"
           href={adminUrl}
+          labelTooltip={!elevated ? 'Admin status cannot be verified without read:org scope — GitHub may return all visible public members from this endpoint regardless of their actual role.' : undefined}
         />
         <RoleRow
-          label="Members"
-          count={effectiveMemberCount}
-          pct={memberPct}
+          label={effectivelyElevated ? 'Members' : 'Public members'}
+          count={effectivelyElevated ? effectiveMemberCount : publicCount}
+          pct={effectivelyElevated ? memberPct : null}
           countTestId="perm-member-count"
           pctTestId="perm-member-pct"
-          linkTestId="perm-member-link"
-          href={memberUrl}
+          linkTestId={effectivelyElevated ? 'perm-member-link' : null}
+          href={effectivelyElevated ? memberUrl : null}
+          publicCount={effectivelyElevated ? publicCount : null}
+          privateCount={effectivelyElevated ? privateMemberCount : null}
         />
         <RoleRow
           label="Outside collaborators"
@@ -317,22 +352,57 @@ function MemberPermissionSummary({
           pctTestId="perm-collab-pct"
           linkTestId={null}
           href={null}
+          labelTooltip="Requires org membership — available via a Personal Access Token with read:org scope from an org owner or admin."
+          labelTooltipAlign="right"
         />
       </div>
-      {!elevated ? (
+      {oauthRestricted ? (
         <p className="text-xs text-slate-500 dark:text-slate-400">
-          Showing public members only. Sign in with{' '}
-          <span className="font-medium">Read org membership</span> or{' '}
-          <span className="font-medium">Org admin</span> permission for full counts.
+          read:org scope was granted, but this org restricts the OAuth app — admin and member counts are unavailable.{' '}
+          <button type="button" onClick={onSignOut} className="font-medium text-sky-700 hover:underline dark:text-sky-400">Sign out</button>
+          {' and sign in again using a '}
+          <span className="font-medium">Personal Access Token</span>
+          {' with '}
+          <code className="font-mono text-[0.7rem]">read:org</code> scope for accurate counts.
         </p>
-      ) : section.applicability === 'partial' && section.unavailableReasons.length > 0 ? (
+      ) : !elevated ? (
         <p className="text-xs text-slate-500 dark:text-slate-400">
-          Some data unavailable:{' '}
-          {section.unavailableReasons.join(', ')}
+          Admin and member breakdown unavailable — org may restrict OAuth app access.{' '}
+          {isPAT
+            ? <>Add <code className="font-mono text-[0.7rem]">read:org</code> scope to your token for full counts.</>
+            : <><button type="button" onClick={onSignOut} className="font-medium text-sky-700 hover:underline dark:text-sky-400">Sign out</button>{' and sign in again using a '}<span className="font-medium">Personal Access Token</span>{' with '}<code className="font-mono text-[0.7rem]">read:org</code>{' scope for full counts.'}</>
+          }
         </p>
+      ) : section.applicability === 'partial' && section.unavailableReasons.filter(r => r !== 'admin-list-possibly-oauth-restricted').length > 0 ? (
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {formatUnavailableReasons(section.unavailableReasons.filter(r => r !== 'admin-list-possibly-oauth-restricted'))}
+          {!isPAT && <>{' '}Use a <span className="font-medium">Personal Access Token</span> for full access.</>}
+        </p>
+      ) : null}
+      {section.publicMembers && section.publicMembers.length > 0 ? (
+        <PublicMemberList members={section.publicMembers} org={org} />
       ) : null}
     </div>
   )
+}
+
+function formatUnavailableReasons(reasons: MemberPermissionUnavailableReason[]): string {
+  const labels: Record<MemberPermissionUnavailableReason, string> = {
+    'admin-list-rate-limited': 'admin list rate-limited',
+    'admin-list-auth-failed': 'admin list auth failed',
+    'admin-list-scope-insufficient': 'admin list requires elevated scope',
+    'admin-list-possibly-oauth-restricted': 'admin count restricted by org OAuth policy',
+    'member-list-rate-limited': 'member list rate-limited',
+    'member-list-auth-failed': 'member list auth failed',
+    'member-list-scope-insufficient': 'member list requires elevated scope',
+    'collaborator-list-rate-limited': 'outside collaborators rate-limited',
+    'collaborator-list-auth-failed': 'outside collaborators auth failed',
+    'collaborator-list-scope-insufficient': 'outside collaborators require Org admin permission',
+    'network': 'network error',
+    'unknown': 'unknown error',
+  }
+  const parts = reasons.map((r) => labels[r] ?? r)
+  return `Some data unavailable: ${parts.join(', ')}.`
 }
 
 function RoleRow({
@@ -343,24 +413,35 @@ function RoleRow({
   pctTestId,
   linkTestId,
   href,
+  publicCount,
+  privateCount,
+  labelTooltip,
+  labelTooltipAlign,
 }: {
   label: string
   count: number | null
-  pct: number
+  pct: number | null
   countTestId: string
   pctTestId: string
   linkTestId: string | null
   href: string | null
+  publicCount?: number | null
+  privateCount?: number | null
+  labelTooltip?: string
+  labelTooltipAlign?: 'left' | 'right'
 }) {
   const countContent = (
     <span className="font-semibold text-slate-900 dark:text-slate-100" data-testid={countTestId}>
-      {count ?? 'Unavailable'}
+      {count ?? 'Not available'}
     </span>
   )
 
   return (
     <div className="rounded border border-slate-100 bg-slate-50 p-2 dark:border-slate-700 dark:bg-slate-800">
-      <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+      <div className="flex items-center gap-1">
+        <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+        {labelTooltip ? <LabelTooltip text={labelTooltip} align={labelTooltipAlign} /> : null}
+      </div>
       <div className="flex items-baseline gap-1">
         {href && linkTestId ? (
           <a href={href} target="_blank" rel="noreferrer" data-testid={linkTestId} className="hover:underline">
@@ -369,13 +450,178 @@ function RoleRow({
         ) : (
           countContent
         )}
-        {count !== null ? (
+        {count !== null && pct !== null ? (
           <span className="text-xs text-slate-500 dark:text-slate-400" data-testid={pctTestId}>
             ({pct}%)
           </span>
         ) : null}
       </div>
+      {count !== null && publicCount !== null && publicCount !== undefined && privateCount !== null && privateCount !== undefined ? (
+        <p className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500" data-testid="perm-member-split">
+          {publicCount} public · {privateCount} private
+        </p>
+      ) : null}
     </div>
+  )
+}
+
+function ElevateAccessLink({ tier, children }: { tier: 'read-org' | 'admin-org'; children: React.ReactNode }) {
+  function handleClick() {
+    if (typeof window !== 'undefined' && window.location.search) {
+      sessionStorage.setItem('oauth_return_search', window.location.search)
+    }
+  }
+  return (
+    <a
+      href={`/api/auth/login?scope_tier=${tier}`}
+      onClick={handleClick}
+      className="font-medium text-sky-700 underline-offset-2 hover:underline dark:text-sky-400"
+    >
+      {children}
+    </a>
+  )
+}
+
+function LabelTooltip({ text, align = 'left' }: { text: string; align?: 'left' | 'right' }) {
+  return (
+    <span className="group relative inline-flex">
+      <span
+        aria-label={text}
+        className="inline-flex h-3.5 w-3.5 cursor-help items-center justify-center rounded-full border border-slate-300 text-[9px] font-semibold text-slate-400 dark:border-slate-600 dark:text-slate-500"
+        data-testid="role-row-tooltip-trigger"
+      >
+        i
+      </span>
+      <span
+        role="tooltip"
+        className={`pointer-events-none absolute bottom-full z-20 mb-1.5 w-64 rounded-md border border-slate-200 bg-white px-3 py-2 text-left text-xs text-slate-600 opacity-0 shadow-md transition-opacity group-hover:opacity-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 ${align === 'right' ? 'right-0' : 'left-0'}`}
+        data-testid="role-row-tooltip"
+      >
+        {text}
+      </span>
+    </span>
+  )
+}
+
+const PUBLIC_MEMBER_PREVIEW_LIMIT = 20
+
+function PublicMemberList({ members, org }: { members: { login: string; avatarUrl: string }[]; org: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const [query, setQuery] = useState('')
+
+  const filtered = query
+    ? members.filter((m) => m.login.toLowerCase().includes(query.toLowerCase()))
+    : members
+
+  const isSearching = query.length > 0
+  const shown = isSearching || expanded ? filtered : filtered.slice(0, PUBLIC_MEMBER_PREVIEW_LIMIT)
+  const remaining = filtered.length - PUBLIC_MEMBER_PREVIEW_LIMIT
+
+  return (
+    <details
+      open={false}
+      className="group rounded border border-slate-100 bg-slate-50 dark:border-slate-700 dark:bg-slate-800/50"
+      data-testid="public-member-list"
+    >
+      <summary className="flex cursor-pointer select-none items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-slate-600 list-none dark:text-slate-300 [&::-webkit-details-marker]:hidden">
+        <svg
+          aria-hidden="true"
+          className="h-3 w-3 shrink-0 -rotate-90 text-slate-400 transition-transform group-open:rotate-0 dark:text-slate-500"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z"
+            clipRule="evenodd"
+          />
+        </svg>
+        Public members ({members.length})
+      </summary>
+      <div className="border-t border-slate-100 px-3 py-2 dark:border-slate-700">
+        <div className="mb-2 flex items-center gap-2">
+          <div className="relative flex-1">
+            <svg aria-hidden="true" className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-slate-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11ZM2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9Z" clipRule="evenodd" />
+            </svg>
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => { setQuery(e.target.value); setExpanded(false) }}
+              placeholder="Search members…"
+              aria-label="Search public members"
+              className="w-full rounded border border-slate-200 bg-white py-1 pl-7 pr-2 text-xs text-slate-700 placeholder-slate-400 focus:border-sky-400 focus:outline-none focus:ring-1 focus:ring-sky-400 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:placeholder-slate-500"
+              data-testid="public-member-search"
+            />
+          </div>
+          {isSearching ? (
+            <span className="shrink-0 text-xs text-slate-500 dark:text-slate-400">
+              {filtered.length} of {members.length}
+            </span>
+          ) : null}
+        </div>
+
+        {shown.length === 0 ? (
+          <p className="py-1 text-xs text-slate-500 dark:text-slate-400">No members match &ldquo;{query}&rdquo;.</p>
+        ) : (
+          <ul className="flex flex-wrap gap-1.5" data-testid="public-member-list-items">
+            {shown.map(({ login, avatarUrl }) => (
+              <li key={login}>
+                <a
+                  href={`https://github.com/${login}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={login}
+                  className="group/chip inline-flex items-center gap-1 rounded-full bg-white py-0.5 pl-0.5 pr-2 text-xs text-slate-700 ring-1 ring-slate-200 transition hover:ring-sky-300 dark:bg-slate-900 dark:text-slate-300 dark:ring-slate-700 dark:hover:ring-sky-700"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={`${avatarUrl}&s=32`}
+                    alt=""
+                    aria-hidden="true"
+                    width={16}
+                    height={16}
+                    className="h-4 w-4 rounded-full bg-slate-100 dark:bg-slate-800"
+                    loading="lazy"
+                  />
+                  <span className="group-hover/chip:text-sky-700 dark:group-hover/chip:text-sky-400">{login}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {!isSearching && !expanded && remaining > 0 ? (
+          <div className="mt-2 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="text-xs text-sky-700 hover:underline dark:text-sky-400"
+              data-testid="public-member-list-show-more"
+            >
+              Show {remaining} more
+            </button>
+            <a
+              href={`https://github.com/orgs/${org}/people`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-slate-500 hover:underline dark:text-slate-400"
+            >
+              View all on GitHub →
+            </a>
+          </div>
+        ) : !isSearching && members.length > PUBLIC_MEMBER_PREVIEW_LIMIT ? (
+          <a
+            href={`https://github.com/orgs/${org}/people`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 block text-xs text-slate-500 hover:underline dark:text-slate-400"
+          >
+            View all on GitHub →
+          </a>
+        ) : null}
+      </div>
+    </details>
   )
 }
 
@@ -411,23 +657,24 @@ function PanelChevron({ expanded }: { expanded: boolean }) {
   )
 }
 
-function HeaderCountStrip({ section }: { section: StaleAdminsSection }) {
+function HeaderCountStrip({ section, elevated }: { section: StaleAdminsSection; elevated: boolean }) {
   if (section.applicability !== 'applicable' || section.admins.length === 0) return null
   const counts = countByClassification(section.admins)
   const total = section.admins.length
+  const noun = elevated ? 'admin' : 'public member'
   return (
     <div
       className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs"
       data-testid="stale-admins-count-strip"
-      aria-label={`Admin summary — ${total} admins`}
+      aria-label={`${elevated ? 'Admin' : 'Public member'} summary — ${total}`}
     >
       <span className="font-medium text-slate-700 dark:text-slate-200">
-        {total} admin{total === 1 ? '' : 's'}
+        {total} {noun}{total === 1 ? '' : 's'}
       </span>
       <span aria-hidden="true" className="text-slate-300 dark:text-slate-600">
         ·
       </span>
-      {GROUP_ORDER.map((c) => (
+      {GROUP_ORDER.filter((c) => counts[c] > 0).map((c) => (
         <CountPill key={c} classification={c} count={counts[c]} />
       ))}
     </div>
@@ -491,11 +738,13 @@ function SectionBody({
   onRetry,
   refreshing,
   nextAutoRetryAt,
+  elevated = true,
 }: {
   section: StaleAdminsSection
   onRetry: () => void
   refreshing: boolean
   nextAutoRetryAt: string | null
+  elevated?: boolean
 }) {
   if (section.applicability === 'not-applicable-non-org') {
     return (
@@ -518,7 +767,7 @@ function SectionBody({
   if (section.admins.length === 0) {
     return (
       <p className="text-sm text-slate-600 dark:text-slate-300">
-        No admins were returned for this organization.
+        {elevated ? 'No admins were returned for this organization.' : 'No public members were returned for this organization.'}
       </p>
     )
   }
@@ -536,6 +785,7 @@ function SectionBody({
           onRetry={onRetry}
           refreshing={refreshing}
           nextAutoRetryAt={nextAutoRetryAt}
+          elevated={elevated}
         />
       ))}
     </div>
@@ -549,6 +799,7 @@ function GroupSection({
   onRetry,
   refreshing,
   nextAutoRetryAt,
+  elevated = true,
 }: {
   classification: StaleAdminClassification
   admins: StaleAdminRecord[]
@@ -556,6 +807,7 @@ function GroupSection({
   onRetry: () => void
   refreshing: boolean
   nextAutoRetryAt: string | null
+  elevated?: boolean
 }) {
   const config = GROUP_CONFIG[classification]
   const isUnavailable = classification === 'unavailable'
@@ -571,7 +823,7 @@ function GroupSection({
     >
       <summary
         className="flex cursor-pointer select-none items-center gap-2 px-3 py-1.5 text-sm font-medium text-slate-800 list-none dark:text-slate-100 [&::-webkit-details-marker]:hidden"
-        aria-label={config.groupAriaLabel}
+        aria-label={elevated ? config.groupAriaLabel : config.groupAriaLabel.replace(/admins?/gi, 'public members')}
       >
         <GroupChevron />
         <span aria-hidden="true">{config.icon}</span>
@@ -887,7 +1139,7 @@ function ModeBadge({ mode }: { mode: StaleAdminMode }) {
 
 const MODE_CONFIG: Record<StaleAdminMode, { label: string; className: string }> = {
   baseline: {
-    label: 'Baseline — public admins only',
+    label: 'Baseline — public members only',
     className: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
   },
   'elevated-effective': {

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -1162,7 +1162,7 @@ const MODE_CONFIG: Record<StaleAdminMode, { label: string; className: string; to
   'elevated-ineffective': {
     label: 'Elevated grant did not widen this view',
     className: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
-    tooltip: 'The read:org scope was granted but this org restricts third-party OAuth apps — the data returned is the same as without it. Are you a member of this org? A Personal Access Token with read:org scope bypasses OAuth app restrictions.',
+    tooltip: 'The admin list returned the same count as the full member list — this typically means the org restricts third-party OAuth apps. Are you a member of this org? A Personal Access Token with read:org scope bypasses OAuth app restrictions.',
   },
 }
 

--- a/components/org-summary/panels/StaleAdminsPanel.tsx
+++ b/components/org-summary/panels/StaleAdminsPanel.tsx
@@ -358,12 +358,13 @@ function MemberPermissionSummary({
       </div>
       {oauthRestricted ? (
         <p className="text-xs text-slate-500 dark:text-slate-400">
-          read:org scope was granted, but this org restricts the OAuth app — admin and member counts are unavailable.{' '}
+          This org restricts third-party OAuth app access — admin and member counts are unavailable.{' '}
           <button type="button" onClick={onSignOut} className="font-medium text-sky-700 hover:underline dark:text-sky-400">Sign out</button>
           {' and sign in again using a '}
           <span className="font-medium">Personal Access Token</span>
           {' with '}
-          <code className="font-mono text-[0.7rem]">read:org</code> scope for accurate counts.
+          <code className="font-mono text-[0.7rem]">read:org</code>
+          {' scope — PATs bypass OAuth app restrictions. You must also be a member of this org to see concealed admins and member counts.'}
         </p>
       ) : !elevated ? (
         <p className="text-xs text-slate-500 dark:text-slate-400">

--- a/components/shared/hooks/useMemberPermissionDistribution.test.ts
+++ b/components/shared/hooks/useMemberPermissionDistribution.test.ts
@@ -7,7 +7,16 @@ function makeSection(overrides: Partial<MemberPermissionDistributionSection> = {
   return {
     kind: 'member-permission-distribution',
     applicability: 'applicable',
+    adminCount: 2,
     memberCount: 8,
+    publicMemberCount: 5,
+    publicMembers: [
+      { login: 'alice', avatarUrl: 'https://github.com/alice.png' },
+      { login: 'bob', avatarUrl: 'https://github.com/bob.png' },
+      { login: 'carol', avatarUrl: 'https://github.com/carol.png' },
+      { login: 'dave', avatarUrl: 'https://github.com/dave.png' },
+      { login: 'eve', avatarUrl: 'https://github.com/eve.png' },
+    ],
     outsideCollaboratorCount: 1,
     unavailableReasons: [],
     resolvedAt: new Date().toISOString(),

--- a/fixtures/demo/org-ossf.json
+++ b/fixtures/demo/org-ossf.json
@@ -1368,6 +1368,8 @@
       "applicability": "partial",
       "adminCount": 21,
       "memberCount": 0,
+      "publicMemberCount": null,
+      "publicMembers": null,
       "outsideCollaboratorCount": null,
       "unavailableReasons": [
         "unknown"

--- a/lib/analyzer/github-graphql.ts
+++ b/lib/analyzer/github-graphql.ts
@@ -52,6 +52,85 @@ export async function queryGitHubGraphQL<T>(
   return { data, rateLimit }
 }
 
+// ── Org member enumeration ─────────────────────────────────────────────────────
+
+const ORG_MEMBERS_WITH_ROLES_QUERY = `
+  query OrgMembersWithRoles($org: String!, $after: String) {
+    organization(login: $org) {
+      membersWithRole(first: 100, after: $after) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        edges { role node { login } }
+      }
+    }
+    rateLimit { limit remaining resetAt }
+  }
+`
+
+interface OrgMembersPage {
+  organization?: {
+    membersWithRole: {
+      totalCount: number
+      pageInfo: { hasNextPage: boolean; endCursor: string }
+      edges: Array<{ role: 'MEMBER' | 'ADMIN'; node: { login: string } }>
+    }
+  }
+  rateLimit?: unknown
+}
+
+export type OrgMembersWithRolesResult =
+  | { kind: 'ok'; admins: string[]; nonAdminMembers: string[]; totalCount: number }
+  | { kind: 'rate-limited' }
+  | { kind: 'auth-failed' }
+  | { kind: 'scope-insufficient' }
+  | { kind: 'network' }
+  | { kind: 'unknown' }
+
+export async function fetchOrgMembersWithRoles(
+  token: string,
+  org: string,
+): Promise<OrgMembersWithRolesResult> {
+  const admins: string[] = []
+  const nonAdminMembers: string[] = []
+  let totalCount = 0
+  let after: string | null = null
+
+  try {
+    while (true) {
+      const result = await queryGitHubGraphQL<OrgMembersPage>(
+        token,
+        ORG_MEMBERS_WITH_ROLES_QUERY,
+        { org, after },
+      )
+
+      const connection = result.data.organization?.membersWithRole
+      if (!connection) return { kind: 'unknown' }
+
+      totalCount = connection.totalCount
+      for (const edge of connection.edges) {
+        if (edge.role === 'ADMIN') {
+          admins.push(edge.node.login)
+        } else {
+          nonAdminMembers.push(edge.node.login)
+        }
+      }
+
+      if (!connection.pageInfo.hasNextPage) break
+      after = connection.pageInfo.endCursor
+    }
+  } catch (err) {
+    const error = err as { status?: number; retryAfter?: number | 'unavailable' }
+    if (error.status === 401) return { kind: 'auth-failed' }
+    if (error.status === 403) {
+      if (typeof error.retryAfter === 'number') return { kind: 'rate-limited' }
+      return { kind: 'scope-insufficient' }
+    }
+    return { kind: 'network' }
+  }
+
+  return { kind: 'ok', admins, nonAdminMembers, totalCount }
+}
+
 function extractRateLimit(data: unknown): RateLimitState | null {
   if (!data || typeof data !== 'object' || !('rateLimit' in data)) {
     return null

--- a/lib/analyzer/github-graphql.ts
+++ b/lib/analyzer/github-graphql.ts
@@ -97,7 +97,7 @@ export async function fetchOrgMembersWithRoles(
 
   try {
     while (true) {
-      const result = await queryGitHubGraphQL<OrgMembersPage>(
+      const result: GitHubGraphQLSuccess<OrgMembersPage> = await queryGitHubGraphQL<OrgMembersPage>(
         token,
         ORG_MEMBERS_WITH_ROLES_QUERY,
         { org, after },

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -233,6 +233,55 @@ export async function fetchOrgMembers(token: string, org: string): Promise<OrgMe
   return { kind: 'ok', members }
 }
 
+export type OrgPublicMember = { login: string; avatarUrl: string }
+
+export type OrgPublicMemberListResult =
+  | { kind: 'ok'; members: OrgPublicMember[] }
+  | { kind: 'rate-limited' }
+  | { kind: 'auth-failed' }
+  | { kind: 'network' }
+  | { kind: 'unknown' }
+
+export async function fetchOrgPublicMembers(
+  token: string,
+  org: string,
+): Promise<OrgPublicMemberListResult> {
+  const members: OrgPublicMember[] = []
+  let url: string | null = `https://api.github.com/orgs/${encodeURIComponent(org)}/public_members?per_page=100`
+
+  try {
+    while (url) {
+      const response: Response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      })
+
+      const status = classifyRestStatus(response)
+      if (status !== 'ok') return status as OrgPublicMemberListResult
+
+      const payload = (await response.json()) as Array<{ login?: unknown; avatar_url?: unknown }>
+      if (!Array.isArray(payload)) return { kind: 'unknown' }
+      for (const m of payload) {
+        if (typeof m.login === 'string' && m.login.length > 0) {
+          members.push({
+            login: m.login,
+            avatarUrl: typeof m.avatar_url === 'string' ? m.avatar_url : `https://github.com/${m.login}.png`,
+          })
+        }
+      }
+
+      url = parseNextLink(response.headers.get('Link'))
+    }
+  } catch {
+    return { kind: 'network' }
+  }
+
+  return { kind: 'ok', members }
+}
+
 export type OrgCollaboratorListResult =
   | { kind: 'ok'; collaborators: { login: string }[] }
   | { kind: 'rate-limited' }
@@ -509,6 +558,7 @@ export async function fetchUserOrgMembership(
 function classifyRestStatus(response: Response): 'ok' | OrgAdminListResult {
   if (response.ok) return 'ok'
   if (response.status === 403 && isRateLimited(response)) return { kind: 'rate-limited' }
+  if (response.status === 403) return { kind: 'scope-insufficient' }
   if (response.status === 401) return { kind: 'auth-failed' }
   if (response.status === 404) return { kind: 'unknown' }
   return { kind: 'unknown' }

--- a/lib/governance/member-permissions.ts
+++ b/lib/governance/member-permissions.ts
@@ -14,6 +14,7 @@ export type MemberPermissionUnavailableReason =
   | 'admin-list-rate-limited'
   | 'admin-list-auth-failed'
   | 'admin-list-scope-insufficient'
+  | 'admin-list-possibly-oauth-restricted'
   | 'member-list-rate-limited'
   | 'member-list-auth-failed'
   | 'member-list-scope-insufficient'
@@ -36,6 +37,10 @@ export interface MemberPermissionDistributionSection {
   adminCount: number | null
   /** Non-admin org members (total - admins) */
   memberCount: number | null
+  /** Public members only (no read:org needed) */
+  publicMemberCount: number | null
+  /** Public members with avatars — for the collapsible list */
+  publicMembers: { login: string; avatarUrl: string }[] | null
   outsideCollaboratorCount: number | null
   unavailableReasons: MemberPermissionUnavailableReason[]
   resolvedAt: string


### PR DESCRIPTION
## Summary

- **Detect OAuth app restriction**: when `role=admin` and `role=all` return the same member count, the API route nulls out `adminCount` and flags `admin-list-possibly-oauth-restricted` — preventing the misleading "86 (100%)" admin display
- **Baseline mode**: shows public member count ("Public members: 86"), hides admin count, removes link on count (inline list makes it redundant), hides activity section (stale/active breakdown of unidentified public members has no governance value)
- **OAuth-restricted mode**: detects from `unavailableReasons` and shows a focused "Sign out and sign in again with a PAT" message
- **PAT as the only upgrade path**: removed `admin:org` from all user-facing suggestions; `read:org` PAT is sufficient for member/admin counts; outside collaborator tooltip reframed as "requires org membership" rather than a specific scope
- **Sign-in page simplified**: removed scope-tier radio buttons — there is now one OAuth sign-in (no scope); upgrade prompts live inline in the org panel; added hover tooltip on "Use a PAT instead" explaining why PATs bypass org restrictions
- **Cosmetic polish**: "Activity unknown" instead of "Unavailable" for rate-limited activity checks; "Not available" for scope-gated role cards; zero-count pills hidden from count strip; panel renamed to "Org member & admin overview"
- **Public member list**: collapsible, searchable avatar chip list fetched from `/orgs/{org}/public_members`

## Test plan

- [x] Sign in with OAuth (default) → org panel shows "Public members: 86", "Admins: Not available", no activity section
- [x] Sign in with PAT + `read:org` on an org with OAuth restrictions → shows full admin/member breakdown and activity section
- [x] Sign in with PAT + `read:org` on a restriction-blocked org → "Not available" for admins (not "86 (100%)") and PAT sign-out message
- [x] Verify "Sign out" link in panel clears session and returns to sign-in page
- [x] Verify public member list is collapsible and searchable
- [x] Verify PAT form on sign-in page links to `read:org`-only token creation URL
- [x] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)