### PR TITLE
fix(#440): show raw URL slugs in textarea; suppress auto-trigger on invalid slug

### DIFF
--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -30,7 +30,7 @@ import type { AspirantReadinessResult, CNCFFieldBadge, FoundationTarget } from '
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition, ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
-import { decodeRepos, decodeFoundationUrl, encodeFoundationUrl } from '@/lib/export/shareable-url'
+import { decodeRepos, decodeFoundationUrl, encodeFoundationUrl, isValidRepoSlug } from '@/lib/export/shareable-url'
 import { parseRepos } from '@/lib/parse-repos'
 import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
 import { fetchBoardRepos, type SkippedIssue } from '@/lib/foundation/fetch-board-repos'
@@ -47,8 +47,15 @@ interface RepoInputClientProps {
 export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProps) {
   const { session } = useAuth()
   const searchParams = useSearchParams()
+  // Raw slugs for textarea display — show everything from the URL including invalid entries
+  // so users can see and correct them. decodeRepos (validated) is used only for auto-trigger gating.
+  const initialRawRepos = (() => {
+    const raw = new URLSearchParams(searchParams.toString()).get('repos')
+    if (!raw) return []
+    return raw.split(',').map((s) => s.trim()).filter(Boolean)
+  })()
+  const initialRepoValue = initialRawRepos.join('\n')
   const initialRepos = decodeRepos(searchParams.toString())
-  const initialRepoValue = initialRepos.join('\n')
   const initialFoundationState = decodeFoundationUrl(searchParams.toString())
   const initialFoundationTarget = (initialFoundationState?.foundation ?? 'cncf-sandbox') as FoundationTarget
   const initialTab = (searchParams.get('tab') ?? 'overview') as ResultTabId
@@ -388,7 +395,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   useEffect(() => {
     if (autoTriggeredRef.current) return
     if (!session?.token) return
-    if (initialRepos.length === 0) return
+    if (initialRawRepos.length === 0) return
+    if (!initialRawRepos.every(isValidRepoSlug)) return
 
     autoTriggeredRef.current = true
     const parsed = parseRepos(initialRepoValue)


### PR DESCRIPTION
## Summary

Fixes #440 — regression introduced by PR #436 (NEW-06), where `decodeRepos` filtering caused invalid slugs to be silently dropped before populating the textarea.

- **Textarea pre-population** now uses raw URL slugs (split on `,`, trim, filter blanks) — invalid entries are shown so users can see and correct them
- **Auto-trigger guard** now checks `initialRawRepos.every(isValidRepoSlug)` instead of just `initialRepos.length === 0` — suppresses analysis when any slug in the URL is invalid
- Analysis-path validation via `decodeRepos` / `isValidRepoSlug` is unchanged

**One file changed:** `components/repo-input/RepoInputClient.tsx` (+11 / -3)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run components/repo-input/RepoInputClient.test.tsx` — all 22 tests pass (including the previously failing `does not auto-trigger analysis when the param contains an invalid slug`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)