### PR TITLE
fix(agent): avoid $() pipe hang when capturing dev-server PID

### DIFF
--- a/scripts/agent.sh
+++ b/scripts/agent.sh
@@ -715,7 +715,12 @@ echo "PORT=$port" >> "$WT_PATH/.env.local"
 ( cd "$WT_PATH" && npm install --silent )
 
 # 4. Start dev server; capture PID for the .agent state file
-DEV_PID="$( cd "$WT_PATH" && nohup npm run dev -- -p "$port" > dev.log 2>&1 & echo $! )"
+# Write PID to a temp file instead of using $() command substitution — $() creates a
+# pipe that Next.js child processes can inherit, causing bash to wait for them before
+# the substitution completes (indefinite hang). cd runs in the subshell foreground (;
+# not &&) so that .dev.pid and dev.log resolve relative to $WT_PATH.
+( cd "$WT_PATH"; nohup npm run dev -- -p "$port" > dev.log 2>&1 & echo $! > .dev.pid )
+DEV_PID="$(cat "$WT_PATH/.dev.pid")"
 echo "Dev server: http://localhost:$port (log: $WT_PATH/dev.log)"
 
 # 5. Generate session UUID and write the .agent state file


### PR DESCRIPTION
## Summary

- `$()` command substitution creates a pipe; bash waits for EOF before the substitution returns
- Next.js forks child processes that inherit the pipe's write-end, so EOF never arrives — **the launch hangs forever** after `npm install` completes
- Fix: use a plain `()` subshell (no pipe) and write the PID to `.dev.pid`, then read with `cat`
- Use `;` not `&&` between `cd` and `nohup` so the `cd` runs in the subshell foreground, ensuring `.dev.pid` and `dev.log` resolve to `$WT_PATH`

## Root cause

```bash
# Before — hangs: $() pipe inherited by Next.js children
DEV_PID="$( cd "$WT_PATH" && nohup npm run dev ... & echo $! )"

# After — fine: () subshell has no pipe; bash doesn't wait for Next.js
( cd "$WT_PATH"; nohup npm run dev ... & echo $! > .dev.pid )
DEV_PID="$(cat "$WT_PATH/.dev.pid")"
```

## Test plan

- [x] Run `./scripts/agent.sh --no-speckit 437` — confirm it gets past the dev-server step and launches Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)