### PR TITLE
fix(org-summary): deduplicate TOTAL CONTRIBUTORS via 365d union

### DIFF
--- a/components/org-summary/panels/ProjectFootprintPanel.tsx
+++ b/components/org-summary/panels/ProjectFootprintPanel.tsx
@@ -34,18 +34,36 @@ export function ProjectFootprintPanel({ panel }: Props) {
           <Stat label="Total stars" value={panel.value.totalStars} />
           <Stat label="Total forks" value={panel.value.totalForks} />
           <Stat label="Total watchers" value={panel.value.totalWatchers} />
-          <Stat label="Total contributors" value={panel.value.totalContributors} />
+          <Stat
+            label="Unique contributors (365d)"
+            value={panel.value.totalContributors}
+            tooltip="Unique contributors across all analyzed repos in the last 365 days"
+          />
         </dl>
       )}
     </section>
   )
 }
 
-function Stat({ label, value }: { label: string; value: number }) {
+function Stat({
+  label,
+  value,
+  tooltip,
+}: {
+  label: string
+  value: number | 'unavailable'
+  tooltip?: string
+}) {
   return (
-    <div>
+    <div title={tooltip}>
       <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
-      <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">{value.toLocaleString()}</dd>
+      <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+        {value === 'unavailable' ? (
+          <span className="text-sm text-slate-400 dark:text-slate-500">—</span>
+        ) : (
+          value.toLocaleString()
+        )}
+      </dd>
     </div>
   )
 }

--- a/lib/org-aggregation/aggregators/project-footprint.test.ts
+++ b/lib/org-aggregation/aggregators/project-footprint.test.ts
@@ -40,28 +40,64 @@ function partialResult(repo: string, override: Partial<AnalysisResult> = {}): An
   } as AnalysisResult
 }
 
