### PR TITLE
fix(DRY-05): extract shared computePercentiles; unify calibration percentile algorithm

### DIFF
--- a/scripts/calibrate-docs.ts
+++ b/scripts/calibrate-docs.ts
@@ -20,6 +20,7 @@ import {
   LICENSING_WEIGHTS,
   COMPOSITE_WEIGHTS,
 } from '../lib/documentation/score-config'
+import { computePercentiles } from './percentile-utils'
 
 loadEnvConfig(process.cwd())
 
@@ -341,25 +342,6 @@ function computeDocScore(repo: DocRepoData): number {
     licensingScore * COMPOSITE_WEIGHTS.licensing +
     inclusiveNamingScore * COMPOSITE_WEIGHTS.inclusiveNaming
   )
-}
-
-// ─── Percentile computation ──────────────────────────────────────────────────
-
-function computePercentiles(values: number[]): { p25: number; p50: number; p75: number; p90: number } {
-  const sorted = [...values].sort((a, b) => a - b)
-  const at = (p: number) => {
-    const idx = (p / 100) * (sorted.length - 1)
-    const lo = Math.floor(idx)
-    const hi = Math.ceil(idx)
-    if (lo === hi) return sorted[lo]!
-    return sorted[lo]! + (sorted[hi]! - sorted[lo]!) * (idx - lo)
-  }
-  return {
-    p25: Math.round(at(25) * 1000) / 1000,
-    p50: Math.round(at(50) * 1000) / 1000,
-    p75: Math.round(at(75) * 1000) / 1000,
-    p90: Math.round(at(90) * 1000) / 1000,
-  }
 }
 
 // ─── Main ────────────────────────────────────────────────────────────────────

--- a/scripts/calibrate-legacy.ts
+++ b/scripts/calibrate-legacy.ts
@@ -18,6 +18,7 @@ import { loadEnvConfig } from '@next/env'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { analyze } from '../lib/analyzer/analyze'
 import type { AnalysisResult } from '../lib/analyzer/analysis-result'
+import { computePercentiles, type PercentileSet } from './percentile-utils'
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -51,13 +52,6 @@ interface Checkpoint {
   sampledRepos: Record<BracketKey, string[]>
 }
 
