### PR TITLE
refactor(PAT-02): extract useLoadingTimer and useSearchDebounce; fix 3 eslint-disable suppressions

### DIFF
--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import { useLoadingTimer } from './useLoadingTimer'
+import { useSearchDebounce } from './useSearchDebounce'
 import { ResultsShell } from '@/components/app-shell/ResultsShell'
 import { ActivityView } from '@/components/activity/ActivityView'
 import { ContributorsView } from '@/components/contributors/ContributorsView'
@@ -30,11 +32,10 @@ import type { AspirantReadinessResult, CNCFFieldBadge, FoundationTarget } from '
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition, ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
-import { decodeRepos, decodeFoundationUrl, encodeFoundationUrl, isValidRepoSlug } from '@/lib/export/shareable-url'
+import { decodeFoundationUrl, encodeFoundationUrl, isValidRepoSlug } from '@/lib/export/shareable-url'
 import { parseRepos } from '@/lib/parse-repos'
 import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
 import { fetchBoardRepos, type SkippedIssue } from '@/lib/foundation/fetch-board-repos'
-import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
 import { RepoInputForm } from './RepoInputForm'
 import { FoundationResultsView, type FoundationResult } from '@/components/foundation/FoundationResultsView'
 import { FoundationNudge } from '@/components/foundation/FoundationNudge'
@@ -47,16 +48,17 @@ interface RepoInputClientProps {
 export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProps) {
   const { session } = useAuth()
   const searchParams = useSearchParams()
-  // Raw slugs for textarea display — show everything from the URL including invalid entries
-  // so users can see and correct them. decodeRepos (validated) is used only for auto-trigger gating.
-  const initialRawRepos = (() => {
+  // Captured once from URL params on mount. useState initializer gives a stable reference
+  // so these can appear in effect dependency arrays without causing re-runs.
+  // Raw slugs include invalid entries so the textarea shows exactly what was in the URL;
+  // isValidRepoSlug guards the auto-trigger to suppress it for malformed inputs.
+  const [initialRawRepos] = useState(() => {
     const raw = new URLSearchParams(searchParams.toString()).get('repos')
-    if (!raw) return []
+    if (!raw) return [] as string[]
     return raw.split(',').map((s) => s.trim()).filter(Boolean)
-  })()
-  const initialRepoValue = initialRawRepos.join('\n')
-  const initialRepos = decodeRepos(searchParams.toString())
-  const initialFoundationState = decodeFoundationUrl(searchParams.toString())
+  })
+  const [initialRepoValue] = useState(() => initialRawRepos.join('\n'))
+  const [initialFoundationState] = useState(() => decodeFoundationUrl(searchParams.toString()))
   const initialFoundationTarget = (initialFoundationState?.foundation ?? 'cncf-sandbox') as FoundationTarget
   const initialTab = (searchParams.get('tab') ?? 'overview') as ResultTabId
   const autoTriggeredRef = useRef(false)
@@ -69,9 +71,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [loadingOrg, setLoadingOrg] = useState<string | null>(null)
   const [resultsResetKey, setResultsResetKey] = useState(0)
   const [inputMode, setInputMode] = useState<'repos' | 'org' | 'foundation'>('repos')
-  const [elapsedSeconds, setElapsedSeconds] = useState(0)
-  const [emptyQuoteIndex, setEmptyQuoteIndex] = useState(() => getRandomQuoteIndex(null))
-  const [quoteIndex, setQuoteIndex] = useState<number | null>(null)
   const [activeTag, setActiveTag] = useState<string | null>(null)
   const [foundationTarget, setFoundationTarget] = useState<FoundationTarget>(initialFoundationTarget)
   const [aspirantResult, setAspirantResult] = useState<AspirantReadinessResult | null>(null)
@@ -92,72 +91,17 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     ? aspirantResult.autoFields.map((field) => ({ fieldId: field.id, label: field.label, status: field.status }))
     : []
   const [searchQuery, setSearchQuery] = useState('')
-  const [debouncedQuery, setDebouncedQuery] = useState('')
   const [preRunDialogRepos, setPreRunDialogRepos] = useState<string[] | null>(null)
   const [notificationOptIn, setNotificationOptIn] = useState(false)
   const repoFetchAbortRef = useRef<AbortController | null>(null)
   const orgFetchAbortRef = useRef<AbortController | null>(null)
   const foundationFetchAbortRef = useRef<AbortController | null>(null)
   const previousFoundationResultRef = useRef<FoundationResult | null>(null)
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  // Ref so the loading-start effect can read the current emptyQuoteIndex without
-  // re-running (and resetting the elapsed timer) each time the idle quote rotates.
-  const emptyQuoteIndexRef = useRef(emptyQuoteIndex)
-  emptyQuoteIndexRef.current = emptyQuoteIndex
 
   const isLoading = loadingRepos.length > 0 || !!loadingOrg || loadingFoundation
-
-  useEffect(() => {
-    if (isLoading) {
-      setElapsedSeconds(0)
-      setQuoteIndex(emptyQuoteIndexRef.current)
-      timerRef.current = setInterval(() => {
-        setElapsedSeconds((s) => s + 1)
-      }, 1000)
-
-      // Rotate quote every 10 seconds
-      quoteTimerRef.current = setInterval(() => {
-        setQuoteIndex((current) => getRandomQuoteIndex(current))
-      }, 10000)
-
-      return () => {
-        if (timerRef.current) clearInterval(timerRef.current)
-        if (quoteTimerRef.current) clearInterval(quoteTimerRef.current)
-      }
-    }
-
-    if (timerRef.current) {
-      clearInterval(timerRef.current)
-      timerRef.current = null
-    }
-    if (quoteTimerRef.current) {
-      clearInterval(quoteTimerRef.current)
-      quoteTimerRef.current = null
-    }
-    setElapsedSeconds(0)
-    setQuoteIndex(null)
-
-    return undefined
-  // emptyQuoteIndex intentionally excluded — read via ref to avoid resetting elapsed timer
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading])
-
-  const currentQuote = quoteIndex !== null ? LOADING_QUOTES[quoteIndex] : null
-
   const isEmptyState = !submissionError && !loadingRepos.length && !loadingOrg && !analysisResponse && !orgInventoryResponse
 
-  useEffect(() => {
-    if (!isEmptyState) return
-
-    const interval = setInterval(() => {
-      setEmptyQuoteIndex((current) => getRandomQuoteIndex(current))
-    }, 10000)
-
-    return () => clearInterval(interval)
-  }, [isEmptyState])
-
-  const emptyQuote = LOADING_QUOTES[emptyQuoteIndex]
+  const { elapsedSeconds, currentQuote, emptyQuote } = useLoadingTimer(isLoading, isEmptyState)
 
   // Search: DOM-based match counts (populated by ResultsShell after highlighting)
   const [domTotalMatches, setDomTotalMatches] = useState(0)
@@ -265,16 +209,14 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setDomMatchedTabCount(counts.domMatchedTabCount)
   }).current
 
