### PR TITLE
refactor(DRY-03): extract makeInsufficientScore factory

### DIFF
--- a/lib/activity/score-config.ts
+++ b/lib/activity/score-config.ts
@@ -13,6 +13,7 @@ import {
   percentileToTone,
 } from '@/lib/scoring/config-loader'
 import { formatHours, formatPercentage } from '@/lib/scoring/formatters'
+import { makeInsufficientScore } from '@/lib/scoring/insufficient'
 
 export { formatHours, formatPercentage }
 
@@ -72,20 +73,15 @@ const ACTIVITY_FACTORS: ActivityFactorDefinition[] = [
   },
 ]
 
-const INSUFFICIENT_SCORE: ActivityScoreDefinition = {
-  value: 'Insufficient verified public data',
-  tone: 'neutral',
+const INSUFFICIENT_SCORE: ActivityScoreDefinition = makeInsufficientScore({
   description: 'RepoPulse cannot verify enough recent activity and delivery-flow data to score this repository yet.',
   summary: 'Verified recent-flow inputs are incomplete.',
-  percentile: 0,
-  bracketLabel: '',
   weightedFactors: ACTIVITY_FACTORS.map((factor) => ({
     label: factor.label,
     weightLabel: `${factor.weight}%`,
     description: factor.description,
   })),
-  missingInputs: [],
-}
+})
 
 export function getActivityScore(
   result: AnalysisResult,

--- a/lib/contributors/score-config.ts
+++ b/lib/contributors/score-config.ts
@@ -2,6 +2,7 @@ import type { AnalysisResult, ContributorWindowDays, Unavailable } from '@/lib/a
 import type { ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
 import { MATURITY_CONFIG, type CalibrationProfile, formatPercentileLabel, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
 import { formatPercentage } from '@/lib/scoring/formatters'
+import { makeInsufficientScore } from '@/lib/scoring/insufficient'
 
 export { formatPercentage }
 
@@ -71,23 +72,18 @@ const CONTRIBUTORS_FACTORS: ContributorsFactorDefinition[] = [
   },
 ]
 
-const INSUFFICIENT_SCORE: ContributorsScoreDefinition = {
-  value: 'Insufficient verified public data',
-  tone: 'neutral',
+const INSUFFICIENT_SCORE: ContributorsScoreDefinition = makeInsufficientScore({
   description: 'RepoPulse cannot verify enough contributor-distribution data to score contributors yet.',
   summary: 'Verified contributor-distribution inputs are incomplete.',
-  percentile: 0,
-  bracketLabel: '',
-  concentration: 'unavailable',
-  topContributorCount: 'unavailable',
-  contributorCount: 'unavailable',
+  concentration: 'unavailable' as const,
+  topContributorCount: 'unavailable' as const,
+  contributorCount: 'unavailable' as const,
   weightedFactors: CONTRIBUTORS_FACTORS.map((factor) => ({
     label: factor.label,
     weightLabel: `${factor.weight}%`,
     description: factor.description,
   })),
-  missingInputs: [],
-}
+})
 
 export interface ContributorsScoreExtras {
   maintainerCount?: number | Unavailable

--- a/lib/responsiveness/score-config.ts
+++ b/lib/responsiveness/score-config.ts
@@ -2,6 +2,7 @@ import { ACTIVITY_WINDOW_DAYS, type ActivityWindowDays, type AnalysisResult, typ
 import type { ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
 import { type BracketCalibration, type CalibrationProfile, formatPercentileLabel, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
 import { formatCount, formatHours, formatPercentage } from '@/lib/scoring/formatters'
+import { makeInsufficientScore } from '@/lib/scoring/insufficient'
 
 export { formatCount, formatHours, formatPercentage }
 
@@ -61,20 +62,15 @@ const RESPONSIVENESS_CATEGORIES: WeightedCategoryDefinition[] = [
   },
 ]
 
-const INSUFFICIENT_SCORE: ResponsivenessScoreDefinition = {
-  value: 'Insufficient verified public data',
-  tone: 'neutral',
+const INSUFFICIENT_SCORE: ResponsivenessScoreDefinition = makeInsufficientScore({
   description: 'RepoPulse cannot verify enough public issue and pull-request event history to score this repository yet.',
   summary: 'Verified responsiveness inputs are incomplete.',
-  percentile: 0,
-  bracketLabel: '',
   weightedCategories: RESPONSIVENESS_CATEGORIES.map((category) => ({
     label: category.label,
     weightLabel: `${category.weight}%`,
     description: category.description,
   })),
-  missingInputs: [],
-}
+})
 
 export function getResponsivenessScore(
   result: AnalysisResult,

--- a/lib/scoring/insufficient.test.ts
+++ b/lib/scoring/insufficient.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { buildResult } from '@/lib/testing/fixtures'
+import { getActivityScore } from '@/lib/activity/score-config'
+import { getResponsivenessScore } from '@/lib/responsiveness/score-config'
+import { getContributorsScore } from '@/lib/contributors/score-config'
+
+describe('insufficient score value parity', () => {
+  it('all scoring modules return the same value string when all inputs are unavailable', () => {
+    const result = buildResult()
+    expect(getActivityScore(result).value).toBe('Insufficient verified public data')
+    expect(getResponsivenessScore(result).value).toBe('Insufficient verified public data')
+    expect(getContributorsScore(result).value).toBe('Insufficient verified public data')
+  })
+
+  it('all scoring modules return neutral tone when all inputs are unavailable', () => {
+    const result = buildResult()
+    expect(getActivityScore(result).tone).toBe('neutral')
+    expect(getResponsivenessScore(result).tone).toBe('neutral')
+    expect(getContributorsScore(result).tone).toBe('neutral')
+  })
+})

--- a/lib/scoring/insufficient.ts
+++ b/lib/scoring/insufficient.ts
@@ -1,0 +1,24 @@
+export function makeInsufficientScore<T extends { description: string; summary: string }>(
+  fields: T,
+): {
+  value: 'Insufficient verified public data'
+  tone: 'neutral'
+  percentile: 0
+  bracketLabel: ''
+  missingInputs: string[]
+} & T {
+  return {
+    value: 'Insufficient verified public data',
+    tone: 'neutral',
+    percentile: 0,
+    bracketLabel: '',
+    missingInputs: [],
+    ...fields,
+  } as {
+    value: 'Insufficient verified public data'
+    tone: 'neutral'
+    percentile: 0
+    bracketLabel: ''
+    missingInputs: string[]
+  } & T
+}


### PR DESCRIPTION
## Summary

- **Audit item**: DRY-03 — `INSUFFICIENT_SCORE` object literal copy-pasted across three score-config modules
- Extracts shared constant fields (`value`, `tone`, `percentile`, `bracketLabel`, `missingInputs`) into `makeInsufficientScore()` in `lib/scoring/insufficient.ts`
- Each module now calls the factory with its module-specific fields (`description`, `summary`, `weightedFactors`/`weightedCategories`, plus contributors' `concentration`/`topContributorCount`/`contributorCount`)
- Adds `lib/scoring/insufficient.test.ts` — cross-module regression test that verifies `value` and `tone` match across all three scoring modules when all inputs are `'unavailable'`

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run lib/scoring/insufficient.test.ts` — 2 tests pass (value parity, tone parity)
- [x] `npx vitest run lib/activity/score-config.test.ts lib/responsiveness/score-config.test.ts lib/contributors/score-config.test.ts` — 15 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)