### PR TITLE
fix(agent): skip project MCP servers on launch to prevent playwright hang

### DIFF
--- a/lib/activity/score-config.ts
+++ b/lib/activity/score-config.ts
@@ -13,6 +13,7 @@ import {
   percentileToTone,
 } from '@/lib/scoring/config-loader'
 import { formatHours, formatPercentage } from '@/lib/scoring/formatters'
+import { makeInsufficientScore } from '@/lib/scoring/insufficient'
 
 export { formatHours, formatPercentage }
 
@@ -72,20 +73,15 @@ const ACTIVITY_FACTORS: ActivityFactorDefinition[] = [
   },
 ]
 
-const INSUFFICIENT_SCORE: ActivityScoreDefinition = {
-  value: 'Insufficient verified public data',
-  tone: 'neutral',
+const INSUFFICIENT_SCORE: ActivityScoreDefinition = makeInsufficientScore({
   description: 'RepoPulse cannot verify enough recent activity and delivery-flow data to score this repository yet.',
   summary: 'Verified recent-flow inputs are incomplete.',
-  percentile: 0,
-  bracketLabel: '',
   weightedFactors: ACTIVITY_FACTORS.map((factor) => ({
     label: factor.label,
     weightLabel: `${factor.weight}%`,
     description: factor.description,
   })),
-  missingInputs: [],
-}
+})
 
 export function getActivityScore(
   result: AnalysisResult,

--- a/lib/contributors/score-config.ts
+++ b/lib/contributors/score-config.ts
@@ -2,6 +2,7 @@ import type { AnalysisResult, ContributorWindowDays, Unavailable } from '@/lib/a
 import type { ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
 import { MATURITY_CONFIG, type CalibrationProfile, formatPercentileLabel, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
 import { formatPercentage } from '@/lib/scoring/formatters'
+import { makeInsufficientScore } from '@/lib/scoring/insufficient'
 
 export { formatPercentage }
 
@@ -71,23 +72,18 @@ const CONTRIBUTORS_FACTORS: ContributorsFactorDefinition[] = [
   },
 ]
 
-const INSUFFICIENT_SCORE: ContributorsScoreDefinition = {
-  value: 'Insufficient verified public data',
-  tone: 'neutral',
+const INSUFFICIENT_SCORE: ContributorsScoreDefinition = makeInsufficientScore({
   description: 'RepoPulse cannot verify enough contributor-distribution data to score contributors yet.',
   summary: 'Verified contributor-distribution inputs are incomplete.',
-  percentile: 0,
-  bracketLabel: '',
-  concentration: 'unavailable',
-  topContributorCount: 'unavailable',
-  contributorCount: 'unavailable',
+  concentration: 'unavailable' as const,
+  topContributorCount: 'unavailable' as const,
+  contributorCount: 'unavailable' as const,
   weightedFactors: CONTRIBUTORS_FACTORS.map((factor) => ({
     label: factor.label,
     weightLabel: `${factor.weight}%`,
     description: factor.description,
   })),
-  missingInputs: [],
-}
+})
 
 export interface ContributorsScoreExtras {
   maintainerCount?: number | Unavailable

--- a/lib/responsiveness/score-config.ts
+++ b/lib/responsiveness/score-config.ts
@@ -2,6 +2,7 @@ import { ACTIVITY_WINDOW_DAYS, type ActivityWindowDays, type AnalysisResult, typ
 import type { ScoreTone, ScoreValue } from '@/specs/008-metric-cards/contracts/metric-card-props'
 import { type BracketCalibration, type CalibrationProfile, formatPercentileLabel, getBracketLabel, getCalibrationForStars, interpolatePercentile, percentileToTone } from '@/lib/scoring/config-loader'
 import { formatCount, formatHours, formatPercentage } from '@/lib/scoring/formatters'
+import { makeInsufficientScore } from '@/lib/scoring/insufficient'
 
 export { formatCount, formatHours, formatPercentage }
 
@@ -61,20 +62,15 @@ const RESPONSIVENESS_CATEGORIES: WeightedCategoryDefinition[] = [
   },
 ]
 
-const INSUFFICIENT_SCORE: ResponsivenessScoreDefinition = {
-  value: 'Insufficient verified public data',
-  tone: 'neutral',
+const INSUFFICIENT_SCORE: ResponsivenessScoreDefinition = makeInsufficientScore({
   description: 'RepoPulse cannot verify enough public issue and pull-request event history to score this repository yet.',
   summary: 'Verified responsiveness inputs are incomplete.',
-  percentile: 0,
-  bracketLabel: '',
   weightedCategories: RESPONSIVENESS_CATEGORIES.map((category) => ({
     label: category.label,
     weightLabel: `${category.weight}%`,
     description: category.description,
   })),
-  missingInputs: [],
-}
+})
 
 export function getResponsivenessScore(
   result: AnalysisResult,

--- a/lib/scoring/insufficient.test.ts
+++ b/lib/scoring/insufficient.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { buildResult } from '@/lib/testing/fixtures'
+import { getActivityScore } from '@/lib/activity/score-config'
+import { getResponsivenessScore } from '@/lib/responsiveness/score-config'
+import { getContributorsScore } from '@/lib/contributors/score-config'
+
+describe('insufficient score value parity', () => {
+  it('all scoring modules return the same value string when all inputs are unavailable', () => {
+    const result = buildResult()
+    expect(getActivityScore(result).value).toBe('Insufficient verified public data')
+    expect(getResponsivenessScore(result).value).toBe('Insufficient verified public data')
+    expect(getContributorsScore(result).value).toBe('Insufficient verified public data')
+  })
+
+  it('all scoring modules return neutral tone when all inputs are unavailable', () => {
+    const result = buildResult()
+    expect(getActivityScore(result).tone).toBe('neutral')
+    expect(getResponsivenessScore(result).tone).toBe('neutral')
+    expect(getContributorsScore(result).tone).toBe('neutral')
+  })
+})

--- a/lib/scoring/insufficient.ts
+++ b/lib/scoring/insufficient.ts
@@ -1,0 +1,24 @@
+export function makeInsufficientScore<T extends { description: string; summary: string }>(
+  fields: T,
+): {
+  value: 'Insufficient verified public data'
+  tone: 'neutral'
+  percentile: 0
+  bracketLabel: ''
+  missingInputs: string[]
+} & T {
+  return {
+    value: 'Insufficient verified public data',
+    tone: 'neutral',
+    percentile: 0,
+    bracketLabel: '',
+    missingInputs: [],
+    ...fields,
+  } as {
+    value: 'Insufficient verified public data'
+    tone: 'neutral'
+    percentile: 0
+    bracketLabel: ''
+    missingInputs: string[]
+  } & T
+}

--- a/scripts/agents/claude.sh
+++ b/scripts/agents/claude.sh
@@ -6,15 +6,19 @@ agent_launch() {
   local wt="$1" issue="$2" port="$3" session_id="$4" kickoff="$5" headless="$6"
 
   cd "$wt"
+  # --strict-mcp-config with no --mcp-config disables project MCP servers for this
+  # session. Without it, servers like playwright (npx @playwright/mcp@latest, no -y)
+  # can hang waiting for an interactive install prompt that never arrives because
+  # Claude Code has already taken over stdin/stdout for MCP communication.
   if (( headless )); then
-    nohup claude -p "$kickoff" --session-id "$session_id" > agent.log 2>&1 &
+    nohup claude -p "$kickoff" --session-id "$session_id" --strict-mcp-config > agent.log 2>&1 &
     local pid=$!
     echo "agent-pid=$pid" >> ".agent"
     echo "Claude (headless) PID $pid — log: $wt/agent.log"
     echo "Session ID: $session_id (recorded in $wt/.agent)"
     echo "Release the pause with: scripts/agent.sh --approve-spec $issue"
   else
-    exec claude --session-id "$session_id" "$kickoff"
+    exec claude --session-id "$session_id" --strict-mcp-config "$kickoff"
   fi
 }
 


### PR DESCRIPTION
## Summary

- `playwright` MCP plugin config uses `npx @playwright/mcp@latest` **without `-y`**, so `npx` waits for an interactive install-confirmation prompt
- Once Claude Code has taken over stdin/stdout for MCP communication, that prompt never receives a response → silent hang after `simple-git-hooks` prints its `[INFO]` messages
- Fix: add `--strict-mcp-config` (no `--mcp-config`) to both headless and interactive agent launches, which disables all project MCP servers for agent sessions
- Agents use built-in tools (`Bash`, `Read`, `Edit`, `Grep`, `Glob`) for coding work and don't need `playwright`, `github MCP`, or `context7`

## Root cause

```
# playwright plugin config (~/.claude/plugins/.../playwright/.mcp.json)
{ "command": "npx", "args": ["@playwright/mcp@latest"] }
#                                                ↑ no -y → hangs waiting for user input
```

vs. context7 which correctly uses `-y`:
```
{ "command": "npx", "args": ["-y", "@upstash/context7-mcp"] }
```

## Test plan

- [x] Run `./scripts/agent.sh --no-speckit 437` and confirm it gets past startup without hanging
- [x] Run `./scripts/agent.sh --headless 437` and confirm `agent.log` starts receiving output

🤖 Generated with [Claude Code](https://claude.com/claude-code)