### PR TITLE
chore: add typecheck pre-commit hook and CI workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,23 @@
+name: Typecheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  typecheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "jsdom": "^29.0.1",
+        "simple-git-hooks": "^2.11.1",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5",
@@ -7690,6 +7691,17 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-git-hooks": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
+      "integrity": "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "simple-git-hooks": "cli.js"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "prepare": "simple-git-hooks",
     "calibrate": "tsx scripts/calibrate.ts",
     "calibrate:dry-run": "tsx scripts/calibrate.ts --dry-run",
     "calibrate:solo": "tsx scripts/calibrate.ts --profile=solo",
@@ -18,6 +20,9 @@
     "list-candidates": "tsx scripts/list-candidates.ts",
     "demo:fixtures": "tsx scripts/generate-demo-fixtures.ts",
     "demo:check-parity": "tsx scripts/check-demo-fixture-parity.ts"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npm run typecheck"
   },
   "dependencies": {
     "chart.js": "^4.5.1",
@@ -42,6 +47,7 @@
     "eslint-config-next": "16.2.1",
     "jsdom": "^29.0.1",
     "tailwindcss": "^4",
+    "simple-git-hooks": "^2.11.1",
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.2"


### PR DESCRIPTION
## Summary

- Adds `npm run typecheck` (`tsc --noEmit`) script to `package.json`
- Wires a `pre-commit` hook via `simple-git-hooks` so commits are blocked when TypeScript errors are present
- Adds `.github/workflows/typecheck.yml` to enforce the same check on every PR and push to `main`

Closes #412

## Why

TypeScript errors in test fixtures have been silently accumulating between cleanup passes (#407, #412) because there was no automated gate — no pre-commit hook, no CI typecheck step. This adds two enforcement layers so fixture drift is caught at commit time rather than discovered later.

The `prepare` script ensures any contributor who runs `npm install` gets the hook automatically.

## Test plan

- [x] `npm run typecheck` exits 0 on a clean checkout
- [x] Introduce a deliberate type error in a test file, confirm `git commit` is blocked with a tsc error
- [x] Confirm the `Typecheck` CI job appears and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)