-interface PercentileSet {
-  p25: number
-  p50: number
-  p75: number
-  p90: number
-}
-
 interface BracketCalibration {
   sampleSize: number
   stars: PercentileSet
@@ -84,22 +78,6 @@ interface CalibrationData {
 }
 
 // ─── Utilities ───────────────────────────────────────────────────────────────
-
-function percentile(values: number[], p: number): number {
-  if (values.length === 0) return 0
-  const sorted = [...values].sort((a, b) => a - b)
-  const index = Math.ceil((p / 100) * sorted.length) - 1
-  return Math.round(sorted[Math.max(0, index)] * 1000) / 1000
-}
-
-function percentiles(values: number[]): PercentileSet {
-  return {
-    p25: percentile(values, 25),
-    p50: percentile(values, 50),
-    p75: percentile(values, 75),
-    p90: percentile(values, 90),
-  }
-}
 
 function defined(v: number | 'unavailable' | undefined): v is number {
   return typeof v === 'number' && isFinite(v)
@@ -269,20 +247,20 @@ function computeBracketCalibration(results: AnalysisResult[]): BracketCalibratio
 
   return {
     sampleSize: results.length,
-    stars: percentiles(collect('stars')),
-    forks: percentiles(collect('forks')),
-    watchers: percentiles(collect('watchers')),
-    forkRate: percentiles(collect('forkRate')),
-    watcherRate: percentiles(collect('watcherRate')),
-    prMergeRate: percentiles(collect('prMergeRate')),
-    issueClosureRate: percentiles(collect('issueClosureRate')),
-    staleIssueRatio: percentiles(collect('staleIssueRatio')),
-    medianTimeToMergeHours: percentiles(collect('medianTimeToMergeHours')),
-    medianTimeToCloseHours: percentiles(collect('medianTimeToCloseHours')),
-    issueFirstResponseMedianHours: percentiles(collect('issueFirstResponseMedianHours')),
-    issueFirstResponseP90Hours: percentiles(collect('issueFirstResponseP90Hours')),
-    prFirstReviewMedianHours: percentiles(collect('prFirstReviewMedianHours')),
-    topContributorShare: percentiles(collect('topContributorShare')),
+    stars: computePercentiles(collect('stars')),
+    forks: computePercentiles(collect('forks')),
+    watchers: computePercentiles(collect('watchers')),
+    forkRate: computePercentiles(collect('forkRate')),
+    watcherRate: computePercentiles(collect('watcherRate')),
+    prMergeRate: computePercentiles(collect('prMergeRate')),
+    issueClosureRate: computePercentiles(collect('issueClosureRate')),
+    staleIssueRatio: computePercentiles(collect('staleIssueRatio')),
+    medianTimeToMergeHours: computePercentiles(collect('medianTimeToMergeHours')),
+    medianTimeToCloseHours: computePercentiles(collect('medianTimeToCloseHours')),
+    issueFirstResponseMedianHours: computePercentiles(collect('issueFirstResponseMedianHours')),
+    issueFirstResponseP90Hours: computePercentiles(collect('issueFirstResponseP90Hours')),
+    prFirstReviewMedianHours: computePercentiles(collect('prFirstReviewMedianHours')),
+    topContributorShare: computePercentiles(collect('topContributorShare')),
   }
 }
 

--- a/scripts/calibrate.ts
+++ b/scripts/calibrate.ts
@@ -18,6 +18,7 @@
 
 import { loadEnvConfig } from '@next/env'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { computePercentiles, type PercentileSet } from './percentile-utils'
 
 loadEnvConfig(process.cwd())
 
@@ -268,13 +269,6 @@ function isGenuineSoftwareProject(repo: SearchRepoItem, starsMin: number, starsM
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface PercentileSet {
-  p25: number
-  p50: number
-  p75: number
-  p90: number
-}
-
 interface RepoMetrics {
   repo: string
   stars: number
@@ -348,22 +342,6 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function percentile(values: number[], p: number): number {
-  if (values.length === 0) return 0
-  const sorted = [...values].sort((a, b) => a - b)
-  const index = Math.ceil((p / 100) * sorted.length) - 1
-  return Math.round(sorted[Math.max(0, index)]! * 1000) / 1000
-}
-
-function percentiles(values: number[]): PercentileSet {
-  return {
-    p25: percentile(values, 25),
-    p50: percentile(values, 50),
-    p75: percentile(values, 75),
-    p90: percentile(values, 90),
-  }
-}
-
 async function fetchWithRetry(url: string, init: RequestInit, maxRetries = 3): Promise<Response> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
@@ -399,7 +377,7 @@ function median(values: number[]): number | null {
 
 function p90Value(values: number[]): number | null {
   if (values.length === 0) return null
-  return percentile(values, 90)
+  return computePercentiles(values).p90
 }
 
 function hoursBetween(a: string, b: string): number {
@@ -884,32 +862,32 @@ function collect(results: RepoMetrics[], key: keyof RepoMetrics): number[] {
 function computeBracketCalibration(results: RepoMetrics[]) {
   return {
     sampleSize: results.length,
-    stars:                           percentiles(collect(results, 'stars')),
-    forks:                           percentiles(collect(results, 'forks')),
-    watchers:                        percentiles(collect(results, 'watchers')),
-    forkRate:                        percentiles(collect(results, 'forkRate')),
-    watcherRate:                     percentiles(collect(results, 'watcherRate')),
-    prMergeRate:                     percentiles(collect(results, 'prMergeRate')),
-    issueClosureRate:                percentiles(collect(results, 'issueClosureRate')),
-    staleIssueRatio:                 percentiles(collect(results, 'staleIssueRatio')),
-    stalePrRatio:                    percentiles(collect(results, 'stalePrRatio')),
-    medianTimeToMergeHours:          percentiles(collect(results, 'medianTimeToMergeHours')),
-    medianTimeToCloseHours:          percentiles(collect(results, 'medianTimeToCloseHours')),
-    issueFirstResponseMedianHours:   percentiles(collect(results, 'issueFirstResponseMedianHours')),
-    issueFirstResponseP90Hours:      percentiles(collect(results, 'issueFirstResponseP90Hours')),
-    prFirstReviewMedianHours:        percentiles(collect(results, 'prFirstReviewMedianHours')),
-    prFirstReviewP90Hours:           percentiles(collect(results, 'prFirstReviewP90Hours')),
-    issueResolutionMedianHours:      percentiles(collect(results, 'issueResolutionMedianHours')),
-    issueResolutionP90Hours:         percentiles(collect(results, 'issueResolutionP90Hours')),
-    prMergeMedianHours:              percentiles(collect(results, 'prMergeMedianHours')),
-    prMergeP90Hours:                 percentiles(collect(results, 'prMergeP90Hours')),
-    issueResolutionRate:             percentiles(collect(results, 'issueResolutionRate')),
-    contributorResponseRate:         percentiles(collect(results, 'contributorResponseRate')),
-    humanResponseRatio:              percentiles(collect(results, 'humanResponseRatio')),
-    botResponseRatio:                percentiles(collect(results, 'botResponseRatio')),
-    prReviewDepth:                   percentiles(collect(results, 'prReviewDepth')),
-    issuesClosedWithoutCommentRatio: percentiles(collect(results, 'issuesClosedWithoutCommentRatio')),
-    topContributorShare:             percentiles(collect(results, 'topContributorShare')),
+    stars:                           computePercentiles(collect(results, 'stars')),
+    forks:                           computePercentiles(collect(results, 'forks')),
+    watchers:                        computePercentiles(collect(results, 'watchers')),
+    forkRate:                        computePercentiles(collect(results, 'forkRate')),
+    watcherRate:                     computePercentiles(collect(results, 'watcherRate')),
+    prMergeRate:                     computePercentiles(collect(results, 'prMergeRate')),
+    issueClosureRate:                computePercentiles(collect(results, 'issueClosureRate')),
+    staleIssueRatio:                 computePercentiles(collect(results, 'staleIssueRatio')),
+    stalePrRatio:                    computePercentiles(collect(results, 'stalePrRatio')),
+    medianTimeToMergeHours:          computePercentiles(collect(results, 'medianTimeToMergeHours')),
+    medianTimeToCloseHours:          computePercentiles(collect(results, 'medianTimeToCloseHours')),
+    issueFirstResponseMedianHours:   computePercentiles(collect(results, 'issueFirstResponseMedianHours')),
+    issueFirstResponseP90Hours:      computePercentiles(collect(results, 'issueFirstResponseP90Hours')),
+    prFirstReviewMedianHours:        computePercentiles(collect(results, 'prFirstReviewMedianHours')),
+    prFirstReviewP90Hours:           computePercentiles(collect(results, 'prFirstReviewP90Hours')),
+    issueResolutionMedianHours:      computePercentiles(collect(results, 'issueResolutionMedianHours')),
+    issueResolutionP90Hours:         computePercentiles(collect(results, 'issueResolutionP90Hours')),
+    prMergeMedianHours:              computePercentiles(collect(results, 'prMergeMedianHours')),
+    prMergeP90Hours:                 computePercentiles(collect(results, 'prMergeP90Hours')),
+    issueResolutionRate:             computePercentiles(collect(results, 'issueResolutionRate')),
+    contributorResponseRate:         computePercentiles(collect(results, 'contributorResponseRate')),
+    humanResponseRatio:              computePercentiles(collect(results, 'humanResponseRatio')),
+    botResponseRatio:                computePercentiles(collect(results, 'botResponseRatio')),
+    prReviewDepth:                   computePercentiles(collect(results, 'prReviewDepth')),
+    issuesClosedWithoutCommentRatio: computePercentiles(collect(results, 'issuesClosedWithoutCommentRatio')),
+    topContributorShare:             computePercentiles(collect(results, 'topContributorShare')),
   }
 }
 

--- a/scripts/percentile-utils.test.ts
+++ b/scripts/percentile-utils.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { computePercentiles } from './percentile-utils'
+
+// Reference implementation of the old Math.ceil nearest-rank method used in
+// calibrate-legacy.ts and calibrate.ts before DRY-05 consolidation.
+function legacyPercentile(values: number[], p: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.ceil((p / 100) * sorted.length) - 1
+  return Math.round(sorted[Math.max(0, index)]! * 1000) / 1000
+}
+
+function legacyPercentiles(values: number[]) {
+  return {
+    p25: legacyPercentile(values, 25),
+    p50: legacyPercentile(values, 50),
+    p75: legacyPercentile(values, 75),
+    p90: legacyPercentile(values, 90),
+  }
+}
+
+describe('computePercentiles', () => {
+  describe('algorithm divergence from legacy Math.ceil method', () => {
+    it('produces different p25 for a 10-element distribution', () => {
+      const dist = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      // legacy: Math.ceil(0.25 * 10) - 1 = index 2 → value 3
+      // linear: 0.25 * 9 = 2.25 → interpolate(3, 4, 0.25) = 3.25
+      expect(legacyPercentiles(dist).p25).toBe(3)
+      expect(computePercentiles(dist).p25).toBe(3.25)
+      expect(computePercentiles(dist).p25).not.toBe(legacyPercentiles(dist).p25)
+    })
+
+    it('produces different p90 for a 10-element distribution', () => {
+      const dist = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      // legacy: Math.ceil(0.9 * 10) - 1 = index 8 → value 9
+      // linear: 0.9 * 9 = 8.1 → interpolate(9, 10, 0.1) = 9.1
+      expect(legacyPercentiles(dist).p90).toBe(9)
+      expect(computePercentiles(dist).p90).toBe(9.1)
+    })
+
+    it('agrees with legacy at exact rank boundaries (single-element)', () => {
+      expect(computePercentiles([42]).p50).toBe(42)
+      expect(legacyPercentiles([42]).p50).toBe(42)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns zeros for an empty array', () => {
+      expect(computePercentiles([])).toEqual({ p25: 0, p50: 0, p75: 0, p90: 0 })
+    })
+
+    it('returns the single value for all percentiles when n=1', () => {
+      expect(computePercentiles([7])).toEqual({ p25: 7, p50: 7, p75: 7, p90: 7 })
+    })
+
+    it('sorts the input before computing (order-independent)', () => {
+      const asc = [1, 2, 3, 4, 5]
+      const desc = [5, 4, 3, 2, 1]
+      expect(computePercentiles(asc)).toEqual(computePercentiles(desc))
+    })
+
+    it('rounds to 3 decimal places', () => {
+      // 0.25 * 4 = 1.0 → exact, no fractional rounding needed
+      const result = computePercentiles([1, 2, 3, 4, 5])
+      expect(result.p25.toString()).toMatch(/^\d+(\.\d{1,3})?$/)
+    })
+  })
+
+  describe('known values', () => {
+    it('computes correct percentiles for [1..10]', () => {
+      const result = computePercentiles([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+      expect(result.p25).toBe(3.25)
+      expect(result.p50).toBe(5.5)
+      expect(result.p75).toBe(7.75)
+      expect(result.p90).toBe(9.1)
+    })
+
+    it('computes correct percentiles for a two-element array', () => {
+      const result = computePercentiles([0, 100])
+      expect(result.p25).toBe(25)
+      expect(result.p50).toBe(50)
+      expect(result.p75).toBe(75)
+      expect(result.p90).toBe(90)
+    })
+  })
+})

--- a/scripts/percentile-utils.ts
+++ b/scripts/percentile-utils.ts
@@ -1,0 +1,29 @@
+export interface PercentileSet {
+  p25: number
+  p50: number
+  p75: number
+  p90: number
+}
+
+/**
+ * Computes p25/p50/p75/p90 using linear interpolation between adjacent sorted
+ * values. Identical to numpy's default (linear) method. Returns zeros for an
+ * empty input.
+ */
+export function computePercentiles(values: number[]): PercentileSet {
+  if (values.length === 0) return { p25: 0, p50: 0, p75: 0, p90: 0 }
+  const sorted = [...values].sort((a, b) => a - b)
+  const at = (p: number): number => {
+    const idx = (p / 100) * (sorted.length - 1)
+    const lo = Math.floor(idx)
+    const hi = Math.ceil(idx)
+    if (lo === hi) return sorted[lo]!
+    return sorted[lo]! + (sorted[hi]! - sorted[lo]!) * (idx - lo)
+  }
+  return {
+    p25: Math.round(at(25) * 1000) / 1000,
+    p50: Math.round(at(50) * 1000) / 1000,
+    p75: Math.round(at(75) * 1000) / 1000,
+    p90: Math.round(at(90) * 1000) / 1000,
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts `scripts/percentile-utils.ts` with a single canonical `computePercentiles` implementation using **linear interpolation** (the method already used by `calibrate-docs.ts`, equivalent to numpy's default)
- Removes the diverging `Math.ceil` nearest-rank implementations from `scripts/calibrate-legacy.ts` and `scripts/calibrate.ts`, and the duplicate linear implementation from `scripts/calibrate-docs.ts`
- All three scripts now share one algorithm — future calibration runs will produce comparable anchors across all signal types
- Also fixes a stray `p90Value` helper in `calibrate.ts` that directly called the now-removed local `percentile()` function

**Algorithm difference (for reference):** on a 10-element distribution `[1..10]`:
| Percentile | Old (`Math.ceil`) | New (linear interpolation) |
|---|---|---|
| p25 | 3 | 3.25 |
| p90 | 9 | 9.1 |

The current `calibration-data.json` was generated with the legacy method. The next calibration run will use the unified algorithm and produce a fresh, consistent snapshot.

## Test plan

- [x] `npx vitest run scripts/percentile-utils.test.ts` — 9 tests pass, including two divergence tests explicitly asserting the old and new algorithms give different results for the same distribution, plus edge cases (empty array, single element, known values)
- [x] `npx tsc --noEmit` — no type errors

Part of the pre-Phase-2 code quality audit. Closes DRY-05 from PR #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)