### PR TITLE
refactor(DRY-04): extract PanelShell wrapper to eliminate 12× panel chrome duplication

### DIFF
--- a/components/org-summary/PanelShell.test.tsx
+++ b/components/org-summary/PanelShell.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PanelShell } from './PanelShell'
+import type { AggregatePanel } from '@/lib/org-aggregation/types'
+
+function makePanel(overrides: Partial<AggregatePanel<string>> = {}): AggregatePanel<string> {
+  return {
+    panelId: 'activity-rollup',
+    contributingReposCount: 1,
+    totalReposInRun: 1,
+    status: 'final',
+    value: null,
+    lastUpdatedAt: null,
+    ...overrides,
+  }
+}
+
+describe('PanelShell', () => {
+  it('renders EmptyState when in-progress and value is null', () => {
+    render(
+      <PanelShell label="Test" panel={makePanel({ status: 'in-progress', value: null })} noDataMessage="No data">
+        <span>body</span>
+      </PanelShell>,
+    )
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.queryByText('body')).not.toBeInTheDocument()
+  })
+
+  it('renders noDataMessage when status is unavailable', () => {
+    render(
+      <PanelShell label="Test" panel={makePanel({ status: 'unavailable', value: null })} noDataMessage="No data.">
+        <span>body</span>
+      </PanelShell>,
+    )
+    expect(screen.getByText('No data.')).toBeInTheDocument()
+    expect(screen.queryByText('body')).not.toBeInTheDocument()
+  })
+
+  it('renders noDataMessage when value is null and status is final', () => {
+    render(
+      <PanelShell label="Test" panel={makePanel({ status: 'final', value: null })} noDataMessage="Nothing here.">
+        <span>body</span>
+      </PanelShell>,
+    )
+    expect(screen.getByText('Nothing here.')).toBeInTheDocument()
+    expect(screen.queryByText('body')).not.toBeInTheDocument()
+  })
+
+  it('renders children when value is present', () => {
+    render(
+      <PanelShell label="Test" panel={makePanel({ status: 'final', value: 'data' })} noDataMessage="No data.">
+        <span>body content</span>
+      </PanelShell>,
+    )
+    expect(screen.getByText('body content')).toBeInTheDocument()
+    expect(screen.queryByText('No data.')).not.toBeInTheDocument()
+  })
+
+  it('renders the label in the heading', () => {
+    render(
+      <PanelShell label="My Panel" panel={makePanel({ status: 'final', value: 'x' })} noDataMessage="No data.">
+        <span>body</span>
+      </PanelShell>,
+    )
+    expect(screen.getByRole('heading', { name: 'My Panel' })).toBeInTheDocument()
+  })
+
+  it('uses ariaLabel for the section aria-label when provided', () => {
+    const { container } = render(
+      <PanelShell label="Short label" ariaLabel="Long aria label" panel={makePanel({ status: 'final', value: 'x' })} noDataMessage="No data.">
+        <span>body</span>
+      </PanelShell>,
+    )
+    expect(container.querySelector('section')?.getAttribute('aria-label')).toBe('Long aria label')
+  })
+
+  it('shows the lastUpdatedAt timestamp when present', () => {
+    const date = new Date(2026, 3, 24, 14, 30, 0)
+    render(
+      <PanelShell label="Test" panel={makePanel({ status: 'final', value: 'x', lastUpdatedAt: date })} noDataMessage="No data.">
+        <span>body</span>
+      </PanelShell>,
+    )
+    expect(screen.getByText(/updated/)).toBeInTheDocument()
+  })
+})

--- a/components/org-summary/PanelShell.tsx
+++ b/components/org-summary/PanelShell.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import type { AggregatePanel } from '@/lib/org-aggregation/types'
+import { EmptyState } from './EmptyState'
+
+interface Props {
+  label: string
+  ariaLabel?: string
+  panel: AggregatePanel<unknown>
+  noDataMessage: string
+  children: React.ReactNode
+}
+
+export function PanelShell({ label, ariaLabel, panel, noDataMessage, children }: Props) {
+  return (
+    <section
+      aria-label={ariaLabel ?? label}
+      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+    >
+      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{label}</h3>
+        {panel.lastUpdatedAt ? (
+          <span className="text-xs text-slate-400 dark:text-slate-500">
+            updated {panel.lastUpdatedAt.toLocaleTimeString()}
+          </span>
+        ) : null}
+      </header>
+
+      {panel.status === 'in-progress' && !panel.value ? (
+        <EmptyState />
+      ) : panel.status === 'unavailable' || !panel.value ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">{noDataMessage}</p>
+      ) : (
+        children
+      )}
+    </section>
+  )
+}