-  // Search: debounce query
+  const debouncedQuery = useSearchDebounce(searchQuery)
+
+  // Reset DOM match counts whenever the search query is cleared
   useEffect(() => {
     if (!searchQuery) {
-      setDebouncedQuery('')
       setDomTotalMatches(0)
       setDomMatchedTabCount(0)
-      return
     }
-    const timeout = setTimeout(() => setDebouncedQuery(searchQuery), 300)
-    return () => clearTimeout(timeout)
   }, [searchQuery])
 
   function handleModeChange(mode: 'repos' | 'org' | 'foundation') {
@@ -291,7 +233,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setSubmissionError(null)
     setResultsResetKey((k) => k + 1)
     setSearchQuery('')
-    setDebouncedQuery('')
     setAspirantResult(null)
     setFoundationResult(null)
     setFoundationError(null)
@@ -392,32 +333,37 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     }
   }, [analysisResponse])
 
+  // Stable latest-value refs so auto-trigger effects can call the handlers without
+  // including them as deps (which would re-run the effect on every render).
+  // Function declarations are hoisted, so these refs are valid here even though
+  // handleSubmit and handleFoundationSubmit are defined later in the file.
+  const handleSubmitRef = useRef(handleSubmit)
+  handleSubmitRef.current = handleSubmit
+  const handleFoundationSubmitRef = useRef(handleFoundationSubmit)
+  handleFoundationSubmitRef.current = handleFoundationSubmit
+
   useEffect(() => {
     if (autoTriggeredRef.current) return
     if (!session?.token) return
     if (initialRawRepos.length === 0) return
     if (!initialRawRepos.every(isValidRepoSlug)) return
-
     autoTriggeredRef.current = true
     const parsed = parseRepos(initialRepoValue)
     if (!parsed.valid) return
-    void handleSubmit(parsed.repos)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session?.token])
+    void handleSubmitRef.current(parsed.repos)
+  }, [session?.token, initialRawRepos, initialRepoValue])
 
   // Auto-trigger Foundation scan when URL has mode=foundation params
   useEffect(() => {
     if (foundationAutoTriggeredRef.current) return
     if (!session?.token) return
     if (!initialFoundationState) return
-
     foundationAutoTriggeredRef.current = true
     setInputMode('foundation')
     setFoundationTarget(initialFoundationState.foundation)
     setFoundationInput(initialFoundationState.input)
-    void handleFoundationSubmit(initialFoundationState.input)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session?.token])
+    void handleFoundationSubmitRef.current(initialFoundationState.input)
+  }, [session?.token, initialFoundationState])
 
   async function handleSubmit(repos: string[]) {
     if (!session?.token) return

--- a/components/repo-input/useLoadingTimer.test.ts
+++ b/components/repo-input/useLoadingTimer.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLoadingTimer } from './useLoadingTimer'
+
+describe('useLoadingTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts elapsed timer when isLoading becomes true', () => {
+    const { result, rerender } = renderHook(({ loading, empty }) => useLoadingTimer(loading, empty), {
+      initialProps: { loading: false, empty: true },
+    })
+    expect(result.current.elapsedSeconds).toBe(0)
+
+    rerender({ loading: true, empty: false })
+    act(() => { vi.advanceTimersByTime(3000) })
+    expect(result.current.elapsedSeconds).toBe(3)
+  })
+
+  it('resets elapsed seconds when loading stops', () => {
+    const { result, rerender } = renderHook(({ loading, empty }) => useLoadingTimer(loading, empty), {
+      initialProps: { loading: true, empty: false },
+    })
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(result.current.elapsedSeconds).toBe(5)
+
+    rerender({ loading: false, empty: true })
+    expect(result.current.elapsedSeconds).toBe(0)
+  })
+
+  it('returns null currentQuote when not loading', () => {
+    const { result } = renderHook(() => useLoadingTimer(false, true))
+    expect(result.current.currentQuote).toBeNull()
+  })
+
+  it('returns a non-null currentQuote while loading', () => {
+    const { result } = renderHook(() => useLoadingTimer(true, false))
+    expect(result.current.currentQuote).not.toBeNull()
+  })
+
+  it('rotates currentQuote every 10 seconds while loading', () => {
+    const { result } = renderHook(() => useLoadingTimer(true, false))
+    const first = result.current.currentQuote
+    act(() => { vi.advanceTimersByTime(10000) })
+    // Quote may or may not change (random), but hook should not throw
+    expect(result.current.currentQuote).toBeDefined()
+    // Advance 5 more rotations — quote rotation runs without error
+    act(() => { vi.advanceTimersByTime(50000) })
+    expect(result.current.currentQuote).toBeDefined()
+    void first
+  })
+
+  it('returns an emptyQuote when not loading', () => {
+    const { result } = renderHook(() => useLoadingTimer(false, true))
+    expect(result.current.emptyQuote).toBeTruthy()
+    expect(typeof result.current.emptyQuote.text).toBe('string')
+  })
+
+  it('rotates emptyQuote every 10 seconds while in empty state', () => {
+    const { result } = renderHook(() => useLoadingTimer(false, true))
+    const first = result.current.emptyQuote
+    // After 10 seconds the quote may change (random); the hook must not throw
+    act(() => { vi.advanceTimersByTime(10000) })
+    expect(result.current.emptyQuote).toBeTruthy()
+    void first
+  })
+
+  it('stops rotating emptyQuote when empty state ends', () => {
+    const { result, rerender } = renderHook(({ loading, empty }) => useLoadingTimer(loading, empty), {
+      initialProps: { loading: false, empty: true },
+    })
+    rerender({ loading: true, empty: false })
+    // Tick 20 seconds — interval should be cleared, no throw
+    act(() => { vi.advanceTimersByTime(20000) })
+    expect(result.current.emptyQuote).toBeTruthy()
+  })
+})

