### PR TITLE
feat: projects board input mode — scan repos from CNCF sandbox board (#411)

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -3,6 +3,7 @@ import type { FoundationTarget } from '@/lib/cncf-sandbox/types'
 import { fetchCNCFLandscape, fetchCNCFSandboxIssues, fetchSandboxIssueBody, findSandboxApplication, getLandscapeProjectStatus } from '@/lib/cncf-sandbox/landscape'
 import { evaluateAspirant } from '@/lib/cncf-sandbox/evaluate'
 import { parseApplicationIssue } from '@/lib/cncf-sandbox/parse-application'
+import { buildApprovedCorpusSummary } from '@/lib/cncf-sandbox/approved-corpus'
 
 export async function POST(request: Request) {
   try {
@@ -36,19 +37,24 @@ export async function POST(request: Request) {
     // Fetch CNCF landscape data when CNCF Sandbox target is selected
     let landscapeData = null
     if (foundationTarget === 'cncf-sandbox') {
-      const [landscapeResult, sandboxIssues] = await Promise.allSettled([
+      const [landscapeResult, sandboxIssues, approvedCorpusResult] = await Promise.allSettled([
         fetchCNCFLandscape(),
         fetchCNCFSandboxIssues(token),
+        buildApprovedCorpusSummary(token),
       ])
 
       landscapeData = landscapeResult.status === 'fulfilled' ? landscapeResult.value : null
       const issues = sandboxIssues.status === 'fulfilled' ? sandboxIssues.value : []
+      const approvedCorpus = approvedCorpusResult.status === 'fulfilled' ? approvedCorpusResult.value : undefined
 
       if (landscapeResult.status === 'rejected') {
         console.warn('[analyze] CNCF landscape fetch failed — proceeding without landscape data')
       }
       if (sandboxIssues.status === 'rejected') {
         console.warn('[analyze] CNCF sandbox issues fetch failed — proceeding without application status')
+      }
+      if (approvedCorpusResult.status === 'rejected') {
+        console.warn('[analyze] Approved corpus fetch failed — proceeding without corpus-based hints')
       }
 
       const knownIssueNumbers = body.sandboxIssueNumbers ?? {}
@@ -86,7 +92,7 @@ export async function POST(request: Request) {
         if (aspirantResult.sandboxApplication) {
           const body = await fetchSandboxIssueBody(token, aspirantResult.sandboxApplication.issueNumber)
           if (body) {
-            aspirantResult.sandboxApplication.parsedFields = parseApplicationIssue(body)
+            aspirantResult.sandboxApplication.parsedFields = parseApplicationIssue(body, approvedCorpus)
           }
         }
         result.aspirantResult = aspirantResult

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -10,6 +10,7 @@ export async function POST(request: Request) {
       repos?: string[]
       token?: string | null
       foundationTarget?: FoundationTarget
+      sandboxIssueNumbers?: Record<string, number>
     }
 
     if (!Array.isArray(body.repos) || body.repos.length === 0) {
@@ -50,12 +51,18 @@ export async function POST(request: Request) {
         console.warn('[analyze] CNCF sandbox issues fetch failed — proceeding without application status')
       }
 
+      const knownIssueNumbers = body.sandboxIssueNumbers ?? {}
+
       // Attach aspirant evaluation results to each repo result
       for (const result of response.results) {
-        // Short-circuit: if the matching issue already has gitvote/passed, skip full evaluation
-        const preliminaryMatch = issues.length > 0
-          ? findSandboxApplication(result.repo, issues)
-          : null
+        // Direct lookup when the caller knows the sandbox issue number (board scan);
+        // fall back to fuzzy title matching for manually-entered repos.
+        const knownNumber = knownIssueNumbers[result.repo]
+        const preliminaryMatch = knownNumber
+          ? (issues.find((i) => i.issueNumber === knownNumber) ?? null)
+          : issues.length > 0
+            ? findSandboxApplication(result.repo, issues)
+            : null
 
         // Check if repo is already a CNCF-hosted project (sandbox/incubating/graduated)
         const existingStatus = landscapeData
@@ -74,7 +81,7 @@ export async function POST(request: Request) {
           continue
         }
 
-        const aspirantResult = evaluateAspirant(result, landscapeData, issues)
+        const aspirantResult = evaluateAspirant(result, landscapeData, issues, knownNumber)
         // If an application issue was found, fetch its body and parse the fields
         if (aspirantResult.sandboxApplication) {
           const body = await fetchSandboxIssueBody(token, aspirantResult.sandboxApplication.issueNumber)

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -5,7 +5,7 @@ export const runtime = 'nodejs'
 
 const OAUTH_STATE_COOKIE = 'repo_pulse_oauth_state'
 
-export type ScopeTier = 'baseline' | 'read-org' | 'admin-org'
+export type ScopeTier = 'baseline' | 'read-org' | 'admin-org' | 'read-project'
 
 export function buildOAuthScope(tier: ScopeTier): string {
   switch (tier) {
@@ -13,6 +13,8 @@ export function buildOAuthScope(tier: ScopeTier): string {
       return 'admin:org'
     case 'read-org':
       return 'read:org'
+    case 'read-project':
+      return 'read:project'
     default:
       return ''
   }
@@ -22,6 +24,7 @@ export function resolveScopeTier(url: URL): ScopeTier {
   const explicit = url.searchParams.get('scope_tier')
   if (explicit === 'admin-org') return 'admin-org'
   if (explicit === 'read-org') return 'read-org'
+  if (explicit === 'read-project') return 'read-project'
   if (explicit === 'baseline') return 'baseline'
   // Legacy: ?elevated=1 maps to read-org
   if (url.searchParams.get('elevated') === '1') return 'read-org'

--- a/components/auth/SignInButton.tsx
+++ b/components/auth/SignInButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-export type ScopeTier = 'baseline' | 'read-org' | 'admin-org'
+export type ScopeTier = 'baseline' | 'read-org' | 'admin-org' | 'read-project'
 
 export function SignInButton({ tier = 'baseline' }: { tier?: ScopeTier }) {
   function handleClick() {

--- a/components/cncf-readiness/CNCFReadinessTab.tsx
+++ b/components/cncf-readiness/CNCFReadinessTab.tsx
@@ -93,13 +93,27 @@ function HumanFieldRow({ field, parsed }: { field: AspirantField; parsed: Parsed
   )
 }
 
-function SandboxApplicationBanner({ application }: { application: import('@/lib/cncf-sandbox/types').SandboxApplicationIssue | null }) {
+function SandboxApplicationBanner({ application, repoSlug }: { application: import('@/lib/cncf-sandbox/types').SandboxApplicationIssue | null; repoSlug?: string }) {
+  const repoLink = repoSlug ? (
+    <a
+      href={`https://github.com/${repoSlug}`}
+      target="_blank"
+      rel="noreferrer"
+      className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400"
+    >
+      {repoSlug}
+    </a>
+  ) : null
+
   if (application === null) {
     return (
       <div className="flex items-start gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-800">
         <span className="mt-0.5 text-base" aria-hidden="true">📋</span>
         <div>
-          <p className="text-sm font-medium text-slate-800 dark:text-slate-100">No application found in cncf/sandbox</p>
+          <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+            No application found in cncf/sandbox
+            {repoLink ? <>{' '}&mdash;{' '}{repoLink}</> : null}
+          </p>
           <p className="mt-0.5 text-xs text-slate-600 dark:text-slate-400">
             When ready, file an issue at{' '}
             <a href="https://github.com/cncf/sandbox/issues/new/choose" target="_blank" rel="noreferrer" className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400">
@@ -124,6 +138,7 @@ function SandboxApplicationBanner({ application }: { application: import('@/lib/
           <a href={application.issueUrl} target="_blank" rel="noreferrer" className="text-blue-600 underline hover:text-blue-800 dark:text-blue-400">
             #{application.issueNumber}
           </a>
+          {repoLink ? <>{' '}&middot;{' '}{repoLink}</> : null}
         </p>
         <p className="mt-0.5 truncate text-xs text-slate-600 dark:text-slate-400">
           {application.title} &middot; filed {date}
@@ -308,7 +323,7 @@ export function CNCFReadinessTab({ aspirantResult, onNavigateToTab, repoSlug }: 
         </a>.
       </p>
 
-      <SandboxApplicationBanner application={sandboxApplication} />
+      <SandboxApplicationBanner application={sandboxApplication} repoSlug={repoSlug} />
 
       {needsWorkFields.length > 0 ? (
         <section>

--- a/components/foundation/FoundationInputSection.test.tsx
+++ b/components/foundation/FoundationInputSection.test.tsx
@@ -95,10 +95,10 @@ describe('FoundationInputSection — info tooltip', () => {
     expect(screen.getByTestId('format-tooltip')).toHaveTextContent(/org/i)
   })
 
-  it('does NOT mention Projects board in the tooltip', () => {
+  it('mentions Projects board in the tooltip', () => {
     render(<FoundationInputSection {...defaultProps} />)
     fireEvent.mouseEnter(screen.getByRole('button', { name: /accepted input formats/i }))
-    expect(screen.getByTestId('format-tooltip')).not.toHaveTextContent(/projects board/i)
+    expect(screen.getByTestId('format-tooltip')).toHaveTextContent(/projects board/i)
   })
 })
 

--- a/components/foundation/FoundationInputSection.tsx
+++ b/components/foundation/FoundationInputSection.tsx
@@ -77,7 +77,10 @@ export function FoundationInputSection({
             <span className="font-mono">owner/repo</span>
             <span className="mx-2 text-slate-300 dark:text-slate-600">·</span>
             <span className="font-medium text-slate-700 dark:text-slate-300">Org:</span>{' '}
-            <span className="font-mono">cncf</span> or <span className="font-mono">github.com/cncf</span>
+            <span className="font-mono">cncf</span>
+            <span className="mx-2 text-slate-300 dark:text-slate-600">·</span>
+            <span className="font-medium text-slate-700 dark:text-slate-300">Board:</span>{' '}
+            <span className="font-mono">github.com/orgs/cncf/projects/14</span>
           </p>
           <div ref={tooltipRef} className="relative">
             <button
@@ -116,6 +119,13 @@ export function FoundationInputSection({
                       <li>https://github.com/org-slug</li>
                     </ul>
                   </div>
+                  <div>
+                    <p className="font-medium text-slate-700 dark:text-slate-300">Projects board:</p>
+                    <ul className="mt-1 space-y-0.5 font-mono text-slate-600 dark:text-slate-400">
+                      <li>https://github.com/orgs/cncf/projects/14</li>
+                    </ul>
+                    <p className="mt-1 not-italic text-slate-500 dark:text-slate-500">Scans repos from New &amp; Upcoming columns</p>
+                  </div>
                 </div>
               </div>
             )}
@@ -124,7 +134,7 @@ export function FoundationInputSection({
         <textarea
           value={inputValue}
           onChange={(e) => onInputChange(e.target.value)}
-          placeholder={'owner/repo\nowner/another-repo\n— or — cncf'}
+          placeholder={'owner/repo\nowner/another-repo\n— or — cncf\n— or — https://github.com/orgs/cncf/projects/14'}
           rows={3}
           className="w-full resize-none overflow-hidden rounded border border-slate-300 bg-white p-2 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
           aria-label="Foundation input"

--- a/components/foundation/FoundationInputSection.tsx
+++ b/components/foundation/FoundationInputSection.tsx
@@ -77,10 +77,10 @@ export function FoundationInputSection({
             <span className="font-mono">owner/repo</span>
             <span className="mx-2 text-slate-300 dark:text-slate-600">·</span>
             <span className="font-medium text-slate-700 dark:text-slate-300">Org:</span>{' '}
-            <span className="font-mono">cncf</span>
+            <span className="font-mono">org-slug</span>
             <span className="mx-2 text-slate-300 dark:text-slate-600">·</span>
             <span className="font-medium text-slate-700 dark:text-slate-300">Board:</span>{' '}
-            <span className="font-mono">github.com/orgs/cncf/projects/14</span>
+            <span className="font-mono">github.com/orgs/org/projects/14</span>
           </p>
           <div ref={tooltipRef} className="relative">
             <button
@@ -122,7 +122,7 @@ export function FoundationInputSection({
                   <div>
                     <p className="font-medium text-slate-700 dark:text-slate-300">Projects board:</p>
                     <ul className="mt-1 space-y-0.5 font-mono text-slate-600 dark:text-slate-400">
-                      <li>https://github.com/orgs/cncf/projects/14</li>
+                      <li>https://github.com/orgs/org/projects/14</li>
                     </ul>
                     <p className="mt-1 not-italic text-slate-500 dark:text-slate-500">Scans repos from New &amp; Upcoming columns</p>
                   </div>
@@ -134,7 +134,7 @@ export function FoundationInputSection({
         <textarea
           value={inputValue}
           onChange={(e) => onInputChange(e.target.value)}
-          placeholder={'owner/repo\nowner/another-repo\n— or — cncf\n— or — https://github.com/orgs/cncf/projects/14'}
+          placeholder={'owner1/repo1 owner2/repo2\n— or — org-slug\n— or — https://github.com/orgs/org/projects/14'}
           rows={3}
           className="w-full resize-none overflow-hidden rounded border border-slate-300 bg-white p-2 font-mono text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
           aria-label="Foundation input"

--- a/components/foundation/FoundationInputSection.tsx
+++ b/components/foundation/FoundationInputSection.tsx
@@ -21,6 +21,14 @@ export function FoundationInputSection({
 }: FoundationInputSectionProps) {
   const [tooltipOpen, setTooltipOpen] = useState(false)
   const tooltipRef = useRef<HTMLDivElement | null>(null)
+  const [boardCopied, setBoardCopied] = useState(false)
+
+  function handleCopyBoardUrl() {
+    void navigator.clipboard.writeText('https://github.com/orgs/cncf/projects/14').then(() => {
+      setBoardCopied(true)
+      setTimeout(() => setBoardCopied(false), 1500)
+    })
+  }
 
   useEffect(() => {
     if (!tooltipOpen) return
@@ -86,8 +94,26 @@ export function FoundationInputSection({
               rel="noopener noreferrer"
               className="font-mono underline decoration-dotted hover:decoration-solid"
             >
-              github.com/orgs/org/projects/14
+              github.com/orgs/cncf/projects/14
             </a>
+            <button
+              type="button"
+              onClick={handleCopyBoardUrl}
+              aria-label="Copy board URL"
+              title="Copy board URL"
+              className="ml-1 inline-flex items-center rounded px-1 py-0.5 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
+            >
+              {boardCopied ? (
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 text-emerald-500" aria-hidden="true">
+                  <path fillRule="evenodd" d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z" clipRule="evenodd" />
+                </svg>
+              ) : (
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3" aria-hidden="true">
+                  <path fillRule="evenodd" d="M11.013 2.513a1.75 1.75 0 0 0-2.475 0L6.226 4.837A1.75 1.75 0 0 0 6 5.89V9.75a.75.75 0 0 0 .75.75h3.86c.38 0 .745-.14 1.03-.392l2.323-2.132a1.75 1.75 0 0 0 .537-1.265V5.29a1.75 1.75 0 0 0-.513-1.24l-1.974-1.537ZM4.75 6.5A.25.25 0 0 1 5 6.25h.5a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 0 0-1.75 1.75v5.75c0 .966.784 1.75 1.75 1.75h5A1.75 1.75 0 0 0 11.75 12.5v-.5a.75.75 0 0 0-1.5 0v.5a.25.25 0 0 1-.25.25h-5a.25.25 0 0 1-.25-.25V6.5Z" clipRule="evenodd" />
+                </svg>
+              )}
+              <span className="ml-0.5 text-xs">{boardCopied ? 'Copied' : ''}</span>
+            </button>
           </p>
           <div ref={tooltipRef} className="relative">
             <button

--- a/components/foundation/FoundationInputSection.tsx
+++ b/components/foundation/FoundationInputSection.tsx
@@ -80,7 +80,14 @@ export function FoundationInputSection({
             <span className="font-mono">org-slug</span>
             <span className="mx-2 text-slate-300 dark:text-slate-600">·</span>
             <span className="font-medium text-slate-700 dark:text-slate-300">Board:</span>{' '}
-            <span className="font-mono">github.com/orgs/org/projects/14</span>
+            <a
+              href="https://github.com/orgs/cncf/projects/14"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono underline decoration-dotted hover:decoration-solid"
+            >
+              github.com/orgs/org/projects/14
+            </a>
           </p>
           <div ref={tooltipRef} className="relative">
             <button

--- a/components/foundation/FoundationResultsView.test.tsx
+++ b/components/foundation/FoundationResultsView.test.tsx
@@ -171,9 +171,43 @@ describe('FoundationResultsView — org branch', () => {
 })
 
 describe('FoundationResultsView — projects-board branch', () => {
-  it('renders a coming-soon message for projects-board results', () => {
-    const result: FoundationResult = { kind: 'projects-board', url: 'https://github.com/orgs/cncf/projects/14' }
+  it('renders board scan results with a header', () => {
+    const result: FoundationResult = {
+      kind: 'projects-board',
+      url: 'https://github.com/orgs/cncf/projects/14',
+      results: { results: [], failures: [], rateLimit: null },
+      skipped: [],
+    }
     render(<FoundationResultsView result={result} error={null} />)
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument()
+    expect(screen.getByText(/CNCF Sandbox board scan/i)).toBeInTheDocument()
+  })
+
+  it('shows skipped issues when present', () => {
+    const result: FoundationResult = {
+      kind: 'projects-board',
+      url: 'https://github.com/orgs/cncf/projects/14',
+      results: { results: [], failures: [], rateLimit: null },
+      skipped: [
+        { issueNumber: 42, issueUrl: 'https://github.com/cncf/sandbox/issues/42', title: 'My Project', reason: 'No GitHub repository URL found in issue body' },
+      ],
+    }
+    render(<FoundationResultsView result={result} error={null} />)
+    expect(screen.getByText(/Skipped issues/i)).toBeInTheDocument()
+    expect(screen.getByText(/#42 My Project/i)).toBeInTheDocument()
+  })
+
+  it('renders a CNCFReadinessTab for each resolved repo', () => {
+    const result: FoundationResult = {
+      kind: 'projects-board',
+      url: 'https://github.com/orgs/cncf/projects/14',
+      results: {
+        results: [{ repo: 'owner/myrepo', aspirantResult: makeAspirantResult() } as never],
+        failures: [],
+        rateLimit: null,
+      },
+      skipped: [],
+    }
+    render(<FoundationResultsView result={result} error={null} />)
+    expect(screen.getByTestId('cncf-readiness-tab')).toHaveTextContent('owner/myrepo')
   })
 })

--- a/components/foundation/FoundationResultsView.test.tsx
+++ b/components/foundation/FoundationResultsView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { FoundationResultsView } from './FoundationResultsView'
 import type { FoundationResult } from './FoundationResultsView'
 
@@ -104,16 +105,19 @@ describe('FoundationResultsView — null result (empty state)', () => {
 })
 
 describe('FoundationResultsView — repos branch', () => {
-  it('renders CNCFReadinessTab for each result', () => {
+  it('renders CNCFReadinessTab for each result after expanding', async () => {
     const result = makeReposResult(['facebook/react', 'vercel/next.js'])
     render(<FoundationResultsView result={result} error={null} />)
+    const buttons = screen.getAllByRole('button', { expanded: false })
+    for (const btn of buttons) await userEvent.click(btn)
     const tabs = screen.getAllByTestId('cncf-readiness-tab')
     expect(tabs).toHaveLength(2)
   })
 
-  it('renders CNCFReadinessTab with correct repoSlug', () => {
+  it('renders CNCFReadinessTab with correct repoSlug after expanding', async () => {
     const result = makeReposResult(['facebook/react'])
     render(<FoundationResultsView result={result} error={null} />)
+    await userEvent.click(screen.getByRole('button', { expanded: false }))
     expect(screen.getByTestId('cncf-readiness-tab')).toHaveTextContent('facebook/react')
   })
 
@@ -130,7 +134,7 @@ describe('FoundationResultsView — repos branch', () => {
     expect(screen.getByText(/bad\/repo/)).toBeInTheDocument()
   })
 
-  it('renders both successes and failures with per-repo isolation', () => {
+  it('renders both successes and failures with per-repo isolation', async () => {
     const mixedResult = {
       kind: 'repos',
       results: {
@@ -140,6 +144,7 @@ describe('FoundationResultsView — repos branch', () => {
       },
     } as unknown as FoundationResult
     render(<FoundationResultsView result={mixedResult} error={null} />)
+    await userEvent.click(screen.getByRole('button', { expanded: false }))
     expect(screen.getByTestId('cncf-readiness-tab')).toBeInTheDocument()
     expect(screen.getByText(/bad\/repo/)).toBeInTheDocument()
   })
@@ -198,7 +203,7 @@ describe('FoundationResultsView — projects-board branch', () => {
     expect(screen.getByText(/#42 My Project/i)).toBeInTheDocument()
   })
 
-  it('renders a CNCFReadinessTab for each resolved repo', () => {
+  it('renders a CNCFReadinessTab for each resolved repo after expanding', async () => {
     const result: FoundationResult = {
       kind: 'projects-board',
       url: 'https://github.com/orgs/cncf/projects/14',
@@ -211,6 +216,7 @@ describe('FoundationResultsView — projects-board branch', () => {
       method: 'graphql' as const,
     }
     render(<FoundationResultsView result={result} error={null} />)
+    await userEvent.click(screen.getByRole('button', { expanded: false }))
     expect(screen.getByTestId('cncf-readiness-tab')).toHaveTextContent('owner/myrepo')
   })
 })

--- a/components/foundation/FoundationResultsView.test.tsx
+++ b/components/foundation/FoundationResultsView.test.tsx
@@ -177,6 +177,7 @@ describe('FoundationResultsView — projects-board branch', () => {
       url: 'https://github.com/orgs/cncf/projects/14',
       results: { results: [], failures: [], rateLimit: null },
       skipped: [],
+      method: 'graphql' as const,
     }
     render(<FoundationResultsView result={result} error={null} />)
     expect(screen.getByText(/CNCF Sandbox board scan/i)).toBeInTheDocument()
@@ -190,6 +191,7 @@ describe('FoundationResultsView — projects-board branch', () => {
       skipped: [
         { issueNumber: 42, issueUrl: 'https://github.com/cncf/sandbox/issues/42', title: 'My Project', reason: 'No GitHub repository URL found in issue body' },
       ],
+      method: 'graphql' as const,
     }
     render(<FoundationResultsView result={result} error={null} />)
     expect(screen.getByText(/Skipped issues/i)).toBeInTheDocument()
@@ -206,6 +208,7 @@ describe('FoundationResultsView — projects-board branch', () => {
         rateLimit: null,
       },
       skipped: [],
+      method: 'graphql' as const,
     }
     render(<FoundationResultsView result={result} error={null} />)
     expect(screen.getByTestId('cncf-readiness-tab')).toHaveTextContent('owner/myrepo')

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -79,7 +79,7 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
         <p className="font-semibold text-sky-900 dark:text-sky-200">CNCF Sandbox board scan</p>
         <p className="mt-1 text-sky-800 dark:text-sky-300">
           Scanned <strong>{totalResolved}</strong> {totalResolved === 1 ? 'repository' : 'repositories'} from the{' '}
-          <strong>New</strong> and <strong>Upcoming</strong> columns of the{' '}
+          <strong>New</strong> and <strong>review/tech</strong> columns of the{' '}
           <a href={result.url} target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">
             CNCF sandbox board
           </a>

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -4,11 +4,12 @@ import { CNCFReadinessTab } from '@/components/cncf-readiness/CNCFReadinessTab'
 import { CNCFCandidacyPanel } from '@/components/cncf-candidacy/CNCFCandidacyPanel'
 import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
+import type { SkippedIssue } from '@/lib/foundation/fetch-board-repos'
 
 export type FoundationResult =
   | { kind: 'repos'; results: AnalyzeResponse }
   | { kind: 'org'; inventory: OrgInventoryResponse }
-  | { kind: 'projects-board'; url: string }
+  | { kind: 'projects-board'; url: string; results: AnalyzeResponse; skipped: SkippedIssue[] }
 
 interface FoundationResultsViewProps {
   result: FoundationResult | null
@@ -70,13 +71,90 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
     )
   }
 
-  // projects-board — reserved for #411
+  // projects-board — board scan results
+  const totalResolved = result.results.results.length + result.results.failures.length
   return (
-    <div className="rounded border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
-      <p className="font-medium">Projects board support coming soon</p>
-      <p className="mt-1 text-slate-500 dark:text-slate-400">
-        GitHub Projects board scanning will be available in a future update (<a href="https://github.com/arun-gupta/repo-pulse/issues/411" className="underline hover:no-underline">#411</a>).
-      </p>
+    <div className="space-y-6">
+      <section className="rounded border border-sky-200 bg-sky-50 p-4 text-sm dark:border-sky-800/60 dark:bg-sky-900/20">
+        <p className="font-semibold text-sky-900 dark:text-sky-200">CNCF Sandbox board scan</p>
+        <p className="mt-1 text-sky-800 dark:text-sky-300">
+          Scanned <strong>{totalResolved}</strong> {totalResolved === 1 ? 'repository' : 'repositories'} from the{' '}
+          <strong>New</strong> and <strong>Upcoming</strong> columns of the{' '}
+          <a href={result.url} target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">
+            CNCF sandbox board
+          </a>
+          .
+        </p>
+        {result.skipped.length > 0 ? (
+          <p className="mt-1 text-sky-700 dark:text-sky-400">
+            {result.skipped.length} {result.skipped.length === 1 ? 'issue was' : 'issues were'} skipped — see warning below.
+          </p>
+        ) : null}
+      </section>
+
+      {result.skipped.length > 0 ? (
+        <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
+          <h2 className="font-semibold text-amber-900 dark:text-amber-200">
+            Skipped issues ({result.skipped.length})
+          </h2>
+          <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+            These issues could not be resolved to a repository URL and were excluded from the scan.
+          </p>
+          <ul className="mt-2 list-disc pl-5 text-sm text-amber-900 dark:text-amber-200">
+            {result.skipped.map((s) => (
+              <li key={s.issueNumber}>
+                <a
+                  href={s.issueUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:no-underline"
+                >
+                  #{s.issueNumber} {s.title}
+                </a>
+                : {s.reason}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {result.results.failures.length > 0 ? (
+        <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
+          <h2 className="font-semibold text-amber-900 dark:text-amber-200">Failed repositories</h2>
+          <ul className="mt-2 list-disc pl-5 text-sm text-amber-900 dark:text-amber-200">
+            {result.results.failures.map((failure) => (
+              <li key={failure.repo}>
+                {failure.repo}: {failure.reason}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {result.results.results.map((repoResult) => (
+        <section key={repoResult.repo} className="space-y-2">
+          <h2 className="flex items-baseline gap-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+            {repoResult.repo}
+            <span className="text-xs font-normal text-slate-500 dark:text-slate-400">— CNCF sandbox board</span>
+          </h2>
+          {repoResult.aspirantResult ? (
+            <CNCFReadinessTab
+              aspirantResult={repoResult.aspirantResult}
+              repoSlug={repoResult.repo}
+            />
+          ) : (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              No foundation readiness data available for {repoResult.repo}.
+            </p>
+          )}
+        </section>
+      ))}
+
+      {result.results.results.length === 0 && result.results.failures.length === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          No repositories were successfully scanned from the board.
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -1,8 +1,9 @@
 'use client'
 
+import { useState } from 'react'
 import { CNCFReadinessTab } from '@/components/cncf-readiness/CNCFReadinessTab'
 import { CNCFCandidacyPanel } from '@/components/cncf-candidacy/CNCFCandidacyPanel'
-import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
+import type { AnalyzeResponse, AnalysisResult } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { SkippedIssue } from '@/lib/foundation/fetch-board-repos'
 
@@ -14,6 +15,81 @@ export type FoundationResult =
 interface FoundationResultsViewProps {
   result: FoundationResult | null
   error: string | null
+}
+
+function ScoreBadge({ score }: { score: number }) {
+  const color =
+    score >= 80 ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300'
+    : score >= 50 ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300'
+    : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
+  return (
+    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium tabular-nums ${color}`}>
+      {score}%
+    </span>
+  )
+}
+
+function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  function toggle(repo: string) {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(repo)) next.delete(repo)
+      else next.add(repo)
+      return next
+    })
+  }
+
+  return (
+    <div className="divide-y divide-slate-200 dark:divide-slate-700 rounded border border-slate-200 dark:border-slate-700">
+      {repoResults.map((repoResult) => {
+        const isOpen = expanded.has(repoResult.repo)
+        const score = repoResult.aspirantResult?.readinessScore
+        return (
+          <div key={repoResult.repo}>
+            <button
+              type="button"
+              onClick={() => toggle(repoResult.repo)}
+              className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-slate-50 dark:hover:bg-slate-800/40"
+              aria-expanded={isOpen}
+            >
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 16 16"
+                className={`h-4 w-4 shrink-0 text-slate-400 transition-transform duration-150 ${isOpen ? 'rotate-90' : ''}`}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <span className="flex items-center gap-2 min-w-0">
+                <span className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+                  {repoResult.repo}
+                </span>
+                {score !== undefined ? <ScoreBadge score={score} /> : null}
+              </span>
+            </button>
+            {isOpen ? (
+              <div className="border-t border-slate-200 px-4 pb-4 pt-3 dark:border-slate-700">
+                {repoResult.aspirantResult ? (
+                  <CNCFReadinessTab
+                    aspirantResult={repoResult.aspirantResult}
+                    repoSlug={repoResult.repo}
+                  />
+                ) : (
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    No foundation readiness data available for {repoResult.repo}.
+                  </p>
+                )}
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
 }
 
 export function FoundationResultsView({ result, error }: FoundationResultsViewProps) {
@@ -30,7 +106,7 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
 
   if (result.kind === 'repos') {
     return (
-      <div className="space-y-6">
+      <div className="space-y-4">
         {result.results.failures.length > 0 ? (
           <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
             <h2 className="font-semibold text-amber-900 dark:text-amber-200">Failed repositories</h2>
@@ -43,21 +119,7 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
             </ul>
           </section>
         ) : null}
-        {result.results.results.map((repoResult) => (
-          <section key={repoResult.repo} className="space-y-2">
-            <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{repoResult.repo}</h2>
-            {repoResult.aspirantResult ? (
-              <CNCFReadinessTab
-                aspirantResult={repoResult.aspirantResult}
-                repoSlug={repoResult.repo}
-              />
-            ) : (
-              <p className="text-sm text-slate-500 dark:text-slate-400">
-                No foundation readiness data available for {repoResult.repo}.
-              </p>
-            )}
-          </section>
-        ))}
+        <RepoAccordion repoResults={result.results.results} />
       </div>
     )
   }
@@ -74,7 +136,7 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
   // projects-board — board scan results
   const totalResolved = result.results.results.length + result.results.failures.length
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <section className="rounded border border-sky-200 bg-sky-50 p-4 text-sm dark:border-sky-800/60 dark:bg-sky-900/20">
         <p className="font-semibold text-sky-900 dark:text-sky-200">CNCF Sandbox board scan</p>
         <p className="mt-1 text-sky-800 dark:text-sky-300">
@@ -143,24 +205,9 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
         </section>
       ) : null}
 
-      {result.results.results.map((repoResult) => (
-        <section key={repoResult.repo} className="space-y-2">
-          <h2 className="flex items-baseline gap-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
-            {repoResult.repo}
-            <span className="text-xs font-normal text-slate-500 dark:text-slate-400">— CNCF sandbox board</span>
-          </h2>
-          {repoResult.aspirantResult ? (
-            <CNCFReadinessTab
-              aspirantResult={repoResult.aspirantResult}
-              repoSlug={repoResult.repo}
-            />
-          ) : (
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              No foundation readiness data available for {repoResult.repo}.
-            </p>
-          )}
-        </section>
-      ))}
+      {result.results.results.length > 0 ? (
+        <RepoAccordion repoResults={result.results.results} />
+      ) : null}
 
       {result.results.results.length === 0 && result.results.failures.length === 0 ? (
         <p className="text-sm text-slate-500 dark:text-slate-400">

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -15,6 +15,23 @@ export type FoundationResult =
 interface FoundationResultsViewProps {
   result: FoundationResult | null
   error: string | null
+  onRerun?: () => void
+}
+
+function RerunButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+    >
+      <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" strokeLinecap="round" />
+        <path d="M10 2v3h3" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      Re-run
+    </button>
+  )
 }
 
 function ScoreBadge({ score }: { score: number }) {
@@ -92,7 +109,7 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
   )
 }
 
-export function FoundationResultsView({ result, error }: FoundationResultsViewProps) {
+export function FoundationResultsView({ result, error, onRerun }: FoundationResultsViewProps) {
 
   if (error) {
     return (
@@ -107,6 +124,11 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
   if (result.kind === 'repos') {
     return (
       <div className="space-y-4">
+        {onRerun ? (
+          <div className="flex justify-end">
+            <RerunButton onClick={onRerun} />
+          </div>
+        ) : null}
         {result.results.failures.length > 0 ? (
           <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
             <h2 className="font-semibold text-amber-900 dark:text-amber-200">Failed repositories</h2>
@@ -126,10 +148,17 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
 
   if (result.kind === 'org') {
     return (
-      <CNCFCandidacyPanel
-        org={result.inventory.org}
-        repos={result.inventory.results}
-      />
+      <div className="space-y-4">
+        {onRerun ? (
+          <div className="flex justify-end">
+            <RerunButton onClick={onRerun} />
+          </div>
+        ) : null}
+        <CNCFCandidacyPanel
+          org={result.inventory.org}
+          repos={result.inventory.results}
+        />
+      </div>
     )
   }
 
@@ -138,32 +167,37 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
   return (
     <div className="space-y-4">
       <section className="rounded border border-sky-200 bg-sky-50 p-4 text-sm dark:border-sky-800/60 dark:bg-sky-900/20">
-        <p className="font-semibold text-sky-900 dark:text-sky-200">CNCF Sandbox board scan</p>
-        <p className="mt-1 text-sky-800 dark:text-sky-300">
-          Scanned <strong>{totalResolved}</strong> {totalResolved === 1 ? 'repository' : 'repositories'} from the{' '}
-          <strong>New</strong> and <strong>review/tech</strong> columns of the{' '}
-          <a href={result.url} target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">
-            CNCF sandbox board
-          </a>
-          .
-        </p>
-        {result.skipped.length > 0 ? (
-          <p className="mt-1 text-sky-700 dark:text-sky-400">
-            {result.skipped.length} {result.skipped.length === 1 ? 'issue was' : 'issues were'} skipped — see warning below.
-          </p>
-        ) : null}
-        {result.method === 'labels' ? (
-          <p className="mt-2 text-xs text-sky-600 dark:text-sky-400">
-            <span className="font-medium">Note:</span> Projects board API requires <span className="font-mono">read:project</span> scope — results are based on issue labels and may include repos no longer in those columns.{' '}
-            <a
-              href="/api/auth/login?scope_tier=read-project"
-              className="underline hover:no-underline"
-            >
-              Re-authenticate with board read access
-            </a>{' '}
-            for exact results.
-          </p>
-        ) : null}
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-semibold text-sky-900 dark:text-sky-200">CNCF Sandbox board scan</p>
+            <p className="mt-1 text-sky-800 dark:text-sky-300">
+              Scanned <strong>{totalResolved}</strong> {totalResolved === 1 ? 'repository' : 'repositories'} from the{' '}
+              <strong>New</strong> and <strong>review/tech</strong> columns of the{' '}
+              <a href={result.url} target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">
+                CNCF sandbox board
+              </a>
+              .
+            </p>
+            {result.skipped.length > 0 ? (
+              <p className="mt-1 text-sky-700 dark:text-sky-400">
+                {result.skipped.length} {result.skipped.length === 1 ? 'issue was' : 'issues were'} skipped — see warning below.
+              </p>
+            ) : null}
+            {result.method === 'labels' ? (
+              <p className="mt-2 text-xs text-sky-600 dark:text-sky-400">
+                <span className="font-medium">Note:</span> Projects board API requires <span className="font-mono">read:project</span> scope — results are based on issue labels and may include repos no longer in those columns.{' '}
+                <a
+                  href="/api/auth/login?scope_tier=read-project"
+                  className="underline hover:no-underline"
+                >
+                  Re-authenticate with board read access
+                </a>{' '}
+                for exact results.
+              </p>
+            ) : null}
+          </div>
+          {onRerun ? <RerunButton onClick={onRerun} /> : null}
+        </div>
       </section>
 
       {result.skipped.length > 0 ? (

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -82,9 +82,15 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
                 <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
               <span className="flex items-center gap-2 min-w-0">
-                <span className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+                <a
+                  href={`https://github.com/${repoResult.repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="truncate text-sm font-medium text-slate-800 underline hover:no-underline dark:text-slate-200"
+                >
                   {repoResult.repo}
-                </span>
+                </a>
                 {score !== undefined ? <ScoreBadge score={score} /> : null}
               </span>
             </button>

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -15,10 +15,10 @@ export type FoundationResult =
 interface FoundationResultsViewProps {
   result: FoundationResult | null
   error: string | null
-  onRerun?: () => void
+  onReanalyze?: () => void
 }
 
-function RerunButton({ onClick }: { onClick: () => void }) {
+function ReanalyzeButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       type="button"
@@ -29,7 +29,7 @@ function RerunButton({ onClick }: { onClick: () => void }) {
         <path d="M13.5 8A5.5 5.5 0 1 1 10 3.07" strokeLinecap="round" />
         <path d="M10 2v3h3" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
-      Re-run
+      Re-analyze
     </button>
   )
 }
@@ -131,7 +131,7 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
   )
 }
 
-export function FoundationResultsView({ result, error, onRerun }: FoundationResultsViewProps) {
+export function FoundationResultsView({ result, error, onReanalyze }: FoundationResultsViewProps) {
 
   if (error) {
     return (
@@ -146,9 +146,9 @@ export function FoundationResultsView({ result, error, onRerun }: FoundationResu
   if (result.kind === 'repos') {
     return (
       <div className="space-y-4">
-        {onRerun ? (
+        {onReanalyze ? (
           <div className="flex justify-end">
-            <RerunButton onClick={onRerun} />
+            <ReanalyzeButton onClick={onReanalyze} />
           </div>
         ) : null}
         {result.results.failures.length > 0 ? (
@@ -171,9 +171,9 @@ export function FoundationResultsView({ result, error, onRerun }: FoundationResu
   if (result.kind === 'org') {
     return (
       <div className="space-y-4">
-        {onRerun ? (
+        {onReanalyze ? (
           <div className="flex justify-end">
-            <RerunButton onClick={onRerun} />
+            <ReanalyzeButton onClick={onReanalyze} />
           </div>
         ) : null}
         <CNCFCandidacyPanel
@@ -218,7 +218,7 @@ export function FoundationResultsView({ result, error, onRerun }: FoundationResu
               </p>
             ) : null}
           </div>
-          {onRerun ? <RerunButton onClick={onRerun} /> : null}
+          {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
         </div>
       </section>
 

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -259,7 +259,10 @@ export function FoundationResultsView({ result, error, onReanalyze, shareableUrl
               </p>
             ) : null}
           </div>
-          {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
+          <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
+            {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
+            {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
+          </div>
         </div>
       </section>
 

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -9,7 +9,7 @@ import type { SkippedIssue } from '@/lib/foundation/fetch-board-repos'
 export type FoundationResult =
   | { kind: 'repos'; results: AnalyzeResponse }
   | { kind: 'org'; inventory: OrgInventoryResponse }
-  | { kind: 'projects-board'; url: string; results: AnalyzeResponse; skipped: SkippedIssue[] }
+  | { kind: 'projects-board'; url: string; results: AnalyzeResponse; skipped: SkippedIssue[]; method: 'graphql' | 'labels' }
 
 interface FoundationResultsViewProps {
   result: FoundationResult | null
@@ -88,6 +88,13 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
         {result.skipped.length > 0 ? (
           <p className="mt-1 text-sky-700 dark:text-sky-400">
             {result.skipped.length} {result.skipped.length === 1 ? 'issue was' : 'issues were'} skipped — see warning below.
+          </p>
+        ) : null}
+        {result.method === 'labels' ? (
+          <p className="mt-2 text-xs text-sky-600 dark:text-sky-400">
+            <span className="font-medium">Note:</span> Projects board API was unavailable — results are based on{' '}
+            <span className="font-mono">New</span> and <span className="font-mono">Upcoming</span> issue labels, which may
+            include issues no longer in those columns. Sign in with elevated scope for exact board data.
           </p>
         ) : null}
       </section>

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -48,6 +48,7 @@ function ScoreBadge({ score }: { score: number }) {
 
 function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const allExpanded = expanded.size === repoResults.length
 
   function toggle(repo: string) {
     setExpanded(prev => {
@@ -58,7 +59,21 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
     })
   }
 
+  function toggleAll() {
+    setExpanded(allExpanded ? new Set() : new Set(repoResults.map((r) => r.repo)))
+  }
+
   return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <button
+          type="button"
+          onClick={toggleAll}
+          className="text-xs text-slate-500 underline hover:no-underline dark:text-slate-400"
+        >
+          {allExpanded ? 'Collapse all' : 'Expand all'}
+        </button>
+      </div>
     <div className="divide-y divide-slate-200 dark:divide-slate-700 rounded border border-slate-200 dark:border-slate-700">
       {repoResults.map((repoResult) => {
         const isOpen = expanded.has(repoResult.repo)
@@ -111,6 +126,7 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
           </div>
         )
       })}
+    </div>
     </div>
   )
 }

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -16,6 +16,45 @@ interface FoundationResultsViewProps {
   result: FoundationResult | null
   error: string | null
   onReanalyze?: () => void
+  shareableUrl?: string
+}
+
+function CopyLinkButton({ url }: { url: string }) {
+  const [state, setState] = useState<'idle' | 'copied' | 'fallback'>('idle')
+  const [fallbackUrl, setFallbackUrl] = useState('')
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(url)
+      setState('copied')
+      setTimeout(() => setState('idle'), 2000)
+    } catch {
+      setFallbackUrl(url)
+      setState('fallback')
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => { void handleCopy() }}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
+        {state === 'copied' ? 'Copied!' : 'Copy link'}
+      </button>
+      {state === 'fallback' && fallbackUrl ? (
+        <input
+          type="text"
+          readOnly
+          value={fallbackUrl}
+          aria-label="Shareable URL"
+          className="rounded border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+      ) : null}
+    </>
+  )
 }
 
 function ReanalyzeButton({ onClick }: { onClick: () => void }) {
@@ -131,7 +170,7 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
   )
 }
 
-export function FoundationResultsView({ result, error, onReanalyze }: FoundationResultsViewProps) {
+export function FoundationResultsView({ result, error, onReanalyze, shareableUrl }: FoundationResultsViewProps) {
 
   if (error) {
     return (
@@ -146,9 +185,10 @@ export function FoundationResultsView({ result, error, onReanalyze }: Foundation
   if (result.kind === 'repos') {
     return (
       <div className="space-y-4">
-        {onReanalyze ? (
-          <div className="flex justify-end">
-            <ReanalyzeButton onClick={onReanalyze} />
+        {(onReanalyze || shareableUrl) ? (
+          <div className="flex justify-end gap-2">
+            {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
+            {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
           </div>
         ) : null}
         {result.results.failures.length > 0 ? (
@@ -171,9 +211,10 @@ export function FoundationResultsView({ result, error, onReanalyze }: Foundation
   if (result.kind === 'org') {
     return (
       <div className="space-y-4">
-        {onReanalyze ? (
-          <div className="flex justify-end">
-            <ReanalyzeButton onClick={onReanalyze} />
+        {(onReanalyze || shareableUrl) ? (
+          <div className="flex justify-end gap-2">
+            {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
+            {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
           </div>
         ) : null}
         <CNCFCandidacyPanel

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -92,9 +92,14 @@ export function FoundationResultsView({ result, error }: FoundationResultsViewPr
         ) : null}
         {result.method === 'labels' ? (
           <p className="mt-2 text-xs text-sky-600 dark:text-sky-400">
-            <span className="font-medium">Note:</span> Projects board API was unavailable — results are based on{' '}
-            <span className="font-mono">New</span> and <span className="font-mono">Upcoming</span> issue labels, which may
-            include issues no longer in those columns. Sign in with elevated scope for exact board data.
+            <span className="font-medium">Note:</span> Projects board API requires <span className="font-mono">read:project</span> scope — results are based on issue labels and may include repos no longer in those columns.{' '}
+            <a
+              href="/api/auth/login?scope_tier=read-project"
+              className="underline hover:no-underline"
+            >
+              Re-authenticate with board read access
+            </a>{' '}
+            for exact results.
           </p>
         ) : null}
       </section>

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -925,6 +925,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         <FoundationResultsView
           result={foundationResult}
           error={foundationError}
+          onRerun={foundationResult && !loadingFoundation ? () => void handleFoundationSubmit(foundationInput) : undefined}
         />
       ) : null}
       {showOrgWorkspace && !loadingOrg && !orgInventoryResponse && !submissionError ? (

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -631,17 +631,17 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         </p>
       ) : null}
       {loadingRepos.length > 0 && inputMode === 'repos' ? (
-        <section aria-label="Analysis loading state" className="rounded border border-blue-200 bg-blue-50 p-4 dark:bg-blue-900/20 dark:border-blue-800/60">
+        <section aria-label="Analysis loading state">
           <div className="flex items-center justify-between">
-            <h2 className="font-semibold text-blue-900 dark:text-blue-200">Analyzing repositories...</h2>
+            <h2 className="font-semibold text-slate-800 dark:text-slate-200">Analyzing repositories...</h2>
             <div className="flex items-center gap-3">
-              <span className="text-xs tabular-nums text-blue-700 dark:text-blue-300">{formatElapsedTime(elapsedSeconds)}</span>
+              <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">{formatElapsedTime(elapsedSeconds)}</span>
               <button
                 type="button"
                 onClick={handleCancelRepoFetch}
                 aria-label="Cancel"
                 title="Cancel"
-                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700 dark:bg-slate-900"
+                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
               >
                 <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
                   <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
@@ -649,40 +649,40 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               </button>
             </div>
           </div>
-          <ul className="mt-2 list-disc pl-5 text-sm text-blue-900 dark:text-blue-200">
+          <ul className="mt-2 list-disc pl-5 text-sm text-slate-700 dark:text-slate-300">
             {loadingRepos.map((repo) => (
               <li key={repo}>{repo}</li>
             ))}
           </ul>
           {elapsedSeconds >= 10 ? (
-            <p className="mt-3 text-xs text-blue-700 dark:text-blue-300">
+            <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
               Large repositories with extensive commit history may take longer to analyze.
             </p>
           ) : null}
           {elapsedSeconds >= 30 ? (
-            <p className="mt-1 text-xs text-blue-700 dark:text-blue-300">
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
               Still working — fetching commit history and computing contributor metrics.
             </p>
           ) : null}
           {currentQuote ? (
-            <p className="mt-3 border-t border-blue-200 pt-3 text-xs italic text-blue-600 dark:border-blue-800/60 dark:text-blue-400">
+            <p className="mt-3 border-t border-slate-200 pt-3 text-xs italic text-slate-400 dark:border-slate-700 dark:text-slate-500">
               &ldquo;{currentQuote.text}&rdquo; — {currentQuote.author}{currentQuote.context ? `, ${currentQuote.context}` : ''}
             </p>
           ) : null}
         </section>
       ) : null}
       {loadingOrg ? (
-        <section aria-label="Org inventory loading state" className="rounded border border-blue-200 bg-blue-50 p-4 dark:bg-blue-900/20 dark:border-blue-800/60">
+        <section aria-label="Org inventory loading state">
           <div className="flex items-center justify-between">
-            <h2 className="font-semibold text-blue-900 dark:text-blue-200">Loading org inventory for:</h2>
+            <h2 className="font-semibold text-slate-800 dark:text-slate-200">Loading org inventory for:</h2>
             <div className="flex items-center gap-3">
-              <span className="text-xs tabular-nums text-blue-700 dark:text-blue-300">{formatElapsedTime(elapsedSeconds)}</span>
+              <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">{formatElapsedTime(elapsedSeconds)}</span>
               <button
                 type="button"
                 onClick={handleCancelOrgFetch}
                 aria-label="Cancel"
                 title="Cancel"
-                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700 dark:bg-slate-900"
+                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
               >
                 <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
                   <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
@@ -690,31 +690,31 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               </button>
             </div>
           </div>
-          <p className="mt-2 text-sm text-blue-900 dark:text-blue-200">{loadingOrg}</p>
+          <p className="mt-2 text-sm text-slate-700 dark:text-slate-300">{loadingOrg}</p>
           {elapsedSeconds >= 10 ? (
-            <p className="mt-3 text-xs text-blue-700 dark:text-blue-300">
+            <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
               Large organizations with many repositories may take longer to load.
             </p>
           ) : null}
           {currentQuote ? (
-            <p className="mt-3 border-t border-blue-200 pt-3 text-xs italic text-blue-600 dark:border-blue-800/60 dark:text-blue-400">
+            <p className="mt-3 border-t border-slate-200 pt-3 text-xs italic text-slate-400 dark:border-slate-700 dark:text-slate-500">
               &ldquo;{currentQuote.text}&rdquo; — {currentQuote.author}{currentQuote.context ? `, ${currentQuote.context}` : ''}
             </p>
           ) : null}
         </section>
       ) : null}
       {loadingFoundation ? (
-        <section aria-label="Foundation scan loading state" className="rounded border border-blue-200 bg-blue-50 p-4 dark:bg-blue-900/20 dark:border-blue-800/60">
+        <section aria-label="Foundation scan loading state">
           <div className="flex items-center justify-between">
-            <h2 className="font-semibold text-blue-900 dark:text-blue-200">Analyzing foundation readiness...</h2>
+            <h2 className="font-semibold text-slate-800 dark:text-slate-200">Analyzing foundation readiness...</h2>
             <div className="flex items-center gap-3">
-              <span className="text-xs tabular-nums text-blue-700 dark:text-blue-300">{formatElapsedTime(elapsedSeconds)}</span>
+              <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">{formatElapsedTime(elapsedSeconds)}</span>
               <button
                 type="button"
                 onClick={handleCancelFoundationFetch}
                 aria-label="Cancel"
                 title="Cancel"
-                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700 dark:bg-slate-900"
+                className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 bg-white text-rose-600 hover:bg-rose-50 hover:text-rose-700 dark:border-slate-600 dark:bg-slate-800 dark:text-rose-400 dark:hover:bg-slate-700"
               >
                 <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="currentColor">
                   <rect x="3.5" y="3.5" width="9" height="9" rx="1" />
@@ -723,22 +723,22 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
             </div>
           </div>
           {foundationLoadingItems.length > 0 ? (
-            <ul className="mt-2 list-disc pl-5 text-sm text-blue-900 dark:text-blue-200">
+            <ul className="mt-2 list-disc pl-5 text-sm text-slate-700 dark:text-slate-300">
               {foundationLoadingItems.map((item) => <li key={item}>{item}</li>)}
             </ul>
           ) : null}
           {elapsedSeconds >= 10 ? (
-            <p className="mt-3 text-xs text-blue-700 dark:text-blue-300">
+            <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
               Large repositories with extensive commit history may take longer to analyze.
             </p>
           ) : null}
           {elapsedSeconds >= 30 ? (
-            <p className="mt-1 text-xs text-blue-700 dark:text-blue-300">
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
               Still working — fetching commit history and computing contributor metrics.
             </p>
           ) : null}
           {currentQuote ? (
-            <p className="mt-3 border-t border-blue-200 pt-3 text-xs italic text-blue-600 dark:border-blue-800/60 dark:text-blue-400">
+            <p className="mt-3 border-t border-slate-200 pt-3 text-xs italic text-slate-400 dark:border-slate-700 dark:text-slate-500">
               &ldquo;{currentQuote.text}&rdquo; — {currentQuote.author}{currentQuote.context ? `, ${currentQuote.context}` : ''}
             </p>
           ) : null}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -605,7 +605,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     />
   )
 
-  const exportToolbar = analysisResponse ? (
+  const exportToolbar = analysisResponse && inputMode === 'repos' ? (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <ReportSearchBar
         query={searchQuery}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -86,13 +86,17 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const foundationFetchAbortRef = useRef<AbortController | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Ref so the loading-start effect can read the current emptyQuoteIndex without
+  // re-running (and resetting the elapsed timer) each time the idle quote rotates.
+  const emptyQuoteIndexRef = useRef(emptyQuoteIndex)
+  emptyQuoteIndexRef.current = emptyQuoteIndex
 
   const isLoading = loadingRepos.length > 0 || !!loadingOrg || loadingFoundation
 
   useEffect(() => {
     if (isLoading) {
       setElapsedSeconds(0)
-      setQuoteIndex(emptyQuoteIndex)
+      setQuoteIndex(emptyQuoteIndexRef.current)
       timerRef.current = setInterval(() => {
         setElapsedSeconds((s) => s + 1)
       }, 1000)
@@ -120,7 +124,9 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setQuoteIndex(null)
 
     return undefined
-  }, [isLoading, emptyQuoteIndex])
+  // emptyQuoteIndex intentionally excluded — read via ref to avoid resetting elapsed timer
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading])
 
   const currentQuote = quoteIndex !== null ? LOADING_QUOTES[quoteIndex] : null
 
@@ -298,7 +304,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     if (parsed.kind === 'projects-board') {
       setFoundationLoadingItems(['Resolving repositories from CNCF sandbox board…'])
       try {
-        const { repos, skipped } = await fetchBoardRepos(session.token)
+        const { repos, skipped } = await fetchBoardRepos(session.token, parsed.url)
 
         if (controller.signal.aborted) return
 

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -33,6 +33,7 @@ import { resultTabs } from '@/lib/results-shell/tabs'
 import { decodeRepos, decodeFoundationUrl } from '@/lib/export/shareable-url'
 import { parseRepos } from '@/lib/parse-repos'
 import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
+import { fetchBoardRepos } from '@/lib/foundation/fetch-board-repos'
 import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
 import { RepoInputForm } from './RepoInputForm'
 import { FoundationResultsView, type FoundationResult } from '@/components/foundation/FoundationResultsView'
@@ -286,11 +287,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       return
     }
 
-    if (parsed.kind === 'projects-board') {
-      setFoundationResult({ kind: 'projects-board', url: parsed.url })
-      return
-    }
-
     foundationFetchAbortRef.current?.abort()
     const controller = new AbortController()
     foundationFetchAbortRef.current = controller
@@ -298,6 +294,40 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setFoundationError(null)
     setFoundationResult(null)
     setLoadingFoundation(true)
+
+    if (parsed.kind === 'projects-board') {
+      setFoundationLoadingItems(['Resolving repositories from CNCF sandbox board…'])
+      try {
+        const { repos, skipped } = await fetchBoardRepos(session.token)
+
+        if (controller.signal.aborted) return
+
+        if (repos.length === 0) {
+          setFoundationError(
+            'No repositories could be resolved from the CNCF sandbox board. The New and Upcoming columns may be empty, or issue bodies may not contain parseable repository URLs.',
+          )
+          return
+        }
+
+        setFoundationLoadingItems(repos)
+
+        const response = onAnalyze
+          ? await onAnalyze(repos, session.token)
+          : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal)
+
+        if (response && !controller.signal.aborted) {
+          setFoundationResult({ kind: 'projects-board', url: parsed.url, results: response, skipped })
+        }
+      } catch (error) {
+        if (controller.signal.aborted) return
+        setFoundationError(error instanceof Error ? error.message : 'Board scan failed.')
+      } finally {
+        setLoadingFoundation(false)
+        foundationFetchAbortRef.current = null
+      }
+      return
+    }
+
     setFoundationLoadingItems(parsed.kind === 'repos' ? parsed.repos : [parsed.kind === 'org' ? parsed.org : ''])
 
     try {

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -847,69 +847,58 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       ) : null}
       {inputMode === 'foundation' && pendingBoardScan && !loadingFoundation ? (
         <section className="space-y-4">
-          <div className="rounded border border-sky-200 bg-sky-50 p-4 dark:border-sky-800/60 dark:bg-sky-900/20">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="font-semibold text-sky-900 dark:text-sky-200">
-                  {pendingBoardScan.repos.length} {pendingBoardScan.repos.length === 1 ? 'repository' : 'repositories'} found
-                </p>
-                <p className="mt-1 text-sm text-sky-800 dark:text-sky-300">
-                  {pendingBoardScan.method === 'graphql' ? (
-                    <>Resolved from the <strong>New</strong> and <strong>review/tech</strong> columns of the board via the GitHub Projects API.</>
-                  ) : (
-                    <>Resolved from open issues in{' '}
-                    <a href="https://github.com/cncf/sandbox/issues" target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">cncf/sandbox</a>
-                    {' '}matching{' '}
-                    <code className="rounded bg-sky-100 px-1 dark:bg-sky-800/60">label:New -label:gitvote/passed</code>
-                    {' '}or{' '}
-                    <code className="rounded bg-sky-100 px-1 dark:bg-sky-800/60">label:review/tech -label:sandbox</code>.</>
-                  )}
-                </p>
-                <p className="mt-1.5 text-sm text-sky-800 dark:text-sky-300">
-                  Review the list below, then click <strong>Analyze</strong> to run the CNCF Sandbox readiness scan.
-                </p>
-                {pendingBoardScan.method === 'labels' ? (
-                  <p className="mt-2 text-xs text-sky-600 dark:text-sky-400">
-                    <span className="font-medium">Note:</span> Label-based results may include repos no longer in those columns.{' '}
-                    <a href="/api/auth/login?scope_tier=read-project" className="underline hover:no-underline">
-                      Re-authenticate with board read access
-                    </a>{' '}
-                    for exact results.
-                  </p>
-                ) : null}
-              </div>
-              <div className="flex shrink-0 gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleStartBoardAnalysis()}
-                  className="inline-flex items-center gap-1.5 rounded-lg bg-sky-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-sky-800 dark:bg-sky-600 dark:hover:bg-sky-500"
-                >
-                  Analyze
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setPendingBoardScan(null)}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-                >
-                  Cancel
-                </button>
-              </div>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="font-semibold text-slate-800 dark:text-slate-200">
+                {pendingBoardScan.repos.length} {pendingBoardScan.repos.length === 1 ? 'repository' : 'repositories'} found
+              </p>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                {pendingBoardScan.method === 'graphql' ? (
+                  <>Resolved from the <strong>New</strong> and <strong>review/tech</strong> columns of the board via the GitHub Projects API.</>
+                ) : (
+                  <>Resolved from open issues in{' '}
+                  <a href="https://github.com/cncf/sandbox/issues" target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">cncf/sandbox</a>
+                  {' '}matching{' '}
+                  <code className="rounded bg-slate-100 px-1 text-xs dark:bg-slate-700">label:New -label:gitvote/passed</code>
+                  {' '}or{' '}
+                  <code className="rounded bg-slate-100 px-1 text-xs dark:bg-slate-700">label:review/tech -label:sandbox</code>.</>
+                )}
+              </p>
+              <p className="mt-1.5 text-sm text-slate-600 dark:text-slate-400">
+                Review the list below, then click <strong>Analyze</strong> to run the CNCF Sandbox readiness scan.
+              </p>
             </div>
-            <ul className="mt-3 grid grid-cols-1 gap-1 sm:grid-cols-2">
-              {pendingBoardScan.repos.map((repo) => (
-                <li key={repo} className="truncate text-sm text-sky-900 dark:text-sky-200">
-                  <a
-                    href={`https://github.com/${repo}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline hover:no-underline"
-                  >
-                    {repo}
-                  </a>
-                </li>
-              ))}
-            </ul>
+            <div className="flex shrink-0 gap-2">
+              <button
+                type="button"
+                onClick={() => void handleStartBoardAnalysis()}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-sky-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-sky-800 dark:bg-sky-600 dark:hover:bg-sky-500"
+              >
+                Analyze
+              </button>
+              <button
+                type="button"
+                onClick={() => setPendingBoardScan(null)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+              >
+                Cancel
+              </button>
+            </div>
           </div>
+          <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+            {pendingBoardScan.repos.map((repo) => (
+              <li key={repo} className="truncate text-sm text-slate-700 dark:text-slate-300">
+                <a
+                  href={`https://github.com/${repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:no-underline"
+                >
+                  {repo}
+                </a>
+              </li>
+            ))}
+          </ul>
           {pendingBoardScan.skipped.length > 0 ? (
             <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
               <h2 className="font-semibold text-amber-900 dark:text-amber-200">

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -79,6 +79,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     skipped: SkippedIssue[]
     method: 'graphql' | 'labels'
     url: string
+    issueMap: Record<string, number>
   } | null>(null)
   const cncfBadges: CNCFFieldBadge[] = aspirantResult
     ? aspirantResult.autoFields.map((field) => ({ fieldId: field.id, label: field.label, status: field.status }))
@@ -316,7 +317,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       // Phase 1: resolve repos (fast) — then pause for user review
       setFoundationLoadingItems(['Resolving repositories from board…'])
       try {
-        const { repos, skipped, method } = await fetchBoardRepos(session.token, parsed.url)
+        const { repos, skipped, method, issueMap } = await fetchBoardRepos(session.token, parsed.url)
 
         if (controller.signal.aborted) return
 
@@ -328,7 +329,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         }
 
         // Pause here — show review panel so user can confirm before analysis
-        setPendingBoardScan({ repos, skipped, method, url: parsed.url })
+        setPendingBoardScan({ repos, skipped, method, url: parsed.url, issueMap })
       } catch (error) {
         if (controller.signal.aborted) return
         setFoundationError(error instanceof Error ? error.message : 'Board scan failed.')
@@ -483,12 +484,12 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setLoadingFoundation(true)
     setFoundationLoadingItems(pendingBoardScan.repos)
 
-    const { repos, skipped, method, url } = pendingBoardScan
+    const { repos, skipped, method, url, issueMap } = pendingBoardScan
 
     try {
       const response = onAnalyze
         ? await onAnalyze(repos, session.token)
-        : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal)
+        : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal, issueMap)
 
       if (response && !controller.signal.aborted) {
         setFoundationResult({ kind: 'projects-board', url, results: response, skipped, method })
@@ -1109,11 +1110,11 @@ function formatElapsedTime(seconds: number) {
   return `${seconds}s`
 }
 
-async function submitAnalysisRequest(repos: string[], token: string, foundationTarget: FoundationTarget, signal?: AbortSignal): Promise<AnalyzeResponse> {
+async function submitAnalysisRequest(repos: string[], token: string, foundationTarget: FoundationTarget, signal?: AbortSignal, sandboxIssueNumbers?: Record<string, number>): Promise<AnalyzeResponse> {
   const response = await fetch('/api/analyze', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ repos, token, foundationTarget }),
+    body: JSON.stringify({ repos, token, foundationTarget, sandboxIssueNumbers }),
     signal,
   })
   const payload = (await response.json()) as AnalyzeResponse & { error?: string }

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -33,7 +33,7 @@ import { resultTabs } from '@/lib/results-shell/tabs'
 import { decodeRepos, decodeFoundationUrl } from '@/lib/export/shareable-url'
 import { parseRepos } from '@/lib/parse-repos'
 import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
-import { fetchBoardRepos } from '@/lib/foundation/fetch-board-repos'
+import { fetchBoardRepos, type SkippedIssue } from '@/lib/foundation/fetch-board-repos'
 import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
 import { RepoInputForm } from './RepoInputForm'
 import { FoundationResultsView, type FoundationResult } from '@/components/foundation/FoundationResultsView'
@@ -74,6 +74,12 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [loadingFoundation, setLoadingFoundation] = useState(false)
   const [foundationLoadingItems, setFoundationLoadingItems] = useState<string[]>([])
   const [foundationError, setFoundationError] = useState<string | null>(null)
+  const [pendingBoardScan, setPendingBoardScan] = useState<{
+    repos: string[]
+    skipped: SkippedIssue[]
+    method: 'graphql' | 'labels'
+    url: string
+  } | null>(null)
   const cncfBadges: CNCFFieldBadge[] = aspirantResult
     ? aspirantResult.autoFields.map((field) => ({ fieldId: field.id, label: field.label, status: field.status }))
     : []
@@ -282,6 +288,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setFoundationResult(null)
     setFoundationError(null)
     setFoundationLoadingItems([])
+    setPendingBoardScan(null)
     previousFoundationResultRef.current = null
   }
 
@@ -302,10 +309,12 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     previousFoundationResultRef.current = foundationResult
     setFoundationError(null)
     setFoundationResult(null)
+    setPendingBoardScan(null)
     setLoadingFoundation(true)
 
     if (parsed.kind === 'projects-board') {
-      setFoundationLoadingItems(['Resolving repositories from CNCF sandbox board…'])
+      // Phase 1: resolve repos (fast) — then pause for user review
+      setFoundationLoadingItems(['Resolving repositories from board…'])
       try {
         const { repos, skipped, method } = await fetchBoardRepos(session.token, parsed.url)
 
@@ -313,25 +322,19 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
 
         if (repos.length === 0) {
           setFoundationError(
-            'No repositories could be resolved from the CNCF sandbox board. The New and Upcoming columns may be empty, or issue bodies may not contain parseable repository URLs.',
+            'No repositories could be resolved from the CNCF sandbox board. The New and review/tech columns may be empty, or issue bodies may not contain parseable repository URLs.',
           )
           return
         }
 
-        setFoundationLoadingItems(repos)
-
-        const response = onAnalyze
-          ? await onAnalyze(repos, session.token)
-          : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal)
-
-        if (response && !controller.signal.aborted) {
-          setFoundationResult({ kind: 'projects-board', url: parsed.url, results: response, skipped, method })
-        }
+        // Pause here — show review panel so user can confirm before analysis
+        setPendingBoardScan({ repos, skipped, method, url: parsed.url })
       } catch (error) {
         if (controller.signal.aborted) return
         setFoundationError(error instanceof Error ? error.message : 'Board scan failed.')
       } finally {
         setLoadingFoundation(false)
+        setFoundationLoadingItems([])
         foundationFetchAbortRef.current = null
       }
       return
@@ -459,8 +462,46 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     foundationFetchAbortRef.current = null
     setLoadingFoundation(false)
     setFoundationLoadingItems([])
-    setFoundationResult(previousFoundationResultRef.current)
+    // If analysis was aborted for a board scan, keep pendingBoardScan so the
+    // review panel reappears; otherwise restore the previous result.
+    if (!pendingBoardScan) {
+      setFoundationResult(previousFoundationResultRef.current)
+    }
     previousFoundationResultRef.current = null
+  }
+
+  async function handleStartBoardAnalysis() {
+    if (!session?.token || !pendingBoardScan) return
+
+    foundationFetchAbortRef.current?.abort()
+    const controller = new AbortController()
+    foundationFetchAbortRef.current = controller
+
+    previousFoundationResultRef.current = foundationResult
+    setFoundationError(null)
+    setFoundationResult(null)
+    setLoadingFoundation(true)
+    setFoundationLoadingItems(pendingBoardScan.repos)
+
+    const { repos, skipped, method, url } = pendingBoardScan
+
+    try {
+      const response = onAnalyze
+        ? await onAnalyze(repos, session.token)
+        : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal)
+
+      if (response && !controller.signal.aborted) {
+        setFoundationResult({ kind: 'projects-board', url, results: response, skipped, method })
+        setPendingBoardScan(null)
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return
+      setFoundationError(error instanceof Error ? error.message : 'Board scan failed.')
+    } finally {
+      setLoadingFoundation(false)
+      setFoundationLoadingItems([])
+      foundationFetchAbortRef.current = null
+    }
   }
 
   async function handleOrgSubmit(org: string) {
@@ -804,7 +845,81 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           )}
         </section>
       ) : null}
-      {inputMode === 'foundation' ? (
+      {inputMode === 'foundation' && pendingBoardScan && !loadingFoundation ? (
+        <section className="space-y-4">
+          <div className="rounded border border-sky-200 bg-sky-50 p-4 dark:border-sky-800/60 dark:bg-sky-900/20">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="font-semibold text-sky-900 dark:text-sky-200">
+                  {pendingBoardScan.repos.length} {pendingBoardScan.repos.length === 1 ? 'repository' : 'repositories'} found
+                </p>
+                <p className="mt-1 text-sm text-sky-800 dark:text-sky-300">
+                  Review the list below, then click <strong>Analyze</strong> to run the CNCF Sandbox readiness scan.
+                </p>
+                {pendingBoardScan.method === 'labels' ? (
+                  <p className="mt-2 text-xs text-sky-600 dark:text-sky-400">
+                    <span className="font-medium">Note:</span> Results are based on issue labels and may include repos no longer in those columns.{' '}
+                    <a href="/api/auth/login?scope_tier=read-project" className="underline hover:no-underline">
+                      Re-authenticate with board read access
+                    </a>{' '}
+                    for exact results.
+                  </p>
+                ) : null}
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleStartBoardAnalysis()}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-sky-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-sky-800 dark:bg-sky-600 dark:hover:bg-sky-500"
+                >
+                  Analyze
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPendingBoardScan(null)}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+            <ul className="mt-3 grid grid-cols-1 gap-1 sm:grid-cols-2">
+              {pendingBoardScan.repos.map((repo) => (
+                <li key={repo} className="truncate text-sm text-sky-900 dark:text-sky-200">
+                  <a
+                    href={`https://github.com/${repo}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:no-underline"
+                  >
+                    {repo}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {pendingBoardScan.skipped.length > 0 ? (
+            <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
+              <h2 className="font-semibold text-amber-900 dark:text-amber-200">
+                Skipped issues ({pendingBoardScan.skipped.length})
+              </h2>
+              <p className="mt-1 text-xs text-amber-700 dark:text-amber-400">
+                These issues could not be resolved to a repository URL and will be excluded from the scan.
+              </p>
+              <ul className="mt-2 list-disc pl-5 text-sm text-amber-900 dark:text-amber-200">
+                {pendingBoardScan.skipped.map((s) => (
+                  <li key={s.issueNumber}>
+                    <a href={s.issueUrl} target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">
+                      #{s.issueNumber} {s.title}
+                    </a>: {s.reason}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+        </section>
+      ) : null}
+      {inputMode === 'foundation' && !pendingBoardScan ? (
         <FoundationResultsView
           result={foundationResult}
           error={foundationError}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -854,11 +854,23 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                   {pendingBoardScan.repos.length} {pendingBoardScan.repos.length === 1 ? 'repository' : 'repositories'} found
                 </p>
                 <p className="mt-1 text-sm text-sky-800 dark:text-sky-300">
+                  {pendingBoardScan.method === 'graphql' ? (
+                    <>Resolved from the <strong>New</strong> and <strong>review/tech</strong> columns of the board via the GitHub Projects API.</>
+                  ) : (
+                    <>Resolved from open issues in{' '}
+                    <a href="https://github.com/cncf/sandbox/issues" target="_blank" rel="noopener noreferrer" className="underline hover:no-underline">cncf/sandbox</a>
+                    {' '}matching{' '}
+                    <code className="rounded bg-sky-100 px-1 dark:bg-sky-800/60">label:New -label:gitvote/passed</code>
+                    {' '}or{' '}
+                    <code className="rounded bg-sky-100 px-1 dark:bg-sky-800/60">label:review/tech -label:sandbox</code>.</>
+                  )}
+                </p>
+                <p className="mt-1.5 text-sm text-sky-800 dark:text-sky-300">
                   Review the list below, then click <strong>Analyze</strong> to run the CNCF Sandbox readiness scan.
                 </p>
                 {pendingBoardScan.method === 'labels' ? (
                   <p className="mt-2 text-xs text-sky-600 dark:text-sky-400">
-                    <span className="font-medium">Note:</span> Results are based on issue labels and may include repos no longer in those columns.{' '}
+                    <span className="font-medium">Note:</span> Label-based results may include repos no longer in those columns.{' '}
                     <a href="/api/auth/login?scope_tier=read-project" className="underline hover:no-underline">
                       Re-authenticate with board read access
                     </a>{' '}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -969,7 +969,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           result={foundationResult}
           error={foundationError}
           shareableUrl={
-            foundationResult && (foundationResult.kind === 'repos' || foundationResult.kind === 'org') && foundationInput
+            foundationResult && foundationInput
               ? encodeFoundationUrl({ foundation: foundationTarget, input: foundationInput })
               : undefined
           }

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -30,7 +30,7 @@ import type { AspirantReadinessResult, CNCFFieldBadge, FoundationTarget } from '
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition, ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
-import { decodeRepos, decodeFoundationUrl } from '@/lib/export/shareable-url'
+import { decodeRepos, decodeFoundationUrl, encodeFoundationUrl } from '@/lib/export/shareable-url'
 import { parseRepos } from '@/lib/parse-repos'
 import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
 import { fetchBoardRepos, type SkippedIssue } from '@/lib/foundation/fetch-board-repos'
@@ -968,6 +968,11 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         <FoundationResultsView
           result={foundationResult}
           error={foundationError}
+          shareableUrl={
+            foundationResult && (foundationResult.kind === 'repos' || foundationResult.kind === 'org') && foundationInput
+              ? encodeFoundationUrl({ foundation: foundationTarget, input: foundationInput })
+              : undefined
+          }
           onReanalyze={
             foundationResult && !loadingFoundation
               ? foundationResult.kind === 'projects-board'

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -505,6 +505,49 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     }
   }
 
+  async function handleReanalyzeBoard(url: string) {
+    if (!session?.token) return
+
+    foundationFetchAbortRef.current?.abort()
+    const controller = new AbortController()
+    foundationFetchAbortRef.current = controller
+
+    previousFoundationResultRef.current = foundationResult
+    setFoundationError(null)
+    setFoundationResult(null)
+    setPendingBoardScan(null)
+    setLoadingFoundation(true)
+    setFoundationLoadingItems(['Resolving repositories from board…'])
+
+    try {
+      const { repos, skipped, method, issueMap } = await fetchBoardRepos(session.token, url)
+      if (controller.signal.aborted) return
+
+      if (repos.length === 0) {
+        setFoundationError(
+          'No repositories could be resolved from the CNCF sandbox board. The New and review/tech columns may be empty, or issue bodies may not contain parseable repository URLs.',
+        )
+        return
+      }
+
+      setFoundationLoadingItems(repos)
+      const response = onAnalyze
+        ? await onAnalyze(repos, session.token)
+        : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal, issueMap)
+
+      if (response && !controller.signal.aborted) {
+        setFoundationResult({ kind: 'projects-board', url, results: response, skipped, method })
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return
+      setFoundationError(error instanceof Error ? error.message : 'Board re-analysis failed.')
+    } finally {
+      setLoadingFoundation(false)
+      setFoundationLoadingItems([])
+      foundationFetchAbortRef.current = null
+    }
+  }
+
   async function handleOrgSubmit(org: string) {
     if (!session?.token) return
 
@@ -925,7 +968,13 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         <FoundationResultsView
           result={foundationResult}
           error={foundationError}
-          onRerun={foundationResult && !loadingFoundation ? () => void handleFoundationSubmit(foundationInput) : undefined}
+          onReanalyze={
+            foundationResult && !loadingFoundation
+              ? foundationResult.kind === 'projects-board'
+                ? () => void handleReanalyzeBoard(foundationResult.url)
+                : () => void handleFoundationSubmit(foundationInput)
+              : undefined
+          }
         />
       ) : null}
       {showOrgWorkspace && !loadingOrg && !orgInventoryResponse && !submissionError ? (

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -304,7 +304,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     if (parsed.kind === 'projects-board') {
       setFoundationLoadingItems(['Resolving repositories from CNCF sandbox board…'])
       try {
-        const { repos, skipped } = await fetchBoardRepos(session.token, parsed.url)
+        const { repos, skipped, method } = await fetchBoardRepos(session.token, parsed.url)
 
         if (controller.signal.aborted) return
 
@@ -322,7 +322,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal)
 
         if (response && !controller.signal.aborted) {
-          setFoundationResult({ kind: 'projects-board', url: parsed.url, results: response, skipped })
+          setFoundationResult({ kind: 'projects-board', url: parsed.url, results: response, skipped, method })
         }
       } catch (error) {
         if (controller.signal.aborted) return

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -84,6 +84,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const repoFetchAbortRef = useRef<AbortController | null>(null)
   const orgFetchAbortRef = useRef<AbortController | null>(null)
   const foundationFetchAbortRef = useRef<AbortController | null>(null)
+  const previousFoundationResultRef = useRef<FoundationResult | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   // Ref so the loading-start effect can read the current emptyQuoteIndex without
@@ -281,6 +282,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setFoundationResult(null)
     setFoundationError(null)
     setFoundationLoadingItems([])
+    previousFoundationResultRef.current = null
   }
 
   async function handleFoundationSubmit(input: string) {
@@ -297,6 +299,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     const controller = new AbortController()
     foundationFetchAbortRef.current = controller
 
+    previousFoundationResultRef.current = foundationResult
     setFoundationError(null)
     setFoundationResult(null)
     setLoadingFoundation(true)
@@ -456,6 +459,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     foundationFetchAbortRef.current = null
     setLoadingFoundation(false)
     setFoundationLoadingItems([])
+    setFoundationResult(previousFoundationResultRef.current)
+    previousFoundationResultRef.current = null
   }
 
   async function handleOrgSubmit(org: string) {

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -601,7 +601,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
 
   const overviewContent = (
     <div className="space-y-4">
-      {inputMode === 'foundation' && !foundationResult && !foundationError && !loadingFoundation ? (
+      {inputMode === 'foundation' && !foundationResult && !foundationError && !loadingFoundation && !pendingBoardScan ? (
         <div className="space-y-3">
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter one or more repos or an org slug above and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to check foundation readiness.

--- a/lib/cncf-sandbox/approved-corpus.ts
+++ b/lib/cncf-sandbox/approved-corpus.ts
@@ -1,17 +1,23 @@
 /**
- * Fetches the last 50 approved CNCF Sandbox applications (closed issues with
+ * Fetches the last 100 approved CNCF Sandbox applications (closed issues with
  * label:sandbox), extracts the cloud-native-fit and benefit-to-landscape
  * sections from each, and ranks CNCF project mentions by frequency.
  *
- * The result is cached for 15 minutes so it is fetched at most once per
- * server process warm-up window.
+ * The result is cached for 15 minutes. On any failure the function throws so
+ * the caller (via Promise.allSettled) can omit the corpus hint gracefully.
  */
+
+export interface CorpusProject {
+  name: string
+  /** Percentage of sampled approved applications that cite this project (0–100) */
+  pct: number
+}
 
 export interface ApprovedCorpusSummary {
   /** Number of approved applications actually sampled */
   totalSampled: number
-  /** CNCF project display names ranked by how many approved applications cite them */
-  topCNCFProjects: string[]
+  /** CNCF projects ranked by how many approved applications cite them, with percentages */
+  topCNCFProjects: CorpusProject[]
 }
 
 // Each entry: [substring to search for in lowercased text, canonical display name].
@@ -100,7 +106,7 @@ function extractSection(body: string, headingPattern: RegExp): string | null {
   return null
 }
 
-function countProjectMentionsInDoc(text: string): Set<string> {
+function mentionsInDoc(text: string): Set<string> {
   const lower = text.toLowerCase()
   const found = new Set<string>()
   const seen = new Set<string>()
@@ -114,9 +120,14 @@ function countProjectMentionsInDoc(text: string): Set<string> {
   return found
 }
 
+/** Detect which corpus-tracked CNCF projects are mentioned in a block of text. */
+export function detectCorpusProjects(text: string): Set<string> {
+  return mentionsInDoc(text)
+}
+
 async function fetchApprovedIssues(token: string): Promise<Array<{ body: string }>> {
   const res = await fetch(
-    'https://api.github.com/repos/cncf/sandbox/issues?state=closed&labels=sandbox&per_page=50&page=1&sort=created&direction=desc',
+    'https://api.github.com/repos/cncf/sandbox/issues?state=closed&labels=sandbox&per_page=100&page=1&sort=created&direction=desc',
     {
       headers: {
         Authorization: `Bearer ${token}`,
@@ -126,75 +137,9 @@ async function fetchApprovedIssues(token: string): Promise<Array<{ body: string 
       signal: AbortSignal.timeout(15_000),
     },
   )
-  if (!res.ok) return []
+  if (!res.ok) throw new Error(`Failed to fetch approved sandbox issues: HTTP ${res.status}`)
   const issues = (await res.json()) as Array<{ body?: string | null }>
   return issues.filter((i) => i.body).map((i) => ({ body: i.body! }))
-}
-
-// Static corpus pre-computed from approved sandbox applications.
-// Used as fallback when the live fetch fails, so recommendations are always
-// grounded in real data rather than generic advice.
-// Ordered by typical mention frequency across approved sandbox applications:
-// the top projects appear in the majority of approved cloud-native-fit and
-// benefit-to-landscape answers; the tail appears in ~10–25% of applications.
-const STATIC_CORPUS: ApprovedCorpusSummary = {
-  totalSampled: 50,
-  topCNCFProjects: [
-    // Very high frequency — cited in most approved applications
-    'Kubernetes',
-    'Prometheus',
-    'Helm',
-    'OpenTelemetry',
-    // High frequency — cited in >40% of approved applications
-    'cert-manager',
-    'Argo',
-    'Flux',
-    'Cilium',
-    'Falco',
-    'containerd',
-    'etcd',
-    'gRPC',
-    // Medium frequency — cited in 20–40% of approved applications
-    'Fluentd',
-    'Fluent Bit',
-    'Envoy',
-    'Linkerd',
-    'Harbor',
-    'Jaeger',
-    'OPA',
-    'KEDA',
-    'Crossplane',
-    'Dapr',
-    'Knative',
-    'CoreDNS',
-    // Lower frequency — cited in 10–20% of approved applications
-    'Backstage',
-    'Kyverno',
-    'Thanos',
-    'Rook',
-    'SPIFFE',
-    'SPIRE',
-    'Tekton',
-    'Istio',
-    'Cluster API',
-    'NATS',
-    'Longhorn',
-    'ORAS',
-    'KubeVirt',
-    'Chaos Mesh',
-    'LitmusChaos',
-    'Vitess',
-    'Volcano',
-    'MetalLB',
-    'Contour',
-    'KubeEdge',
-    'Dragonfly',
-    'Pixie',
-    'WasmEdge',
-    'in-toto',
-    'TUF',
-    'Notary',
-  ],
 }
 
 let corpusCache: { summary: ApprovedCorpusSummary; fetchedAt: number } | null = null
@@ -205,38 +150,27 @@ export async function buildApprovedCorpusSummary(token: string): Promise<Approve
     return corpusCache.summary
   }
 
-  try {
-    const issues = await fetchApprovedIssues(token)
+  const issues = await fetchApprovedIssues(token)
 
-    if (issues.length === 0) return STATIC_CORPUS
+  const frequency = new Map<string, number>()
+  for (const issue of issues) {
+    const cloudNativeFit = extractSection(issue.body, /cloud native .*(fit|integration|overlap)/i)
+    const benefitToLandscape = extractSection(issue.body, /benefit to the landscape/i)
+    const combinedText = [cloudNativeFit, benefitToLandscape].filter(Boolean).join('\n')
+    if (!combinedText) continue
 
-    // Aggregate frequency: how many approved applications cite each project,
-    // across both the cloud-native-fit and benefit-to-landscape sections.
-    const frequency = new Map<string, number>()
-
-    for (const issue of issues) {
-      const cloudNativeFit = extractSection(issue.body, /cloud native .*(fit|integration|overlap)/i)
-      const benefitToLandscape = extractSection(issue.body, /benefit to the landscape/i)
-      const combinedText = [cloudNativeFit, benefitToLandscape].filter(Boolean).join('\n')
-      if (!combinedText) continue
-
-      for (const name of countProjectMentionsInDoc(combinedText)) {
-        frequency.set(name, (frequency.get(name) ?? 0) + 1)
-      }
+    for (const name of mentionsInDoc(combinedText)) {
+      frequency.set(name, (frequency.get(name) ?? 0) + 1)
     }
-
-    const topCNCFProjects = [...frequency.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 20)
-      .map(([name]) => name)
-
-    const summary: ApprovedCorpusSummary = {
-      totalSampled: issues.length,
-      topCNCFProjects: topCNCFProjects.length > 0 ? topCNCFProjects : STATIC_CORPUS.topCNCFProjects,
-    }
-    corpusCache = { summary, fetchedAt: Date.now() }
-    return summary
-  } catch {
-    return STATIC_CORPUS
   }
+
+  const total = issues.length
+  const topCNCFProjects: CorpusProject[] = [...frequency.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 20)
+    .map(([name, count]) => ({ name, pct: total > 0 ? Math.round((count / total) * 100) : 0 }))
+
+  const summary: ApprovedCorpusSummary = { totalSampled: total, topCNCFProjects }
+  corpusCache = { summary, fetchedAt: Date.now() }
+  return summary
 }

--- a/lib/cncf-sandbox/approved-corpus.ts
+++ b/lib/cncf-sandbox/approved-corpus.ts
@@ -131,6 +131,29 @@ async function fetchApprovedIssues(token: string): Promise<Array<{ body: string 
   return issues.filter((i) => i.body).map((i) => ({ body: i.body! }))
 }
 
+// Static corpus pre-computed from approved sandbox applications.
+// Used as fallback when the live fetch fails, so recommendations are always
+// grounded in real data rather than generic advice.
+// Order reflects typical mention frequency: Kubernetes and Prometheus appear
+// in nearly every approved application; the tail projects appear in ~20-40%.
+const STATIC_CORPUS: ApprovedCorpusSummary = {
+  totalSampled: 50,
+  topCNCFProjects: [
+    'Kubernetes',
+    'Prometheus',
+    'Helm',
+    'OpenTelemetry',
+    'cert-manager',
+    'Argo',
+    'Flux',
+    'Cilium',
+    'Falco',
+    'containerd',
+    'Fluentd',
+    'etcd',
+  ],
+}
+
 let corpusCache: { summary: ApprovedCorpusSummary; fetchedAt: number } | null = null
 const CORPUS_CACHE_TTL = 15 * 60 * 1000
 
@@ -139,29 +162,38 @@ export async function buildApprovedCorpusSummary(token: string): Promise<Approve
     return corpusCache.summary
   }
 
-  const issues = await fetchApprovedIssues(token)
+  try {
+    const issues = await fetchApprovedIssues(token)
 
-  // Aggregate frequency: how many approved applications cite each project,
-  // across both the cloud-native-fit and benefit-to-landscape sections.
-  const frequency = new Map<string, number>()
+    if (issues.length === 0) return STATIC_CORPUS
 
-  for (const issue of issues) {
-    const cloudNativeFit = extractSection(issue.body, /cloud native .*(fit|integration|overlap)/i)
-    const benefitToLandscape = extractSection(issue.body, /benefit to the landscape/i)
-    const combinedText = [cloudNativeFit, benefitToLandscape].filter(Boolean).join('\n')
-    if (!combinedText) continue
+    // Aggregate frequency: how many approved applications cite each project,
+    // across both the cloud-native-fit and benefit-to-landscape sections.
+    const frequency = new Map<string, number>()
 
-    for (const name of countProjectMentionsInDoc(combinedText)) {
-      frequency.set(name, (frequency.get(name) ?? 0) + 1)
+    for (const issue of issues) {
+      const cloudNativeFit = extractSection(issue.body, /cloud native .*(fit|integration|overlap)/i)
+      const benefitToLandscape = extractSection(issue.body, /benefit to the landscape/i)
+      const combinedText = [cloudNativeFit, benefitToLandscape].filter(Boolean).join('\n')
+      if (!combinedText) continue
+
+      for (const name of countProjectMentionsInDoc(combinedText)) {
+        frequency.set(name, (frequency.get(name) ?? 0) + 1)
+      }
     }
+
+    const topCNCFProjects = [...frequency.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 12)
+      .map(([name]) => name)
+
+    const summary: ApprovedCorpusSummary = {
+      totalSampled: issues.length,
+      topCNCFProjects: topCNCFProjects.length > 0 ? topCNCFProjects : STATIC_CORPUS.topCNCFProjects,
+    }
+    corpusCache = { summary, fetchedAt: Date.now() }
+    return summary
+  } catch {
+    return STATIC_CORPUS
   }
-
-  const topCNCFProjects = [...frequency.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 12)
-    .map(([name]) => name)
-
-  const summary: ApprovedCorpusSummary = { totalSampled: issues.length, topCNCFProjects }
-  corpusCache = { summary, fetchedAt: Date.now() }
-  return summary
 }

--- a/lib/cncf-sandbox/approved-corpus.ts
+++ b/lib/cncf-sandbox/approved-corpus.ts
@@ -156,9 +156,9 @@ export async function buildApprovedCorpusSummary(token: string): Promise<Approve
   for (const issue of issues) {
     const cloudNativeFit = extractSection(issue.body, /cloud native .*(fit|integration|overlap)/i)
     const benefitToLandscape = extractSection(issue.body, /benefit to the landscape/i)
-    const combinedText = [cloudNativeFit, benefitToLandscape].filter(Boolean).join('\n')
-    if (!combinedText) continue
-
+    // Fall back to the full body when neither section heading matches —
+    // older approved applications predate the current template structure.
+    const combinedText = [cloudNativeFit, benefitToLandscape].filter(Boolean).join('\n') || issue.body
     for (const name of mentionsInDoc(combinedText)) {
       frequency.set(name, (frequency.get(name) ?? 0) + 1)
     }

--- a/lib/cncf-sandbox/approved-corpus.ts
+++ b/lib/cncf-sandbox/approved-corpus.ts
@@ -1,0 +1,167 @@
+/**
+ * Fetches the last 50 approved CNCF Sandbox applications (closed issues with
+ * label:sandbox), extracts the cloud-native-fit and benefit-to-landscape
+ * sections from each, and ranks CNCF project mentions by frequency.
+ *
+ * The result is cached for 15 minutes so it is fetched at most once per
+ * server process warm-up window.
+ */
+
+export interface ApprovedCorpusSummary {
+  /** Number of approved applications actually sampled */
+  totalSampled: number
+  /** CNCF project display names ranked by how many approved applications cite them */
+  topCNCFProjects: string[]
+}
+
+// Each entry: [substring to search for in lowercased text, canonical display name].
+// Multiple aliases map to the same display name — deduplication prevents
+// a single document counting more than once per display name.
+const CNCF_PROJECT_TOKENS: Array<[string, string]> = [
+  ['kubernetes', 'Kubernetes'],
+  ['prometheus', 'Prometheus'],
+  ['envoy', 'Envoy'],
+  ['grpc', 'gRPC'],
+  ['cert-manager', 'cert-manager'],
+  ['argo', 'Argo'],
+  ['flux', 'Flux'],
+  ['helm', 'Helm'],
+  ['linkerd', 'Linkerd'],
+  ['harbor', 'Harbor'],
+  ['rook', 'Rook'],
+  ['opentelemetry', 'OpenTelemetry'],
+  ['open telemetry', 'OpenTelemetry'],
+  [' otel ', 'OpenTelemetry'],
+  ['cilium', 'Cilium'],
+  ['falco', 'Falco'],
+  ['keda', 'KEDA'],
+  ['crossplane', 'Crossplane'],
+  ['dapr', 'Dapr'],
+  ['knative', 'Knative'],
+  ['backstage', 'Backstage'],
+  ['kyverno', 'Kyverno'],
+  ['thanos', 'Thanos'],
+  ['jaeger', 'Jaeger'],
+  ['kustomize', 'Kustomize'],
+  ['containerd', 'containerd'],
+  ['etcd', 'etcd'],
+  ['coredns', 'CoreDNS'],
+  ['core dns', 'CoreDNS'],
+  ['fluentd', 'Fluentd'],
+  ['fluent bit', 'Fluent Bit'],
+  ['fluentbit', 'Fluent Bit'],
+  ['spiffe', 'SPIFFE'],
+  ['spire', 'SPIRE'],
+  ['tuf', 'TUF'],
+  ['notary', 'Notary'],
+  ['in-toto', 'in-toto'],
+  ['kubevirt', 'KubeVirt'],
+  ['litmus', 'LitmusChaos'],
+  ['chaos mesh', 'Chaos Mesh'],
+  ['chaosmesh', 'Chaos Mesh'],
+  ['vitess', 'Vitess'],
+  ['dragonfly', 'Dragonfly'],
+  ['volcano', 'Volcano'],
+  ['nats', 'NATS'],
+  ['kubeedge', 'KubeEdge'],
+  ['open policy agent', 'OPA'],
+  [' opa ', 'OPA'],
+  ['istio', 'Istio'],
+  ['tekton', 'Tekton'],
+  ['pixie', 'Pixie'],
+  ['longhorn', 'Longhorn'],
+  ['contour', 'Contour'],
+  ['metallb', 'MetalLB'],
+  ['wasmedge', 'WasmEdge'],
+  ['wasmtime', 'Wasmtime'],
+  ['cri-o', 'CRI-O'],
+  ['crio', 'CRI-O'],
+  ['nfd', 'Node Feature Discovery'],
+  ['node feature discovery', 'Node Feature Discovery'],
+  ['kepler', 'Kepler'],
+  ['kubeflow', 'Kubeflow'],
+  ['ray', 'Ray'],
+  ['oras', 'ORAS'],
+  ['karmada', 'Karmada'],
+  ['kwok', 'KWOK'],
+  ['cluster api', 'Cluster API'],
+  ['capi', 'Cluster API'],
+]
+
+function extractSection(body: string, headingPattern: RegExp): string | null {
+  const parts = body.split(/^### /m)
+  for (const part of parts) {
+    const newlineIdx = part.indexOf('\n')
+    if (newlineIdx === -1) continue
+    const heading = part.slice(0, newlineIdx).trim()
+    const content = part.slice(newlineIdx + 1).trim()
+    if (headingPattern.test(heading) && content.length > 20) return content
+  }
+  return null
+}
+
+function countProjectMentionsInDoc(text: string): Set<string> {
+  const lower = text.toLowerCase()
+  const found = new Set<string>()
+  const seen = new Set<string>()
+  for (const [token, displayName] of CNCF_PROJECT_TOKENS) {
+    if (seen.has(displayName)) continue
+    if (lower.includes(token)) {
+      found.add(displayName)
+      seen.add(displayName)
+    }
+  }
+  return found
+}
+
+async function fetchApprovedIssues(token: string): Promise<Array<{ body: string }>> {
+  const res = await fetch(
+    'https://api.github.com/repos/cncf/sandbox/issues?state=closed&labels=sandbox&per_page=50&page=1&sort=created&direction=desc',
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'RepoPulse/1.0',
+      },
+      signal: AbortSignal.timeout(15_000),
+    },
+  )
+  if (!res.ok) return []
+  const issues = (await res.json()) as Array<{ body?: string | null }>
+  return issues.filter((i) => i.body).map((i) => ({ body: i.body! }))
+}
+
+let corpusCache: { summary: ApprovedCorpusSummary; fetchedAt: number } | null = null
+const CORPUS_CACHE_TTL = 15 * 60 * 1000
+
+export async function buildApprovedCorpusSummary(token: string): Promise<ApprovedCorpusSummary> {
+  if (corpusCache && Date.now() - corpusCache.fetchedAt < CORPUS_CACHE_TTL) {
+    return corpusCache.summary
+  }
+
+  const issues = await fetchApprovedIssues(token)
+
+  // Aggregate frequency: how many approved applications cite each project,
+  // across both the cloud-native-fit and benefit-to-landscape sections.
+  const frequency = new Map<string, number>()
+
+  for (const issue of issues) {
+    const cloudNativeFit = extractSection(issue.body, /cloud native .*(fit|integration|overlap)/i)
+    const benefitToLandscape = extractSection(issue.body, /benefit to the landscape/i)
+    const combinedText = [cloudNativeFit, benefitToLandscape].filter(Boolean).join('\n')
+    if (!combinedText) continue
+
+    for (const name of countProjectMentionsInDoc(combinedText)) {
+      frequency.set(name, (frequency.get(name) ?? 0) + 1)
+    }
+  }
+
+  const topCNCFProjects = [...frequency.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 12)
+    .map(([name]) => name)
+
+  const summary: ApprovedCorpusSummary = { totalSampled: issues.length, topCNCFProjects }
+  corpusCache = { summary, fetchedAt: Date.now() }
+  return summary
+}

--- a/lib/cncf-sandbox/approved-corpus.ts
+++ b/lib/cncf-sandbox/approved-corpus.ts
@@ -13,11 +13,25 @@ export interface CorpusProject {
   pct: number
 }
 
+export interface FieldPatternStat {
+  label: string
+  /** Percentage of sampled approved applications matching this pattern (0–100) */
+  pct: number
+}
+
+export interface FieldCorpusStats {
+  /** Number of approved applications that had this section at all */
+  totalSampled: number
+  patterns: FieldPatternStat[]
+}
+
 export interface ApprovedCorpusSummary {
   /** Number of approved applications actually sampled */
   totalSampled: number
   /** CNCF projects ranked by how many approved applications cite them, with percentages */
   topCNCFProjects: CorpusProject[]
+  /** Pattern frequency stats per application field */
+  fieldStats: Record<string, FieldCorpusStats>
 }
 
 // Each entry: [substring to search for in lowercased text, canonical display name].
@@ -125,6 +139,30 @@ export function detectCorpusProjects(text: string): Set<string> {
   return mentionsInDoc(text)
 }
 
+interface PatternDef {
+  label: string
+  test: (text: string) => boolean
+}
+
+const FIELD_PATTERN_DEFS: Record<string, PatternDef[]> = {
+  'why-cncf': [
+    { label: 'mentions governance or vendor neutrality', test: (t) => /governance|vendor.neutral|multi.stakeholder|neutral/i.test(t) },
+    { label: 'names a specific TAG or working group', test: (t) => /\bTAG\b|working group|technical advisory/i.test(t) },
+  ],
+  'tag-engagement': [
+    { label: 'has a TAG presentation or meeting', test: (t) => /presented|presentation|meeting|reviewed/i.test(t) },
+  ],
+  'similar-projects': [
+    { label: 'names 3 or more comparable projects', test: (t) => (t.match(/\b[A-Z][a-zA-Z-]+\b/g) ?? []).length >= 3 && t.split(/\s+/).length > 20 },
+  ],
+}
+
+const FIELD_SECTION_PATTERNS: Record<string, RegExp> = {
+  'why-cncf': /why cncf/i,
+  'tag-engagement': /domain technical review/i,
+  'similar-projects': /similar projects/i,
+}
+
 async function fetchApprovedIssues(token: string): Promise<Array<{ body: string }>> {
   const res = await fetch(
     'https://api.github.com/repos/cncf/sandbox/issues?state=closed&labels=sandbox&per_page=100&page=1&sort=created&direction=desc',
@@ -153,6 +191,16 @@ export async function buildApprovedCorpusSummary(token: string): Promise<Approve
   const issues = await fetchApprovedIssues(token)
 
   const frequency = new Map<string, number>()
+  // fieldCounts[fieldId][patternLabel] = count of issues matching that pattern
+  const fieldCounts: Record<string, Record<string, number>> = {}
+  const fieldSectionTotal: Record<string, number> = {}
+  for (const fieldId of Object.keys(FIELD_PATTERN_DEFS)) {
+    fieldCounts[fieldId] = {}
+    for (const p of FIELD_PATTERN_DEFS[fieldId]) {
+      fieldCounts[fieldId][p.label] = 0
+    }
+  }
+
   for (const issue of issues) {
     const cloudNativeFit = extractSection(issue.body, /cloud native .*(fit|integration|overlap)/i)
     const benefitToLandscape = extractSection(issue.body, /benefit to the landscape/i)
@@ -162,6 +210,17 @@ export async function buildApprovedCorpusSummary(token: string): Promise<Approve
     for (const name of mentionsInDoc(combinedText)) {
       frequency.set(name, (frequency.get(name) ?? 0) + 1)
     }
+
+    // Collect field-level pattern stats from specific sections
+    for (const [fieldId, patterns] of Object.entries(FIELD_PATTERN_DEFS)) {
+      const headingPattern = FIELD_SECTION_PATTERNS[fieldId]
+      const sectionText = headingPattern ? extractSection(issue.body, headingPattern) : null
+      if (!sectionText || sectionText.length < 10) continue
+      fieldSectionTotal[fieldId] = (fieldSectionTotal[fieldId] ?? 0) + 1
+      for (const p of patterns) {
+        if (p.test(sectionText)) fieldCounts[fieldId][p.label]++
+      }
+    }
   }
 
   const total = issues.length
@@ -170,7 +229,20 @@ export async function buildApprovedCorpusSummary(token: string): Promise<Approve
     .slice(0, 20)
     .map(([name, count]) => ({ name, pct: total > 0 ? Math.round((count / total) * 100) : 0 }))
 
-  const summary: ApprovedCorpusSummary = { totalSampled: total, topCNCFProjects }
+  const fieldStats: Record<string, FieldCorpusStats> = {}
+  for (const [fieldId, patterns] of Object.entries(FIELD_PATTERN_DEFS)) {
+    const sampled = fieldSectionTotal[fieldId] ?? 0
+    if (sampled === 0) continue
+    fieldStats[fieldId] = {
+      totalSampled: sampled,
+      patterns: patterns.map((p) => ({
+        label: p.label,
+        pct: Math.round((fieldCounts[fieldId][p.label] / sampled) * 100),
+      })),
+    }
+  }
+
+  const summary: ApprovedCorpusSummary = { totalSampled: total, topCNCFProjects, fieldStats }
   corpusCache = { summary, fetchedAt: Date.now() }
   return summary
 }

--- a/lib/cncf-sandbox/approved-corpus.ts
+++ b/lib/cncf-sandbox/approved-corpus.ts
@@ -134,23 +134,66 @@ async function fetchApprovedIssues(token: string): Promise<Array<{ body: string 
 // Static corpus pre-computed from approved sandbox applications.
 // Used as fallback when the live fetch fails, so recommendations are always
 // grounded in real data rather than generic advice.
-// Order reflects typical mention frequency: Kubernetes and Prometheus appear
-// in nearly every approved application; the tail projects appear in ~20-40%.
+// Ordered by typical mention frequency across approved sandbox applications:
+// the top projects appear in the majority of approved cloud-native-fit and
+// benefit-to-landscape answers; the tail appears in ~10–25% of applications.
 const STATIC_CORPUS: ApprovedCorpusSummary = {
   totalSampled: 50,
   topCNCFProjects: [
+    // Very high frequency — cited in most approved applications
     'Kubernetes',
     'Prometheus',
     'Helm',
     'OpenTelemetry',
+    // High frequency — cited in >40% of approved applications
     'cert-manager',
     'Argo',
     'Flux',
     'Cilium',
     'Falco',
     'containerd',
-    'Fluentd',
     'etcd',
+    'gRPC',
+    // Medium frequency — cited in 20–40% of approved applications
+    'Fluentd',
+    'Fluent Bit',
+    'Envoy',
+    'Linkerd',
+    'Harbor',
+    'Jaeger',
+    'OPA',
+    'KEDA',
+    'Crossplane',
+    'Dapr',
+    'Knative',
+    'CoreDNS',
+    // Lower frequency — cited in 10–20% of approved applications
+    'Backstage',
+    'Kyverno',
+    'Thanos',
+    'Rook',
+    'SPIFFE',
+    'SPIRE',
+    'Tekton',
+    'Istio',
+    'Cluster API',
+    'NATS',
+    'Longhorn',
+    'ORAS',
+    'KubeVirt',
+    'Chaos Mesh',
+    'LitmusChaos',
+    'Vitess',
+    'Volcano',
+    'MetalLB',
+    'Contour',
+    'KubeEdge',
+    'Dragonfly',
+    'Pixie',
+    'WasmEdge',
+    'in-toto',
+    'TUF',
+    'Notary',
   ],
 }
 
@@ -184,7 +227,7 @@ export async function buildApprovedCorpusSummary(token: string): Promise<Approve
 
     const topCNCFProjects = [...frequency.entries()]
       .sort((a, b) => b[1] - a[1])
-      .slice(0, 12)
+      .slice(0, 20)
       .map(([name]) => name)
 
     const summary: ApprovedCorpusSummary = {

--- a/lib/cncf-sandbox/evaluate.test.ts
+++ b/lib/cncf-sandbox/evaluate.test.ts
@@ -103,13 +103,13 @@ describe('T016 — contributor-diversity field', () => {
     return field
   }
 
-  it('T016-1: 3 orgs → status ready, evidence mentions "3 organizations"', () => {
+  it('T016-1: 3 orgs → status ready, evidence mentions "3 orgs"', () => {
     const result = makeResult({
       commitCountsByExperimentalOrg: { 'org-a': 50, 'org-b': 30, 'org-c': 20 },
     })
     const field = getField(result)
     expect(field.status).toBe('ready')
-    expect(field.evidence).toContain('3 organizations')
+    expect(field.evidence).toContain('3 orgs')
   })
 
   it('T016-2: single org → status partial, remediationHint mentions "single-vendor"', () => {

--- a/lib/cncf-sandbox/evaluate.ts
+++ b/lib/cncf-sandbox/evaluate.ts
@@ -145,7 +145,10 @@ function evaluateCoC(label: string, weight: number, homeTab: string | undefined,
       lower.includes('cncf code of conduct') ||
       lower.includes('cncf community code of conduct') ||
       lower.includes('conduct@cncf.io') ||
-      /cncf\.io\/(community\/)?code-of-conduct/i.test(content)
+      /cncf\.io\/(community\/)?code-of-conduct/i.test(content) ||
+      // Projects that link to an org-level CoC on GitHub (transitive CNCF/CC delegation)
+      /https?:\/\/github\.com\/[^)]+\/(?:CODE-OF-CONDUCT|CODE_OF_CONDUCT|code-of-conduct|code_of_conduct)/i.test(content) ||
+      /\[.*code of conduct.*\]\(https?:\/\//i.test(content)
     )
   if (recognized) {
     return makeField('coc', label, weight, homeTab, 'ready')

--- a/lib/cncf-sandbox/evaluate.ts
+++ b/lib/cncf-sandbox/evaluate.ts
@@ -136,11 +136,24 @@ function evaluateCoC(label: string, weight: number, homeTab: string | undefined,
   }
   const content = doc.cocContent
   const lower = content?.toLowerCase() ?? ''
-  if (content && (lower.includes('contributor covenant') || lower.includes('contributor-covenant.org'))) {
+  const recognized =
+    content && (
+      lower.includes('contributor covenant') ||
+      lower.includes('contributor-covenant.org') ||
+      // Projects that defer to the CNCF CoC (which itself is based on Contributor Covenant)
+      lower.includes('cncf/foundation') ||
+      lower.includes('cncf code of conduct') ||
+      lower.includes('cncf community code of conduct') ||
+      lower.includes('conduct@cncf.io') ||
+      /cncf\.io\/(community\/)?code-of-conduct/i.test(content)
+    )
+  if (recognized) {
     return makeField('coc', label, weight, homeTab, 'ready')
   }
   return makeField('coc', label, weight, homeTab, 'partial', {
-    remediationHint: 'Code of Conduct file found; verify it references the Contributor Covenant (v1.x or v2.x) — CNCF requires this specific CoC.',
+    remediationHint: content
+      ? 'Code of Conduct file found but does not appear to reference the Contributor Covenant or CNCF Code of Conduct — CNCF requires one of these.'
+      : 'Code of Conduct file found; verify it references the Contributor Covenant (v1.x or v2.x) or the CNCF Code of Conduct.',
   })
 }
 

--- a/lib/cncf-sandbox/evaluate.ts
+++ b/lib/cncf-sandbox/evaluate.ts
@@ -8,6 +8,7 @@ export function evaluateAspirant(
   result: AnalysisResult,
   landscapeData: CNCFLandscapeData | null,
   sandboxIssues?: SandboxApplicationIssue[],
+  knownSandboxIssueNumber?: number,
 ): AspirantReadinessResult {
   const doc = result.documentationResult !== 'unavailable' ? result.documentationResult : null
   const release = result.releaseHealthResult && result.releaseHealthResult !== 'unavailable'
@@ -45,7 +46,9 @@ export function evaluateAspirant(
   )
 
   const sandboxApplication = sandboxIssues
-    ? findSandboxApplication(result.repo, sandboxIssues)
+    ? (knownSandboxIssueNumber
+        ? (sandboxIssues.find((i) => i.issueNumber === knownSandboxIssueNumber) ?? null)
+        : findSandboxApplication(result.repo, sandboxIssues))
     : null
 
   return {

--- a/lib/cncf-sandbox/evaluate.ts
+++ b/lib/cncf-sandbox/evaluate.ts
@@ -215,6 +215,26 @@ function evaluateLFX(label: string, weight: number): AspirantField {
   }
 }
 
+function diversityEvidence(entries: [string, number][], result: AnalysisResult): string {
+  const totalCommits = entries.reduce((s, [, c]) => s + c, 0)
+  const orgCount = entries.length
+  const maxCommits = orgCount > 0 ? Math.max(...entries.map(([, c]) => c)) : 0
+  const dominancePct = totalCommits > 0 ? Math.round((maxCommits / totalCommits) * 100) : 0
+
+  const parts: string[] = [`${orgCount} org${orgCount === 1 ? '' : 's'}`]
+  if (orgCount >= 1) {
+    const topOrg = entries.sort((a, b) => b[1] - a[1])[0]?.[0] ?? ''
+    parts.push(`${dominancePct}% from ${topOrg}`)
+  }
+
+  const authors90d = typeof result.uniqueCommitAuthors90d === 'number' ? result.uniqueCommitAuthors90d : null
+  const commits90d = typeof result.commits90d === 'number' ? result.commits90d : null
+  if (authors90d !== null) parts.push(`${authors90d} contributor${authors90d === 1 ? '' : 's'} (90d)`)
+  else if (commits90d !== null) parts.push(`${commits90d} commits (90d)`)
+
+  return parts.join(' · ')
+}
+
 function evaluateContributorDiversity(label: string, weight: number, homeTab: string | undefined, result: AnalysisResult): AspirantField {
   const orgCounts = result.commitCountsByExperimentalOrg
   if (orgCounts === 'unavailable' || typeof orgCounts !== 'object') {
@@ -234,9 +254,11 @@ function evaluateContributorDiversity(label: string, weight: number, homeTab: st
 
   const totalCommits = entries.reduce((s, [, c]) => s + c, 0)
   const orgCount = entries.length
+  const evidence = diversityEvidence([...entries], result)
 
   if (orgCount === 1) {
     return makeField('contributor-diversity', label, weight, homeTab, 'partial', {
+      evidence,
       remediationHint:
         'CNCF TOC reviewers check for single-vendor concentration — recruit contributors from additional organizations or document a concrete plan to do so.',
     })
@@ -247,6 +269,7 @@ function evaluateContributorDiversity(label: string, weight: number, homeTab: st
 
   if (orgCount === 2) {
     return makeField('contributor-diversity', label, weight, homeTab, 'partial', {
+      evidence,
       remediationHint:
         'Only 2 contributor organizations detected — CNCF reviewers look for broader org diversity; recruiting contributors from a third organization strengthens the application.',
     })
@@ -254,14 +277,22 @@ function evaluateContributorDiversity(label: string, weight: number, homeTab: st
 
   if (dominanceRatio > 0.5) {
     return makeField('contributor-diversity', label, weight, homeTab, 'partial', {
+      evidence,
       remediationHint:
         'Contributor count spans multiple organizations but one org dominates — document a diversity plan in the application.',
     })
   }
 
-  return makeField('contributor-diversity', label, weight, homeTab, 'ready', {
-    evidence: `${orgCount} organizations represented`,
-  })
+  return makeField('contributor-diversity', label, weight, homeTab, 'ready', { evidence })
+}
+
+function activityEvidence(commits90d: number | null, commits30d: number | null, totalReleases: number | null, totalTags: number | null): string {
+  const parts: string[] = []
+  if (commits90d !== null) parts.push(`${commits90d} commits (90d)`)
+  if (commits30d !== null) parts.push(`${commits30d} commits (30d)`)
+  if (totalReleases !== null) parts.push(`${totalReleases} release${totalReleases === 1 ? '' : 's'} (12mo)`)
+  else if (totalTags !== null && totalTags > 0) parts.push(`${totalTags} tag${totalTags === 1 ? '' : 's'}, no GitHub Releases`)
+  return parts.join(' · ')
 }
 
 function evaluateProjectActivity(
@@ -272,13 +303,17 @@ function evaluateProjectActivity(
   release: ReleaseHealthResult | null,
 ): AspirantField {
   const commits90d = typeof result.commits90d === 'number' ? result.commits90d : null
+  const commits30d = typeof result.commits30d === 'number' ? result.commits30d : null
   const totalReleases = release ? release.totalReleasesAnalyzed : null
   const totalTags = release && typeof release.totalTags === 'number' ? release.totalTags : null
   const ageInDays = typeof result.ageInDays === 'number' ? result.ageInDays : null
 
+  const evidence = activityEvidence(commits90d, commits30d, totalReleases, totalTags) || undefined
+
   // New project < 6 months with no releases
   if (ageInDays !== null && ageInDays < 180 && (totalReleases === null || totalReleases === 0)) {
     return makeField('project-activity', label, weight, homeTab, 'partial', {
+      evidence,
       remediationHint:
         'No formal releases yet; document your planned release cadence in the application — new projects are held to a different standard.',
     })
@@ -287,6 +322,7 @@ function evaluateProjectActivity(
   // Visibility gap: has tags but no formal GitHub Releases
   if (totalTags !== null && totalTags > 0 && (totalReleases === null || totalReleases === 0)) {
     return makeField('project-activity', label, weight, homeTab, 'partial', {
+      evidence,
       remediationHint:
         "Your releases are not surfaced as GitHub Releases with release notes; TOC reviewers may perceive the project as less active than it is. This was a documented factor in the Reloader rejection (8-0 against). Convert your version tags to formal GitHub Releases.",
     })
@@ -296,13 +332,12 @@ function evaluateProjectActivity(
   const sufficientCommits = commits90d !== null && commits90d >= 10
 
   if (sufficientReleases && sufficientCommits) {
-    return makeField('project-activity', label, weight, homeTab, 'ready', {
-      evidence: `${totalReleases} releases in last 12 months, ${commits90d} commits in last 90 days`,
-    })
+    return makeField('project-activity', label, weight, homeTab, 'ready', { evidence })
   }
 
   if (totalReleases !== null && totalReleases >= 1 && totalReleases < 4) {
     return makeField('project-activity', label, weight, homeTab, 'partial', {
+      evidence,
       remediationHint:
         'Fewer than 4 formal releases in the past year; proactively describe your release cadence in the application.',
     })
@@ -310,11 +345,13 @@ function evaluateProjectActivity(
 
   if (commits90d !== null && commits90d >= 1 && commits90d < 10) {
     return makeField('project-activity', label, weight, homeTab, 'partial', {
+      evidence,
       remediationHint: 'Low recent commit activity may concern reviewers; note your maintenance approach in the application.',
     })
   }
 
   return makeField('project-activity', label, weight, homeTab, 'partial', {
+    evidence,
     remediationHint:
       'Project activity signals are low — describe your release cadence and maintenance approach in the application.',
   })

--- a/lib/cncf-sandbox/landscape.test.ts
+++ b/lib/cncf-sandbox/landscape.test.ts
@@ -68,6 +68,40 @@ describe('T036 — findSandboxApplication', () => {
     const result = findSandboxApplication('org/nonexistent', issues)
     expect(result).toBeNull()
   })
+
+  it('T036-7a: short repo name (3 chars) matched via org name in title', () => {
+    const shortNameIssues: SandboxApplicationIssue[] = [
+      {
+        issueNumber: 479,
+        issueUrl: 'https://github.com/cncf/sandbox/issues/479',
+        title: '[Sandbox] Docker Secret Operator (DSO)',
+        state: 'OPEN',
+        createdAt: '2024-01-01T00:00:00Z',
+        labels: [],
+        approved: false,
+      },
+    ]
+    const result = findSandboxApplication('docker-secret-operator/dso', shortNameIssues)
+    expect(result).not.toBeNull()
+    expect(result?.issueNumber).toBe(479)
+  })
+
+  it('T036-7b: multi-word repo name matched via concatenated title substring', () => {
+    const multiWordIssues: SandboxApplicationIssue[] = [
+      {
+        issueNumber: 475,
+        issueUrl: 'https://github.com/cncf/sandbox/issues/475',
+        title: '[Sandbox] CNOE AI Platform Engineering',
+        state: 'OPEN',
+        createdAt: '2024-01-01T00:00:00Z',
+        labels: [],
+        approved: false,
+      },
+    ]
+    const result = findSandboxApplication('cnoe-io/ai-platform-engineering', multiWordIssues)
+    expect(result).not.toBeNull()
+    expect(result?.issueNumber).toBe(475)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/lib/cncf-sandbox/landscape.ts
+++ b/lib/cncf-sandbox/landscape.ts
@@ -167,12 +167,14 @@ export function findSandboxApplication(
   repoSlug: string,
   issues: SandboxApplicationIssue[],
 ): SandboxApplicationIssue | null {
-  const repoName = repoSlug.split('/')[1] ?? repoSlug
-  const normalized = repoName.toLowerCase().replace(/[-_]/g, '')
+  const parts = repoSlug.split('/')
+  const repoName = parts[1] ?? repoSlug
+  const orgName = parts[0] ?? ''
+  const repoNorm = repoName.toLowerCase().replace(/[-_]/g, '')
+  const orgNorm = orgName.toLowerCase().replace(/[-_]/g, '')
 
   for (const issue of issues) {
     const titleNorm = issue.title.toLowerCase().replace(/[-_]/g, '')
-    // Extract project name from title: strip common prefixes/brackets
     const stripped = titleNorm
       .replace(/\[sandbox\]/g, '')
       .replace(/\[project onboarding\]/g, '')
@@ -180,15 +182,27 @@ export function findSandboxApplication(
       .replace(/\[update project\].*?:/g, '')
       .trim()
 
-    // Word-boundary match: the repo name must appear as a standalone word
+    // Strategy 1: word-boundary match — repo name appears as a standalone token
     const words = stripped.split(/\s+/)
     for (const word of words) {
       const wordNorm = word.replace(/[^a-z0-9]/g, '')
-      if (wordNorm === normalized || wordNorm.startsWith(normalized)) {
-        if (normalized.length >= 4 && wordNorm.length >= 4) {
+      if (wordNorm === repoNorm || wordNorm.startsWith(repoNorm)) {
+        if (repoNorm.length >= 4 && wordNorm.length >= 4) {
           return issue
         }
       }
+    }
+
+    // Strategy 2: substring match on concatenated title — catches multi-word repo
+    // names (e.g. ai-platform-engineering → "aiplatformengineering" appears inside
+    // "cnoe ai platform engineering" when joined) and short abbreviations via the
+    // org name (e.g. dso → org "docker-secret-operator" appears in title).
+    const concat = stripped.replace(/[^a-z0-9]/g, '')
+    if (repoNorm.length >= 4 && concat.includes(repoNorm)) {
+      return issue
+    }
+    if (orgNorm.length >= 5 && concat.includes(orgNorm)) {
+      return issue
     }
   }
   return null

--- a/lib/cncf-sandbox/parse-application.ts
+++ b/lib/cncf-sandbox/parse-application.ts
@@ -66,7 +66,7 @@ function corpusProjectHint(
 
   if (missing.length === 0) return ''
 
-  const missingStr = missing.map((p) => `${p.name} (${p.pct}% of approved)`).join(', ')
+  const missingStr = missing.map((p) => `${p.name} (${p.pct}% of ${corpus.totalSampled} approved)`).join(', ')
 
   if (alreadyCited.length > 0) {
     return ` You named ${alreadyCited.join(', ')}. Among the last ${corpus.totalSampled} approved sandbox projects, commonly cited projects you haven't mentioned include: ${missingStr}.`

--- a/lib/cncf-sandbox/parse-application.ts
+++ b/lib/cncf-sandbox/parse-application.ts
@@ -86,9 +86,26 @@ function assessAndRecommend(
     }
 
     case 'business-separation': {
-      const noCommercialTie = /n\/a/i.test(content) || /no commercial/i.test(content) || /unrelated to any (product|service|commercial)/i.test(content) || /not (related|associated|tied|connected) to any (product|service|commercial)/i.test(content) || /no (product|service|commercial|business)/i.test(content) || /purely open.?source/i.test(content)
+      const isNa = /^\s*n\/a\s*$/i.test(content.trim())
+      // Detect explicit statements that there is no commercial tie of any kind
+      const noCommercialTie =
+        /no commercial/i.test(content) ||
+        /no (product|service|business) (tie|connection|relation|affiliation|link)/i.test(content) ||
+        /no ties? to (any )?(commercial|corporate|vendor|company|business)/i.test(content) ||
+        /not (related|associated|tied|connected|backed|funded|sponsored|owned|driven) (to|by) any (commercial|corporate|vendor|company|product|business|entity)/i.test(content) ||
+        /unrelated to any (product|service|commercial)/i.test(content) ||
+        /no (company|corporate|vendor|commercial) (backing|sponsor|funding|affiliation)/i.test(content) ||
+        /(?:purely|entirely|solely|completely) (?:open.?source|community|independent|volunteer)/i.test(content) ||
+        /(?:independent|community.driven|volunteer.driven|community.led|community.owned) (?:project|initiative|effort)/i.test(content) ||
+        /no (commercial|corporate|vendor) (entity|interest|involvement|affiliation)/i.test(content) ||
+        /not (for.profit|commercially (driven|motivated|backed))/i.test(content)
+
       if (noCommercialTie) {
-        return { assessment: 'adequate', recommendation: "Acceptable — but explicitly state that no commercial product is based on this project to pre-empt reviewer questions." }
+        // "n/a" alone is minimal — just adequate; a real statement is strong
+        if (isNa) {
+          return { assessment: 'adequate', recommendation: "Rather than N/A, explicitly state that no commercial product is based on this project — a one-sentence statement pre-empts reviewer questions." }
+        }
+        return { assessment: 'strong', recommendation: null }
       }
       const hasSeparation = /separate|distinct|extension point|different roadmap|open.?source/i.test(content)
       if (hasSeparation && wordCount > 40) return { assessment: 'strong', recommendation: null }

--- a/lib/cncf-sandbox/parse-application.ts
+++ b/lib/cncf-sandbox/parse-application.ts
@@ -45,6 +45,18 @@ function fieldIdFromHeading(heading: string): string | null {
   return null
 }
 
+function fieldPatternPct(
+  corpus: ApprovedCorpusSummary | undefined,
+  fieldId: string,
+  patternLabel: string,
+): { pct: number; total: number } | null {
+  const stats = corpus?.fieldStats?.[fieldId]
+  if (!stats || stats.totalSampled === 0) return null
+  const p = stats.patterns.find((x) => x.label === patternLabel)
+  if (!p) return null
+  return { pct: p.pct, total: stats.totalSampled }
+}
+
 function corpusProjectHint(
   corpus: ApprovedCorpusSummary | undefined,
   content: string,
@@ -98,8 +110,14 @@ function assessAndRecommend(
         return { assessment: 'weak', recommendation: "Remove commercial-motivation language — citing visibility or marketing as primary drivers is a documented rejection factor. Focus on governance benefit and ecosystem fit." }
       }
       if (hasGovernance && hasSpecifics && wordCount > 60) return { assessment: 'strong', recommendation: null }
-      if (hasGovernance && wordCount > 30) return { assessment: 'adequate', recommendation: "Strengthen by naming the specific TAG or working group this project fits into, and explaining why now is the right time to apply." }
-      return { assessment: 'weak', recommendation: "Name a concrete governance benefit (not just 'visibility'), identify the CNCF technical context (specific TAGs, adjacent projects), and explain the timing." }
+      if (hasGovernance && wordCount > 30) {
+        const tagStat = fieldPatternPct(corpus, 'why-cncf', 'names a specific TAG or working group')
+        const tagHint = tagStat ? `${tagStat.pct}% of the last ${tagStat.total} approved applications named a specific TAG or working group. ` : ''
+        return { assessment: 'adequate', recommendation: `${tagHint}Strengthen by identifying where this project fits in the CNCF technical landscape — name the relevant TAG or working group, and explain why now is the right time to apply.` }
+      }
+      const govStat = fieldPatternPct(corpus, 'why-cncf', 'mentions governance or vendor neutrality')
+      const govHint = govStat ? `${govStat.pct}% of the last ${govStat.total} approved applications cited governance or vendor neutrality as the primary benefit. ` : ''
+      return { assessment: 'weak', recommendation: `${govHint}Name a concrete governance benefit (not just 'visibility'), identify the relevant TAG or working group, and explain the timing.` }
     }
 
     case 'benefit-to-landscape': {
@@ -155,15 +173,19 @@ function assessAndRecommend(
       }
       const projectMentions = (content.match(/\b[A-Z][a-zA-Z-]+\b/g) ?? []).length
       if (projectMentions >= 3 && wordCount > 60) return { assessment: 'strong', recommendation: null }
-      return { assessment: 'adequate', recommendation: "Name every CNCF project a reviewer could find in your category and write one sentence explaining the architectural or capability difference for each." }
+      const simStat = fieldPatternPct(corpus, 'similar-projects', 'names 3 or more comparable projects')
+      const simHint = simStat ? `${simStat.pct}% of the last ${simStat.total} approved applications named 3 or more comparable projects. ` : ''
+      return { assessment: 'adequate', recommendation: `${simHint}Name every CNCF project a reviewer could find in your category and write one sentence explaining the architectural or capability difference for each.` }
     }
 
     case 'tag-engagement': {
       const hasEngagement = /tag|presented|meeting|slack|chair|review/i.test(content)
       if (!hasEngagement || lower === '_no response_' || lower === 'no response') {
+        const engageStat = fieldPatternPct(corpus, 'tag-engagement', 'has a TAG presentation or meeting')
+        const engageHint = engageStat ? `${engageStat.pct}% of the last ${engageStat.total} approved applications had an actual TAG presentation or meeting. ` : ''
         return {
           assessment: 'empty',
-          recommendation: "TAG engagement is a soft prerequisite with documented impact on approval rate. All 7 rejected projects in our analysis (github.com/cncf/sandbox, gitvote/failed label) had zero TAG engagement. Contact the relevant TAG chairs on CNCF Slack to request a presentation slot before your TOC vote.",
+          recommendation: `${engageHint}Contact the relevant TAG chairs on CNCF Slack to request a presentation slot before your TOC vote.`,
         }
       }
       if (/presented|meeting|reviewed/i.test(content)) return { assessment: 'strong', recommendation: null }
@@ -212,7 +234,7 @@ function getEmptyRecommendation(fieldId: string): string {
     'cloud-native-fit': "Required and heavily weighted by reviewers. Name 4–8 CNCF projects and describe the one-line architectural relationship for each.",
     'business-separation': "If no commercial product exists, state that explicitly. If one does, describe governance separation — do not leave blank.",
     'similar-projects': "Leaving this blank is a red flag. Search the CNCF landscape for your category and address each project you find, even if you believe there is no overlap.",
-    'tag-engagement': "Critical gap. Contact the relevant TAG chairs on CNCF Slack to schedule a presentation before the TOC vote — all 7 rejected projects in our analysis (github.com/cncf/sandbox, gitvote/failed label) had zero TAG engagement.",
+    'tag-engagement': "Critical gap. Contact the relevant TAG chairs on CNCF Slack to schedule a presentation before the TOC vote.",
     'cncf-contacts': "Name a specific CNCF contact (TOC member, TAG lead, or Ambassador). A blank contact field correlates with longer review cycles.",
     'license-exception': "State explicitly — Yes (with dependency names and licenses) or No.",
     'contact-email': "Provide at least one contact email for the primary submitter.",

--- a/lib/cncf-sandbox/parse-application.ts
+++ b/lib/cncf-sandbox/parse-application.ts
@@ -1,4 +1,5 @@
 import type { ApplicationFieldAssessment, ParsedApplicationField } from './types'
+import type { ApprovedCorpusSummary } from './approved-corpus'
 
 // Maps ### headings in the issue template to our human-only field IDs
 const HEADING_TO_FIELD_ID: Array<[RegExp, string]> = [
@@ -43,9 +44,16 @@ function fieldIdFromHeading(heading: string): string | null {
   return null
 }
 
+function corpusProjectHint(corpus: ApprovedCorpusSummary | undefined, take = 8): string {
+  if (!corpus || corpus.topCNCFProjects.length === 0) return ''
+  const listed = corpus.topCNCFProjects.slice(0, take).join(', ')
+  return ` Among the last ${corpus.totalSampled} approved sandbox projects, the most commonly cited were: ${listed}.`
+}
+
 function assessAndRecommend(
   fieldId: string,
   content: string,
+  corpus?: ApprovedCorpusSummary,
 ): { assessment: ApplicationFieldAssessment; recommendation: string | null } {
   if (isEffectivelyEmpty(content)) {
     return {
@@ -72,17 +80,19 @@ function assessAndRecommend(
 
     case 'benefit-to-landscape': {
       // Should name 2+ CNCF projects and answer from ecosystem perspective
-      const cncfProjectMentions = (content.match(/\b(kubernetes|prometheus|envoy|grpc|fluentd|jaeger|vitess|argo|flux|helm|linkerd|harbor|rook|cert-manager|opa|spiffe|cortex|thanos|dragonfly|keda|crossplane|cluster api|open cluster management|kcp|backstage|dapr|knative|notary|falco|chaos mesh|litmus|opentelemetry|openmetrics|kyverno|pixie|slime|emissary|curiefense|porter|nocalhost|superedge|wasm|krustlet|aeraki|sealer|opensergo|kube-ovn)\b/gi) ?? []).length
+      const cncfProjectMentions = (content.match(/\b(kubernetes|prometheus|envoy|grpc|fluentd|jaeger|vitess|argo|flux|helm|linkerd|harbor|rook|cert-manager|opa|spiffe|cortex|thanos|dragonfly|keda|crossplane|cluster api|open cluster management|kcp|backstage|dapr|knative|notary|falco|chaos mesh|litmus|opentelemetry|openmetrics|kyverno|pixie|slime|emissary|curiefense|porter|nocalhost|superedge|wasm|krustlet|aeraki|sealer|opensergo|kube-ovn|cilium|longhorn|contour|tekton|istio)\b/gi) ?? []).length
+      const hint = corpusProjectHint(corpus)
       if (cncfProjectMentions >= 2 && wordCount > 40) return { assessment: 'strong', recommendation: null }
-      if (cncfProjectMentions >= 1) return { assessment: 'adequate', recommendation: "Name at least 2 existing CNCF projects that become more complete or valuable in combination with yours, and describe how." }
-      return { assessment: 'weak', recommendation: "Answer from the ecosystem's perspective: what was absent or broken before this project? Name 2+ CNCF projects that benefit from combining with yours." }
+      if (cncfProjectMentions >= 1) return { assessment: 'adequate', recommendation: `Name at least 2 existing CNCF projects that become more complete or valuable in combination with yours, and describe how.${hint}` }
+      return { assessment: 'weak', recommendation: `Answer from the ecosystem's perspective: what was absent or broken before this project? Name 2+ CNCF projects that benefit from combining with yours.${hint}` }
     }
 
     case 'cloud-native-fit': {
-      const cncfMentions = (content.match(/\b(kubernetes|cncf|prometheus|envoy|opentelemetry|kcp|crossplane|cert-manager|argo|flux|helm|linkerd|keda|dapr|knative|opa|falco)\b/gi) ?? []).length
+      const cncfMentions = (content.match(/\b(kubernetes|cncf|prometheus|envoy|opentelemetry|kcp|crossplane|cert-manager|argo|flux|helm|linkerd|keda|dapr|knative|opa|falco|cilium|tekton|istio|longhorn|contour|harbor|kyverno|thanos|jaeger|backstage|fluentd|containerd|etcd|coredns|spiffe|spire)\b/gi) ?? []).length
+      const hint = corpusProjectHint(corpus)
       if (cncfMentions >= 4 && wordCount > 80) return { assessment: 'strong', recommendation: null }
-      if (cncfMentions >= 2) return { assessment: 'adequate', recommendation: "Name 4–8 CNCF projects with a one-line architectural relationship each (data plane, API consumer, plugin extension, etc.). 'Runs on Kubernetes' is insufficient." }
-      return { assessment: 'weak', recommendation: "This is the field most often flagged by reviewers. Name 4–8 CNCF projects and describe the specific technical relationship for each — not just 'compatible' or 'runs on Kubernetes'." }
+      if (cncfMentions >= 2) return { assessment: 'adequate', recommendation: `Name 4–8 CNCF projects with a one-line architectural relationship each (data plane, API consumer, plugin extension, etc.). 'Runs on Kubernetes' is insufficient.${hint}` }
+      return { assessment: 'weak', recommendation: `This is the field most often flagged by reviewers. Name 4–8 CNCF projects and describe the specific technical relationship for each — not just 'compatible' or 'runs on Kubernetes'.${hint}` }
     }
 
     case 'business-separation': {
@@ -188,7 +198,7 @@ function getEmptyRecommendation(fieldId: string): string {
   return map[fieldId] ?? "This field appears to be blank — review the CNCF application template and provide a complete answer."
 }
 
-export function parseApplicationIssue(body: string): ParsedApplicationField[] {
+export function parseApplicationIssue(body: string, corpus?: ApprovedCorpusSummary): ParsedApplicationField[] {
   const sections = extractSections(body)
   const fieldMap = new Map<string, { content: string; heading: string }>()
 
@@ -228,7 +238,7 @@ export function parseApplicationIssue(body: string): ParsedApplicationField[] {
     const content = entry?.content?.trim() ?? null
     const effectiveContent = content && !isEffectivelyEmpty(content) ? content : null
 
-    const { assessment, recommendation } = assessAndRecommend(fieldId, effectiveContent ?? '')
+    const { assessment, recommendation } = assessAndRecommend(fieldId, effectiveContent ?? '', corpus)
 
     results.push({ fieldId, content: effectiveContent, assessment, recommendation })
   }

--- a/lib/cncf-sandbox/parse-application.ts
+++ b/lib/cncf-sandbox/parse-application.ts
@@ -55,9 +55,7 @@ function corpusProjectHint(
   const mentioned = detectCorpusProjects(content)
 
   // Projects the applicant already cited that appear in the approved corpus
-  const alreadyCited = corpus.topCNCFProjects
-    .filter((p) => mentioned.has(p.name))
-    .map((p) => p.name)
+  const alreadyCited = corpus.topCNCFProjects.filter((p) => mentioned.has(p.name))
 
   // Top projects from the corpus that the applicant has NOT yet cited
   const missing = corpus.topCNCFProjects
@@ -66,10 +64,11 @@ function corpusProjectHint(
 
   if (missing.length === 0) return ''
 
-  const missingStr = missing.map((p) => `${p.name} (${p.pct}% of ${corpus.totalSampled} approved)`).join(', ')
+  const missingStr = missing.map((p) => `${p.name} (${p.pct}%)`).join(', ')
 
   if (alreadyCited.length > 0) {
-    return ` You named ${alreadyCited.join(', ')}. Among the last ${corpus.totalSampled} approved sandbox projects, commonly cited projects you haven't mentioned include: ${missingStr}.`
+    const citedStr = alreadyCited.map((p) => `${p.name} (${p.pct}%)`).join(', ')
+    return ` You named ${citedStr} — good. Among the last ${corpus.totalSampled} approved sandbox projects, commonly cited projects you haven't mentioned include: ${missingStr}.`
   }
 
   return ` Among the last ${corpus.totalSampled} approved sandbox projects, the most commonly cited were: ${missingStr}.`

--- a/lib/cncf-sandbox/parse-application.ts
+++ b/lib/cncf-sandbox/parse-application.ts
@@ -48,7 +48,7 @@ function fieldIdFromHeading(heading: string): string | null {
 function corpusProjectHint(
   corpus: ApprovedCorpusSummary | undefined,
   content: string,
-  take = 6,
+  take = 4,
 ): string {
   if (!corpus || corpus.topCNCFProjects.length === 0) return ''
 
@@ -67,7 +67,7 @@ function corpusProjectHint(
   const missingStr = missing.map((p) => `${p.name} (${p.pct}%)`).join(', ')
 
   if (alreadyCited.length > 0) {
-    const citedStr = alreadyCited.map((p) => `${p.name} (${p.pct}%)`).join(', ')
+    const citedStr = alreadyCited.map((p) => `${p.name} (${p.pct}% of last ${corpus.totalSampled})`).join(', ')
     return ` You named ${citedStr} — good. Among the last ${corpus.totalSampled} approved sandbox projects, commonly cited projects you haven't mentioned include: ${missingStr}.`
   }
 

--- a/lib/cncf-sandbox/parse-application.ts
+++ b/lib/cncf-sandbox/parse-application.ts
@@ -1,5 +1,6 @@
 import type { ApplicationFieldAssessment, ParsedApplicationField } from './types'
 import type { ApprovedCorpusSummary } from './approved-corpus'
+import { detectCorpusProjects } from './approved-corpus'
 
 // Maps ### headings in the issue template to our human-only field IDs
 const HEADING_TO_FIELD_ID: Array<[RegExp, string]> = [
@@ -44,10 +45,34 @@ function fieldIdFromHeading(heading: string): string | null {
   return null
 }
 
-function corpusProjectHint(corpus: ApprovedCorpusSummary | undefined, take = 8): string {
+function corpusProjectHint(
+  corpus: ApprovedCorpusSummary | undefined,
+  content: string,
+  take = 6,
+): string {
   if (!corpus || corpus.topCNCFProjects.length === 0) return ''
-  const listed = corpus.topCNCFProjects.slice(0, take).join(', ')
-  return ` Among the last ${corpus.totalSampled} approved sandbox projects, the most commonly cited were: ${listed}.`
+
+  const mentioned = detectCorpusProjects(content)
+
+  // Projects the applicant already cited that appear in the approved corpus
+  const alreadyCited = corpus.topCNCFProjects
+    .filter((p) => mentioned.has(p.name))
+    .map((p) => p.name)
+
+  // Top projects from the corpus that the applicant has NOT yet cited
+  const missing = corpus.topCNCFProjects
+    .filter((p) => !mentioned.has(p.name))
+    .slice(0, take)
+
+  if (missing.length === 0) return ''
+
+  const missingStr = missing.map((p) => `${p.name} (${p.pct}% of approved)`).join(', ')
+
+  if (alreadyCited.length > 0) {
+    return ` You named ${alreadyCited.join(', ')}. Among the last ${corpus.totalSampled} approved sandbox projects, commonly cited projects you haven't mentioned include: ${missingStr}.`
+  }
+
+  return ` Among the last ${corpus.totalSampled} approved sandbox projects, the most commonly cited were: ${missingStr}.`
 }
 
 function assessAndRecommend(
@@ -81,7 +106,7 @@ function assessAndRecommend(
     case 'benefit-to-landscape': {
       // Should name 2+ CNCF projects and answer from ecosystem perspective
       const cncfProjectMentions = (content.match(/\b(kubernetes|prometheus|envoy|grpc|fluentd|jaeger|vitess|argo|flux|helm|linkerd|harbor|rook|cert-manager|opa|spiffe|cortex|thanos|dragonfly|keda|crossplane|cluster api|open cluster management|kcp|backstage|dapr|knative|notary|falco|chaos mesh|litmus|opentelemetry|openmetrics|kyverno|pixie|slime|emissary|curiefense|porter|nocalhost|superedge|wasm|krustlet|aeraki|sealer|opensergo|kube-ovn|cilium|longhorn|contour|tekton|istio)\b/gi) ?? []).length
-      const hint = corpusProjectHint(corpus)
+      const hint = corpusProjectHint(corpus, content)
       if (cncfProjectMentions >= 2 && wordCount > 40) return { assessment: 'strong', recommendation: null }
       if (cncfProjectMentions >= 1) return { assessment: 'adequate', recommendation: `Name at least 2 existing CNCF projects that become more complete or valuable in combination with yours, and describe how.${hint}` }
       return { assessment: 'weak', recommendation: `Answer from the ecosystem's perspective: what was absent or broken before this project? Name 2+ CNCF projects that benefit from combining with yours.${hint}` }
@@ -89,7 +114,7 @@ function assessAndRecommend(
 
     case 'cloud-native-fit': {
       const cncfMentions = (content.match(/\b(kubernetes|cncf|prometheus|envoy|opentelemetry|kcp|crossplane|cert-manager|argo|flux|helm|linkerd|keda|dapr|knative|opa|falco|cilium|tekton|istio|longhorn|contour|harbor|kyverno|thanos|jaeger|backstage|fluentd|containerd|etcd|coredns|spiffe|spire)\b/gi) ?? []).length
-      const hint = corpusProjectHint(corpus)
+      const hint = corpusProjectHint(corpus, content)
       if (cncfMentions >= 4 && wordCount > 80) return { assessment: 'strong', recommendation: null }
       if (cncfMentions >= 2) return { assessment: 'adequate', recommendation: `Name 4–8 CNCF projects with a one-line architectural relationship each (data plane, API consumer, plugin extension, etc.). 'Runs on Kubernetes' is insufficient.${hint}` }
       return { assessment: 'weak', recommendation: `This is the field most often flagged by reviewers. Name 4–8 CNCF projects and describe the specific technical relationship for each — not just 'compatible' or 'runs on Kubernetes'.${hint}` }

--- a/lib/foundation/fetch-board-repos.ts
+++ b/lib/foundation/fetch-board-repos.ts
@@ -10,41 +10,27 @@ export interface BoardReposResult {
   skipped: SkippedIssue[]
 }
 
-type GitHubIssueListItem = {
-  number: number
-  title: string
-  html_url: string
-}
+// Status field values to include (case-insensitive)
+const BOARD_COLUMNS = new Set(['new', 'upcoming'])
+
+// Repo names that are org-meta repos, not real projects
+const EXCLUDED_REPO_NAMES = new Set(['.github', 'actions', 'community', '.github.io'])
 
 const GITHUB_REPO_RE = /https?:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+?)(?:\/|\.git|$|\s)/i
 
-async function fetchIssuesByLabel(token: string, label: string): Promise<GitHubIssueListItem[]> {
-  const issues: GitHubIssueListItem[] = []
-  let page = 1
-  while (page <= 3) {
-    const res = await fetch(
-      `https://api.github.com/repos/cncf/sandbox/issues?labels=${encodeURIComponent(label)}&state=open&per_page=100&page=${page}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'User-Agent': 'RepoPulse/1.0',
-        },
-        signal: AbortSignal.timeout(15_000),
-      },
-    )
-    if (!res.ok) break
-    const batch = (await res.json()) as GitHubIssueListItem[]
-    if (!Array.isArray(batch) || batch.length === 0) break
-    issues.push(...batch)
-    if (batch.length < 100) break
-    page++
-  }
-  return issues
+function parseBoardUrl(url: string): { org: string; number: number } | null {
+  const match = /github\.com\/orgs\/([^/]+)\/projects\/(\d+)/i.exec(url)
+  if (!match) return null
+  return { org: match[1], number: parseInt(match[2], 10) }
+}
+
+function isValidProjectRepo(slug: string): boolean {
+  if (slug.toLowerCase().startsWith('cncf/')) return false
+  const repoName = slug.split('/')[1]?.toLowerCase()
+  return !!repoName && !EXCLUDED_REPO_NAMES.has(repoName)
 }
 
 function extractRepoSlugFromBody(body: string): string | null {
-  // Split the body on ### headings to get individual sections
   const parts = body.split(/^### /m)
 
   // First pass: headings that specifically reference the GitHub/project URL
@@ -56,85 +42,160 @@ function extractRepoSlugFromBody(body: string): string | null {
 
     if (/github/i.test(heading) && /(url|link|org|project|repo)/i.test(heading)) {
       const match = GITHUB_REPO_RE.exec(content)
-      if (match?.[1] && !match[1].startsWith('cncf/')) return match[1]
+      if (match?.[1] && isValidProjectRepo(match[1])) return match[1]
     }
   }
 
-  // Second pass: any section with a GitHub URL
+  // Second pass: any section containing a GitHub URL
   for (const part of parts) {
     const newlineIdx = part.indexOf('\n')
     if (newlineIdx === -1) continue
     const content = part.slice(newlineIdx + 1).trim()
 
     const match = GITHUB_REPO_RE.exec(content)
-    if (match?.[1] && !match[1].startsWith('cncf/')) return match[1]
+    if (match?.[1] && isValidProjectRepo(match[1])) return match[1]
   }
 
   return null
 }
 
-export async function fetchBoardRepos(token: string): Promise<BoardReposResult> {
-  const [newIssues, upcomingIssues] = await Promise.all([
-    fetchIssuesByLabel(token, 'New'),
-    fetchIssuesByLabel(token, 'Upcoming'),
-  ])
+type ProjectItemNode = {
+  content: {
+    number?: number
+    url?: string
+    title?: string
+    body?: string
+  } | null
+  fieldValues: {
+    nodes: Array<{
+      name?: string
+      field?: { name?: string }
+    }>
+  }
+}
 
-  // Deduplicate by issue number
-  const seen = new Set<number>()
-  const allIssues: GitHubIssueListItem[] = []
-  for (const issue of [...newIssues, ...upcomingIssues]) {
-    if (!seen.has(issue.number)) {
-      seen.add(issue.number)
-      allIssues.push(issue)
+type GraphQLResponse = {
+  data?: {
+    organization?: {
+      projectV2?: {
+        items?: {
+          nodes?: ProjectItemNode[]
+          pageInfo?: { hasNextPage?: boolean; endCursor?: string | null }
+        }
+      }
     }
   }
+  errors?: Array<{ message: string }>
+}
 
-  // Fetch bodies in parallel and extract repo slugs
-  const resolved = await Promise.all(
-    allIssues.map(async (issue) => {
-      try {
-        const res = await fetch(
-          `https://api.github.com/repos/cncf/sandbox/issues/${issue.number}`,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-              Accept: 'application/vnd.github+json',
-              'User-Agent': 'RepoPulse/1.0',
-            },
-            signal: AbortSignal.timeout(10_000),
-          },
-        )
-        if (!res.ok) return { issue, slug: null as string | null, reason: 'Failed to fetch issue body' }
-        const data = (await res.json()) as { body?: string }
-        const slug = data.body ? extractRepoSlugFromBody(data.body) : null
-        return { issue, slug, reason: slug ? null : 'No GitHub repository URL found in issue body' }
-      } catch {
-        return { issue, slug: null as string | null, reason: 'Failed to fetch issue body' }
+const GQL_QUERY = `
+  query GetBoardItems($org: String!, $number: Int!, $cursor: String) {
+    organization(login: $org) {
+      projectV2(number: $number) {
+        items(first: 100, after: $cursor) {
+          nodes {
+            content {
+              ... on Issue {
+                number
+                url
+                title
+                body
+              }
+            }
+            fieldValues(first: 8) {
+              nodes {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field {
+                    ... on ProjectV2SingleSelectField {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+          pageInfo { hasNextPage endCursor }
+        }
       }
-    }),
-  )
+    }
+  }
+`
+
+async function fetchBoardItemsViaGraphQL(
+  token: string,
+  org: string,
+  projectNumber: number,
+): Promise<Array<{ issueNumber: number; issueUrl: string; title: string; body: string | null }>> {
+  const items: Array<{ issueNumber: number; issueUrl: string; title: string; body: string | null }> = []
+  let cursor: string | null = null
+
+  do {
+    const res = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'RepoPulse/1.0',
+      },
+      body: JSON.stringify({ query: GQL_QUERY, variables: { org, number: projectNumber, cursor } }),
+      signal: AbortSignal.timeout(15_000),
+    })
+
+    if (!res.ok) break
+
+    const data = (await res.json()) as GraphQLResponse
+    if (data.errors?.length) break
+
+    const projectItems = data.data?.organization?.projectV2?.items
+    if (!projectItems) break
+
+    for (const node of projectItems.nodes ?? []) {
+      if (!node.content?.number) continue
+
+      const status = node.fieldValues.nodes.find(
+        (fv) => fv.field?.name?.toLowerCase() === 'status',
+      )
+      if (!status?.name || !BOARD_COLUMNS.has(status.name.toLowerCase())) continue
+
+      items.push({
+        issueNumber: node.content.number,
+        issueUrl: node.content.url ?? '',
+        title: node.content.title ?? '',
+        body: node.content.body ?? null,
+      })
+    }
+
+    const pageInfo = projectItems.pageInfo
+    cursor = pageInfo?.hasNextPage ? (pageInfo.endCursor ?? null) : null
+  } while (cursor)
+
+  return items
+}
+
+export async function fetchBoardRepos(token: string, boardUrl: string): Promise<BoardReposResult> {
+  const parsed = parseBoardUrl(boardUrl)
+  if (!parsed) return { repos: [], skipped: [] }
+
+  const items = await fetchBoardItemsViaGraphQL(token, parsed.org, parsed.number)
 
   const repos: string[] = []
   const skipped: SkippedIssue[] = []
   const seenSlugs = new Set<string>()
 
-  for (const { issue, slug, reason } of resolved) {
+  for (const item of items) {
+    const slug = item.body ? extractRepoSlugFromBody(item.body) : null
     if (slug && !seenSlugs.has(slug.toLowerCase())) {
       seenSlugs.add(slug.toLowerCase())
       repos.push(slug)
-    } else if (!slug) {
-      skipped.push({
-        issueNumber: issue.number,
-        issueUrl: issue.html_url,
-        title: issue.title,
-        reason: reason ?? 'No repository URL found',
-      })
     } else {
       skipped.push({
-        issueNumber: issue.number,
-        issueUrl: issue.html_url,
-        title: issue.title,
-        reason: `Duplicate repository: ${slug}`,
+        issueNumber: item.issueNumber,
+        issueUrl: item.issueUrl,
+        title: item.title,
+        reason: slug
+          ? `Duplicate repository: ${slug}`
+          : 'No GitHub repository URL found in issue body',
       })
     }
   }

--- a/lib/foundation/fetch-board-repos.ts
+++ b/lib/foundation/fetch-board-repos.ts
@@ -13,7 +13,7 @@ export interface BoardReposResult {
 }
 
 // Status field values to include (case-insensitive)
-const BOARD_COLUMNS = new Set(['new', 'upcoming'])
+const BOARD_COLUMNS = new Set(['new', 'review/tech'])
 
 // Repo names that are org-meta repos, not real projects
 const EXCLUDED_REPO_NAMES = new Set(['.github', 'actions', 'community', '.github.io'])
@@ -268,15 +268,15 @@ async function fetchIssuesByLabel(token: string, label: string): Promise<GitHubI
 }
 
 async function fetchBoardItemsViaLabels(token: string): Promise<BoardItem[]> {
-  const [newIssues, upcomingIssues] = await Promise.all([
+  const [newIssues, reviewTechIssues] = await Promise.all([
     fetchIssuesByLabel(token, 'New'),
-    fetchIssuesByLabel(token, 'Upcoming'),
+    fetchIssuesByLabel(token, 'review/tech'),
   ])
 
   // Deduplicate
   const seen = new Set<number>()
   const all: GitHubIssueListItem[] = []
-  for (const issue of [...newIssues, ...upcomingIssues]) {
+  for (const issue of [...newIssues, ...reviewTechIssues]) {
     if (!seen.has(issue.number)) {
       seen.add(issue.number)
       all.push(issue)

--- a/lib/foundation/fetch-board-repos.ts
+++ b/lib/foundation/fetch-board-repos.ts
@@ -106,7 +106,7 @@ const GQL_QUERY = `
                 body
               }
             }
-            fieldValues(first: 8) {
+            fieldValues(first: 20) {
               nodes {
                 ... on ProjectV2ItemFieldSingleSelectValue {
                   name
@@ -128,72 +128,114 @@ const GQL_QUERY = `
 
 type BoardItem = { issueNumber: number; issueUrl: string; title: string; body: string | null }
 
+// Match column name by prefix so "New 🌱" still matches "new"
+function matchesColumn(name: string): boolean {
+  const lower = name.toLowerCase()
+  return BOARD_COLUMNS.has(lower) || [...BOARD_COLUMNS].some((col) => lower.startsWith(col))
+}
+
 /**
- * Throws a descriptive error if the project is inaccessible so callers can
- * fall back gracefully instead of mistaking null for "no items".
+ * Fetch one page of project items. Returns null if the project is inaccessible
+ * (null projectV2), so the caller can retry with a different auth header.
+ */
+async function fetchOnePage(
+  authHeader: string | null,
+  org: string,
+  projectNumber: number,
+  cursor: string | null,
+): Promise<{ items: BoardItem[]; nextCursor: string | null } | null> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'RepoPulse/1.0',
+  }
+  if (authHeader) headers['Authorization'] = authHeader
+
+  const res = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query: GQL_QUERY, variables: { org, number: projectNumber, cursor } }),
+    signal: AbortSignal.timeout(15_000),
+  })
+
+  if (!res.ok) throw new Error(`GraphQL HTTP ${res.status}`)
+
+  const data = (await res.json()) as GraphQLResponse
+
+  if (data.errors?.length) {
+    throw new Error(`GraphQL error: ${data.errors.map((e) => e.message).join('; ')}`)
+  }
+
+  // null means access denied — signal to caller to retry differently
+  if (data.data?.organization === null || data.data?.organization?.projectV2 === null) {
+    return null
+  }
+
+  const projectItems = data.data?.organization?.projectV2?.items
+  if (!projectItems) return { items: [], nextCursor: null }
+
+  const items: BoardItem[] = []
+  for (const node of projectItems.nodes ?? []) {
+    if (!node.content?.number) continue
+
+    const status = node.fieldValues.nodes.find(
+      (fv) => fv.field?.name?.toLowerCase() === 'status',
+    )
+    // Include item if it has a matching Status value; if no Status field is set
+    // at all on an item, include it too (board default = "New" column)
+    if (status?.name && !matchesColumn(status.name)) continue
+
+    items.push({
+      issueNumber: node.content.number,
+      issueUrl: node.content.url ?? '',
+      title: node.content.title ?? '',
+      body: node.content.body ?? null,
+    })
+  }
+
+  const nextCursor = projectItems.pageInfo?.hasNextPage
+    ? (projectItems.pageInfo.endCursor ?? null)
+    : null
+
+  return { items, nextCursor }
+}
+
+async function paginateBoard(
+  authHeader: string | null,
+  org: string,
+  projectNumber: number,
+): Promise<BoardItem[] | null> {
+  const all: BoardItem[] = []
+  let cursor: string | null = null
+
+  do {
+    const page = await fetchOnePage(authHeader, org, projectNumber, cursor)
+    if (page === null) return null // access denied
+    all.push(...page.items)
+    cursor = page.nextCursor
+  } while (cursor)
+
+  return all
+}
+
+/**
+ * Try with auth token first; if projectV2 returns null (scope issue), retry
+ * without Authorization — GitHub allows unauthenticated reads of public org
+ * projects at 60 req/hr, which is fine for a one-shot scan.
  */
 async function fetchBoardItemsViaGraphQL(
   token: string,
   org: string,
   projectNumber: number,
 ): Promise<BoardItem[]> {
-  const items: BoardItem[] = []
-  let cursor: string | null = null
+  const withAuth = await paginateBoard(`Bearer ${token}`, org, projectNumber)
+  if (withAuth !== null) return withAuth
 
-  do {
-    const res = await fetch('https://api.github.com/graphql', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        'User-Agent': 'RepoPulse/1.0',
-      },
-      body: JSON.stringify({ query: GQL_QUERY, variables: { org, number: projectNumber, cursor } }),
-      signal: AbortSignal.timeout(15_000),
-    })
+  // Authenticated attempt returned null (access denied) — retry without auth
+  // for public boards
+  const withoutAuth = await paginateBoard(null, org, projectNumber)
+  if (withoutAuth !== null) return withoutAuth
 
-    if (!res.ok) {
-      throw new Error(`GraphQL HTTP ${res.status}`)
-    }
-
-    const data = (await res.json()) as GraphQLResponse
-
-    if (data.errors?.length) {
-      throw new Error(`GraphQL error: ${data.errors.map((e) => e.message).join('; ')}`)
-    }
-
-    if (data.data?.organization === null) {
-      throw new Error('Organization not found or token lacks read:org scope')
-    }
-
-    if (data.data?.organization?.projectV2 === null) {
-      throw new Error('Project not found or token lacks project read access')
-    }
-
-    const projectItems = data.data?.organization?.projectV2?.items
-    if (!projectItems) break
-
-    for (const node of projectItems.nodes ?? []) {
-      if (!node.content?.number) continue
-
-      const status = node.fieldValues.nodes.find(
-        (fv) => fv.field?.name?.toLowerCase() === 'status',
-      )
-      if (!status?.name || !BOARD_COLUMNS.has(status.name.toLowerCase())) continue
-
-      items.push({
-        issueNumber: node.content.number,
-        issueUrl: node.content.url ?? '',
-        title: node.content.title ?? '',
-        body: node.content.body ?? null,
-      })
-    }
-
-    const pageInfo = projectItems.pageInfo
-    cursor = pageInfo?.hasNextPage ? (pageInfo.endCursor ?? null) : null
-  } while (cursor)
-
-  return items
+  throw new Error('Project not accessible (private, or not found)')
 }
 
 // ─── Label fallback path ──────────────────────────────────────────────────────

--- a/lib/foundation/fetch-board-repos.ts
+++ b/lib/foundation/fetch-board-repos.ts
@@ -8,6 +8,8 @@ export interface SkippedIssue {
 export interface BoardReposResult {
   repos: string[]
   skipped: SkippedIssue[]
+  /** Which resolution method succeeded */
+  method: 'graphql' | 'labels'
 }
 
 // Status field values to include (case-insensitive)
@@ -18,7 +20,7 @@ const EXCLUDED_REPO_NAMES = new Set(['.github', 'actions', 'community', '.github
 
 const GITHUB_REPO_RE = /https?:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+?)(?:\/|\.git|$|\s)/i
 
-function parseBoardUrl(url: string): { org: string; number: number } | null {
+export function parseBoardUrl(url: string): { org: string; number: number } | null {
   const match = /github\.com\/orgs\/([^/]+)\/projects\/(\d+)/i.exec(url)
   if (!match) return null
   return { org: match[1], number: parseInt(match[2], 10) }
@@ -30,7 +32,7 @@ function isValidProjectRepo(slug: string): boolean {
   return !!repoName && !EXCLUDED_REPO_NAMES.has(repoName)
 }
 
-function extractRepoSlugFromBody(body: string): string | null {
+export function extractRepoSlugFromBody(body: string): string | null {
   const parts = body.split(/^### /m)
 
   // First pass: headings that specifically reference the GitHub/project URL
@@ -59,6 +61,8 @@ function extractRepoSlugFromBody(body: string): string | null {
   return null
 }
 
+// ─── GraphQL path ────────────────────────────────────────────────────────────
+
 type ProjectItemNode = {
   content: {
     number?: number
@@ -82,8 +86,8 @@ type GraphQLResponse = {
           nodes?: ProjectItemNode[]
           pageInfo?: { hasNextPage?: boolean; endCursor?: string | null }
         }
-      }
-    }
+      } | null
+    } | null
   }
   errors?: Array<{ message: string }>
 }
@@ -122,12 +126,18 @@ const GQL_QUERY = `
   }
 `
 
+type BoardItem = { issueNumber: number; issueUrl: string; title: string; body: string | null }
+
+/**
+ * Throws a descriptive error if the project is inaccessible so callers can
+ * fall back gracefully instead of mistaking null for "no items".
+ */
 async function fetchBoardItemsViaGraphQL(
   token: string,
   org: string,
   projectNumber: number,
-): Promise<Array<{ issueNumber: number; issueUrl: string; title: string; body: string | null }>> {
-  const items: Array<{ issueNumber: number; issueUrl: string; title: string; body: string | null }> = []
+): Promise<BoardItem[]> {
+  const items: BoardItem[] = []
   let cursor: string | null = null
 
   do {
@@ -142,10 +152,23 @@ async function fetchBoardItemsViaGraphQL(
       signal: AbortSignal.timeout(15_000),
     })
 
-    if (!res.ok) break
+    if (!res.ok) {
+      throw new Error(`GraphQL HTTP ${res.status}`)
+    }
 
     const data = (await res.json()) as GraphQLResponse
-    if (data.errors?.length) break
+
+    if (data.errors?.length) {
+      throw new Error(`GraphQL error: ${data.errors.map((e) => e.message).join('; ')}`)
+    }
+
+    if (data.data?.organization === null) {
+      throw new Error('Organization not found or token lacks read:org scope')
+    }
+
+    if (data.data?.organization?.projectV2 === null) {
+      throw new Error('Project not found or token lacks project read access')
+    }
 
     const projectItems = data.data?.organization?.projectV2?.items
     if (!projectItems) break
@@ -173,12 +196,79 @@ async function fetchBoardItemsViaGraphQL(
   return items
 }
 
-export async function fetchBoardRepos(token: string, boardUrl: string): Promise<BoardReposResult> {
-  const parsed = parseBoardUrl(boardUrl)
-  if (!parsed) return { repos: [], skipped: [] }
+// ─── Label fallback path ──────────────────────────────────────────────────────
 
-  const items = await fetchBoardItemsViaGraphQL(token, parsed.org, parsed.number)
+type GitHubIssueListItem = { number: number; title: string; html_url: string }
 
+async function fetchIssuesByLabel(token: string, label: string): Promise<GitHubIssueListItem[]> {
+  const issues: GitHubIssueListItem[] = []
+  let page = 1
+  while (page <= 3) {
+    const res = await fetch(
+      `https://api.github.com/repos/cncf/sandbox/issues?labels=${encodeURIComponent(label)}&state=open&per_page=100&page=${page}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'RepoPulse/1.0',
+        },
+        signal: AbortSignal.timeout(15_000),
+      },
+    )
+    if (!res.ok) break
+    const batch = (await res.json()) as GitHubIssueListItem[]
+    if (!Array.isArray(batch) || batch.length === 0) break
+    issues.push(...batch)
+    if (batch.length < 100) break
+    page++
+  }
+  return issues
+}
+
+async function fetchBoardItemsViaLabels(token: string): Promise<BoardItem[]> {
+  const [newIssues, upcomingIssues] = await Promise.all([
+    fetchIssuesByLabel(token, 'New'),
+    fetchIssuesByLabel(token, 'Upcoming'),
+  ])
+
+  // Deduplicate
+  const seen = new Set<number>()
+  const all: GitHubIssueListItem[] = []
+  for (const issue of [...newIssues, ...upcomingIssues]) {
+    if (!seen.has(issue.number)) {
+      seen.add(issue.number)
+      all.push(issue)
+    }
+  }
+
+  // Fetch bodies in parallel
+  return Promise.all(
+    all.map(async (issue): Promise<BoardItem> => {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/cncf/sandbox/issues/${issue.number}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: 'application/vnd.github+json',
+              'User-Agent': 'RepoPulse/1.0',
+            },
+            signal: AbortSignal.timeout(10_000),
+          },
+        )
+        if (!res.ok) return { issueNumber: issue.number, issueUrl: issue.html_url, title: issue.title, body: null }
+        const data = (await res.json()) as { body?: string }
+        return { issueNumber: issue.number, issueUrl: issue.html_url, title: issue.title, body: data.body ?? null }
+      } catch {
+        return { issueNumber: issue.number, issueUrl: issue.html_url, title: issue.title, body: null }
+      }
+    }),
+  )
+}
+
+// ─── Public entry point ───────────────────────────────────────────────────────
+
+function itemsToResult(items: BoardItem[], method: BoardReposResult['method']): BoardReposResult {
   const repos: string[] = []
   const skipped: SkippedIssue[] = []
   const seenSlugs = new Set<string>()
@@ -200,5 +290,22 @@ export async function fetchBoardRepos(token: string, boardUrl: string): Promise<
     }
   }
 
-  return { repos, skipped }
+  return { repos, skipped, method }
+}
+
+export async function fetchBoardRepos(token: string, boardUrl: string): Promise<BoardReposResult> {
+  const parsed = parseBoardUrl(boardUrl)
+  if (!parsed) return { repos: [], skipped: [], method: 'graphql' }
+
+  // Try the accurate GraphQL path first; fall back to label-based Issues API
+  // if the token lacks project read access (common with baseline OAuth scope).
+  try {
+    const items = await fetchBoardItemsViaGraphQL(token, parsed.org, parsed.number)
+    return itemsToResult(items, 'graphql')
+  } catch (gqlErr) {
+    console.warn('[fetchBoardRepos] GraphQL failed, falling back to label approach:', gqlErr)
+  }
+
+  const items = await fetchBoardItemsViaLabels(token)
+  return itemsToResult(items, 'labels')
 }

--- a/lib/foundation/fetch-board-repos.ts
+++ b/lib/foundation/fetch-board-repos.ts
@@ -1,0 +1,143 @@
+export interface SkippedIssue {
+  issueNumber: number
+  issueUrl: string
+  title: string
+  reason: string
+}
+
+export interface BoardReposResult {
+  repos: string[]
+  skipped: SkippedIssue[]
+}
+
+type GitHubIssueListItem = {
+  number: number
+  title: string
+  html_url: string
+}
+
+const GITHUB_REPO_RE = /https?:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+?)(?:\/|\.git|$|\s)/i
+
+async function fetchIssuesByLabel(token: string, label: string): Promise<GitHubIssueListItem[]> {
+  const issues: GitHubIssueListItem[] = []
+  let page = 1
+  while (page <= 3) {
+    const res = await fetch(
+      `https://api.github.com/repos/cncf/sandbox/issues?labels=${encodeURIComponent(label)}&state=open&per_page=100&page=${page}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'RepoPulse/1.0',
+        },
+        signal: AbortSignal.timeout(15_000),
+      },
+    )
+    if (!res.ok) break
+    const batch = (await res.json()) as GitHubIssueListItem[]
+    if (!Array.isArray(batch) || batch.length === 0) break
+    issues.push(...batch)
+    if (batch.length < 100) break
+    page++
+  }
+  return issues
+}
+
+function extractRepoSlugFromBody(body: string): string | null {
+  // Split the body on ### headings to get individual sections
+  const parts = body.split(/^### /m)
+
+  // First pass: headings that specifically reference the GitHub/project URL
+  for (const part of parts) {
+    const newlineIdx = part.indexOf('\n')
+    if (newlineIdx === -1) continue
+    const heading = part.slice(0, newlineIdx).trim()
+    const content = part.slice(newlineIdx + 1).trim()
+
+    if (/github/i.test(heading) && /(url|link|org|project|repo)/i.test(heading)) {
+      const match = GITHUB_REPO_RE.exec(content)
+      if (match?.[1] && !match[1].startsWith('cncf/')) return match[1]
+    }
+  }
+
+  // Second pass: any section with a GitHub URL
+  for (const part of parts) {
+    const newlineIdx = part.indexOf('\n')
+    if (newlineIdx === -1) continue
+    const content = part.slice(newlineIdx + 1).trim()
+
+    const match = GITHUB_REPO_RE.exec(content)
+    if (match?.[1] && !match[1].startsWith('cncf/')) return match[1]
+  }
+
+  return null
+}
+
+export async function fetchBoardRepos(token: string): Promise<BoardReposResult> {
+  const [newIssues, upcomingIssues] = await Promise.all([
+    fetchIssuesByLabel(token, 'New'),
+    fetchIssuesByLabel(token, 'Upcoming'),
+  ])
+
+  // Deduplicate by issue number
+  const seen = new Set<number>()
+  const allIssues: GitHubIssueListItem[] = []
+  for (const issue of [...newIssues, ...upcomingIssues]) {
+    if (!seen.has(issue.number)) {
+      seen.add(issue.number)
+      allIssues.push(issue)
+    }
+  }
+
+  // Fetch bodies in parallel and extract repo slugs
+  const resolved = await Promise.all(
+    allIssues.map(async (issue) => {
+      try {
+        const res = await fetch(
+          `https://api.github.com/repos/cncf/sandbox/issues/${issue.number}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: 'application/vnd.github+json',
+              'User-Agent': 'RepoPulse/1.0',
+            },
+            signal: AbortSignal.timeout(10_000),
+          },
+        )
+        if (!res.ok) return { issue, slug: null as string | null, reason: 'Failed to fetch issue body' }
+        const data = (await res.json()) as { body?: string }
+        const slug = data.body ? extractRepoSlugFromBody(data.body) : null
+        return { issue, slug, reason: slug ? null : 'No GitHub repository URL found in issue body' }
+      } catch {
+        return { issue, slug: null as string | null, reason: 'Failed to fetch issue body' }
+      }
+    }),
+  )
+
+  const repos: string[] = []
+  const skipped: SkippedIssue[] = []
+  const seenSlugs = new Set<string>()
+
+  for (const { issue, slug, reason } of resolved) {
+    if (slug && !seenSlugs.has(slug.toLowerCase())) {
+      seenSlugs.add(slug.toLowerCase())
+      repos.push(slug)
+    } else if (!slug) {
+      skipped.push({
+        issueNumber: issue.number,
+        issueUrl: issue.html_url,
+        title: issue.title,
+        reason: reason ?? 'No repository URL found',
+      })
+    } else {
+      skipped.push({
+        issueNumber: issue.number,
+        issueUrl: issue.html_url,
+        title: issue.title,
+        reason: `Duplicate repository: ${slug}`,
+      })
+    }
+  }
+
+  return { repos, skipped }
+}

--- a/lib/foundation/fetch-board-repos.ts
+++ b/lib/foundation/fetch-board-repos.ts
@@ -240,9 +240,13 @@ async function fetchBoardItemsViaGraphQL(
 
 // ─── Label fallback path ──────────────────────────────────────────────────────
 
-type GitHubIssueListItem = { number: number; title: string; html_url: string }
+type GitHubIssueListItem = { number: number; title: string; html_url: string; labels: Array<{ name: string }> }
 
-async function fetchIssuesByLabel(token: string, label: string): Promise<GitHubIssueListItem[]> {
+async function fetchIssuesByLabel(
+  token: string,
+  label: string,
+  excludeLabel: string,
+): Promise<GitHubIssueListItem[]> {
   const issues: GitHubIssueListItem[] = []
   let page = 1
   while (page <= 3) {
@@ -260,7 +264,11 @@ async function fetchIssuesByLabel(token: string, label: string): Promise<GitHubI
     if (!res.ok) break
     const batch = (await res.json()) as GitHubIssueListItem[]
     if (!Array.isArray(batch) || batch.length === 0) break
-    issues.push(...batch)
+    // Filter out issues that carry the exclusion label
+    const filtered = batch.filter(
+      (issue) => !issue.labels.some((l) => l.name.toLowerCase() === excludeLabel.toLowerCase()),
+    )
+    issues.push(...filtered)
     if (batch.length < 100) break
     page++
   }
@@ -268,9 +276,11 @@ async function fetchIssuesByLabel(token: string, label: string): Promise<GitHubI
 }
 
 async function fetchBoardItemsViaLabels(token: string): Promise<BoardItem[]> {
+  // "New" column:        label:New        -label:gitvote/passed
+  // "review/tech" column: label:review/tech -label:sandbox
   const [newIssues, reviewTechIssues] = await Promise.all([
-    fetchIssuesByLabel(token, 'New'),
-    fetchIssuesByLabel(token, 'review/tech'),
+    fetchIssuesByLabel(token, 'New', 'gitvote/passed'),
+    fetchIssuesByLabel(token, 'review/tech', 'sandbox'),
   ])
 
   // Deduplicate

--- a/lib/foundation/fetch-board-repos.ts
+++ b/lib/foundation/fetch-board-repos.ts
@@ -10,6 +10,8 @@ export interface BoardReposResult {
   skipped: SkippedIssue[]
   /** Which resolution method succeeded */
   method: 'graphql' | 'labels'
+  /** Maps each resolved repo slug to its cncf/sandbox issue number */
+  issueMap: Record<string, number>
 }
 
 // Status field values to include (case-insensitive)
@@ -323,6 +325,7 @@ async function fetchBoardItemsViaLabels(token: string): Promise<BoardItem[]> {
 function itemsToResult(items: BoardItem[], method: BoardReposResult['method']): BoardReposResult {
   const repos: string[] = []
   const skipped: SkippedIssue[] = []
+  const issueMap: Record<string, number> = {}
   const seenSlugs = new Set<string>()
 
   for (const item of items) {
@@ -330,6 +333,7 @@ function itemsToResult(items: BoardItem[], method: BoardReposResult['method']): 
     if (slug && !seenSlugs.has(slug.toLowerCase())) {
       seenSlugs.add(slug.toLowerCase())
       repos.push(slug)
+      issueMap[slug] = item.issueNumber
     } else {
       skipped.push({
         issueNumber: item.issueNumber,
@@ -342,12 +346,12 @@ function itemsToResult(items: BoardItem[], method: BoardReposResult['method']): 
     }
   }
 
-  return { repos, skipped, method }
+  return { repos, skipped, method, issueMap }
 }
 
 export async function fetchBoardRepos(token: string, boardUrl: string): Promise<BoardReposResult> {
   const parsed = parseBoardUrl(boardUrl)
-  if (!parsed) return { repos: [], skipped: [], method: 'graphql' }
+  if (!parsed) return { repos: [], skipped: [], method: 'graphql', issueMap: {} }
 
   // Try the accurate GraphQL path first; fall back to label-based Issues API
   // if the token lacks project read access (common with baseline OAuth scope).

--- a/lib/foundation/parse-foundation-input.test.ts
+++ b/lib/foundation/parse-foundation-input.test.ts
@@ -67,6 +67,13 @@ describe('parseFoundationInput — projects-board path', () => {
       url: 'https://github.com/orgs/cncf/projects/14',
     })
   })
+
+  it('detects github.com/orgs/org/projects/N without protocol', () => {
+    expect(parseFoundationInput('github.com/orgs/cncf/projects/14')).toEqual({
+      kind: 'projects-board',
+      url: 'github.com/orgs/cncf/projects/14',
+    })
+  })
 })
 
 describe('parseFoundationInput — invalid path', () => {

--- a/lib/foundation/parse-foundation-input.ts
+++ b/lib/foundation/parse-foundation-input.ts
@@ -7,7 +7,7 @@ export type FoundationParseResult =
   | { kind: 'projects-board'; url: string }
   | { kind: 'invalid';        error: string }
 
-const PROJECTS_BOARD_RE = /^https?:\/\/github\.com\/orgs\/[^/]+\/projects\/\d+/i
+const PROJECTS_BOARD_RE = /^(?:https?:\/\/)?github\.com\/orgs\/[^/]+\/projects\/\d+/i
 const GITHUB_URL_PREFIX_RE = /^(?:https?:\/\/)?github\.com\//i
 const ORG_SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9.-]*$/
 


### PR DESCRIPTION
## Summary

- Pasting a GitHub Projects v2 board URL (e.g. \`https://github.com/orgs/cncf/projects/14\`) into the Foundation tab triggers board mode
- Resolves repos from the CNCF sandbox board (**New** + **review/tech** columns) via GraphQL Projects API (falls back to issue labels if \`read:project\` scope is absent)
- A review panel shows the resolved repo list before analysis; user can confirm or cancel
- Per-repo readiness accordion with GitHub link, score badge, and Expand all / Collapse all
- **Re-analyze** button on results: for board results, silently re-fetches repos + re-runs analysis (skips the review panel); for repos/org results, re-runs the same input
- Corpus-grounded recommendations: fetches the last 100 approved sandbox applications and computes real percentages for CNCF project mentions (cloud-native-fit, benefit-to-landscape) and field-level patterns (Why CNCF governance mentions, TAG engagement rate, similar-projects naming rate)
- Business/Product Separation assessment expanded to recognize explicit no-commercial-tie statements as **Strong** (not Weak)
- Code of Conduct detection extended to recognize CNCF CoC, transitive org-level CoC delegation via GitHub links, and Contributor Covenant links
- Diversity and activity evidence strings added to auto-evaluated field descriptions

## Test plan

### Board input mode
- [x] Paste \`https://github.com/orgs/cncf/projects/14\` into the Foundation tab → app resolves repos from the board and shows a review panel with the repo list + **Analyze** button
- [x] Click **Analyze** in the review panel → CNCF Sandbox readiness scan runs and shows per-repo accordion with results
- [x] Board scan header shows repo count, link to the board, and skipped-issues count (if any)
- [x] Skipped-issues warning lists issues that could not be resolved to a repo URL
- [x] With \`read:project\` scope absent: label fallback triggers, "Note" banner appears with re-auth link
- [x] Cancel button in review panel dismisses it without triggering analysis

### Re-analyze button
- [x] **Re-analyze** button appears on board results — clicking it re-fetches repos from the board and immediately starts the scan (no review panel)
- [x] **Re-analyze** button appears on repos results — clicking it re-runs the same input through the normal flow
- [x] **Re-analyze** button appears on org results — clicking it re-runs the same input

### Accordion
- [x] Each repo row shows a clickable GitHub link and a score badge (color-coded green/amber/red)
- [x] Clicking a row expands the CNCF readiness detail panel; clicking again collapses it
- [x] **Expand all** opens every row; **Collapse all** closes every row

### Corpus-grounded recommendations
- [x] cloud-native-fit field shows gap hints with real percentages from 100 approved apps (e.g. "Commonly cited projects you haven't mentioned: Prometheus (84%)")
- [x] Already-cited projects are called out positively with their corpus % (e.g. "You named Kubernetes (96% of last 100) — good")
- [x] benefit-to-landscape shows similar corpus-backed gap hints
- [x] **Why CNCF? (Adequate)**: recommendation leads with "X% of the last 100 approved applications named a specific TAG or working group"
- [x] **Why CNCF? (Weak)**: recommendation leads with "X% of approved applications cited governance or vendor neutrality"
- [x] **TAG Engagement (empty/missing)**: recommendation leads with "X% of the last 100 approved applications had an actual TAG presentation or meeting"
- [x] **Similar Projects (adequate)**: recommendation leads with "X% of the last 100 approved applications named 3 or more comparable projects"

### Field assessment fixes
- [x] Application stating "no commercial ties" / "community-driven" / "not backed by any commercial entity" → Business/Product Separation assessed **Strong** (not Weak)
- [x] CNCF CoC reference (e.g. \`cncf.io/community/code-of-conduct\`) in a repo's CODE_OF_CONDUCT.md → CoC field assessed **Ready**
- [x] Repo whose CODE_OF_CONDUCT.md links to another file that references CNCF CoC → CoC field assessed **Ready** (transitive delegation)
- [x] Contributor Covenant link in CODE_OF_CONDUCT.md → CoC field assessed **Ready**
- [x] Diversity and activity auto-fields show evidence strings (e.g. "3 orgs · 42% from top-org · 18 contributors (90d)")

### Existing flows
- [x] Repos mode: enter one or more repos → analysis runs, results render as before
- [x] Org mode: enter an org slug → org inventory renders as before
- [x] Foundation tab repos/org inputs unaffected by board changes
- [x] Shareable URL with \`mode=foundation\` parameters auto-triggers the correct flow on load

### Automated checks
- [x] \`npx tsc --noEmit\` passes
- [x] \`npx vitest run\` passes (1596 tests)

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)