### PR TITLE
fix(PAT-06): replace unsafe error casts with toAnalyzerError() narrowing helper

### DIFF
--- a/lib/analyzer/analyze-error-cast.test.ts
+++ b/lib/analyzer/analyze-error-cast.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { toAnalyzerError } from './analyze'
+
+describe('toAnalyzerError', () => {
+  it('extracts message, status, and retryAfter from a plain Error object', () => {
+    const err = Object.assign(new Error('not found'), { status: 404 })
+    const result = toAnalyzerError(err)
+    expect(result.message).toBe('not found')
+    expect(result.status).toBe(404)
+    expect(result.retryAfter).toBeUndefined()
+  })
+
+  it('extracts retryAfter when it is a number', () => {
+    const err = Object.assign(new Error('rate limit'), { status: 403, retryAfter: 60 })
+    const result = toAnalyzerError(err)
+    expect(result.retryAfter).toBe(60)
+  })
+
+  it('extracts retryAfter when it is the "unavailable" sentinel', () => {
+    const err = Object.assign(new Error('rate limit'), { status: 403, retryAfter: 'unavailable' })
+    const result = toAnalyzerError(err)
+    expect(result.retryAfter).toBe('unavailable')
+  })
+
+  it('returns empty object for a thrown string', () => {
+    const result = toAnalyzerError('something went wrong')
+    expect(result).toEqual({})
+  })
+
+  it('returns empty object for null', () => {
+    expect(toAnalyzerError(null)).toEqual({})
+  })
+
+  it('returns empty object for undefined', () => {
+    expect(toAnalyzerError(undefined)).toEqual({})
+  })
+
+  it('returns empty object for a thrown number', () => {
+    expect(toAnalyzerError(42)).toEqual({})
+  })
+
+  it('extracts fields from a plain object (non-Error throw)', () => {
+    const result = toAnalyzerError({ message: 'custom error', status: 401 })
+    expect(result.message).toBe('custom error')
+    expect(result.status).toBe(401)
+  })
+
+  it('ignores status when it is not a number', () => {
+    const result = toAnalyzerError({ status: 'forbidden' })
+    expect(result.status).toBeUndefined()
+  })
+
+  it('ignores retryAfter when it is an unexpected type', () => {
+    const result = toAnalyzerError({ retryAfter: true })
+    expect(result.retryAfter).toBeUndefined()
+  })
+})

--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -688,8 +688,26 @@ interface ResponseSignal {
   firstHumanResponseAt: string | null
 }
 
+interface AnalyzerError {
+  message?: string
+  status?: number
+  retryAfter?: number | Unavailable
+}
+
+export function toAnalyzerError(error: unknown): AnalyzerError {
+  if (error === null || typeof error !== 'object') return {}
+  const e = error as Record<string, unknown>
+  return {
+    message: typeof e.message === 'string' ? e.message : undefined,
+    status: typeof e.status === 'number' ? e.status : undefined,
+    retryAfter: typeof e.retryAfter === 'number' || e.retryAfter === 'unavailable'
+      ? e.retryAfter as number | Unavailable
+      : undefined,
+  }
+}
+
 function extractRateLimitFromError(error: unknown): RateLimitState | null {
-  const maybeError = error as Error & { status?: number; retryAfter?: number | Unavailable }
+  const maybeError = toAnalyzerError(error)
 
   if (maybeError.status !== 403 && maybeError.retryAfter == null) {
     return null
@@ -2534,8 +2552,8 @@ function getCommitActorKey(node: CommitNode): string | null {
 }
 
 function buildFailure(repo: string, error: unknown): RepositoryFetchFailure {
-  const maybeError = error as Error & { status?: number; retryAfter?: number | Unavailable }
-  const message = maybeError?.message?.toLowerCase() ?? ''
+  const maybeError = toAnalyzerError(error)
+  const message = maybeError.message?.toLowerCase() ?? ''
 
   if (message.includes('not found')) {
     return { repo, reason: 'Repository could not be analyzed.', code: 'NOT_FOUND' }
@@ -2575,13 +2593,13 @@ function buildDiagnostic(
   error: unknown,
   level: AnalysisDiagnostic['level'] = 'warn',
 ): AnalysisDiagnostic {
-  const maybeError = error as Error & { status?: number; retryAfter?: number | Unavailable }
+  const maybeError = toAnalyzerError(error)
 
   return {
     level,
     repo,
     source,
-    message: maybeError?.message ?? 'Unknown analysis error',
+    message: maybeError.message ?? 'Unknown analysis error',
     status: maybeError.status,
     retryAfter: maybeError.retryAfter,
   }


### PR DESCRIPTION
## Summary

- Introduces `toAnalyzerError(error: unknown): AnalyzerError` — a type-safe narrowing helper that replaces the three `error as Error & { status?, retryAfter? }` casts in `lib/analyzer/analyze.ts`
- The old casts silently produced `undefined` for `.message` when the thrown value was not an `Error` instance (e.g. `throw 'rate limit exceeded'` or a plain `{ status: 403 }` object)
- The new helper checks `typeof error === 'object'` and guards each property (`message`, `status`, `retryAfter`) with `typeof` narrowing before returning — primitive throws (strings, numbers) return `{}`
- Exports `toAnalyzerError` so it is directly unit-testable now; `buildFailure` becomes testable after the future PAT-03 split of `analyze.ts`

## Test plan

- [x] `npx vitest run lib/analyzer/analyze-error-cast.test.ts` — 10 unit tests pass, covering: `Error` instance with `status`, numeric `retryAfter`, `'unavailable'` sentinel, thrown string, `null`, `undefined`, thrown number, plain object, non-numeric `status`, unexpected `retryAfter` type
- [x] `npx tsc --noEmit` — no type errors

Part of the pre-Phase-2 code quality audit. Closes PAT-06 from PR #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)