--- a/components/repo-input/useLoadingTimer.ts
+++ b/components/repo-input/useLoadingTimer.ts
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'react'
+import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
+
+export function useLoadingTimer(isLoading: boolean, isEmptyState: boolean) {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0)
+  const [emptyQuoteIndex, setEmptyQuoteIndex] = useState(() => getRandomQuoteIndex(null))
+  const [quoteIndex, setQuoteIndex] = useState<number | null>(null)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const quoteTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Read via ref so the loading-start effect doesn't re-run (resetting elapsed seconds)
+  // each time the idle quote rotates.
+  const emptyQuoteIndexRef = useRef(emptyQuoteIndex)
+  emptyQuoteIndexRef.current = emptyQuoteIndex
+
+  useEffect(() => {
+    if (isLoading) {
+      setElapsedSeconds(0)
+      setQuoteIndex(emptyQuoteIndexRef.current)
+      timerRef.current = setInterval(() => setElapsedSeconds((s) => s + 1), 1000)
+      quoteTimerRef.current = setInterval(() => setQuoteIndex((c) => getRandomQuoteIndex(c)), 10000)
+      return () => {
+        if (timerRef.current) clearInterval(timerRef.current)
+        if (quoteTimerRef.current) clearInterval(quoteTimerRef.current)
+      }
+    }
+    if (timerRef.current) { clearInterval(timerRef.current); timerRef.current = null }
+    if (quoteTimerRef.current) { clearInterval(quoteTimerRef.current); quoteTimerRef.current = null }
+    setElapsedSeconds(0)
+    setQuoteIndex(null)
+    return undefined
+  }, [isLoading])
+
+  useEffect(() => {
+    if (!isEmptyState) return
+    const interval = setInterval(() => setEmptyQuoteIndex((c) => getRandomQuoteIndex(c)), 10000)
+    return () => clearInterval(interval)
+  }, [isEmptyState])
+
+  return {
+    elapsedSeconds,
+    currentQuote: quoteIndex !== null ? LOADING_QUOTES[quoteIndex] : null,
+    emptyQuote: LOADING_QUOTES[emptyQuoteIndex],
+  }
+}