--- a/components/org-summary/panels/ActivityRollupPanel.tsx
+++ b/components/org-summary/panels/ActivityRollupPanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 export function ActivityRollupPanel({ panel }: Props) {
   return (
     <PanelShell label="Activity rollup" panel={panel} noDataMessage="No activity data available across this run.">
-      <Body value={panel.value!} />
+      {panel.value ? <Body value={panel.value} /> : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/ActivityRollupPanel.tsx
+++ b/components/org-summary/panels/ActivityRollupPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { ActivityRollupValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props {
   panel: AggregatePanel<ActivityRollupValue>
@@ -10,29 +10,9 @@ interface Props {
 
 export function ActivityRollupPanel({ panel }: Props) {
   return (
-    <section
-      aria-label="Activity rollup"
-      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
-    >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Activity rollup</h3>
-        {panel.lastUpdatedAt ? (
-          <span className="text-xs text-slate-400 dark:text-slate-500">
-            updated {panel.lastUpdatedAt.toLocaleTimeString()}
-          </span>
-        ) : null}
-      </header>
-
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          No activity data available across this run.
-        </p>
-      ) : (
-        <Body value={panel.value} />
-      )}
-    </section>
+    <PanelShell label="Activity rollup" panel={panel} noDataMessage="No activity data available across this run.">
+      <Body value={panel.value!} />
+    </PanelShell>
   )
 }
 

--- a/components/org-summary/panels/AdoptersPanel.tsx
+++ b/components/org-summary/panels/AdoptersPanel.tsx
@@ -11,22 +11,24 @@ interface Props {
 export function AdoptersPanel({ panel }: Props) {
   return (
     <PanelShell label="Adopters" panel={panel} noDataMessage="No ADOPTERS.md found across this run.">
-      <div>
-        <p className="text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
-          ADOPTERS.md found in <span className="font-medium">{panel.value!.flagshipUsed}</span>
-        </p>
-        {panel.value!.entries.length > 0 ? (
-          <ul className="mt-2 list-disc pl-5 text-sm text-slate-600 dark:text-slate-400 dark:text-slate-300">
-            {panel.value!.entries.map((entry, i) => (
-              <li key={i}>{entry}</li>
-            ))}
-          </ul>
-        ) : (
-          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-            Full adopter parsing deferred to a future issue.
+      {panel.value ? (
+        <div>
+          <p className="text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
+            ADOPTERS.md found in <span className="font-medium">{panel.value.flagshipUsed}</span>
           </p>
-        )}
-      </div>
+          {panel.value.entries.length > 0 ? (
+            <ul className="mt-2 list-disc pl-5 text-sm text-slate-600 dark:text-slate-400 dark:text-slate-300">
+              {panel.value.entries.map((entry, i) => (
+                <li key={i}>{entry}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Full adopter parsing deferred to a future issue.
+            </p>
+          )}
+        </div>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/AdoptersPanel.tsx
+++ b/components/org-summary/panels/AdoptersPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { AdoptersValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props {
   panel: AggregatePanel<AdoptersValue>
@@ -10,43 +10,23 @@ interface Props {
 
 export function AdoptersPanel({ panel }: Props) {
   return (
-    <section
-      aria-label="Adopters"
-      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
-    >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Adopters</h3>
-        {panel.lastUpdatedAt ? (
-          <span className="text-xs text-slate-400 dark:text-slate-500">
-            updated {panel.lastUpdatedAt.toLocaleTimeString()}
-          </span>
-        ) : null}
-      </header>
-
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          No ADOPTERS.md found across this run.
+    <PanelShell label="Adopters" panel={panel} noDataMessage="No ADOPTERS.md found across this run.">
+      <div>
+        <p className="text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
+          ADOPTERS.md found in <span className="font-medium">{panel.value!.flagshipUsed}</span>
         </p>
-      ) : (
-        <div>
-          <p className="text-sm text-slate-700 dark:text-slate-300 dark:text-slate-200">
-            ADOPTERS.md found in <span className="font-medium">{panel.value.flagshipUsed}</span>
+        {panel.value!.entries.length > 0 ? (
+          <ul className="mt-2 list-disc pl-5 text-sm text-slate-600 dark:text-slate-400 dark:text-slate-300">
+            {panel.value!.entries.map((entry, i) => (
+              <li key={i}>{entry}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            Full adopter parsing deferred to a future issue.
           </p>
-          {panel.value.entries.length > 0 ? (
-            <ul className="mt-2 list-disc pl-5 text-sm text-slate-600 dark:text-slate-400 dark:text-slate-300">
-              {panel.value.entries.map((entry, i) => (
-                <li key={i}>{entry}</li>
-              ))}
-            </ul>
-          ) : (
-            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-              Full adopter parsing deferred to a future issue.
-            </p>
-          )}
-        </div>
-      )}
-    </section>
+        )}
+      </div>
+    </PanelShell>
   )
 }

--- a/components/org-summary/panels/BusFactorPanel.tsx
+++ b/components/org-summary/panels/BusFactorPanel.tsx
@@ -9,13 +9,13 @@ interface Props { panel: AggregatePanel<BusFactorValue> }
 export function BusFactorPanel({ panel }: Props) {
   return (
     <PanelShell label="Bus factor" panel={panel} noDataMessage="No commit author data available.">
-      {panel.value!.highConcentrationRepos.length === 0 ? (
-        <p className="text-sm text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">No repos have a single author contributing &gt;{(panel.value!.threshold * 100).toFixed(0)}% of commits.</p>
+      {panel.value ? panel.value.highConcentrationRepos.length === 0 ? (
+        <p className="text-sm text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">No repos have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits.</p>
       ) : (
         <>
-          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400 dark:text-amber-300">{panel.value!.highConcentrationRepos.length} repo(s) have a single author contributing &gt;{(panel.value!.threshold * 100).toFixed(0)}% of commits</p>
+          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400 dark:text-amber-300">{panel.value.highConcentrationRepos.length} repo(s) have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits</p>
           <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
-            {panel.value!.highConcentrationRepos.map((r) => (
+            {panel.value.highConcentrationRepos.map((r) => (
               <li key={r.repo} className="flex items-center justify-between gap-3 py-2">
                 <span className="truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{r.repo}</span>
                 <span className="text-xs font-medium text-amber-700 dark:text-amber-400 dark:text-amber-300">{(r.topAuthorShare * 100).toFixed(1)}%</span>
@@ -23,7 +23,7 @@ export function BusFactorPanel({ panel }: Props) {
             ))}
           </ul>
         </>
-      )}
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/BusFactorPanel.tsx
+++ b/components/org-summary/panels/BusFactorPanel.tsx
@@ -2,26 +2,20 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { BusFactorValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props { panel: AggregatePanel<BusFactorValue> }
 
 export function BusFactorPanel({ panel }: Props) {
   return (
-    <section aria-label="Bus factor" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Bus factor</h3>
-        {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
-      </header>
-      {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No commit author data available.</p>
-      ) : panel.value.highConcentrationRepos.length === 0 ? (
-        <p className="text-sm text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">No repos have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits.</p>
+    <PanelShell label="Bus factor" panel={panel} noDataMessage="No commit author data available.">
+      {panel.value!.highConcentrationRepos.length === 0 ? (
+        <p className="text-sm text-emerald-700 dark:text-emerald-400 dark:text-emerald-300">No repos have a single author contributing &gt;{(panel.value!.threshold * 100).toFixed(0)}% of commits.</p>
       ) : (
         <>
-          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400 dark:text-amber-300">{panel.value.highConcentrationRepos.length} repo(s) have a single author contributing &gt;{(panel.value.threshold * 100).toFixed(0)}% of commits</p>
+          <p className="mb-3 text-sm text-amber-700 dark:text-amber-400 dark:text-amber-300">{panel.value!.highConcentrationRepos.length} repo(s) have a single author contributing &gt;{(panel.value!.threshold * 100).toFixed(0)}% of commits</p>
           <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
-            {panel.value.highConcentrationRepos.map((r) => (
+            {panel.value!.highConcentrationRepos.map((r) => (
               <li key={r.repo} className="flex items-center justify-between gap-3 py-2">
                 <span className="truncate text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{r.repo}</span>
                 <span className="text-xs font-medium text-amber-700 dark:text-amber-400 dark:text-amber-300">{(r.topAuthorShare * 100).toFixed(1)}%</span>
@@ -30,6 +24,6 @@ export function BusFactorPanel({ panel }: Props) {
           </ul>
         </>
       )}
-    </section>
+    </PanelShell>
   )
 }

--- a/components/org-summary/panels/DocumentationCoveragePanel.tsx
+++ b/components/org-summary/panels/DocumentationCoveragePanel.tsx
@@ -2,35 +2,27 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { DocumentationCoverageValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props { panel: AggregatePanel<DocumentationCoverageValue> }
 
 export function DocumentationCoveragePanel({ panel }: Props) {
   return (
-    <section aria-label="Documentation coverage" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Documentation coverage</h3>
-        {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
-      </header>
-      {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No documentation data available.</p>
-      ) : (
-        <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
-          {panel.value.perCheck.map((c) => (
-            <li key={c.name} className="flex items-center justify-between gap-3 py-2">
-              <span className="text-sm text-slate-800 dark:text-slate-200 capitalize dark:text-slate-100">{c.name.replace(/_/g, ' ')}</span>
-              <div className="flex items-center gap-2">
-                <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
-                  <div className="h-full bg-sky-600 dark:bg-sky-500" style={{ width: `${Math.min(c.presentInPercent, 100)}%` }} />
-                </div>
-                <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">{Math.round(c.presentInPercent)}%</span>
-                <span className="text-xs text-slate-400 dark:text-slate-500">({c.presentReposCount})</span>
+    <PanelShell label="Documentation coverage" panel={panel} noDataMessage="No documentation data available.">
+      <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
+        {panel.value!.perCheck.map((c) => (
+          <li key={c.name} className="flex items-center justify-between gap-3 py-2">
+            <span className="text-sm text-slate-800 dark:text-slate-200 capitalize dark:text-slate-100">{c.name.replace(/_/g, ' ')}</span>
+            <div className="flex items-center gap-2">
+              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+                <div className="h-full bg-sky-600 dark:bg-sky-500" style={{ width: `${Math.min(c.presentInPercent, 100)}%` }} />
               </div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
+              <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">{Math.round(c.presentInPercent)}%</span>
+              <span className="text-xs text-slate-400 dark:text-slate-500">({c.presentReposCount})</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
   )
 }

--- a/components/org-summary/panels/DocumentationCoveragePanel.tsx
+++ b/components/org-summary/panels/DocumentationCoveragePanel.tsx
@@ -9,20 +9,22 @@ interface Props { panel: AggregatePanel<DocumentationCoverageValue> }
 export function DocumentationCoveragePanel({ panel }: Props) {
   return (
     <PanelShell label="Documentation coverage" panel={panel} noDataMessage="No documentation data available.">
-      <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
-        {panel.value!.perCheck.map((c) => (
-          <li key={c.name} className="flex items-center justify-between gap-3 py-2">
-            <span className="text-sm text-slate-800 dark:text-slate-200 capitalize dark:text-slate-100">{c.name.replace(/_/g, ' ')}</span>
-            <div className="flex items-center gap-2">
-              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
-                <div className="h-full bg-sky-600 dark:bg-sky-500" style={{ width: `${Math.min(c.presentInPercent, 100)}%` }} />
+      {panel.value ? (
+        <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
+          {panel.value.perCheck.map((c) => (
+            <li key={c.name} className="flex items-center justify-between gap-3 py-2">
+              <span className="text-sm text-slate-800 dark:text-slate-200 capitalize dark:text-slate-100">{c.name.replace(/_/g, ' ')}</span>
+              <div className="flex items-center gap-2">
+                <div className="h-1.5 w-16 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+                  <div className="h-full bg-sky-600 dark:bg-sky-500" style={{ width: `${Math.min(c.presentInPercent, 100)}%` }} />
+                </div>
+                <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">{Math.round(c.presentInPercent)}%</span>
+                <span className="text-xs text-slate-400 dark:text-slate-500">({c.presentReposCount})</span>
               </div>
-              <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">{Math.round(c.presentInPercent)}%</span>
-              <span className="text-xs text-slate-400 dark:text-slate-500">({c.presentReposCount})</span>
-            </div>
-          </li>
-        ))}
-      </ul>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
+++ b/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
@@ -3,7 +3,7 @@
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { InclusiveNamingRollupValue } from '@/lib/org-aggregation/aggregators/types'
 import { HelpLabel } from '@/components/shared/HelpLabel'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props { panel: AggregatePanel<InclusiveNamingRollupValue> }
 
@@ -15,48 +15,40 @@ const TIER_TOOLTIPS = {
 
 export function InclusiveNamingRollupPanel({ panel }: Props) {
   return (
-    <section aria-label="Inclusive naming" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Inclusive naming</h3>
-        {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
-      </header>
-      {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No inclusive naming data available.</p>
-      ) : (
-        <>
-          <dl className="mb-2 grid grid-cols-2 gap-3 sm:grid-cols-4">
-            <Stat
-              label="Tier 1 violations"
-              tooltip={TIER_TOOLTIPS.tier1}
-              value={panel.value.tier1}
-              tone={panel.value.tier1 > 0 ? 'bad' : 'good'}
-            />
-            <Stat
-              label="Tier 2 violations"
-              tooltip={TIER_TOOLTIPS.tier2}
-              value={panel.value.tier2}
-              tone={panel.value.tier2 > 0 ? 'warn' : 'good'}
-            />
-            <Stat
-              label="Tier 3 violations"
-              tooltip={TIER_TOOLTIPS.tier3}
-              value={panel.value.tier3}
-              tone="neutral"
-            />
-            <Stat
-              label="Repos with violations"
-              tooltip={`${panel.value.reposWithAnyViolation} of ${panel.contributingReposCount} scanned ${panel.contributingReposCount === 1 ? 'repo' : 'repos'} have at least one Tier 1–3 violation.`}
-              value={panel.value.reposWithAnyViolation}
-              denominator={panel.contributingReposCount}
-              tone={panel.value.reposWithAnyViolation > 0 ? 'warn' : 'good'}
-            />
-          </dl>
-          <p className="text-xs text-slate-500 dark:text-slate-400">
-            Tier counts are violation occurrences (one repo can contribute multiple). Hover each label for the tier definition.
-          </p>
-        </>
-      )}
-    </section>
+    <PanelShell label="Inclusive naming" panel={panel} noDataMessage="No inclusive naming data available.">
+      <>
+        <dl className="mb-2 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat
+            label="Tier 1 violations"
+            tooltip={TIER_TOOLTIPS.tier1}
+            value={panel.value!.tier1}
+            tone={panel.value!.tier1 > 0 ? 'bad' : 'good'}
+          />
+          <Stat
+            label="Tier 2 violations"
+            tooltip={TIER_TOOLTIPS.tier2}
+            value={panel.value!.tier2}
+            tone={panel.value!.tier2 > 0 ? 'warn' : 'good'}
+          />
+          <Stat
+            label="Tier 3 violations"
+            tooltip={TIER_TOOLTIPS.tier3}
+            value={panel.value!.tier3}
+            tone="neutral"
+          />
+          <Stat
+            label="Repos with violations"
+            tooltip={`${panel.value!.reposWithAnyViolation} of ${panel.contributingReposCount} scanned ${panel.contributingReposCount === 1 ? 'repo' : 'repos'} have at least one Tier 1–3 violation.`}
+            value={panel.value!.reposWithAnyViolation}
+            denominator={panel.contributingReposCount}
+            tone={panel.value!.reposWithAnyViolation > 0 ? 'warn' : 'good'}
+          />
+        </dl>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Tier counts are violation occurrences (one repo can contribute multiple). Hover each label for the tier definition.
+        </p>
+      </>
+    </PanelShell>
   )
 }
 

--- a/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
+++ b/components/org-summary/panels/InclusiveNamingRollupPanel.tsx
@@ -16,38 +16,40 @@ const TIER_TOOLTIPS = {
 export function InclusiveNamingRollupPanel({ panel }: Props) {
   return (
     <PanelShell label="Inclusive naming" panel={panel} noDataMessage="No inclusive naming data available.">
-      <>
-        <dl className="mb-2 grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Stat
-            label="Tier 1 violations"
-            tooltip={TIER_TOOLTIPS.tier1}
-            value={panel.value!.tier1}
-            tone={panel.value!.tier1 > 0 ? 'bad' : 'good'}
-          />
-          <Stat
-            label="Tier 2 violations"
-            tooltip={TIER_TOOLTIPS.tier2}
-            value={panel.value!.tier2}
-            tone={panel.value!.tier2 > 0 ? 'warn' : 'good'}
-          />
-          <Stat
-            label="Tier 3 violations"
-            tooltip={TIER_TOOLTIPS.tier3}
-            value={panel.value!.tier3}
-            tone="neutral"
-          />
-          <Stat
-            label="Repos with violations"
-            tooltip={`${panel.value!.reposWithAnyViolation} of ${panel.contributingReposCount} scanned ${panel.contributingReposCount === 1 ? 'repo' : 'repos'} have at least one Tier 1–3 violation.`}
-            value={panel.value!.reposWithAnyViolation}
-            denominator={panel.contributingReposCount}
-            tone={panel.value!.reposWithAnyViolation > 0 ? 'warn' : 'good'}
-          />
-        </dl>
-        <p className="text-xs text-slate-500 dark:text-slate-400">
-          Tier counts are violation occurrences (one repo can contribute multiple). Hover each label for the tier definition.
-        </p>
-      </>
+      {panel.value ? (
+        <>
+          <dl className="mb-2 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat
+              label="Tier 1 violations"
+              tooltip={TIER_TOOLTIPS.tier1}
+              value={panel.value.tier1}
+              tone={panel.value.tier1 > 0 ? 'bad' : 'good'}
+            />
+            <Stat
+              label="Tier 2 violations"
+              tooltip={TIER_TOOLTIPS.tier2}
+              value={panel.value.tier2}
+              tone={panel.value.tier2 > 0 ? 'warn' : 'good'}
+            />
+            <Stat
+              label="Tier 3 violations"
+              tooltip={TIER_TOOLTIPS.tier3}
+              value={panel.value.tier3}
+              tone="neutral"
+            />
+            <Stat
+              label="Repos with violations"
+              tooltip={`${panel.value.reposWithAnyViolation} of ${panel.contributingReposCount} scanned ${panel.contributingReposCount === 1 ? 'repo' : 'repos'} have at least one Tier 1–3 violation.`}
+              value={panel.value.reposWithAnyViolation}
+              denominator={panel.contributingReposCount}
+              tone={panel.value.reposWithAnyViolation > 0 ? 'warn' : 'good'}
+            />
+          </dl>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Tier counts are violation occurrences (one repo can contribute multiple). Hover each label for the tier definition.
+          </p>
+        </>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/LanguagesPanel.tsx
+++ b/components/org-summary/panels/LanguagesPanel.tsx
@@ -2,29 +2,21 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { LanguagesValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props { panel: AggregatePanel<LanguagesValue> }
 
 export function LanguagesPanel({ panel }: Props) {
   return (
-    <section aria-label="Languages" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Languages</h3>
-        {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
-      </header>
-      {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No language data available.</p>
-      ) : (
-        <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
-          {panel.value.perLanguage.map((l) => (
-            <li key={l.language} className="flex items-center justify-between gap-3 py-2">
-              <span className="text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{l.language}</span>
-              <span className="text-xs text-slate-500 dark:text-slate-400">{l.repoCount} {l.repoCount === 1 ? 'repo' : 'repos'}</span>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
+    <PanelShell label="Languages" panel={panel} noDataMessage="No language data available.">
+      <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
+        {panel.value!.perLanguage.map((l) => (
+          <li key={l.language} className="flex items-center justify-between gap-3 py-2">
+            <span className="text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{l.language}</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">{l.repoCount} {l.repoCount === 1 ? 'repo' : 'repos'}</span>
+          </li>
+        ))}
+      </ul>
+    </PanelShell>
   )
 }

--- a/components/org-summary/panels/LanguagesPanel.tsx
+++ b/components/org-summary/panels/LanguagesPanel.tsx
@@ -9,14 +9,16 @@ interface Props { panel: AggregatePanel<LanguagesValue> }
 export function LanguagesPanel({ panel }: Props) {
   return (
     <PanelShell label="Languages" panel={panel} noDataMessage="No language data available.">
-      <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
-        {panel.value!.perLanguage.map((l) => (
-          <li key={l.language} className="flex items-center justify-between gap-3 py-2">
-            <span className="text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{l.language}</span>
-            <span className="text-xs text-slate-500 dark:text-slate-400">{l.repoCount} {l.repoCount === 1 ? 'repo' : 'repos'}</span>
-          </li>
-        ))}
-      </ul>
+      {panel.value ? (
+        <ul role="list" className="divide-y divide-slate-200 dark:divide-slate-700">
+          {panel.value.perLanguage.map((l) => (
+            <li key={l.language} className="flex items-center justify-between gap-3 py-2">
+              <span className="text-sm text-slate-800 dark:text-slate-200 dark:text-slate-100">{l.language}</span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">{l.repoCount} {l.repoCount === 1 ? 'repo' : 'repos'}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/ProjectFootprintPanel.tsx
+++ b/components/org-summary/panels/ProjectFootprintPanel.tsx
@@ -12,16 +12,18 @@ interface Props {
 export function ProjectFootprintPanel({ panel }: Props) {
   return (
     <PanelShell label="Project footprint" panel={panel} noDataMessage="No footprint data available across this run.">
-      <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat label="Total stars" value={panel.value!.totalStars} />
-        <Stat label="Total forks" value={panel.value!.totalForks} />
-        <Stat label="Total watchers" value={panel.value!.totalWatchers} />
-        <Stat
-          label="Unique contributors (365d)"
-          value={panel.value!.totalContributors}
-          tooltip="Unique contributors across all analyzed repos in the last 365 days"
-        />
-      </dl>
+      {panel.value ? (
+        <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Total stars" value={panel.value.totalStars} />
+          <Stat label="Total forks" value={panel.value.totalForks} />
+          <Stat label="Total watchers" value={panel.value.totalWatchers} />
+          <Stat
+            label="Unique contributors (365d)"
+            value={panel.value.totalContributors}
+            tooltip="Unique contributors across all analyzed repos in the last 365 days"
+          />
+        </dl>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/ProjectFootprintPanel.tsx
+++ b/components/org-summary/panels/ProjectFootprintPanel.tsx
@@ -2,7 +2,8 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { ProjectFootprintValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import type { Unavailable } from '@/lib/analyzer/analysis-result'
+import { PanelShell } from '../PanelShell'
 
 interface Props {
   panel: AggregatePanel<ProjectFootprintValue>
@@ -10,38 +11,18 @@ interface Props {
 
 export function ProjectFootprintPanel({ panel }: Props) {
   return (
-    <section
-      aria-label="Project footprint"
-      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
-    >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Project footprint</h3>
-        {panel.lastUpdatedAt ? (
-          <span className="text-xs text-slate-400 dark:text-slate-500">
-            updated {panel.lastUpdatedAt.toLocaleTimeString()}
-          </span>
-        ) : null}
-      </header>
-
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          No footprint data available across this run.
-        </p>
-      ) : (
-        <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <Stat label="Total stars" value={panel.value.totalStars} />
-          <Stat label="Total forks" value={panel.value.totalForks} />
-          <Stat label="Total watchers" value={panel.value.totalWatchers} />
-          <Stat
-            label="Unique contributors (365d)"
-            value={panel.value.totalContributors}
-            tooltip="Unique contributors across all analyzed repos in the last 365 days"
-          />
-        </dl>
-      )}
-    </section>
+    <PanelShell label="Project footprint" panel={panel} noDataMessage="No footprint data available across this run.">
+      <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="Total stars" value={panel.value!.totalStars} />
+        <Stat label="Total forks" value={panel.value!.totalForks} />
+        <Stat label="Total watchers" value={panel.value!.totalWatchers} />
+        <Stat
+          label="Unique contributors (365d)"
+          value={panel.value!.totalContributors}
+          tooltip="Unique contributors across all analyzed repos in the last 365 days"
+        />
+      </dl>
+    </PanelShell>
   )
 }
 
@@ -51,7 +32,7 @@ function Stat({
   tooltip,
 }: {
   label: string
-  value: number | 'unavailable'
+  value: number | Unavailable
   tooltip?: string
 }) {
   return (

--- a/components/org-summary/panels/ReleaseCadencePanel.tsx
+++ b/components/org-summary/panels/ReleaseCadencePanel.tsx
@@ -2,7 +2,7 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { ReleaseCadenceValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props {
   panel: AggregatePanel<ReleaseCadenceValue>
@@ -10,29 +10,9 @@ interface Props {
 
 export function ReleaseCadencePanel({ panel }: Props) {
   return (
-    <section
-      aria-label="Release cadence"
-      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
-    >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Release cadence</h3>
-        {panel.lastUpdatedAt ? (
-          <span className="text-xs text-slate-400 dark:text-slate-500">
-            updated {panel.lastUpdatedAt.toLocaleTimeString()}
-          </span>
-        ) : null}
-      </header>
-
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          No release data available across this run.
-        </p>
-      ) : (
-        <Body value={panel.value} />
-      )}
-    </section>
+    <PanelShell label="Release cadence" panel={panel} noDataMessage="No release data available across this run.">
+      <Body value={panel.value!} />
+    </PanelShell>
   )
 }
 

--- a/components/org-summary/panels/ReleaseCadencePanel.tsx
+++ b/components/org-summary/panels/ReleaseCadencePanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 export function ReleaseCadencePanel({ panel }: Props) {
   return (
     <PanelShell label="Release cadence" panel={panel} noDataMessage="No release data available across this run.">
-      <Body value={panel.value!} />
+      {panel.value ? <Body value={panel.value} /> : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/RepoAgePanel.tsx
+++ b/components/org-summary/panels/RepoAgePanel.tsx
@@ -13,22 +13,24 @@ function fmt(d: Date): string {
 export function RepoAgePanel({ panel }: Props) {
   return (
     <PanelShell label="Repo age" panel={panel} noDataMessage="No repo age data available.">
-      <dl className="grid grid-cols-2 gap-3">
-        {panel.value!.newest ? (
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Newest</dt>
-            <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value!.newest.repo}</dd>
-            <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value!.newest.createdAt)}</dd>
-          </div>
-        ) : null}
-        {panel.value!.oldest ? (
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Oldest</dt>
-            <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value!.oldest.repo}</dd>
-            <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value!.oldest.createdAt)}</dd>
-          </div>
-        ) : null}
-      </dl>
+      {panel.value ? (
+        <dl className="grid grid-cols-2 gap-3">
+          {panel.value.newest ? (
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Newest</dt>
+              <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value.newest.repo}</dd>
+              <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value.newest.createdAt)}</dd>
+            </div>
+          ) : null}
+          {panel.value.oldest ? (
+            <div>
+              <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Oldest</dt>
+              <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value.oldest.repo}</dd>
+              <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value.oldest.createdAt)}</dd>
+            </div>
+          ) : null}
+        </dl>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/RepoAgePanel.tsx
+++ b/components/org-summary/panels/RepoAgePanel.tsx
@@ -2,7 +2,7 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { RepoAgeValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props { panel: AggregatePanel<RepoAgeValue> }
 
@@ -12,31 +12,23 @@ function fmt(d: Date): string {
 
 export function RepoAgePanel({ panel }: Props) {
   return (
-    <section aria-label="Repo age" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Repo age</h3>
-        {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
-      </header>
-      {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No repo age data available.</p>
-      ) : (
-        <dl className="grid grid-cols-2 gap-3">
-          {panel.value.newest ? (
-            <div>
-              <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Newest</dt>
-              <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value.newest.repo}</dd>
-              <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value.newest.createdAt)}</dd>
-            </div>
-          ) : null}
-          {panel.value.oldest ? (
-            <div>
-              <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Oldest</dt>
-              <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value.oldest.repo}</dd>
-              <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value.oldest.createdAt)}</dd>
-            </div>
-          ) : null}
-        </dl>
-      )}
-    </section>
+    <PanelShell label="Repo age" panel={panel} noDataMessage="No repo age data available.">
+      <dl className="grid grid-cols-2 gap-3">
+        {panel.value!.newest ? (
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Newest</dt>
+            <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value!.newest.repo}</dd>
+            <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value!.newest.createdAt)}</dd>
+          </div>
+        ) : null}
+        {panel.value!.oldest ? (
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Oldest</dt>
+            <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">{panel.value!.oldest.repo}</dd>
+            <dd className="text-xs text-slate-500 dark:text-slate-400">{fmt(panel.value!.oldest.createdAt)}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </PanelShell>
   )
 }

--- a/components/org-summary/panels/ResponsivenessRollupPanel.tsx
+++ b/components/org-summary/panels/ResponsivenessRollupPanel.tsx
@@ -3,7 +3,7 @@
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { ResponsivenessRollupValue } from '@/lib/org-aggregation/aggregators/types'
 import { HelpLabel } from '@/components/shared/HelpLabel'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props {
   panel: AggregatePanel<ResponsivenessRollupValue>
@@ -18,55 +18,40 @@ function formatHours(hours: number): string {
 
 export function ResponsivenessRollupPanel({ panel }: Props) {
   return (
-    <section
-      aria-label="Responsiveness rollup"
-      className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900"
+    <PanelShell
+      label="Responsiveness"
+      ariaLabel="Responsiveness rollup"
+      panel={panel}
+      noDataMessage="No responsiveness data available across this run."
     >
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Responsiveness</h3>
-        {panel.lastUpdatedAt ? (
-          <span className="text-xs text-slate-400 dark:text-slate-500">
-            updated {panel.lastUpdatedAt.toLocaleTimeString()}
-          </span>
-        ) : null}
-      </header>
-
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          No responsiveness data available across this run.
-        </p>
-      ) : (
-        <dl className="grid grid-cols-2 gap-3">
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              <HelpLabel
-                label="First response (median)"
-                helpText="Weighted median time to first response on issues across the org. Weighted by each repo's open issue count."
-              />
-            </dt>
-            <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-              {panel.value.weightedMedianFirstResponseHours !== null
-                ? formatHours(panel.value.weightedMedianFirstResponseHours)
-                : '—'}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-              <HelpLabel
-                label="PR merge (median)"
-                helpText="Weighted median time to merge pull requests across the org. Weighted by each repo's merged PR count."
-              />
-            </dt>
-            <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-              {panel.value.weightedMedianPrMergeHours !== null
-                ? formatHours(panel.value.weightedMedianPrMergeHours)
-                : '—'}
-            </dd>
-          </div>
-        </dl>
-      )}
-    </section>
+      <dl className="grid grid-cols-2 gap-3">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <HelpLabel
+              label="First response (median)"
+              helpText="Weighted median time to first response on issues across the org. Weighted by each repo's open issue count."
+            />
+          </dt>
+          <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+            {panel.value!.weightedMedianFirstResponseHours !== null
+              ? formatHours(panel.value!.weightedMedianFirstResponseHours)
+              : '—'}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            <HelpLabel
+              label="PR merge (median)"
+              helpText="Weighted median time to merge pull requests across the org. Weighted by each repo's merged PR count."
+            />
+          </dt>
+          <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+            {panel.value!.weightedMedianPrMergeHours !== null
+              ? formatHours(panel.value!.weightedMedianPrMergeHours)
+              : '—'}
+          </dd>
+        </div>
+      </dl>
+    </PanelShell>
   )
 }

--- a/components/org-summary/panels/ResponsivenessRollupPanel.tsx
+++ b/components/org-summary/panels/ResponsivenessRollupPanel.tsx
@@ -24,34 +24,36 @@ export function ResponsivenessRollupPanel({ panel }: Props) {
       panel={panel}
       noDataMessage="No responsiveness data available across this run."
     >
-      <dl className="grid grid-cols-2 gap-3">
-        <div>
-          <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            <HelpLabel
-              label="First response (median)"
-              helpText="Weighted median time to first response on issues across the org. Weighted by each repo's open issue count."
-            />
-          </dt>
-          <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-            {panel.value!.weightedMedianFirstResponseHours !== null
-              ? formatHours(panel.value!.weightedMedianFirstResponseHours)
-              : '—'}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            <HelpLabel
-              label="PR merge (median)"
-              helpText="Weighted median time to merge pull requests across the org. Weighted by each repo's merged PR count."
-            />
-          </dt>
-          <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-            {panel.value!.weightedMedianPrMergeHours !== null
-              ? formatHours(panel.value!.weightedMedianPrMergeHours)
-              : '—'}
-          </dd>
-        </div>
-      </dl>
+      {panel.value ? (
+        <dl className="grid grid-cols-2 gap-3">
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <HelpLabel
+                label="First response (median)"
+                helpText="Weighted median time to first response on issues across the org. Weighted by each repo's open issue count."
+              />
+            </dt>
+            <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              {panel.value.weightedMedianFirstResponseHours !== null
+                ? formatHours(panel.value.weightedMedianFirstResponseHours)
+                : '—'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <HelpLabel
+                label="PR merge (median)"
+                helpText="Weighted median time to merge pull requests across the org. Weighted by each repo's merged PR count."
+              />
+            </dt>
+            <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+              {panel.value.weightedMedianPrMergeHours !== null
+                ? formatHours(panel.value.weightedMedianPrMergeHours)
+                : '—'}
+            </dd>
+          </div>
+        </dl>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/SecurityRollupPanel.tsx
+++ b/components/org-summary/panels/SecurityRollupPanel.tsx
@@ -28,7 +28,7 @@ export function SecurityRollupPanel({ panel }: Props) {
       panel={panel}
       noDataMessage="No security data available across this run."
     >
-      <Body value={panel.value!} />
+      {panel.value ? <Body value={panel.value} /> : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/SecurityRollupPanel.tsx
+++ b/components/org-summary/panels/SecurityRollupPanel.tsx
@@ -3,7 +3,7 @@
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { SecurityRollupValue } from '@/lib/org-aggregation/aggregators/types'
 import { HelpLabel } from '@/components/shared/HelpLabel'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props {
   panel: AggregatePanel<SecurityRollupValue>
@@ -22,22 +22,14 @@ function pct(present: number, total: number): string {
 
 export function SecurityRollupPanel({ panel }: Props) {
   return (
-    <section aria-label="Security rollup" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Security (OpenSSF Scorecard)</h3>
-        {panel.lastUpdatedAt ? (
-          <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span>
-        ) : null}
-      </header>
-
-      {panel.status === 'in-progress' && !panel.value ? (
-        <EmptyState />
-      ) : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No security data available across this run.</p>
-      ) : (
-        <Body value={panel.value} />
-      )}
-    </section>
+    <PanelShell
+      label="Security (OpenSSF Scorecard)"
+      ariaLabel="Security rollup"
+      panel={panel}
+      noDataMessage="No security data available across this run."
+    >
+      <Body value={panel.value!} />
+    </PanelShell>
   )
 }
 

--- a/components/org-summary/panels/StaleWorkPanel.tsx
+++ b/components/org-summary/panels/StaleWorkPanel.tsx
@@ -9,11 +9,13 @@ interface Props { panel: AggregatePanel<StaleWorkValue> }
 export function StaleWorkPanel({ panel }: Props) {
   return (
     <PanelShell label="Stale work" panel={panel} noDataMessage="No stale work data available.">
-      <dl className="grid grid-cols-3 gap-3">
-        <Stat label="Open issues" value={panel.value!.totalOpenIssues.toLocaleString()} />
-        <Stat label="Open PRs (90d)" value={panel.value!.totalOpenPullRequests.toLocaleString()} />
-        <Stat label="Stale issue ratio" value={panel.value!.weightedStaleIssueRatio !== null ? `${(panel.value!.weightedStaleIssueRatio * 100).toFixed(1)}%` : '—'} />
-      </dl>
+      {panel.value ? (
+        <dl className="grid grid-cols-3 gap-3">
+          <Stat label="Open issues" value={panel.value.totalOpenIssues.toLocaleString()} />
+          <Stat label="Open PRs (90d)" value={panel.value.totalOpenPullRequests.toLocaleString()} />
+          <Stat label="Stale issue ratio" value={panel.value.weightedStaleIssueRatio !== null ? `${(panel.value.weightedStaleIssueRatio * 100).toFixed(1)}%` : '—'} />
+        </dl>
+      ) : null}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/StaleWorkPanel.tsx
+++ b/components/org-summary/panels/StaleWorkPanel.tsx
@@ -2,30 +2,27 @@
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
 import type { StaleWorkValue } from '@/lib/org-aggregation/aggregators/types'
-import { EmptyState } from '../EmptyState'
+import { PanelShell } from '../PanelShell'
 
 interface Props { panel: AggregatePanel<StaleWorkValue> }
 
 export function StaleWorkPanel({ panel }: Props) {
   return (
-    <section aria-label="Stale work" className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Stale work</h3>
-        {panel.lastUpdatedAt ? <span className="text-xs text-slate-400 dark:text-slate-500">updated {panel.lastUpdatedAt.toLocaleTimeString()}</span> : null}
-      </header>
-      {panel.status === 'in-progress' && !panel.value ? <EmptyState /> : panel.status === 'unavailable' || !panel.value ? (
-        <p className="text-sm text-slate-500 dark:text-slate-400">No stale work data available.</p>
-      ) : (
-        <dl className="grid grid-cols-3 gap-3">
-          <Stat label="Open issues" value={panel.value.totalOpenIssues.toLocaleString()} />
-          <Stat label="Open PRs (90d)" value={panel.value.totalOpenPullRequests.toLocaleString()} />
-          <Stat label="Stale issue ratio" value={panel.value.weightedStaleIssueRatio !== null ? `${(panel.value.weightedStaleIssueRatio * 100).toFixed(1)}%` : '—'} />
-        </dl>
-      )}
-    </section>
+    <PanelShell label="Stale work" panel={panel} noDataMessage="No stale work data available.">
+      <dl className="grid grid-cols-3 gap-3">
+        <Stat label="Open issues" value={panel.value!.totalOpenIssues.toLocaleString()} />
+        <Stat label="Open PRs (90d)" value={panel.value!.totalOpenPullRequests.toLocaleString()} />
+        <Stat label="Stale issue ratio" value={panel.value!.weightedStaleIssueRatio !== null ? `${(panel.value!.weightedStaleIssueRatio * 100).toFixed(1)}%` : '—'} />
+      </dl>
+    </PanelShell>
   )
 }
 
 function Stat({ label, value }: { label: string; value: string }) {
-  return (<div><dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt><dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">{value}</dd></div>)
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
+      <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">{value}</dd>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary

- **Audit item**: DRY-04 — org-summary panel header/shell markup copy-pasted 7+ times
- Introduces `components/org-summary/PanelShell.tsx` — accepts `label`, `ariaLabel?`, `panel`, `noDataMessage`, and `children`; handles the `<section>`, `<header>`, `lastUpdatedAt` timestamp, `EmptyState` guard, and no-data fallback in one place
- Migrates 12 panels that share the exact same pattern: `ActivityRollupPanel`, `ResponsivenessRollupPanel`, `AdoptersPanel`, `ProjectFootprintPanel`, `StaleWorkPanel`, `BusFactorPanel`, `DocumentationCoveragePanel`, `InclusiveNamingRollupPanel`, `LanguagesPanel`, `RepoAgePanel`, `ReleaseCadencePanel`, `SecurityRollupPanel`
- Panels with special headers (`GovernancePanel`, `LicenseConsistencyPanel`, `ContributorDiversityPanel`, `InactiveReposPanel`, `OrgAffiliationsPanel`, `PlaceholderPanel`) are intentionally left unchanged
- Adds `PanelShell.test.tsx` — 7 unit tests covering all three rendering states

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run components/org-summary/PanelShell.test.tsx` — 7 tests pass (in-progress, unavailable, populated, heading, ariaLabel, timestamp)
- [x] `npx vitest run components/org-summary/panels/InactiveReposPanel.test.tsx components/org-summary/panels/GovernancePanel.test.tsx components/org-summary/panels/registry.test.tsx` — 18 existing panel tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)