### PR TITLE
fix(CON-04): sync stale spec contract with AnalyzeResponse implementation

### DIFF
--- a/specs/003-data-fetching/contracts/analysis-result.ts
+++ b/specs/003-data-fetching/contracts/analysis-result.ts
@@ -31,14 +31,25 @@ export interface RepositoryFetchFailure {
   code: string
 }
 
+export interface AnalysisDiagnostic {
+  level: 'warn' | 'error'
+  repo: string
+  source: string
+  message: string
+  status?: number
+  retryAfter?: number | Unavailable
+}
+
 export interface RateLimitState {
+  limit: number | Unavailable
   remaining: number | Unavailable
   resetAt: string | Unavailable
   retryAfter: number | Unavailable
 }
 
-export interface AnalyzeApiResponse {
+export interface AnalyzeResponse {
   results: AnalysisResult[]
   failures: RepositoryFetchFailure[]
   rateLimit: RateLimitState | null
+  diagnostics?: AnalysisDiagnostic[]
 }


### PR DESCRIPTION
## Summary

- Adds `AnalysisDiagnostic` interface (was entirely absent from the contract)
- Adds `limit: number | Unavailable` to `RateLimitState`
- Adds `diagnostics?: AnalysisDiagnostic[]` to the response type
- Renames `AnalyzeApiResponse` → `AnalyzeResponse` to match the live implementation in `lib/analyzer/analysis-result.ts`

Spec contract: `specs/003-data-fetching/contracts/analysis-result.ts`

Part of the **Fix Soon** stage of the pre-Phase-2 audit (#427). This is sub-PR B (CON-04).

## Test plan

- [x] `npm run typecheck` passes (tsc --noEmit clean)
- [x] No references to `AnalyzeApiResponse` anywhere in `specs/` (verified: zero hits)
- [x] Manually confirm contract interfaces match `lib/analyzer/analysis-result.ts` field-for-field for the three changed types

🤖 Generated with [Claude Code](https://claude.com/claude-code)