--- a/components/repo-input/useSearchDebounce.test.ts
+++ b/components/repo-input/useSearchDebounce.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSearchDebounce } from './useSearchDebounce'
+
+describe('useSearchDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns empty string immediately when query is empty', () => {
+    const { result } = renderHook(() => useSearchDebounce(''))
+    expect(result.current).toBe('')
+  })
+
+  it('clears debounced value immediately when query becomes empty', () => {
+    const { result, rerender } = renderHook(({ q }) => useSearchDebounce(q), {
+      initialProps: { q: 'hello' },
+    })
+    // Before delay fires, debounced is still initial value
+    rerender({ q: '' })
+    expect(result.current).toBe('')
+  })
+
+  it('debounces updates by the default 300ms delay', () => {
+    const { result, rerender } = renderHook(({ q }) => useSearchDebounce(q), {
+      initialProps: { q: '' },
+    })
+    rerender({ q: 'react' })
+    expect(result.current).toBe('')
+
+    act(() => { vi.advanceTimersByTime(299) })
+    expect(result.current).toBe('')
+
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(result.current).toBe('react')
+  })
+
+  it('uses a custom delay when provided', () => {
+    const { result, rerender } = renderHook(({ q }) => useSearchDebounce(q, 500), {
+      initialProps: { q: '' },
+    })
+    rerender({ q: 'test' })
+    act(() => { vi.advanceTimersByTime(499) })
+    expect(result.current).toBe('')
+
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(result.current).toBe('test')
+  })
+
+  it('resets the debounce timer on each keystroke', () => {
+    const { result, rerender } = renderHook(({ q }) => useSearchDebounce(q), {
+      initialProps: { q: '' },
+    })
+    rerender({ q: 'r' })
+    act(() => { vi.advanceTimersByTime(200) })
+    rerender({ q: 're' })
+    act(() => { vi.advanceTimersByTime(200) })
+    // Total 400ms since first keystroke, but only 200ms since last — still debouncing
+    expect(result.current).toBe('')
+
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(result.current).toBe('re')
+  })
+})

--- a/components/repo-input/useSearchDebounce.ts
+++ b/components/repo-input/useSearchDebounce.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+
+export function useSearchDebounce(query: string, delay = 300) {
+  const [debounced, setDebounced] = useState(query)
+
+  useEffect(() => {
+    if (!query) {
+      setDebounced('')
+      return
+    }
+    const timeout = setTimeout(() => setDebounced(query), delay)
+    return () => clearTimeout(timeout)
+  }, [query, delay])
+
+  return debounced
+}


### PR DESCRIPTION
## Summary

- **`useLoadingTimer(isLoading, isEmptyState)`** — extracts the elapsed-seconds timer, loading-quote rotation, and idle-quote rotation out of `RepoInputClient`. The `emptyQuoteIndexRef` trick (which motivated the first `eslint-disable`) is now internal to the hook.
- **`useSearchDebounce(query, delay?)`** — extracts the search debounce effect and `debouncedQuery` state into a clean, reusable hook.
- **Initial URL-param values** (`initialRawRepos`, `initialRepoValue`, `initialFoundationState`) switched from inline IIFE to `useState` initialisers, giving them stable array/object references that can appear in effect dep arrays.
- **Stable handler refs** for `handleSubmit` and `handleFoundationSubmit` (latest-value ref pattern) allow the two one-shot auto-trigger effects to declare proper dep arrays — no eslint-disable required.
- **All 3 `// eslint-disable-next-line react-hooks/exhaustive-deps` suppressions removed** from `RepoInputClient.tsx`.

## Test plan

- [x] `npx vitest run components/repo-input/` — 48 tests pass (13 new for the extracted hooks, 35 existing)
- [x] `npx tsc --noEmit` — clean
- [x] Verify auto-trigger still fires once on page load with `?repos=owner/repo` in the URL
- [x] Verify Foundation auto-trigger still fires once with `?mode=foundation&...` params

🤖 Generated with [Claude Code](https://claude.com/claude-code)