+function with365Contributors(
+  repo: string,
+  commitCountsByAuthor: Record<string, number>,
+  extra: Partial<AnalysisResult> = {},
+): AnalysisResult {
+  return partialResult(repo, {
+    contributorMetricsByWindow: {
+      30: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+      60: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+      90: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+      180: { uniqueCommitAuthors: 'unavailable', commitCountsByAuthor: 'unavailable', repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+      365: { uniqueCommitAuthors: Object.keys(commitCountsByAuthor).length, commitCountsByAuthor, repeatContributors: 'unavailable', newContributors: 'unavailable', commitCountsByExperimentalOrg: 'unavailable', experimentalAttributedAuthors: 'unavailable', experimentalUnattributedAuthors: 'unavailable' },
+    },
+    ...extra,
+  })
+}
+
 const CONTEXT = { totalReposInRun: 3, flagshipRepos: [], inactiveRepoWindowMonths: 12 }
 
 describe('projectFootprintAggregator — FR-019', () => {
-  it('typical: sums stars, forks, watchers, totalContributors across repos', () => {
+  it('deduplicates contributors across repos: 3 humans in 5 repos shows 3 not 6', () => {
+    // alice and bob appear in two repos each; carol in one — 3 unique total
     const results = [
-      partialResult('o/alpha', { stars: 100, forks: 20, watchers: 50, totalContributors: 10 }),
-      partialResult('o/bravo', { stars: 200, forks: 30, watchers: 80, totalContributors: 25 }),
-      partialResult('o/charlie', { stars: 50, forks: 5, watchers: 15, totalContributors: 3 }),
+      with365Contributors('o/repo-a', { alice: 10, bob: 5 }, { stars: 100, forks: 10, watchers: 20 }),
+      with365Contributors('o/repo-b', { alice: 3, carol: 8 }, { stars: 50, forks: 5, watchers: 10 }),
+      with365Contributors('o/repo-c', { bob: 2 }, { stars: 200, forks: 30, watchers: 60 }),
     ]
     const panel = projectFootprintAggregator(results, CONTEXT)
     expect(panel.status).toBe('final')
-    expect(panel.panelId).toBe('project-footprint')
-    expect(panel.contributingReposCount).toBe(3)
-    expect(panel.value).toEqual({
-      totalStars: 350,
-      totalForks: 55,
-      totalWatchers: 145,
-      totalContributors: 38,
-    })
+    expect(panel.value?.totalContributors).toBe(3)
+    expect(panel.value?.totalStars).toBe(350)
+    expect(panel.value?.totalForks).toBe(45)
+    expect(panel.value?.totalWatchers).toBe(90)
   })
 
-  it('all-unavailable: every repo has all four fields unavailable → panel is unavailable', () => {
+  it('all-365d-unavailable: every repo lacks 365d contributor data → totalContributors is unavailable', () => {
+    const results = [
+      partialResult('o/alpha', { stars: 100, forks: 10, watchers: 20 }),
+      partialResult('o/bravo', { stars: 200, forks: 20, watchers: 40 }),
+    ]
+    const panel = projectFootprintAggregator(results, { ...CONTEXT, totalReposInRun: 2 })
+    expect(panel.status).toBe('final')
+    expect(panel.value?.totalContributors).toBe('unavailable')
+    expect(panel.value?.totalStars).toBe(300)
+  })
+
+  it('partial 365d availability: unions repos that have data, ignores unavailable repos', () => {
+    const results = [
+      with365Contributors('o/has-data', { alice: 5, bob: 3 }, { stars: 100 }),
+      partialResult('o/no-data', { stars: 200 }), // no 365d contributors
+    ]
+    const panel = projectFootprintAggregator(results, { ...CONTEXT, totalReposInRun: 2 })
+    expect(panel.status).toBe('final')
+    expect(panel.value?.totalContributors).toBe(2) // alice + bob from the one repo that has data
+    expect(panel.value?.totalStars).toBe(300)
+  })
+
+  it('all-fields-unavailable: every repo has all four fields unavailable → panel is unavailable', () => {
     const results = [
       partialResult('o/alpha'),
       partialResult('o/bravo'),
@@ -72,21 +108,19 @@ describe('projectFootprintAggregator — FR-019', () => {
     expect(panel.contributingReposCount).toBe(0)
   })
 
-  it('mixed: repos with some unavailable fields still contribute; unavailable fields skipped', () => {
+  it('mixed availability: repos with some unavailable star/fork/watcher fields still contribute', () => {
     const results = [
-      partialResult('o/alpha', { stars: 100, forks: 'unavailable', watchers: 50, totalContributors: 10 }),
+      with365Contributors('o/alpha', { alice: 10 }, { stars: 100, watchers: 50 }),
       partialResult('o/bravo'), // all unavailable — excluded
-      partialResult('o/charlie', { stars: 'unavailable', forks: 5, watchers: 'unavailable', totalContributors: 3 }),
+      with365Contributors('o/charlie', { alice: 3, bob: 5 }, { forks: 5 }),
     ]
     const panel = projectFootprintAggregator(results, CONTEXT)
     expect(panel.status).toBe('final')
     expect(panel.contributingReposCount).toBe(2)
-    expect(panel.value).toEqual({
-      totalStars: 100,
-      totalForks: 5,
-      totalWatchers: 50,
-      totalContributors: 13,
-    })
+    expect(panel.value?.totalStars).toBe(100)
+    expect(panel.value?.totalForks).toBe(5)
+    expect(panel.value?.totalWatchers).toBe(50)
+    expect(panel.value?.totalContributors).toBe(2) // alice + bob (alice deduped)
   })
 
   it('empty: results array is empty → in-progress with null value', () => {

--- a/lib/org-aggregation/aggregators/project-footprint.ts
+++ b/lib/org-aggregation/aggregators/project-footprint.ts
@@ -4,11 +4,16 @@ import type { Aggregator, ProjectFootprintValue } from './types'
 
 /**
  * FR-019: Org-level project footprint — sum of stars, forks, watchers,
- * and totalContributors across all repos.
+ * and de-duplicated unique contributors (365d window) across all repos.
  *
  * Pure function. No I/O. Repos where ALL four fields are 'unavailable'
  * are excluded; the panel is 'unavailable' only when zero repos
  * contribute any numeric value.
+ *
+ * totalContributors uses the 365d commitCountsByAuthor union to avoid
+ * double-counting humans who contribute to multiple repos (issue #299).
+ * If no repo has 365d commitCountsByAuthor data, totalContributors is
+ * 'unavailable' — a misleading sum is worse than a blank.
  */
 export const projectFootprintAggregator: Aggregator<ProjectFootprintValue> = (
   results,
@@ -27,23 +32,32 @@ export const projectFootprintAggregator: Aggregator<ProjectFootprintValue> = (
   let totalStars = 0
   let totalForks = 0
   let totalWatchers = 0
-  let totalContributors = 0
   let contributingReposCount = 0
+
+  const authorUnion = new Set<string>()
+  let contributorDataRepos = 0
 
   for (const r of results) {
     const ar = r as AnalysisResult
     const hasStars = typeof ar.stars === 'number'
     const hasForks = typeof ar.forks === 'number'
     const hasWatchers = typeof ar.watchers === 'number'
-    const hasContributors = typeof ar.totalContributors === 'number'
 
-    if (!hasStars && !hasForks && !hasWatchers && !hasContributors) continue
+    const counts = ar.contributorMetricsByWindow?.[365]?.commitCountsByAuthor
+    const has365Contributors = counts !== undefined && counts !== 'unavailable'
+
+    if (!hasStars && !hasForks && !hasWatchers && !has365Contributors) continue
 
     contributingReposCount++
     if (hasStars) totalStars += ar.stars as number
     if (hasForks) totalForks += ar.forks as number
     if (hasWatchers) totalWatchers += ar.watchers as number
-    if (hasContributors) totalContributors += ar.totalContributors as number
+    if (has365Contributors) {
+      contributorDataRepos++
+      for (const author of Object.keys(counts as Record<string, number>)) {
+        authorUnion.add(author)
+      }
+    }
   }
 
   if (contributingReposCount === 0) {
@@ -55,6 +69,9 @@ export const projectFootprintAggregator: Aggregator<ProjectFootprintValue> = (
       value: null,
     }
   }
+
+  const totalContributors: number | 'unavailable' =
+    contributorDataRepos > 0 ? authorUnion.size : 'unavailable'
 
   return {
     panelId: 'project-footprint',

--- a/lib/org-aggregation/aggregators/types.ts
+++ b/lib/org-aggregation/aggregators/types.ts
@@ -89,7 +89,7 @@ export type ProjectFootprintValue = {
   totalStars: number
   totalForks: number
   totalWatchers: number
-  totalContributors: number
+  totalContributors: number | 'unavailable'
 }
 
 export type ActivityRollupValue = {

--- a/specs/231-org-aggregation/contracts/aggregator-contracts.ts
+++ b/specs/231-org-aggregation/contracts/aggregator-contracts.ts
@@ -64,7 +64,7 @@ export type ProjectFootprintValue = {
   totalStars: number
   totalForks: number
   totalWatchers: number
-  totalContributors: number
+  totalContributors: number | 'unavailable'
 }
 
 export type ActivityRollupValue = {


### PR DESCRIPTION
## Summary

- Replaces the per-repo `totalContributors` sum (which double-counted humans who contribute to multiple repos) with a **365-day `commitCountsByAuthor` union** — the same de-duplication pattern already used by `contributorDiversityAggregator`
- `ProjectFootprintValue.totalContributors` type widens to `number | 'unavailable'`; when no repo has 365d data the field renders as `—` rather than a misleading inflated number
- Panel label updated from "Total contributors" to "Unique contributors (365d)" with a tooltip explaining the 365d window

## Files changed

| File | Change |
|---|---|
| `lib/org-aggregation/aggregators/project-footprint.ts` | Replace sum with `Set<string>` union over `contributorMetricsByWindow[365].commitCountsByAuthor` |
| `lib/org-aggregation/aggregators/types.ts` | `totalContributors: number → number \| 'unavailable'` |
| `specs/231-org-aggregation/contracts/aggregator-contracts.ts` | Sync type (kept in sync per comment) |
| `components/org-summary/panels/ProjectFootprintPanel.tsx` | Label, tooltip, dash for unavailable |
| `lib/org-aggregation/aggregators/project-footprint.test.ts` | Double-count, partial-availability, all-unavailable scenarios |

Closes #299

## Test plan

- [x] `npx vitest run lib/org-aggregation/aggregators/project-footprint.test.ts` — 6 tests pass (double-count dedup, partial availability, all-unavailable, all-fields-unavailable, mixed, empty)
- [x] `npm test` — 1496 tests pass, 164 files
- [x] `npm run lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `npx tsc --noEmit` — 0 errors in modified files (pre-existing unrelated test-fixture errors unchanged)
- [x] Manual: Org summary → Project footprint panel shows "Unique contributors (365d)" label with tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)