### PR TITLE
refactor(PAT-03): split analyze.ts god module into domain modules for testability

### DIFF
--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -28,22 +28,56 @@ import { detectReleaseHealth } from '@/lib/release-health/detect'
 import type { SecurityResult, DirectSecurityCheck } from '@/lib/security/analysis-result'
 import { fetchScorecardData } from '@/lib/security/scorecard-client'
 import { fetchBranchProtection } from '@/lib/security/direct-checks'
+import { newContributorMinSampleSize as NEW_CONTRIBUTOR_MIN_SAMPLE_SIZE } from '@/lib/community/score-config'
 
-interface DocBlob {
-  text?: string
-  oid?: string
-}
+import type {
+  CommitHistoryConnection,
+  CommitNode,
+  DocBlob,
+  LegacyRepoActivityResponse,
+  RepoActivityCountsResponse,
+  RepoActivityResponse,
+  RepoCommitAndReleasesResponse,
+  RepoCommitHistoryPageResponse,
+  RepoOverviewResponse,
+  RepoResponsivenessResponse,
+  ResolvedReadme,
+  ResponseSignal,
+} from './types'
 
-interface ResolvedReadme {
-  path: string
-  text: string | null
-}
+import {
+  buildDiagnostic,
+  buildFailure,
+  collectIssueCloseTimestamps,
+  collectIssueFirstResponseTimestamps,
+  collectPullRequestMergeTimestamps,
+  computeStaleIssueRatio,
+  countReleaseDatesWithinWindow,
+  computeMedianDurationHoursWithinWindow,
+  extractRateLimitFromError,
+} from './analyzer-utils'
 
-// GitHub GraphQL `object(expression: "HEAD:<path>")` is case-sensitive on the
-// filename, so the README is detected via a case-insensitive match on the root
-// tree's entries instead of a fixed set of path probes (issue #351). Matches
-// README, README.md, README.rst, README.txt, README.markdown, etc. regardless
-// of casing.
+export { toAnalyzerError } from './analyzer-utils'
+
+import {
+  buildActivityCadenceByWindow,
+  buildActivityMetricsByWindow,
+  buildUnavailableActivityCounts,
+  collectRecentDiscussionTimestamps,
+  extractReleaseHealthResult,
+} from './extract-activity'
+
+import {
+  buildContributorMetricsByWindow,
+  buildExperimentalOrganizationCommitCountsByWindow,
+  collectRecentCommitHistory,
+} from './extract-contributors'
+
+import {
+  buildResponsivenessMetricsByWindow,
+  fetchResponsivenessTwoPass,
+} from './extract-responsiveness'
+
 const README_FILENAME_PATTERN = /^readme(\.[a-z0-9]+)?$/i
 
 function findReadmeEntry(
@@ -74,331 +108,6 @@ async function resolveReadme(
     readme: { path: match.name, text: response.data.repository?.object?.text ?? null },
     rateLimit: response.rateLimit ?? null,
   }
-}
-
-interface RepoOverviewResponse {
-  repository: {
-    name: string
-    description: string | null
-    createdAt: string
-    primaryLanguage: { name: string } | null
-    stargazerCount: number
-    forkCount: number
-    watchers: { totalCount: number }
-    issues: { totalCount: number }
-    pullRequests?: { totalCount: number }
-    defaultBranchRef?: { name: string } | null
-    repositoryTopics?: { nodes: Array<{ topic: { name: string } }> } | null
-    licenseInfo?: { spdxId: string | null; name: string | null } | null
-    rootTree?: { entries: Array<{ name: string; type: string }> } | null
-    docLicense?: DocBlob | null
-    docLicenseLower?: DocBlob | null
-    docLicenseMd?: DocBlob | null
-    docLicenseMdLower?: DocBlob | null
-    docLicenseTxt?: DocBlob | null
-    docLicenseTxtLower?: DocBlob | null
-    docCopying?: DocBlob | null
-    docCopyingLower?: DocBlob | null
-    docLicenseMit?: DocBlob | null
-    docLicenseApache?: DocBlob | null
-    docLicenseBsd?: DocBlob | null
-    docContributing?: DocBlob | null
-    docContributingRst?: DocBlob | null
-    docContributingTxt?: DocBlob | null
-    docContributingLower?: DocBlob | null
-    docContributingDocs?: DocBlob | null
-    docContributingGithub?: DocBlob | null
-    docCodeOfConduct?: DocBlob | null
-    docCodeOfConductRst?: DocBlob | null
-    docCodeOfConductTxt?: DocBlob | null
-    docCodeOfConductHyphenLower?: DocBlob | null
-    docCodeOfConductUnderscoreLower?: DocBlob | null
-    docCodeOfConductDocs?: DocBlob | null
-    docCodeOfConductGithub?: DocBlob | null
-    cncfAdopters?: DocBlob | null
-    cncfAdoptersLower?: DocBlob | null
-    cncfAdoptersPlain?: DocBlob | null
-    cncfAdoptersDocs?: DocBlob | null
-    cncfRoadmap?: DocBlob | null
-    cncfRoadmapLower?: DocBlob | null
-    cncfRoadmapDocs?: DocBlob | null
-    cncfMaintainers?: DocBlob | null
-    cncfMaintainersMd?: DocBlob | null
-    cncfMaintainersMdLower?: DocBlob | null
-    cncfCodeowners?: DocBlob | null
-    cncfCodeownersGithub?: DocBlob | null
-    docLicenseRst?: DocBlob | null
-    docLicenseRstLower?: DocBlob | null
-    docSecurity?: DocBlob | null
-    docSecurityLower?: DocBlob | null
-    docSecurityRst?: DocBlob | null
-    docSecurityGithub?: DocBlob | null
-    docSecurityGithubLower?: DocBlob | null
-    docSecurityDocs?: DocBlob | null
-    docSecurityDocsLower?: DocBlob | null
-    docSecurityContacts?: DocBlob | null
-    docChangelog?: DocBlob | null
-    docChangelogPlain?: DocBlob | null
-    docChangelogDocs?: DocBlob | null
-    docChanges?: DocBlob | null
-    docChangesRst?: DocBlob | null
-    docHistory?: DocBlob | null
-    docNews?: DocBlob | null
-    secDependabot?: DocBlob | null
-    secDependabotYaml?: DocBlob | null
-    secRenovateRoot?: DocBlob | null
-    secRenovateGithub?: DocBlob | null
-    secRenovateConfig?: DocBlob | null
-    secRenovateRc?: DocBlob | null
-    hasDiscussionsEnabled?: boolean | null
-    commFunding?: { oid: string } | null
-    commIssueTemplateLegacyRoot?: { oid: string } | null
-    commIssueTemplateLegacyGithub?: { oid: string } | null
-    commIssueTemplateDir?: { entries: Array<{ name: string }> } | null
-    commPrTemplateRoot?: { oid: string } | null
-    commPrTemplateGithub?: { oid: string } | null
-    commPrTemplateDocs?: { oid: string } | null
-    commDiscussionsRecent?: {
-      totalCount?: number
-      pageInfo?: { hasNextPage: boolean; endCursor: string | null }
-      nodes: Array<{ createdAt: string }>
-    } | null
-    commGovernanceRoot?: { oid: string } | null
-    commGovernanceGithub?: { oid: string } | null
-    commGovernanceDocs?: { oid: string } | null
-    onbDevcontainerDir?: { entries: Array<{ name: string }> } | null
-    onbDevcontainerJson?: { oid: string } | null
-    onbDockerComposeYml?: { oid: string } | null
-    onbDockerComposeYaml?: { oid: string } | null
-    onbGitpod?: { oid: string } | null
-    workflowDir?: {
-      entries: Array<{
-        name: string
-        object: { text: string } | null
-      }>
-    } | null
-  } | null
-}
-
-interface RepoCommitAndReleasesResponse {
-  repository: {
-    releases: {
-      totalCount: number
-      nodes: Array<{
-        tagName: string
-        name: string | null
-        description: string | null
-        isPrerelease: boolean
-        createdAt: string
-        publishedAt: string | null
-      }>
-    }
-    refs: { totalCount: number } | null
-    defaultBranchRef: {
-      target: {
-        lifetime?: { totalCount: number }
-        recent30: { totalCount: number }
-        recent60: { totalCount: number }
-        recent90: { totalCount: number }
-        recent180: { totalCount: number }
-        recent365?: { totalCount: number }
-        recent365Commits: CommitHistoryConnection | null
-      } | null
-    } | null
-  } | null
-}
-
-interface SearchCount { issueCount: number }
-
-interface RepoActivityCountsResponse {
-  prsOpened30: SearchCount
-  prsOpened60: SearchCount
-  prsOpened90: SearchCount
-  prsOpened180: SearchCount
-  prsOpened365: SearchCount
-  prsMerged30: SearchCount
-  prsMerged60: SearchCount
-  prsMerged90: SearchCount
-  prsMerged180: SearchCount
-  prsMerged365: SearchCount
-  issuesOpened30: SearchCount
-  issuesOpened60: SearchCount
-  issuesOpened90: SearchCount
-  issuesOpened180: SearchCount
-  issuesOpened365: SearchCount
-  issuesClosed30: SearchCount
-  issuesClosed60: SearchCount
-  issuesClosed90: SearchCount
-  issuesClosed180: SearchCount
-  issuesClosed365: SearchCount
-  staleIssues30: SearchCount
-  staleIssues60: SearchCount
-  staleIssues90: SearchCount
-  staleIssues180: SearchCount
-  staleIssues365: SearchCount
-  goodFirstIssues?: SearchCount
-  goodFirstIssuesHyphenated?: SearchCount
-  goodFirstIssuesBeginner?: SearchCount
-  goodFirstIssuesStarter?: SearchCount
-  recentMergedPullRequests: {
-    nodes: Array<{
-      createdAt: string
-      mergedAt: string | null
-      authorAssociation?: string | null
-    }>
-  }
-  recentClosedIssues: {
-    nodes: Array<{
-      createdAt: string
-      closedAt: string | null
-    }>
-  }
-}
-
-type RepoActivityResponse = RepoCommitAndReleasesResponse & RepoActivityCountsResponse
-
-interface SearchActorNode {
-  login: string | null
-}
-
-interface SearchCommentNode {
-  createdAt: string
-  author: SearchActorNode | null
-}
-
-interface SearchReviewNode {
-  createdAt: string
-  author: SearchActorNode | null
-}
-
-interface ResponsivenessIssueNode {
-  createdAt: string
-  closedAt?: string | null
-  author: SearchActorNode | null
-  comments: {
-    totalCount: number
-    nodes: SearchCommentNode[]
-  }
-}
-
-interface ResponsivenessPullRequestNode {
-  createdAt: string
-  author: SearchActorNode | null
-  comments: {
-    totalCount: number
-    nodes: SearchCommentNode[]
-  }
-  reviews: {
-    totalCount: number
-    nodes: SearchReviewNode[]
-  }
-}
-
-// Pass 1 metadata types — no nested comment/review nodes
-interface MetadataIssueNode {
-  id: string
-  createdAt: string
-  closedAt?: string | null
-  author: SearchActorNode | null
-  comments: { totalCount: number }
-}
-
-interface MetadataPullRequestNode {
-  id: string
-  createdAt: string
-  author: SearchActorNode | null
-  comments: { totalCount: number }
-  reviews: { totalCount: number }
-}
-
-interface RepoResponsivenessMetadataResponse {
-  recentCreatedIssues: { nodes: MetadataIssueNode[] }
-  recentClosedIssues: { nodes: MetadataIssueNode[] }
-  recentCreatedPullRequests: { nodes: MetadataPullRequestNode[] }
-  recentMergedPullRequests: { nodes: Array<{ createdAt: string; mergedAt: string | null }> }
-  staleOpenPullRequests30: { issueCount: number }
-  staleOpenPullRequests60: { issueCount: number }
-  staleOpenPullRequests90: { issueCount: number }
-  staleOpenPullRequests180: { issueCount: number }
-  staleOpenPullRequests365: { issueCount: number }
-}
-
-// Pass 2 detail node — returned by node() queries
-interface DetailNode {
-  id: string
-  createdAt: string
-  author: SearchActorNode | null
-  comments?: { totalCount: number; nodes: SearchCommentNode[] }
-  reviews?: { totalCount: number; nodes: SearchReviewNode[] }
-}
-
-interface RepoResponsivenessResponse {
-  recentCreatedIssues: {
-    nodes: ResponsivenessIssueNode[]
-  }
-  recentClosedIssues: {
-    nodes: ResponsivenessIssueNode[]
-  }
-  recentCreatedPullRequests: {
-    nodes: ResponsivenessPullRequestNode[]
-  }
-  recentMergedPullRequests: {
-    nodes: Array<{
-      createdAt: string
-      mergedAt: string | null
-    }>
-  }
-  staleOpenPullRequests30: {
-    issueCount: number
-  }
-  staleOpenPullRequests60: {
-    issueCount: number
-  }
-  staleOpenPullRequests90: {
-    issueCount: number
-  }
-  staleOpenPullRequests180: {
-    issueCount: number
-  }
-  staleOpenPullRequests365: {
-    issueCount: number
-  }
-}
-
-interface LegacyRepoActivityResponse {
-  prsOpened?: { issueCount: number }
-  prsMerged?: { issueCount: number }
-  issuesClosed?: { issueCount: number }
-}
-
-interface RepoCommitHistoryPageResponse {
-  repository: {
-    defaultBranchRef: {
-      target: {
-        recent365Commits: CommitHistoryConnection | null
-      } | null
-    } | null
-  } | null
-}
-
-interface CommitHistoryConnection {
-  pageInfo: {
-    hasNextPage: boolean
-    endCursor: string | null
-  }
-  nodes: CommitNode[]
-}
-
-interface CommitNode {
-  authoredDate: string
-  message?: string
-  author: {
-    name: string | null
-    email: string | null
-    user: {
-      login: string
-    } | null
-  } | null
 }
 
 const UNAVAILABLE_FIELDS: Array<keyof AnalysisResult> = [
@@ -683,273 +392,6 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
   }
 }
 
-interface ResponseSignal {
-  firstResponderKind: 'bot' | 'human' | null
-  firstHumanResponseAt: string | null
-}
-
-interface AnalyzerError {
-  message?: string
-  status?: number
-  retryAfter?: number | Unavailable
-}
-
-export function toAnalyzerError(error: unknown): AnalyzerError {
-  if (error === null || typeof error !== 'object') return {}
-  const e = error as Record<string, unknown>
-  return {
-    message: typeof e.message === 'string' ? e.message : undefined,
-    status: typeof e.status === 'number' ? e.status : undefined,
-    retryAfter: typeof e.retryAfter === 'number' || e.retryAfter === 'unavailable'
-      ? e.retryAfter as number | Unavailable
-      : undefined,
-  }
-}
-
-function extractRateLimitFromError(error: unknown): RateLimitState | null {
-  const maybeError = toAnalyzerError(error)
-
-  if (maybeError.status !== 403 && maybeError.retryAfter == null) {
-    return null
-  }
-
-  return {
-    limit: 'unavailable',
-    remaining: 'unavailable',
-    resetAt: 'unavailable',
-    retryAfter: maybeError.retryAfter ?? 'unavailable',
-  }
-}
-
-function buildAnalysisResult(
-  repo: string,
-  overview: RepoOverviewResponse,
-  activity: RepoActivityResponse,
-  responsiveness: RepoResponsivenessResponse,
-  contributorMetricsByWindow: Record<ContributorWindowDays, ContributorWindowMetrics>,
-  activityMetricsByWindow: Record<ActivityWindowDays, ActivityWindowMetrics>,
-  activityCadenceByWindow: Record<ActivityWindowDays, ActivityCadenceMetrics> | undefined,
-  commitTimestamps365d: string[] | Unavailable,
-  totalContributorCount: number | Unavailable,
-  maintainerCount: number | Unavailable,
-  maintainerTokens: MaintainerToken[] | Unavailable,
-  experimentalMetricsByWindow: Record<ContributorWindowDays, ContributorWindowMetrics>,
-  recentCommitNodes: CommitNode[],
-  readmeResolved: ResolvedReadme | null,
-  discussionTimestamps?: string[],
-  discussionsTruncated?: boolean,
-  now: Date = new Date(),
-): AnalysisResult {
-  const defaultBranchTarget = activity.repository?.defaultBranchRef?.target
-  const legacyActivity = activity as RepoActivityResponse & LegacyRepoActivityResponse
-  const contributorMetrics = contributorMetricsByWindow[90]
-  const experimentalMetrics = experimentalMetricsByWindow[90]
-  const responsivenessMetricsByWindow = buildResponsivenessMetricsByWindow(
-    responsiveness,
-    activityMetricsByWindow,
-    overview.repository?.issues.totalCount,
-    overview.repository?.pullRequests?.totalCount,
-  )
-  const responsivenessMetrics = responsivenessMetricsByWindow[90]
-  const issueFirstResponseTimestamps = collectIssueFirstResponseTimestamps(responsiveness.recentCreatedIssues?.nodes ?? [], 90)
-  const issueCloseTimestamps = collectIssueCloseTimestamps(responsiveness.recentClosedIssues?.nodes ?? [], 90)
-  const prMergeTimestamps = collectPullRequestMergeTimestamps(responsiveness.recentMergedPullRequests?.nodes ?? [], 90)
-  const onboardingSignals = extractOnboardingSignals(overview.repository, activity)
-  const missingFields = [...UNAVAILABLE_FIELDS].filter((field) => {
-    if (field === 'releases12mo') {
-      return activityMetricsByWindow[365].releases === 'unavailable'
-    }
-
-    if (field === 'uniqueCommitAuthors90d') {
-      return contributorMetrics.uniqueCommitAuthors === 'unavailable'
-    }
-
-    if (field === 'commitCountsByAuthor') {
-      return contributorMetrics.commitCountsByAuthor === 'unavailable'
-    }
-
-    if (field === 'totalContributors') {
-      const resolvedTotal = totalContributorCount !== 'unavailable'
-        ? totalContributorCount
-        : contributorMetricsByWindow[365].uniqueCommitAuthors !== 'unavailable' && contributorMetricsByWindow[365].uniqueCommitAuthors > 0
-          ? contributorMetricsByWindow[365].uniqueCommitAuthors
-          : 'unavailable'
-      return resolvedTotal === 'unavailable'
-    }
-
-    if (field === 'maintainerCount') {
-      return maintainerCount === 'unavailable'
-    }
-
-    if (field === 'commitCountsByExperimentalOrg') {
-      return experimentalMetrics.commitCountsByExperimentalOrg === 'unavailable'
-    }
-
-    if (field === 'experimentalAttributedAuthors90d') {
-      return experimentalMetrics.experimentalAttributedAuthors === 'unavailable'
-    }
-
-    if (field === 'experimentalUnattributedAuthors90d') {
-      return experimentalMetrics.experimentalUnattributedAuthors === 'unavailable'
-    }
-
-    if (field === 'issueFirstResponseTimestamps') {
-      return issueFirstResponseTimestamps === 'unavailable'
-    }
-
-    if (field === 'issueCloseTimestamps') {
-      return issueCloseTimestamps === 'unavailable'
-    }
-
-    if (field === 'prMergeTimestamps') {
-      return prMergeTimestamps === 'unavailable'
-    }
-
-    if (field === 'goodFirstIssueCount') {
-      return onboardingSignals.goodFirstIssueCount === 'unavailable'
-    }
-
-    if (field === 'devEnvironmentSetup') {
-      return onboardingSignals.devEnvironmentSetup === 'unavailable'
-    }
-
-    if (field === 'gitpodPresent') {
-      return onboardingSignals.gitpodPresent === 'unavailable'
-    }
-
-    if (field === 'newContributorPRAcceptanceRate') {
-      return onboardingSignals.newContributorPRAcceptanceRate === 'unavailable'
-    }
-
-    return false
-  })
-
-  return {
-    repo,
-    name: overview.repository?.name ?? 'unavailable',
-    description: overview.repository?.description ?? 'unavailable',
-    createdAt: overview.repository?.createdAt ?? 'unavailable',
-    primaryLanguage: overview.repository?.primaryLanguage?.name ?? 'unavailable',
-    stars: overview.repository?.stargazerCount ?? 'unavailable',
-    forks: overview.repository?.forkCount ?? 'unavailable',
-    watchers: overview.repository?.watchers.totalCount ?? 'unavailable',
-    commits30d: defaultBranchTarget?.recent30.totalCount ?? 'unavailable',
-    commits90d: defaultBranchTarget?.recent90.totalCount ?? 'unavailable',
-    releases12mo: activityMetricsByWindow[365].releases,
-    prsOpened90d: activity.prsOpened90?.issueCount ?? legacyActivity.prsOpened?.issueCount ?? 'unavailable',
-    prsMerged90d: activity.prsMerged90?.issueCount ?? legacyActivity.prsMerged?.issueCount ?? 'unavailable',
-    issuesOpen: overview.repository?.issues.totalCount ?? 'unavailable',
-    issuesClosed90d: activity.issuesClosed90?.issueCount ?? legacyActivity.issuesClosed?.issueCount ?? 'unavailable',
-    uniqueCommitAuthors90d: contributorMetrics.uniqueCommitAuthors,
-    totalContributors: totalContributorCount !== 'unavailable'
-      ? totalContributorCount
-      : contributorMetricsByWindow[365].uniqueCommitAuthors !== 'unavailable' && contributorMetricsByWindow[365].uniqueCommitAuthors > 0
-        ? contributorMetricsByWindow[365].uniqueCommitAuthors
-        : 'unavailable',
-    totalContributorsSource: totalContributorCount !== 'unavailable' ? 'api' : 'commit-history',
-    maintainerCount,
-    maintainerTokens,
-    commitCountsByAuthor: contributorMetrics.commitCountsByAuthor,
-    commitCountsByExperimentalOrg: experimentalMetrics.commitCountsByExperimentalOrg,
-    experimentalAttributedAuthors90d: experimentalMetrics.experimentalAttributedAuthors,
-    experimentalUnattributedAuthors90d: experimentalMetrics.experimentalUnattributedAuthors,
-    contributorMetricsByWindow: Object.fromEntries(
-      CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => [
-        windowDays,
-        {
-          ...contributorMetricsByWindow[windowDays],
-          commitCountsByExperimentalOrg: experimentalMetricsByWindow[windowDays].commitCountsByExperimentalOrg,
-          experimentalAttributedAuthors: experimentalMetricsByWindow[windowDays].experimentalAttributedAuthors,
-          experimentalUnattributedAuthors: experimentalMetricsByWindow[windowDays].experimentalUnattributedAuthors,
-        },
-      ]),
-    ) as Record<ContributorWindowDays, ContributorWindowMetrics>,
-    activityMetricsByWindow,
-    activityCadenceByWindow,
-    commitTimestamps365d,
-    responsivenessMetricsByWindow,
-    responsivenessMetrics,
-    staleIssueRatio: activityMetricsByWindow[90].staleIssueRatio,
-    medianTimeToMergeHours: activityMetricsByWindow[90].medianTimeToMergeHours,
-    medianTimeToCloseHours: activityMetricsByWindow[90].medianTimeToCloseHours,
-    documentationResult: extractDocumentationResult(overview.repository, readmeResolved),
-    licensingResult: overview.repository
-      ? (() => {
-          const repo = overview.repository
-          // Collect license file content for SPDX expression parsing
-          const licenseFileContent =
-            repo.docLicense?.text ?? repo.docLicenseLower?.text ??
-            repo.docLicenseMd?.text ?? repo.docLicenseMdLower?.text ??
-            repo.docLicenseTxt?.text ?? repo.docLicenseTxtLower?.text ??
-            repo.docLicenseRst?.text ?? repo.docLicenseRstLower?.text ??
-            repo.docCopying?.text ?? repo.docCopyingLower?.text ?? null
-          // Collect additional license files (LICENSE-MIT, LICENSE-APACHE, etc.)
-          const additionalLicenseFiles: LicenseFileInfo[] = [
-            { suffix: 'MIT', content: repo.docLicenseMit?.text ?? null },
-            { suffix: 'APACHE', content: repo.docLicenseApache?.text ?? null },
-            { suffix: 'BSD', content: repo.docLicenseBsd?.text ?? null },
-          ]
-          return extractLicensingResult(
-            repo.licenseInfo ?? null,
-            recentCommitNodes.filter((n): n is CommitNode & { message: string } => typeof n.message === 'string'),
-            repo.workflowDir ?? null,
-            licenseFileContent,
-            additionalLicenseFiles,
-          )
-        })()
-      : 'unavailable',
-    defaultBranchName: overview.repository?.defaultBranchRef?.name ?? 'unavailable',
-    topics: overview.repository?.repositoryTopics?.nodes.map((n) => n.topic.name) ?? [],
-    inclusiveNamingResult: overview.repository
-      ? extractInclusiveNamingResult(
-          overview.repository.defaultBranchRef?.name ?? null,
-          overview.repository.description ?? null,
-          overview.repository.repositoryTopics?.nodes.map((n) => n.topic.name) ?? [],
-        )
-      : 'unavailable',
-    issueFirstResponseTimestamps,
-    issueCloseTimestamps,
-    prMergeTimestamps,
-    securityResult: extractSecurityResult(overview.repository),
-    ...extractCommunitySignals(overview.repository, 90, discussionTimestamps, discussionsTruncated),
-    releaseHealthResult: extractReleaseHealthResult(activity, now),
-    ...onboardingSignals,
-    ...extractMaturitySignals({
-      createdAt: overview.repository?.createdAt ?? 'unavailable',
-      stars: overview.repository?.stargazerCount ?? 'unavailable',
-      totalContributors: totalContributorCount !== 'unavailable'
-        ? totalContributorCount
-        : contributorMetricsByWindow[365].uniqueCommitAuthors !== 'unavailable' && contributorMetricsByWindow[365].uniqueCommitAuthors > 0
-          ? contributorMetricsByWindow[365].uniqueCommitAuthors
-          : 'unavailable',
-      lifetimeCommits: defaultBranchTarget?.lifetime?.totalCount ?? 'unavailable',
-      recent365Commits: defaultBranchTarget?.recent365?.totalCount ?? 'unavailable',
-      now,
-    }),
-    missingFields,
-  }
-}
-
-function buildActivityCadenceByWindow(
-  commitTimestamps365d: string[] | Unavailable,
-  now: Date,
-): Record<ActivityWindowDays, ActivityCadenceMetrics> | undefined {
-  if (!Array.isArray(commitTimestamps365d)) {
-    return undefined
-  }
-
-  return Object.fromEntries(
-    ACTIVITY_WINDOW_DAYS.map((windowDays) => [
-      windowDays,
-      buildActivityCadenceMetrics({
-        commitTimestamps: commitTimestamps365d,
-        now,
-        windowDays,
-      }),
-    ]),
-  ) as Record<ActivityWindowDays, ActivityCadenceMetrics>
-}
-
 const DAYS_PER_YEAR = 365.25
 const DAYS_PER_MONTH = 30.4375
 
@@ -1053,35 +495,6 @@ export function extractMaturitySignals(inputs: MaturityExtractInputs): {
     commitsPerMonthRecent12mo,
     growthTrajectory,
   }
-}
-
-function extractReleaseHealthResult(
-  activity: RepoActivityResponse,
-  now: Date,
-): AnalysisResult['releaseHealthResult'] {
-  const repo = activity.repository
-  if (!repo) return 'unavailable'
-  const releasesConnection = repo.releases
-  const rawNodes = releasesConnection?.nodes ?? []
-  const totalReleasesAllTime = typeof releasesConnection?.totalCount === 'number'
-    ? releasesConnection.totalCount
-    : rawNodes.length
-  const totalTags: number | Unavailable = typeof repo.refs?.totalCount === 'number'
-    ? repo.refs.totalCount
-    : 'unavailable'
-  return detectReleaseHealth({
-    releases: rawNodes.map((r) => ({
-      tagName: r.tagName,
-      name: r.name,
-      body: r.description,
-      isPrerelease: r.isPrerelease,
-      createdAt: r.createdAt,
-      publishedAt: r.publishedAt,
-    })),
-    totalReleasesAllTime,
-    totalTags,
-    now,
-  })
 }
 
 export function extractDocumentationResult(
@@ -1333,8 +746,6 @@ export function extractCommunitySignals(
   }
 }
 
-import { newContributorMinSampleSize as NEW_CONTRIBUTOR_MIN_SAMPLE_SIZE } from '@/lib/community/score-config'
-
 interface OnboardingSignalSet {
   goodFirstIssueCount: number | Unavailable
   devEnvironmentSetup: boolean | Unavailable
@@ -1524,1083 +935,211 @@ export function buildGoodFirstIssueQueries(repoSearch: string): Record<
   }
 }
 
-// ─── Two-pass responsiveness fetch ───────────────────────────────────────────
-
-const DETAIL_BATCH_SIZE = 10
-
-async function fetchResponsivenessTwoPass(
-  token: string,
-  variables: Record<string, string>,
-  diagnostics: Array<{ repo: string; source: string; message: string }>,
+function buildAnalysisResult(
   repo: string,
-): Promise<{ data: RepoResponsivenessResponse; rateLimit: RateLimitState | null }> {
-  // Pass 1: Lightweight metadata query
-  const metadataResult = await queryGitHubGraphQL<RepoResponsivenessMetadataResponse>(
-    token,
-    REPO_RESPONSIVENESS_METADATA_QUERY,
-    variables,
-  ).catch((error) => {
-    diagnostics.push(buildDiagnostic(repo, 'github-graphql:responsiveness-metadata', error))
-    return null
-  })
-
-  if (!metadataResult) {
-    return { data: createUnavailableResponsivenessResponse(), rateLimit: null }
-  }
-
-  const metadata = metadataResult.data
-
-  // Collect node IDs that need detail fetching (issues with comments, PRs with comments/reviews)
-  const detailRequests: Array<{ id: string; type: 'issue' | 'pr' }> = []
-
-  for (const issue of metadata.recentCreatedIssues?.nodes ?? []) {
-    if (issue?.id && issue.comments?.totalCount > 0) {
-      detailRequests.push({ id: issue.id, type: 'issue' })
-    }
-  }
-  for (const issue of metadata.recentClosedIssues?.nodes ?? []) {
-    if (issue?.id && issue.comments?.totalCount > 0) {
-      detailRequests.push({ id: issue.id, type: 'issue' })
-    }
-  }
-  for (const pr of metadata.recentCreatedPullRequests?.nodes ?? []) {
-    if (pr?.id && (pr.comments?.totalCount > 0 || pr.reviews?.totalCount > 0)) {
-      detailRequests.push({ id: pr.id, type: 'pr' })
-    }
-  }
-
-  // Deduplicate by id
-  const seen = new Set<string>()
-  const uniqueRequests = detailRequests.filter((r) => {
-    if (seen.has(r.id)) return false
-    seen.add(r.id)
-    return true
-  })
-
-  // Pass 2: Fetch comment/review details in batches
-  const detailMap = new Map<string, DetailNode>()
-  let latestRateLimit = metadataResult.rateLimit
-
-  for (let i = 0; i < uniqueRequests.length; i += DETAIL_BATCH_SIZE) {
-    const batch = uniqueRequests.slice(i, i + DETAIL_BATCH_SIZE)
-    const detailQuery = buildResponsivenessDetailQuery(batch)
-
-    const detailResult = await queryGitHubGraphQL<Record<string, DetailNode | null>>(
-      token,
-      detailQuery,
-      {},
-    ).catch((error) => {
-      diagnostics.push(buildDiagnostic(repo, 'github-graphql:responsiveness-detail', error))
-      return null
-    })
-
-    if (detailResult) {
-      latestRateLimit = detailResult.rateLimit ?? latestRateLimit
-      for (let j = 0; j < batch.length; j++) {
-        const node = detailResult.data[`node${j}`]
-        if (node?.id) {
-          detailMap.set(node.id, node)
-        }
-      }
-    }
-  }
-
-  // Merge metadata + details into the full response shape
-  const response = mergeResponsivenessData(metadata, detailMap)
-
-  return { data: response, rateLimit: latestRateLimit }
-}
-
-function mergeResponsivenessData(
-  metadata: RepoResponsivenessMetadataResponse,
-  detailMap: Map<string, DetailNode>,
-): RepoResponsivenessResponse {
-  function enrichIssue(meta: MetadataIssueNode): ResponsivenessIssueNode {
-    const detail = detailMap.get(meta.id)
-    return {
-      createdAt: meta.createdAt,
-      closedAt: meta.closedAt,
-      author: meta.author,
-      comments: detail?.comments ?? { totalCount: meta.comments.totalCount, nodes: [] },
-    }
-  }
-
-  function enrichPR(meta: MetadataPullRequestNode): ResponsivenessPullRequestNode {
-    const detail = detailMap.get(meta.id)
-    return {
-      createdAt: meta.createdAt,
-      author: meta.author,
-      comments: detail?.comments ?? { totalCount: meta.comments.totalCount, nodes: [] },
-      reviews: detail?.reviews ?? { totalCount: meta.reviews.totalCount, nodes: [] },
-    }
-  }
-
-  return {
-    recentCreatedIssues: {
-      nodes: (metadata.recentCreatedIssues?.nodes ?? []).filter(Boolean).map(enrichIssue),
-    },
-    recentClosedIssues: {
-      nodes: (metadata.recentClosedIssues?.nodes ?? []).filter(Boolean).map(enrichIssue),
-    },
-    recentCreatedPullRequests: {
-      nodes: (metadata.recentCreatedPullRequests?.nodes ?? []).filter(Boolean).map(enrichPR),
-    },
-    recentMergedPullRequests: metadata.recentMergedPullRequests,
-    staleOpenPullRequests30: metadata.staleOpenPullRequests30,
-    staleOpenPullRequests60: metadata.staleOpenPullRequests60,
-    staleOpenPullRequests90: metadata.staleOpenPullRequests90,
-    staleOpenPullRequests180: metadata.staleOpenPullRequests180,
-    staleOpenPullRequests365: metadata.staleOpenPullRequests365,
-  }
-}
-
-function createUnavailableResponsivenessResponse(): RepoResponsivenessResponse {
-  return {
-    recentCreatedIssues: { nodes: [] },
-    recentClosedIssues: { nodes: [] },
-    recentCreatedPullRequests: { nodes: [] },
-    recentMergedPullRequests: { nodes: [] },
-    staleOpenPullRequests30: { issueCount: 0 },
-    staleOpenPullRequests60: { issueCount: 0 },
-    staleOpenPullRequests90: { issueCount: 0 },
-    staleOpenPullRequests180: { issueCount: 0 },
-    staleOpenPullRequests365: { issueCount: 0 },
-  }
-}
-
-function buildResponsivenessMetricsByWindow(
-  responsiveness: RepoResponsivenessResponse,
-  activityMetricsByWindow: Record<ActivityWindowDays, ActivityWindowMetrics>,
-  openIssueCount: number | undefined,
-  openPullRequestCount: number | undefined,
-): Record<ActivityWindowDays, ResponsivenessMetrics> {
-  const recentCreatedIssues = responsiveness.recentCreatedIssues?.nodes ?? []
-  const recentClosedIssues = responsiveness.recentClosedIssues?.nodes ?? []
-  const recentCreatedPullRequests = responsiveness.recentCreatedPullRequests?.nodes ?? []
-  const recentMergedPullRequests = responsiveness.recentMergedPullRequests?.nodes ?? []
-
-  return {
-    30: buildResponsivenessMetricsForWindow(
-      30,
-      recentCreatedIssues,
-      recentClosedIssues,
-      recentCreatedPullRequests,
-      recentMergedPullRequests,
-      activityMetricsByWindow[30],
-      responsiveness.staleOpenPullRequests30?.issueCount,
-      openIssueCount,
-      openPullRequestCount,
-    ),
-    60: buildResponsivenessMetricsForWindow(
-      60,
-      recentCreatedIssues,
-      recentClosedIssues,
-      recentCreatedPullRequests,
-      recentMergedPullRequests,
-      activityMetricsByWindow[60],
-      responsiveness.staleOpenPullRequests60?.issueCount,
-      openIssueCount,
-      openPullRequestCount,
-    ),
-    90: buildResponsivenessMetricsForWindow(
-      90,
-      recentCreatedIssues,
-      recentClosedIssues,
-      recentCreatedPullRequests,
-      recentMergedPullRequests,
-      activityMetricsByWindow[90],
-      responsiveness.staleOpenPullRequests90?.issueCount,
-      openIssueCount,
-      openPullRequestCount,
-    ),
-    180: buildResponsivenessMetricsForWindow(
-      180,
-      recentCreatedIssues,
-      recentClosedIssues,
-      recentCreatedPullRequests,
-      recentMergedPullRequests,
-      activityMetricsByWindow[180],
-      responsiveness.staleOpenPullRequests180?.issueCount,
-      openIssueCount,
-      openPullRequestCount,
-    ),
-    365: buildResponsivenessMetricsForWindow(
-      365,
-      recentCreatedIssues,
-      recentClosedIssues,
-      recentCreatedPullRequests,
-      recentMergedPullRequests,
-      activityMetricsByWindow[365],
-      responsiveness.staleOpenPullRequests365?.issueCount,
-      openIssueCount,
-      openPullRequestCount,
-    ),
-  }
-}
-
-function buildResponsivenessMetricsForWindow(
-  windowDays: ActivityWindowDays,
-  recentCreatedIssues: ResponsivenessIssueNode[],
-  recentClosedIssues: ResponsivenessIssueNode[],
-  recentCreatedPullRequests: ResponsivenessPullRequestNode[],
-  recentMergedPullRequests: Array<{ createdAt: string; mergedAt: string | null }>,
-  activityMetrics: ActivityWindowMetrics,
-  staleOpenPullRequestCount: number | undefined,
-  openIssueCount: number | undefined,
-  openPullRequestCount: number | undefined,
-): ResponsivenessMetrics {
-  const issueNodesInWindow = filterNodesByStartDate(recentCreatedIssues, windowDays)
-  const closedIssueNodesInWindow = filterNodesByEndDate(recentClosedIssues, 'closedAt', windowDays)
-  const createdPullRequestsInWindow = filterNodesByStartDate(recentCreatedPullRequests, windowDays)
-  const mergedPullRequestsInWindow = filterNodesByEndDate(recentMergedPullRequests, 'mergedAt', windowDays)
-
-  const issueFirstResponseDurations = issueNodesInWindow
-    .map((issue) => getIssueFirstResponseDurationHours(issue))
-    .filter((value): value is number => value != null)
-  const prFirstReviewDurations = createdPullRequestsInWindow
-    .map((pullRequest) => getPullRequestFirstReviewDurationHours(pullRequest))
-    .filter((value): value is number => value != null)
-  const issueResolutionDurations = closedIssueNodesInWindow
-    .map((issue) => getDurationHours(issue.createdAt, issue.closedAt ?? null))
-    .filter((value): value is number => value != null)
-  const prMergeDurations = mergedPullRequestsInWindow
-    .map((pullRequest) => getDurationHours(pullRequest.createdAt, pullRequest.mergedAt))
-    .filter((value): value is number => value != null)
-
-  const interactionSignals = [
-    ...issueNodesInWindow.map((issue) => getResponseSignal(issue.author?.login ?? null, issue.comments.nodes)),
-    ...createdPullRequestsInWindow.map((pullRequest) =>
-      getResponseSignal(pullRequest.author?.login ?? null, [...pullRequest.comments.nodes, ...pullRequest.reviews.nodes]),
-    ),
-  ].filter((signal): signal is ResponseSignal => signal != null)
-
-  const itemsWithHumanResponse = interactionSignals.filter((signal) => signal.firstHumanResponseAt != null).length
-  const itemsWithBotFirstResponse = interactionSignals.filter((signal) => signal.firstResponderKind === 'bot').length
-  const itemsWithHumanFirstResponse = interactionSignals.filter((signal) => signal.firstResponderKind === 'human').length
-  const itemsWithAnyFirstResponse = interactionSignals.filter((signal) => signal.firstResponderKind != null).length
-
-  return {
-    issueFirstResponseMedianHours: computeMedian(issueFirstResponseDurations),
-    issueFirstResponseP90Hours: computePercentile(issueFirstResponseDurations, 0.9),
-    prFirstReviewMedianHours: computeMedian(prFirstReviewDurations),
-    prFirstReviewP90Hours: computePercentile(prFirstReviewDurations, 0.9),
-    issueResolutionMedianHours: computeMedian(issueResolutionDurations),
-    issueResolutionP90Hours: computePercentile(issueResolutionDurations, 0.9),
-    prMergeMedianHours: computeMedian(prMergeDurations),
-    prMergeP90Hours: computePercentile(prMergeDurations, 0.9),
-    issueResolutionRate: computeRatio(activityMetrics.issuesClosed, activityMetrics.issuesOpened),
-    contributorResponseRate:
-      interactionSignals.length > 0 ? itemsWithHumanResponse / interactionSignals.length : 'unavailable',
-    botResponseRatio: itemsWithAnyFirstResponse > 0 ? itemsWithBotFirstResponse / itemsWithAnyFirstResponse : 'unavailable',
-    humanResponseRatio: itemsWithAnyFirstResponse > 0 ? itemsWithHumanFirstResponse / itemsWithAnyFirstResponse : 'unavailable',
-    staleIssueRatio: activityMetrics.staleIssueRatio,
-    stalePrRatio: computeStaleItemRatio(staleOpenPullRequestCount, openPullRequestCount),
-    prReviewDepth:
-      createdPullRequestsInWindow.length > 0
-        ? createdPullRequestsInWindow.reduce((total, pullRequest) => total + pullRequest.reviews.totalCount, 0) /
-          createdPullRequestsInWindow.length
-        : 'unavailable',
-    issuesClosedWithoutCommentRatio:
-      closedIssueNodesInWindow.length > 0
-        ? closedIssueNodesInWindow.filter((issue) => issue.comments.totalCount === 0).length / closedIssueNodesInWindow.length
-        : 'unavailable',
-    openIssueCount: typeof openIssueCount === 'number' ? openIssueCount : 'unavailable',
-    openPullRequestCount: typeof openPullRequestCount === 'number' ? openPullRequestCount : 'unavailable',
-  }
-}
-
-function buildActivityMetricsByWindow(
+  overview: RepoOverviewResponse,
   activity: RepoActivityResponse,
-  now: Date,
+  responsiveness: RepoResponsivenessResponse,
+  contributorMetricsByWindow: Record<ContributorWindowDays, ContributorWindowMetrics>,
+  activityMetricsByWindow: Record<ActivityWindowDays, ActivityWindowMetrics>,
+  activityCadenceByWindow: Record<ActivityWindowDays, ActivityCadenceMetrics> | undefined,
+  commitTimestamps365d: string[] | Unavailable,
+  totalContributorCount: number | Unavailable,
+  maintainerCount: number | Unavailable,
+  maintainerTokens: MaintainerToken[] | Unavailable,
+  experimentalMetricsByWindow: Record<ContributorWindowDays, ContributorWindowMetrics>,
   recentCommitNodes: CommitNode[],
-  openIssueCount: number | undefined,
-): Record<ActivityWindowDays, ActivityWindowMetrics> {
-  const legacyActivity = activity as RepoActivityResponse & LegacyRepoActivityResponse
+  readmeResolved: ResolvedReadme | null,
+  discussionTimestamps?: string[],
+  discussionsTruncated?: boolean,
+  now: Date = new Date(),
+): AnalysisResult {
   const defaultBranchTarget = activity.repository?.defaultBranchRef?.target
-  const releaseDates =
-    activity.repository?.releases?.nodes?.map((release) => release.publishedAt ?? release.createdAt).filter((value): value is string => Boolean(value)) ??
-    []
-
-  const commitCountsByWindow: Record<ActivityWindowDays, number | Unavailable> = {
-    30: defaultBranchTarget?.recent30?.totalCount ?? 'unavailable',
-    60: defaultBranchTarget?.recent60?.totalCount ?? 'unavailable',
-    90: defaultBranchTarget?.recent90?.totalCount ?? 'unavailable',
-    180: defaultBranchTarget?.recent180?.totalCount ?? 'unavailable',
-    365: recentCommitNodes.length > 0 ? recentCommitNodes.length : defaultBranchTarget?.recent365Commits?.nodes.length ?? 'unavailable',
-  }
-
-  const mergedPullRequestNodes = activity.recentMergedPullRequests?.nodes ?? []
-  const closedIssueNodes = activity.recentClosedIssues?.nodes ?? []
-
-  return {
-    30: {
-      commits: commitCountsByWindow[30],
-      prsOpened: activity.prsOpened30?.issueCount ?? 'unavailable',
-      prsMerged: activity.prsMerged30?.issueCount ?? 'unavailable',
-      issuesOpened: activity.issuesOpened30?.issueCount ?? 'unavailable',
-      issuesClosed: activity.issuesClosed30?.issueCount ?? 'unavailable',
-      releases: countReleaseDatesWithinWindow(releaseDates, now, 30),
-      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues30?.issueCount, openIssueCount),
-      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 30),
-      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 30),
-    },
-    60: {
-      commits: commitCountsByWindow[60],
-      prsOpened: activity.prsOpened60?.issueCount ?? 'unavailable',
-      prsMerged: activity.prsMerged60?.issueCount ?? 'unavailable',
-      issuesOpened: activity.issuesOpened60?.issueCount ?? 'unavailable',
-      issuesClosed: activity.issuesClosed60?.issueCount ?? 'unavailable',
-      releases: countReleaseDatesWithinWindow(releaseDates, now, 60),
-      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues60?.issueCount, openIssueCount),
-      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 60),
-      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 60),
-    },
-    90: {
-      commits: commitCountsByWindow[90],
-      prsOpened: activity.prsOpened90?.issueCount ?? legacyActivity.prsOpened?.issueCount ?? 'unavailable',
-      prsMerged: activity.prsMerged90?.issueCount ?? legacyActivity.prsMerged?.issueCount ?? 'unavailable',
-      issuesOpened: activity.issuesOpened90?.issueCount ?? 'unavailable',
-      issuesClosed: activity.issuesClosed90?.issueCount ?? legacyActivity.issuesClosed?.issueCount ?? 'unavailable',
-      releases: countReleaseDatesWithinWindow(releaseDates, now, 90),
-      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues90?.issueCount, openIssueCount),
-      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 90),
-      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 90),
-    },
-    180: {
-      commits: commitCountsByWindow[180],
-      prsOpened: activity.prsOpened180?.issueCount ?? 'unavailable',
-      prsMerged: activity.prsMerged180?.issueCount ?? 'unavailable',
-      issuesOpened: activity.issuesOpened180?.issueCount ?? 'unavailable',
-      issuesClosed: activity.issuesClosed180?.issueCount ?? 'unavailable',
-      releases: countReleaseDatesWithinWindow(releaseDates, now, 180),
-      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues180?.issueCount, openIssueCount),
-      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 180),
-      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 180),
-    },
-    365: {
-      commits: commitCountsByWindow[365],
-      prsOpened: activity.prsOpened365?.issueCount ?? 'unavailable',
-      prsMerged: activity.prsMerged365?.issueCount ?? 'unavailable',
-      issuesOpened: activity.issuesOpened365?.issueCount ?? 'unavailable',
-      issuesClosed: activity.issuesClosed365?.issueCount ?? 'unavailable',
-      releases: countReleaseDatesWithinWindow(releaseDates, now, 365),
-      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues365?.issueCount, openIssueCount),
-      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 365),
-      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 365),
-    },
-  }
-}
-
-function countReleaseDatesWithinWindow(releaseDates: string[], now: Date, windowDays: ActivityWindowDays): number | Unavailable {
-  if (releaseDates.length === 0) {
-    return 0
-  }
-
-  const cutoff = new Date(now)
-  cutoff.setDate(cutoff.getDate() - windowDays)
-
-  return releaseDates.filter((value) => {
-    const date = new Date(value)
-    return !Number.isNaN(date.getTime()) && date >= cutoff
-  }).length
-}
-
-function computeStaleIssueRatio(staleIssueCount: number | undefined, openIssueCount: number | undefined): number | Unavailable {
-  if (typeof staleIssueCount !== 'number' || typeof openIssueCount !== 'number' || openIssueCount <= 0) {
-    return 'unavailable'
-  }
-
-  return staleIssueCount / openIssueCount
-}
-
-function computeStaleItemRatio(staleItemCount: number | undefined, openItemCount: number | undefined): number | Unavailable {
-  if (typeof staleItemCount !== 'number' || typeof openItemCount !== 'number' || openItemCount <= 0) {
-    return 'unavailable'
-  }
-
-  return staleItemCount / openItemCount
-}
-
-function collectIssueFirstResponseTimestamps(issues: ResponsivenessIssueNode[], windowDays: ActivityWindowDays): string[] | Unavailable {
-  const timestamps = filterNodesByStartDate(issues, windowDays)
-    .map((issue) => getFirstNonAuthorInteraction(issue.author?.login ?? null, issue.comments.nodes)?.createdAt ?? null)
-    .filter((value): value is string => Boolean(value))
-
-  return timestamps.length > 0 ? timestamps : 'unavailable'
-}
-
-function collectIssueCloseTimestamps(issues: ResponsivenessIssueNode[], windowDays: ActivityWindowDays): string[] | Unavailable {
-  const timestamps = filterNodesByEndDate(issues, 'closedAt', windowDays)
-    .map((issue) => issue.closedAt)
-    .filter((value): value is string => Boolean(value))
-  return timestamps.length > 0 ? timestamps : 'unavailable'
-}
-
-function collectPullRequestMergeTimestamps(
-  pullRequests: Array<{
-    createdAt: string
-    mergedAt: string | null
-  }>,
-  windowDays: ActivityWindowDays,
-): string[] | Unavailable {
-  const timestamps = filterNodesByEndDate(pullRequests, 'mergedAt', windowDays)
-    .map((pullRequest) => pullRequest.mergedAt)
-    .filter((value): value is string => Boolean(value))
-  return timestamps.length > 0 ? timestamps : 'unavailable'
-}
-
-function computeMedianDurationHours<T extends { createdAt: string }>(
-  nodes: Array<T & Record<string, string | null>> | undefined,
-  endField: string,
-): number | Unavailable {
-  if (!nodes?.length) {
-    return 'unavailable'
-  }
-
-  const durations = nodes
-    .map((node) => {
-      const createdAt = new Date(node.createdAt)
-      const endValue = node[endField]
-      const endedAt = typeof endValue === 'string' ? new Date(endValue) : null
-
-      if (Number.isNaN(createdAt.getTime()) || !endedAt || Number.isNaN(endedAt.getTime()) || endedAt < createdAt) {
-        return null
-      }
-
-      return (endedAt.getTime() - createdAt.getTime()) / (1000 * 60 * 60)
-    })
-    .filter((value): value is number => value != null)
-    .sort((left, right) => left - right)
-
-  if (durations.length === 0) {
-    return 'unavailable'
-  }
-
-  const middle = Math.floor(durations.length / 2)
-  if (durations.length % 2 === 1) {
-    return durations[middle] ?? 'unavailable'
-  }
-
-  const lower = durations[middle - 1]
-  const upper = durations[middle]
-  if (lower == null || upper == null) {
-    return 'unavailable'
-  }
-
-  return (lower + upper) / 2
-}
-
-function computeMedian(values: number[]): number | Unavailable {
-  if (values.length === 0) {
-    return 'unavailable'
-  }
-
-  const sorted = [...values].sort((left, right) => left - right)
-  const middle = Math.floor(sorted.length / 2)
-  if (sorted.length % 2 === 1) {
-    return sorted[middle] ?? 'unavailable'
-  }
-
-  const lower = sorted[middle - 1]
-  const upper = sorted[middle]
-  if (lower == null || upper == null) {
-    return 'unavailable'
-  }
-
-  return (lower + upper) / 2
-}
-
-function computePercentile(values: number[], percentile: number): number | Unavailable {
-  if (values.length === 0) {
-    return 'unavailable'
-  }
-
-  const sorted = [...values].sort((left, right) => left - right)
-  const index = Math.max(0, Math.ceil(sorted.length * percentile) - 1)
-  return sorted[index] ?? 'unavailable'
-}
-
-function computeRatio(numerator: number | Unavailable, denominator: number | Unavailable): number | Unavailable {
-  if (typeof numerator !== 'number' || typeof denominator !== 'number' || denominator <= 0) {
-    return 'unavailable'
-  }
-
-  return numerator / denominator
-}
-
-function getIssueFirstResponseDurationHours(issue: ResponsivenessIssueNode): number | null {
-  return getDurationHours(issue.createdAt, getFirstNonAuthorInteraction(issue.author?.login ?? null, issue.comments.nodes)?.createdAt ?? null)
-}
-
-function getPullRequestFirstReviewDurationHours(pullRequest: ResponsivenessPullRequestNode): number | null {
-  const firstReview = getFirstNonAuthorInteraction(pullRequest.author?.login ?? null, pullRequest.reviews.nodes)
-  return getDurationHours(pullRequest.createdAt, firstReview?.createdAt ?? null)
-}
-
-function getResponseSignal(
-  authorLogin: string | null,
-  interactions: Array<{ createdAt: string; author: SearchActorNode | null }>,
-): ResponseSignal | null {
-  const firstResponse = getFirstNonAuthorInteraction(authorLogin, interactions)
-  if (!firstResponse) {
-    return {
-      firstResponderKind: null,
-      firstHumanResponseAt: null,
-    }
-  }
-
-  return {
-    firstResponderKind: isBotLogin(firstResponse.author?.login ?? null) ? 'bot' : 'human',
-    firstHumanResponseAt: isBotLogin(firstResponse.author?.login ?? null) ? null : firstResponse.createdAt,
-  }
-}
-
-function getFirstNonAuthorInteraction<T extends { createdAt: string; author: SearchActorNode | null }>(
-  authorLogin: string | null,
-  interactions: T[],
-): T | null {
-  const createdAtSorted = [...interactions].sort(
-    (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+  const legacyActivity = activity as RepoActivityResponse & LegacyRepoActivityResponse
+  const contributorMetrics = contributorMetricsByWindow[90]
+  const experimentalMetrics = experimentalMetricsByWindow[90]
+  const responsivenessMetricsByWindow = buildResponsivenessMetricsByWindow(
+    responsiveness,
+    activityMetricsByWindow,
+    overview.repository?.issues.totalCount,
+    overview.repository?.pullRequests?.totalCount,
   )
-
-  for (const interaction of createdAtSorted) {
-    const responderLogin = interaction.author?.login ?? null
-    if (!responderLogin || responderLogin === authorLogin) {
-      continue
+  const responsivenessMetrics = responsivenessMetricsByWindow[90]
+  const issueFirstResponseTimestamps = collectIssueFirstResponseTimestamps(responsiveness.recentCreatedIssues?.nodes ?? [], 90)
+  const issueCloseTimestamps = collectIssueCloseTimestamps(responsiveness.recentClosedIssues?.nodes ?? [], 90)
+  const prMergeTimestamps = collectPullRequestMergeTimestamps(responsiveness.recentMergedPullRequests?.nodes ?? [], 90)
+  const onboardingSignals = extractOnboardingSignals(overview.repository, activity)
+  const missingFields = [...UNAVAILABLE_FIELDS].filter((field) => {
+    if (field === 'releases12mo') {
+      return activityMetricsByWindow[365].releases === 'unavailable'
     }
 
-    return interaction
-  }
-
-  return null
-}
-
-function getDurationHours(start: string, end: string | null): number | null {
-  if (!end) {
-    return null
-  }
-
-  const startedAt = new Date(start)
-  const endedAt = new Date(end)
-
-  if (Number.isNaN(startedAt.getTime()) || Number.isNaN(endedAt.getTime()) || endedAt < startedAt) {
-    return null
-  }
-
-  return (endedAt.getTime() - startedAt.getTime()) / (1000 * 60 * 60)
-}
-
-function filterNodesByStartDate<T extends { createdAt: string }>(nodes: T[], windowDays: ActivityWindowDays) {
-  const cutoffTime = getWindowCutoffTime(windowDays)
-
-  return nodes.filter((node) => {
-    const createdAt = new Date(node.createdAt).getTime()
-    return !Number.isNaN(createdAt) && createdAt >= cutoffTime
-  })
-}
-
-function filterNodesByEndDate<T extends object, K extends keyof T>(
-  nodes: T[],
-  endField: K,
-  windowDays: ActivityWindowDays,
-) {
-  const cutoffTime = getWindowCutoffTime(windowDays)
-
-  return nodes.filter((node) => {
-    const endValue = node[endField]
-    if (typeof endValue !== 'string') {
-      return false
+    if (field === 'uniqueCommitAuthors90d') {
+      return contributorMetrics.uniqueCommitAuthors === 'unavailable'
     }
 
-    const endedAt = new Date(endValue).getTime()
-    return !Number.isNaN(endedAt) && endedAt >= cutoffTime
-  })
-}
+    if (field === 'commitCountsByAuthor') {
+      return contributorMetrics.commitCountsByAuthor === 'unavailable'
+    }
 
-function getWindowCutoffTime(windowDays: ActivityWindowDays) {
-  return Date.now() - windowDays * 24 * 60 * 60 * 1000
-}
+    if (field === 'totalContributors') {
+      const resolvedTotal = totalContributorCount !== 'unavailable'
+        ? totalContributorCount
+        : contributorMetricsByWindow[365].uniqueCommitAuthors !== 'unavailable' && contributorMetricsByWindow[365].uniqueCommitAuthors > 0
+          ? contributorMetricsByWindow[365].uniqueCommitAuthors
+          : 'unavailable'
+      return resolvedTotal === 'unavailable'
+    }
 
-function isBotLogin(login: string | null) {
-  if (!login) {
+    if (field === 'maintainerCount') {
+      return maintainerCount === 'unavailable'
+    }
+
+    if (field === 'commitCountsByExperimentalOrg') {
+      return experimentalMetrics.commitCountsByExperimentalOrg === 'unavailable'
+    }
+
+    if (field === 'experimentalAttributedAuthors90d') {
+      return experimentalMetrics.experimentalAttributedAuthors === 'unavailable'
+    }
+
+    if (field === 'experimentalUnattributedAuthors90d') {
+      return experimentalMetrics.experimentalUnattributedAuthors === 'unavailable'
+    }
+
+    if (field === 'issueFirstResponseTimestamps') {
+      return issueFirstResponseTimestamps === 'unavailable'
+    }
+
+    if (field === 'issueCloseTimestamps') {
+      return issueCloseTimestamps === 'unavailable'
+    }
+
+    if (field === 'prMergeTimestamps') {
+      return prMergeTimestamps === 'unavailable'
+    }
+
+    if (field === 'goodFirstIssueCount') {
+      return onboardingSignals.goodFirstIssueCount === 'unavailable'
+    }
+
+    if (field === 'devEnvironmentSetup') {
+      return onboardingSignals.devEnvironmentSetup === 'unavailable'
+    }
+
+    if (field === 'gitpodPresent') {
+      return onboardingSignals.gitpodPresent === 'unavailable'
+    }
+
+    if (field === 'newContributorPRAcceptanceRate') {
+      return onboardingSignals.newContributorPRAcceptanceRate === 'unavailable'
+    }
+
     return false
-  }
-
-  return login.includes('[bot]') || login.endsWith('-bot')
-}
-
-function computeMedianDurationHoursWithinWindow<T extends { createdAt: string }>(
-  nodes: Array<T & Record<string, string | null>>,
-  endField: string,
-  now: Date,
-  windowDays: ActivityWindowDays,
-): number | Unavailable {
-  const cutoff = new Date(now)
-  cutoff.setDate(cutoff.getDate() - windowDays)
-
-  const windowNodes = nodes.filter((node) => {
-    const endValue = node[endField]
-    if (typeof endValue !== 'string') {
-      return false
-    }
-
-    const endDate = new Date(endValue)
-    return !Number.isNaN(endDate.getTime()) && endDate >= cutoff
   })
 
-  return computeMedianDurationHours(windowNodes, endField)
-}
-
-async function buildExperimentalOrganizationCommitCountsByWindow(
-  token: string,
-  recentCommitNodes: CommitNode[],
-  now: Date,
-): Promise<{
-  data: Record<ContributorWindowDays, ContributorWindowMetrics>
-  rateLimit: RateLimitState | null
-}> {
-  if (recentCommitNodes.length === 0) {
-    return {
-      data: createUnavailableContributorWindowMetrics(),
-      rateLimit: null,
-    }
-  }
-
-  const uniqueLogins = new Set<string>()
-  for (const node of recentCommitNodes) {
-    const login = node.author?.user?.login?.trim()
-    if (login) {
-      uniqueLogins.add(login)
-    }
-  }
-
-  let rateLimit: RateLimitState | null = null
-  const organizationsByLogin = new Map<string, string[]>()
-
-  for (const login of uniqueLogins) {
-    const response = await fetchPublicUserOrganizations(token, login).catch((error) => ({
-      data: 'unavailable' as const,
-      rateLimit: extractRateLimitFromError(error),
-    }))
-    rateLimit = response.rateLimit ?? rateLimit
-
-    if (response.data === 'unavailable') {
-      organizationsByLogin.set(login, [])
-      continue
-    }
-
-    organizationsByLogin.set(login, response.data)
-  }
-
   return {
-    data: buildExperimentalMetricsByWindow(recentCommitNodes, organizationsByLogin, now),
-    rateLimit,
-  }
-}
-
-// Cap discussions pagination. Discussions pages are small and cheap, but
-// we still bound worst-case cost for hyperactive forums (e.g. vercel/next.js
-// which has thousands). 20 pages × 100 = 2,000 within-year discussions —
-// comfortably above the saturation point while preventing runaway cost.
-const MAX_DISCUSSION_PAGES = 20
-const DISCUSSION_WINDOW_CAP_DAYS = 365
-
-async function collectRecentDiscussionTimestamps({
-  token,
-  owner,
-  name,
-  initialConnection,
-}: {
-  token: string
-  owner: string
-  name: string
-  initialConnection: NonNullable<RepoOverviewResponse['repository']>['commDiscussionsRecent'] | null | undefined
-}): Promise<{ createdAt: string[]; truncated: boolean; rateLimit: RateLimitState | null }> {
-  if (!initialConnection) {
-    return { createdAt: [], truncated: false, rateLimit: null }
-  }
-
-  const createdAt: string[] = initialConnection.nodes.map((n) => n.createdAt)
-  const cutoffMs = Date.now() - DISCUSSION_WINDOW_CAP_DAYS * 24 * 60 * 60 * 1000
-  let rateLimit: RateLimitState | null = null
-  let hasNextPage = initialConnection.pageInfo?.hasNextPage ?? false
-  let cursor = initialConnection.pageInfo?.endCursor ?? null
-
-  // Short-circuit: if the first page already crossed the 365d cutoff,
-  // everything we care about is in hand.
-  const crossedCutoff = (nodes: string[]): boolean => {
-    if (nodes.length === 0) return false
-    const oldestMs = Date.parse(nodes[nodes.length - 1]!)
-    return Number.isFinite(oldestMs) && oldestMs < cutoffMs
-  }
-  if (crossedCutoff(createdAt)) {
-    return { createdAt, truncated: false, rateLimit }
-  }
-
-  let pagesFetched = 1 // the initial overview page counts as page 1
-  while (
-    hasNextPage &&
-    cursor &&
-    pagesFetched < MAX_DISCUSSION_PAGES
-  ) {
-    const response = await queryGitHubGraphQL<{
-      repository: { discussions: { pageInfo: { hasNextPage: boolean; endCursor: string | null }; nodes: Array<{ createdAt: string }> } } | null
-    }>(token, REPO_DISCUSSIONS_PAGE_QUERY, { owner, name, after: cursor })
-    rateLimit = response.rateLimit ?? rateLimit
-    const connection = response.data.repository?.discussions
-    if (!connection) break
-    const pageTimestamps = connection.nodes.map((n) => n.createdAt)
-    createdAt.push(...pageTimestamps)
-    pagesFetched += 1
-    if (crossedCutoff(pageTimestamps)) {
-      return { createdAt, truncated: false, rateLimit }
-    }
-    hasNextPage = connection.pageInfo.hasNextPage
-    cursor = connection.pageInfo.endCursor
-  }
-
-  // Truncated only when we hit the page cap while still inside the window.
-  const truncated = hasNextPage && pagesFetched >= MAX_DISCUSSION_PAGES
-  return { createdAt, truncated, rateLimit }
-}
-
-// Cap commit history pagination to avoid extremely long analysis times
-// for repos like torvalds/linux (50,000+ commits/year). 2,000 commits
-// is enough to identify unique contributors and compute accurate ratios.
-const MAX_COMMIT_HISTORY_NODES = 2000
-
-async function collectRecentCommitHistory({
-  token,
-  owner,
-  name,
-  since365,
-  initialConnection,
-}: {
-  token: string
-  owner: string
-  name: string
-  since365: string
-  initialConnection: CommitHistoryConnection | null
-}): Promise<{ nodes: CommitNode[]; rateLimit: RateLimitState | null }> {
-  if (!initialConnection) {
-    return { nodes: [], rateLimit: null }
-  }
-
-  const nodes = [...initialConnection.nodes]
-  let rateLimit: RateLimitState | null = null
-  let hasNextPage = initialConnection.pageInfo.hasNextPage
-  let cursor = initialConnection.pageInfo.endCursor
-
-  while (hasNextPage && cursor && nodes.length < MAX_COMMIT_HISTORY_NODES) {
-    const response = await queryGitHubGraphQL<RepoCommitHistoryPageResponse>(token, REPO_COMMIT_HISTORY_PAGE_QUERY, {
-      owner,
-      name,
-      since365,
-      after: cursor,
-    })
-
-    rateLimit = response.rateLimit ?? rateLimit
-
-    const connection = response.data.repository?.defaultBranchRef?.target?.recent365Commits
-    if (!connection) {
-      break
-    }
-
-    nodes.push(...connection.nodes)
-    hasNextPage = connection.pageInfo.hasNextPage
-    cursor = connection.pageInfo.endCursor
-  }
-
-  return { nodes, rateLimit }
-}
-
-function buildContributorMetricsByWindow(
-  recentCommitNodes: CommitNode[],
-  now: Date,
-): Record<ContributorWindowDays, ContributorWindowMetrics> {
-  const earliestContributionByAuthor = buildEarliestContributionByAuthor(recentCommitNodes)
-
-  return Object.fromEntries(
-    CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => {
-      const windowNodes = filterCommitNodesByWindow(recentCommitNodes, now, windowDays)
-      const metrics = buildContributorMetrics(windowNodes, earliestContributionByAuthor, now, windowDays)
-
-      return [
-        windowDays,
-        {
-          ...metrics,
-          commitCountsByExperimentalOrg: 'unavailable',
-          experimentalAttributedAuthors: 'unavailable',
-          experimentalUnattributedAuthors: 'unavailable',
-        },
-      ]
-    }),
-  ) as Record<ContributorWindowDays, ContributorWindowMetrics>
-}
-
-function buildContributorMetrics(
-  recentCommitNodes: CommitNode[],
-  earliestContributionByAuthor: Map<string, number> | Unavailable,
-  now: Date,
-  windowDays: ContributorWindowDays,
-): Pick<ContributorWindowMetrics, 'uniqueCommitAuthors' | 'commitCountsByAuthor' | 'repeatContributors' | 'newContributors'> {
-  if (recentCommitNodes.length === 0) {
-    return {
-      uniqueCommitAuthors: 0,
-      commitCountsByAuthor: {},
-      repeatContributors: 0,
-      newContributors: 0,
-    }
-  }
-
-  const commitCountsByAuthor = new Map<string, number>()
-
-  for (const node of recentCommitNodes) {
-    const actorKey = getCommitActorKey(node)
-
-    if (!actorKey) {
-      return {
-        uniqueCommitAuthors: 'unavailable',
-        commitCountsByAuthor: 'unavailable',
-        repeatContributors: 'unavailable',
-        newContributors: 'unavailable',
-      }
-    }
-
-    commitCountsByAuthor.set(actorKey, (commitCountsByAuthor.get(actorKey) ?? 0) + 1)
-  }
-
-  const repeatContributors = Array.from(commitCountsByAuthor.values()).filter((count) => count > 1).length
-  const newContributorCutoff = new Date(now)
-  newContributorCutoff.setDate(now.getDate() - windowDays)
-
-  const newContributors =
-    earliestContributionByAuthor === 'unavailable'
-      ? 'unavailable'
-      : Array.from(commitCountsByAuthor.keys()).filter((actorKey) => {
-          const firstSeenAt = earliestContributionByAuthor.get(actorKey)
-          return typeof firstSeenAt === 'number' && firstSeenAt >= newContributorCutoff.getTime()
-        }).length
-
-  return {
-    uniqueCommitAuthors: commitCountsByAuthor.size,
-    commitCountsByAuthor: Object.fromEntries(commitCountsByAuthor.entries()),
-    repeatContributors,
-    newContributors,
-  }
-}
-
-function createUnavailableContributorWindowMetrics(): Record<ContributorWindowDays, ContributorWindowMetrics> {
-  return Object.fromEntries(
-    CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => [
-      windowDays,
-      {
-        uniqueCommitAuthors: 'unavailable',
-        commitCountsByAuthor: 'unavailable',
-        repeatContributors: 'unavailable',
-        newContributors: 'unavailable',
-        commitCountsByExperimentalOrg: 'unavailable',
-        experimentalAttributedAuthors: 'unavailable',
-        experimentalUnattributedAuthors: 'unavailable',
-      },
-    ]),
-  ) as Record<ContributorWindowDays, ContributorWindowMetrics>
-}
-
-function buildExperimentalMetricsByWindow(
-  recentCommitNodes: CommitNode[],
-  organizationsByLogin: Map<string, string[]>,
-  now: Date,
-): Record<ContributorWindowDays, ContributorWindowMetrics> {
-  return Object.fromEntries(
-    CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => {
-      const windowNodes = filterCommitNodesByWindow(recentCommitNodes, now, windowDays)
-      if (windowNodes.length === 0) {
-        return [
-          windowDays,
-          {
-            uniqueCommitAuthors: 'unavailable',
-            commitCountsByAuthor: 'unavailable',
-            repeatContributors: 'unavailable',
-            newContributors: 'unavailable',
-            commitCountsByExperimentalOrg: 'unavailable',
-            experimentalAttributedAuthors: 'unavailable',
-            experimentalUnattributedAuthors: 'unavailable',
-          },
-        ]
-      }
-
-      const commitCountsByExperimentalOrg = new Map<string, number>()
-      const attributedAuthors = new Set<string>()
-      const unattributedAuthors = new Set<string>()
-      let sawResolvableAuthor = false
-
-      for (const node of windowNodes) {
-        const actorKey = getCommitActorKey(node)
-        if (!actorKey) {
-          continue
-        }
-        sawResolvableAuthor = true
-
-        const login = node.author?.user?.login?.trim()
-        if (!login) {
-          unattributedAuthors.add(actorKey)
-          continue
-        }
-
-        const orgs = organizationsByLogin.get(login) ?? []
-        if (orgs.length === 0) {
-          unattributedAuthors.add(actorKey)
-          continue
-        }
-
-        attributedAuthors.add(actorKey)
-        // Attribute commit to all public organizations the contributor belongs to
-        for (const org of orgs) {
-          commitCountsByExperimentalOrg.set(org, (commitCountsByExperimentalOrg.get(org) ?? 0) + 1)
-        }
-      }
-
-      // Include unaffiliated commits in the org map for transparent reporting
-      if (unattributedAuthors.size > 0 && sawResolvableAuthor) {
-        let unaffiliatedCommits = 0
-        for (const node of windowNodes) {
-          const actorKey = getCommitActorKey(node)
-          if (actorKey && unattributedAuthors.has(actorKey)) {
-            unaffiliatedCommits++
-          }
-        }
-        if (unaffiliatedCommits > 0) {
-          commitCountsByExperimentalOrg.set('Unaffiliated', unaffiliatedCommits)
-        }
-      }
-
-      return [
-        windowDays,
-        {
-          uniqueCommitAuthors: 'unavailable',
-          commitCountsByAuthor: 'unavailable',
-          repeatContributors: 'unavailable',
-          newContributors: 'unavailable',
-          commitCountsByExperimentalOrg:
-            sawResolvableAuthor && commitCountsByExperimentalOrg.size > 0
-              ? Object.fromEntries(commitCountsByExperimentalOrg.entries())
-              : 'unavailable',
-          experimentalAttributedAuthors: sawResolvableAuthor ? attributedAuthors.size : 'unavailable',
-          experimentalUnattributedAuthors: sawResolvableAuthor ? unattributedAuthors.size : 'unavailable',
-        },
-      ]
-    }),
-  ) as Record<ContributorWindowDays, ContributorWindowMetrics>
-}
-
-function filterCommitNodesByWindow(recentCommitNodes: CommitNode[], now: Date, windowDays: ContributorWindowDays) {
-  const cutoff = new Date(now)
-  cutoff.setDate(now.getDate() - windowDays)
-
-  return recentCommitNodes.filter((node) => {
-    const authoredDate = Date.parse(node.authoredDate)
-    if (Number.isNaN(authoredDate)) {
-      return false
-    }
-
-    return authoredDate >= cutoff.getTime()
-  })
-}
-
-function buildEarliestContributionByAuthor(recentCommitNodes: CommitNode[]): Map<string, number> | Unavailable {
-  if (recentCommitNodes.length === 0) {
-    return 'unavailable'
-  }
-
-  const earliestContributionByAuthor = new Map<string, number>()
-
-  for (const node of recentCommitNodes) {
-    const actorKey = getCommitActorKey(node)
-    const authoredAt = Date.parse(node.authoredDate)
-
-    if (!actorKey || Number.isNaN(authoredAt)) {
-      return 'unavailable'
-    }
-
-    const currentEarliest = earliestContributionByAuthor.get(actorKey)
-    if (currentEarliest == null || authoredAt < currentEarliest) {
-      earliestContributionByAuthor.set(actorKey, authoredAt)
-    }
-  }
-
-  return earliestContributionByAuthor
-}
-
-function getCommitActorKey(node: CommitNode): string | null {
-  const login = node.author?.user?.login?.trim()
-  if (login) {
-    return `login:${login}`
-  }
-
-  const email = node.author?.email?.trim()
-  if (email) {
-    return `email:${email.toLowerCase()}`
-  }
-
-  const name = node.author?.name?.trim()
-  if (name) {
-    return `name:${name.toLowerCase()}`
-  }
-
-  return null
-}
-
-function buildFailure(repo: string, error: unknown): RepositoryFetchFailure {
-  const maybeError = toAnalyzerError(error)
-  const message = maybeError.message?.toLowerCase() ?? ''
-
-  if (message.includes('not found')) {
-    return { repo, reason: 'Repository could not be analyzed.', code: 'NOT_FOUND' }
-  }
-
-  if (maybeError.status === 401) {
-    return { repo, reason: 'GitHub rejected the provided token.', code: 'UNAUTHORIZED' }
-  }
-
-  if (maybeError.status === 403 || message.includes('rate limit')) {
-    return { repo, reason: 'GitHub rate limit prevented analysis.', code: 'RATE_LIMITED' }
-  }
-
-  return { repo, reason: 'Repository could not be analyzed.', code: 'FETCH_FAILED' }
-}
-
-function buildUnavailableActivityCounts(): RepoActivityCountsResponse {
-  const unavailable = { issueCount: 0 }
-  return {
-    prsOpened30: unavailable, prsOpened60: unavailable, prsOpened90: unavailable, prsOpened180: unavailable, prsOpened365: unavailable,
-    prsMerged30: unavailable, prsMerged60: unavailable, prsMerged90: unavailable, prsMerged180: unavailable, prsMerged365: unavailable,
-    issuesOpened30: unavailable, issuesOpened60: unavailable, issuesOpened90: unavailable, issuesOpened180: unavailable, issuesOpened365: unavailable,
-    issuesClosed30: unavailable, issuesClosed60: unavailable, issuesClosed90: unavailable, issuesClosed180: unavailable, issuesClosed365: unavailable,
-    staleIssues30: unavailable, staleIssues60: unavailable, staleIssues90: unavailable, staleIssues180: unavailable, staleIssues365: unavailable,
-    goodFirstIssues: unavailable,
-    goodFirstIssuesHyphenated: unavailable,
-    goodFirstIssuesBeginner: unavailable,
-    goodFirstIssuesStarter: unavailable,
-    recentMergedPullRequests: { nodes: [] },
-    recentClosedIssues: { nodes: [] },
-  }
-}
-
-function buildDiagnostic(
-  repo: string,
-  source: string,
-  error: unknown,
-  level: AnalysisDiagnostic['level'] = 'warn',
-): AnalysisDiagnostic {
-  const maybeError = toAnalyzerError(error)
-
-  return {
-    level,
     repo,
-    source,
-    message: maybeError.message ?? 'Unknown analysis error',
-    status: maybeError.status,
-    retryAfter: maybeError.retryAfter,
+    name: overview.repository?.name ?? 'unavailable',
+    description: overview.repository?.description ?? 'unavailable',
+    createdAt: overview.repository?.createdAt ?? 'unavailable',
+    primaryLanguage: overview.repository?.primaryLanguage?.name ?? 'unavailable',
+    stars: overview.repository?.stargazerCount ?? 'unavailable',
+    forks: overview.repository?.forkCount ?? 'unavailable',
+    watchers: overview.repository?.watchers.totalCount ?? 'unavailable',
+    commits30d: defaultBranchTarget?.recent30.totalCount ?? 'unavailable',
+    commits90d: defaultBranchTarget?.recent90.totalCount ?? 'unavailable',
+    releases12mo: activityMetricsByWindow[365].releases,
+    prsOpened90d: activity.prsOpened90?.issueCount ?? legacyActivity.prsOpened?.issueCount ?? 'unavailable',
+    prsMerged90d: activity.prsMerged90?.issueCount ?? legacyActivity.prsMerged?.issueCount ?? 'unavailable',
+    issuesOpen: overview.repository?.issues.totalCount ?? 'unavailable',
+    issuesClosed90d: activity.issuesClosed90?.issueCount ?? legacyActivity.issuesClosed?.issueCount ?? 'unavailable',
+    uniqueCommitAuthors90d: contributorMetrics.uniqueCommitAuthors,
+    totalContributors: totalContributorCount !== 'unavailable'
+      ? totalContributorCount
+      : contributorMetricsByWindow[365].uniqueCommitAuthors !== 'unavailable' && contributorMetricsByWindow[365].uniqueCommitAuthors > 0
+        ? contributorMetricsByWindow[365].uniqueCommitAuthors
+        : 'unavailable',
+    totalContributorsSource: totalContributorCount !== 'unavailable' ? 'api' : 'commit-history',
+    maintainerCount,
+    maintainerTokens,
+    commitCountsByAuthor: contributorMetrics.commitCountsByAuthor,
+    commitCountsByExperimentalOrg: experimentalMetrics.commitCountsByExperimentalOrg,
+    experimentalAttributedAuthors90d: experimentalMetrics.experimentalAttributedAuthors,
+    experimentalUnattributedAuthors90d: experimentalMetrics.experimentalUnattributedAuthors,
+    contributorMetricsByWindow: Object.fromEntries(
+      CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => [
+        windowDays,
+        {
+          ...contributorMetricsByWindow[windowDays],
+          commitCountsByExperimentalOrg: experimentalMetricsByWindow[windowDays].commitCountsByExperimentalOrg,
+          experimentalAttributedAuthors: experimentalMetricsByWindow[windowDays].experimentalAttributedAuthors,
+          experimentalUnattributedAuthors: experimentalMetricsByWindow[windowDays].experimentalUnattributedAuthors,
+        },
+      ]),
+    ) as Record<ContributorWindowDays, ContributorWindowMetrics>,
+    activityMetricsByWindow,
+    activityCadenceByWindow,
+    commitTimestamps365d,
+    responsivenessMetricsByWindow,
+    responsivenessMetrics,
+    staleIssueRatio: activityMetricsByWindow[90].staleIssueRatio,
+    medianTimeToMergeHours: activityMetricsByWindow[90].medianTimeToMergeHours,
+    medianTimeToCloseHours: activityMetricsByWindow[90].medianTimeToCloseHours,
+    documentationResult: extractDocumentationResult(overview.repository, readmeResolved),
+    licensingResult: overview.repository
+      ? (() => {
+          const repo = overview.repository
+          // Collect license file content for SPDX expression parsing
+          const licenseFileContent =
+            repo.docLicense?.text ?? repo.docLicenseLower?.text ??
+            repo.docLicenseMd?.text ?? repo.docLicenseMdLower?.text ??
+            repo.docLicenseTxt?.text ?? repo.docLicenseTxtLower?.text ??
+            repo.docLicenseRst?.text ?? repo.docLicenseRstLower?.text ??
+            repo.docCopying?.text ?? repo.docCopyingLower?.text ?? null
+          // Collect additional license files (LICENSE-MIT, LICENSE-APACHE, etc.)
+          const additionalLicenseFiles: LicenseFileInfo[] = [
+            { suffix: 'MIT', content: repo.docLicenseMit?.text ?? null },
+            { suffix: 'APACHE', content: repo.docLicenseApache?.text ?? null },
+            { suffix: 'BSD', content: repo.docLicenseBsd?.text ?? null },
+          ]
+          return extractLicensingResult(
+            repo.licenseInfo ?? null,
+            recentCommitNodes.filter((n): n is CommitNode & { message: string } => typeof n.message === 'string'),
+            repo.workflowDir ?? null,
+            licenseFileContent,
+            additionalLicenseFiles,
+          )
+        })()
+      : 'unavailable',
+    defaultBranchName: overview.repository?.defaultBranchRef?.name ?? 'unavailable',
+    topics: overview.repository?.repositoryTopics?.nodes.map((n) => n.topic.name) ?? [],
+    inclusiveNamingResult: overview.repository
+      ? extractInclusiveNamingResult(
+          overview.repository.defaultBranchRef?.name ?? null,
+          overview.repository.description ?? null,
+          overview.repository.repositoryTopics?.nodes.map((n) => n.topic.name) ?? [],
+        )
+      : 'unavailable',
+    issueFirstResponseTimestamps,
+    issueCloseTimestamps,
+    prMergeTimestamps,
+    securityResult: extractSecurityResult(overview.repository),
+    ...extractCommunitySignals(overview.repository, 90, discussionTimestamps, discussionsTruncated),
+    releaseHealthResult: extractReleaseHealthResult(activity, now),
+    ...onboardingSignals,
+    ...extractMaturitySignals({
+      createdAt: overview.repository?.createdAt ?? 'unavailable',
+      stars: overview.repository?.stargazerCount ?? 'unavailable',
+      totalContributors: totalContributorCount !== 'unavailable'
+        ? totalContributorCount
+        : contributorMetricsByWindow[365].uniqueCommitAuthors !== 'unavailable' && contributorMetricsByWindow[365].uniqueCommitAuthors > 0
+          ? contributorMetricsByWindow[365].uniqueCommitAuthors
+          : 'unavailable',
+      lifetimeCommits: defaultBranchTarget?.lifetime?.totalCount ?? 'unavailable',
+      recent365Commits: defaultBranchTarget?.recent365?.totalCount ?? 'unavailable',
+      now,
+    }),
+    missingFields,
   }
 }

--- a/lib/analyzer/analyzer-utils.test.ts
+++ b/lib/analyzer/analyzer-utils.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDiagnostic,
+  buildFailure,
+  collectIssueCloseTimestamps,
+  collectIssueFirstResponseTimestamps,
+  collectPullRequestMergeTimestamps,
+  computeMedian,
+  computeMedianDurationHours,
+  computeMedianDurationHoursWithinWindow,
+  computePercentile,
+  computeRatio,
+  computeStaleIssueRatio,
+  computeStaleItemRatio,
+  countReleaseDatesWithinWindow,
+  extractRateLimitFromError,
+  filterNodesByEndDate,
+  filterNodesByStartDate,
+  getDurationHours,
+  getFirstNonAuthorInteraction,
+  getResponseSignal,
+  getWindowCutoffTime,
+  isBotLogin,
+  toAnalyzerError,
+} from './analyzer-utils'
+
+describe('toAnalyzerError', () => {
+  it('returns empty object for null/primitive', () => {
+    expect(toAnalyzerError(null)).toEqual({})
+    expect(toAnalyzerError('string')).toEqual({})
+    expect(toAnalyzerError(42)).toEqual({})
+  })
+
+  it('extracts message, status, retryAfter from error-like object', () => {
+    const error = { message: 'rate limited', status: 403, retryAfter: 60 }
+    expect(toAnalyzerError(error)).toEqual({ message: 'rate limited', status: 403, retryAfter: 60 })
+  })
+
+  it('accepts retryAfter=unavailable', () => {
+    const error = { retryAfter: 'unavailable' }
+    expect(toAnalyzerError(error).retryAfter).toBe('unavailable')
+  })
+})
+
+describe('extractRateLimitFromError', () => {
+  it('returns null when error has no rate-limit signals', () => {
+    expect(extractRateLimitFromError(new Error('not found'))).toBeNull()
+  })
+
+  it('returns rate-limit state when status is 403', () => {
+    const result = extractRateLimitFromError({ status: 403 })
+    expect(result).not.toBeNull()
+    expect(result?.limit).toBe('unavailable')
+  })
+
+  it('returns rate-limit state when retryAfter is set', () => {
+    const result = extractRateLimitFromError({ retryAfter: 120 })
+    expect(result?.retryAfter).toBe(120)
+  })
+})
+
+describe('buildFailure', () => {
+  it('maps NOT_FOUND message to NOT_FOUND code', () => {
+    const result = buildFailure('owner/repo', { message: 'not found' })
+    expect(result.code).toBe('NOT_FOUND')
+  })
+
+  it('maps status 401 to UNAUTHORIZED code', () => {
+    const result = buildFailure('owner/repo', { status: 401 })
+    expect(result.code).toBe('UNAUTHORIZED')
+  })
+
+  it('maps status 403 to RATE_LIMITED code', () => {
+    const result = buildFailure('owner/repo', { status: 403 })
+    expect(result.code).toBe('RATE_LIMITED')
+  })
+
+  it('maps unknown error to FETCH_FAILED code', () => {
+    const result = buildFailure('owner/repo', { message: 'something unexpected' })
+    expect(result.code).toBe('FETCH_FAILED')
+  })
+})
+
+describe('buildDiagnostic', () => {
+  it('defaults to warn level and extracts message', () => {
+    const result = buildDiagnostic('owner/repo', 'test-source', { message: 'oops' })
+    expect(result.level).toBe('warn')
+    expect(result.repo).toBe('owner/repo')
+    expect(result.source).toBe('test-source')
+    expect(result.message).toBe('oops')
+  })
+
+  it('accepts explicit level', () => {
+    const result = buildDiagnostic('owner/repo', 'test', new Error('x'), 'error')
+    expect(result.level).toBe('error')
+  })
+})
+
+describe('computeMedian', () => {
+  it('returns unavailable for empty array', () => {
+    expect(computeMedian([])).toBe('unavailable')
+  })
+
+  it('returns middle value for odd-length array', () => {
+    expect(computeMedian([3, 1, 2])).toBe(2)
+  })
+
+  it('returns average of two middle values for even-length array', () => {
+    expect(computeMedian([1, 2, 3, 4])).toBe(2.5)
+  })
+})
+
+describe('computePercentile', () => {
+  it('returns unavailable for empty array', () => {
+    expect(computePercentile([], 0.9)).toBe('unavailable')
+  })
+
+  it('returns p90 of values', () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const p90 = computePercentile(values, 0.9)
+    expect(typeof p90).toBe('number')
+    expect(p90).toBeGreaterThanOrEqual(9)
+  })
+})
+
+describe('computeRatio', () => {
+  it('returns unavailable when either value is unavailable', () => {
+    expect(computeRatio('unavailable', 10)).toBe('unavailable')
+    expect(computeRatio(5, 'unavailable')).toBe('unavailable')
+  })
+
+  it('returns unavailable when denominator is 0', () => {
+    expect(computeRatio(5, 0)).toBe('unavailable')
+  })
+
+  it('computes ratio correctly', () => {
+    expect(computeRatio(3, 6)).toBe(0.5)
+  })
+})
+
+describe('computeMedianDurationHours', () => {
+  it('returns unavailable when nodes is empty', () => {
+    expect(computeMedianDurationHours([], 'closedAt')).toBe('unavailable')
+  })
+
+  it('computes median duration', () => {
+    const now = new Date()
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString()
+    const fourHoursAgo = new Date(now.getTime() - 4 * 60 * 60 * 1000).toISOString()
+    const nodes = [
+      { createdAt: fourHoursAgo, closedAt: now.toISOString() },
+      { createdAt: twoHoursAgo, closedAt: now.toISOString() },
+    ]
+    const result = computeMedianDurationHours(nodes, 'closedAt')
+    expect(typeof result).toBe('number')
+    expect(result as number).toBeCloseTo(3, 0)
+  })
+})
+
+describe('computeMedianDurationHoursWithinWindow', () => {
+  it('returns unavailable when no nodes fall within the window', () => {
+    const now = new Date()
+    const old = new Date(now.getTime() - 200 * 24 * 60 * 60 * 1000)
+    const nodes = [{ createdAt: old.toISOString(), closedAt: old.toISOString() }]
+    expect(computeMedianDurationHoursWithinWindow(nodes, 'closedAt', now, 30)).toBe('unavailable')
+  })
+})
+
+describe('isBotLogin', () => {
+  it('identifies [bot] suffix', () => {
+    expect(isBotLogin('github-actions[bot]')).toBe(true)
+  })
+
+  it('identifies -bot suffix', () => {
+    expect(isBotLogin('dependabot-bot')).toBe(true)
+  })
+
+  it('returns false for human logins', () => {
+    expect(isBotLogin('octocat')).toBe(false)
+    expect(isBotLogin(null)).toBe(false)
+  })
+})
+
+describe('getFirstNonAuthorInteraction', () => {
+  it('returns null when all interactions are by the author', () => {
+    const interactions = [
+      { createdAt: '2024-01-01T00:00:00Z', author: { login: 'author' } },
+    ]
+    expect(getFirstNonAuthorInteraction('author', interactions)).toBeNull()
+  })
+
+  it('returns the first non-author interaction sorted by date', () => {
+    const interactions = [
+      { createdAt: '2024-01-03T00:00:00Z', author: { login: 'responder2' } },
+      { createdAt: '2024-01-02T00:00:00Z', author: { login: 'responder1' } },
+    ]
+    const result = getFirstNonAuthorInteraction('author', interactions)
+    expect(result?.author?.login).toBe('responder1')
+  })
+})
+
+describe('getDurationHours', () => {
+  it('returns null when end is null', () => {
+    expect(getDurationHours('2024-01-01T00:00:00Z', null)).toBeNull()
+  })
+
+  it('returns null when end is before start', () => {
+    expect(getDurationHours('2024-01-02T00:00:00Z', '2024-01-01T00:00:00Z')).toBeNull()
+  })
+
+  it('computes duration in hours', () => {
+    const result = getDurationHours('2024-01-01T00:00:00Z', '2024-01-01T02:00:00Z')
+    expect(result).toBe(2)
+  })
+})
+
+describe('getResponseSignal', () => {
+  it('returns null firstResponderKind when no interactions', () => {
+    const signal = getResponseSignal('author', [])
+    expect(signal?.firstResponderKind).toBeNull()
+  })
+
+  it('identifies bot first responder', () => {
+    const signal = getResponseSignal('author', [
+      { createdAt: '2024-01-01T01:00:00Z', author: { login: 'bot[bot]' } },
+    ])
+    expect(signal?.firstResponderKind).toBe('bot')
+    expect(signal?.firstHumanResponseAt).toBeNull()
+  })
+
+  it('identifies human first responder', () => {
+    const signal = getResponseSignal('author', [
+      { createdAt: '2024-01-01T01:00:00Z', author: { login: 'human-reviewer' } },
+    ])
+    expect(signal?.firstResponderKind).toBe('human')
+    expect(signal?.firstHumanResponseAt).toBe('2024-01-01T01:00:00Z')
+  })
+})
+
+describe('filterNodesByStartDate', () => {
+  it('filters out nodes before the window', () => {
+    const now = Date.now()
+    const recent = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const old = new Date(now - 100 * 24 * 60 * 60 * 1000).toISOString()
+    const nodes = [{ createdAt: recent }, { createdAt: old }]
+    const result = filterNodesByStartDate(nodes, 30)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.createdAt).toBe(recent)
+  })
+})
+
+describe('filterNodesByEndDate', () => {
+  it('filters nodes by end field within window', () => {
+    const now = Date.now()
+    const recentClose = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const oldClose = new Date(now - 100 * 24 * 60 * 60 * 1000).toISOString()
+    const nodes = [
+      { createdAt: '2024-01-01T00:00:00Z', closedAt: recentClose },
+      { createdAt: '2024-01-01T00:00:00Z', closedAt: oldClose },
+    ]
+    const result = filterNodesByEndDate(nodes, 'closedAt', 30)
+    expect(result).toHaveLength(1)
+  })
+})
+
+describe('getWindowCutoffTime', () => {
+  it('returns a timestamp approximately windowDays ago', () => {
+    const cutoff = getWindowCutoffTime(30)
+    const expected = Date.now() - 30 * 24 * 60 * 60 * 1000
+    expect(Math.abs(cutoff - expected)).toBeLessThan(1000)
+  })
+})
+
+describe('countReleaseDatesWithinWindow', () => {
+  it('returns 0 for empty array', () => {
+    expect(countReleaseDatesWithinWindow([], new Date(), 30)).toBe(0)
+  })
+
+  it('counts releases within window', () => {
+    const now = new Date()
+    const recent = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const old = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString()
+    expect(countReleaseDatesWithinWindow([recent, old], now, 30)).toBe(1)
+  })
+})
+
+describe('computeStaleIssueRatio', () => {
+  it('returns unavailable when inputs are undefined', () => {
+    expect(computeStaleIssueRatio(undefined, undefined)).toBe('unavailable')
+    expect(computeStaleIssueRatio(5, undefined)).toBe('unavailable')
+  })
+
+  it('returns unavailable when openIssueCount is 0', () => {
+    expect(computeStaleIssueRatio(5, 0)).toBe('unavailable')
+  })
+
+  it('computes ratio', () => {
+    expect(computeStaleIssueRatio(3, 10)).toBe(0.3)
+  })
+})
+
+describe('computeStaleItemRatio', () => {
+  it('computes ratio', () => {
+    expect(computeStaleItemRatio(2, 5)).toBe(0.4)
+  })
+})
+
+describe('collectIssueFirstResponseTimestamps', () => {
+  it('returns unavailable when no responses exist', () => {
+    const now = Date.now()
+    const issues = [
+      {
+        createdAt: new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString(),
+        author: { login: 'opener' },
+        comments: { totalCount: 0, nodes: [] },
+      },
+    ]
+    expect(collectIssueFirstResponseTimestamps(issues, 30)).toBe('unavailable')
+  })
+
+  it('collects first response timestamps within window', () => {
+    const now = Date.now()
+    const createdAt = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const responseAt = new Date(now - 4 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      {
+        createdAt,
+        author: { login: 'opener' },
+        comments: {
+          totalCount: 1,
+          nodes: [{ createdAt: responseAt, author: { login: 'responder' } }],
+        },
+      },
+    ]
+    const result = collectIssueFirstResponseTimestamps(issues, 30)
+    expect(Array.isArray(result)).toBe(true)
+    expect((result as string[])[0]).toBe(responseAt)
+  })
+})
+
+describe('collectIssueCloseTimestamps', () => {
+  it('returns unavailable when no closed issues in window', () => {
+    const old = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString()
+    const issues = [{ createdAt: old, closedAt: old, author: null, comments: { totalCount: 0, nodes: [] } }]
+    expect(collectIssueCloseTimestamps(issues, 30)).toBe('unavailable')
+  })
+})
+
+describe('collectPullRequestMergeTimestamps', () => {
+  it('collects merge timestamps within window', () => {
+    const now = Date.now()
+    const mergedAt = new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const prs = [{ createdAt: mergedAt, mergedAt }]
+    const result = collectPullRequestMergeTimestamps(prs, 30)
+    expect(Array.isArray(result)).toBe(true)
+  })
+})

--- a/lib/analyzer/analyzer-utils.ts
+++ b/lib/analyzer/analyzer-utils.ts
@@ -1,0 +1,336 @@
+import type { ActivityWindowDays, AnalysisDiagnostic, RateLimitState, RepositoryFetchFailure, Unavailable } from './analysis-result'
+import type {
+  AnalyzerError,
+  ResponsivenessIssueNode,
+  ResponseSignal,
+  SearchActorNode,
+  SearchCommentNode,
+  SearchReviewNode,
+} from './types'
+
+export function toAnalyzerError(error: unknown): AnalyzerError {
+  if (error === null || typeof error !== 'object') return {}
+  const e = error as Record<string, unknown>
+  return {
+    message: typeof e.message === 'string' ? e.message : undefined,
+    status: typeof e.status === 'number' ? e.status : undefined,
+    retryAfter: typeof e.retryAfter === 'number' || e.retryAfter === 'unavailable'
+      ? e.retryAfter as number | Unavailable
+      : undefined,
+  }
+}
+
+export function extractRateLimitFromError(error: unknown): RateLimitState | null {
+  const maybeError = toAnalyzerError(error)
+
+  if (maybeError.status !== 403 && maybeError.retryAfter == null) {
+    return null
+  }
+
+  return {
+    limit: 'unavailable',
+    remaining: 'unavailable',
+    resetAt: 'unavailable',
+    retryAfter: maybeError.retryAfter ?? 'unavailable',
+  }
+}
+
+export function buildFailure(repo: string, error: unknown): RepositoryFetchFailure {
+  const maybeError = toAnalyzerError(error)
+  const message = maybeError.message?.toLowerCase() ?? ''
+
+  if (message.includes('not found')) {
+    return { repo, reason: 'Repository could not be analyzed.', code: 'NOT_FOUND' }
+  }
+
+  if (maybeError.status === 401) {
+    return { repo, reason: 'GitHub rejected the provided token.', code: 'UNAUTHORIZED' }
+  }
+
+  if (maybeError.status === 403 || message.includes('rate limit')) {
+    return { repo, reason: 'GitHub rate limit prevented analysis.', code: 'RATE_LIMITED' }
+  }
+
+  return { repo, reason: 'Repository could not be analyzed.', code: 'FETCH_FAILED' }
+}
+
+export function buildDiagnostic(
+  repo: string,
+  source: string,
+  error: unknown,
+  level: AnalysisDiagnostic['level'] = 'warn',
+): AnalysisDiagnostic {
+  const maybeError = toAnalyzerError(error)
+
+  return {
+    level,
+    repo,
+    source,
+    message: maybeError.message ?? 'Unknown analysis error',
+    status: maybeError.status,
+    retryAfter: maybeError.retryAfter,
+  }
+}
+
+export function computeMedian(values: number[]): number | Unavailable {
+  if (values.length === 0) {
+    return 'unavailable'
+  }
+
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? 'unavailable'
+  }
+
+  const lower = sorted[middle - 1]
+  const upper = sorted[middle]
+  if (lower == null || upper == null) {
+    return 'unavailable'
+  }
+
+  return (lower + upper) / 2
+}
+
+export function computePercentile(values: number[], percentile: number): number | Unavailable {
+  if (values.length === 0) {
+    return 'unavailable'
+  }
+
+  const sorted = [...values].sort((left, right) => left - right)
+  const index = Math.max(0, Math.ceil(sorted.length * percentile) - 1)
+  return sorted[index] ?? 'unavailable'
+}
+
+export function computeRatio(numerator: number | Unavailable, denominator: number | Unavailable): number | Unavailable {
+  if (typeof numerator !== 'number' || typeof denominator !== 'number' || denominator <= 0) {
+    return 'unavailable'
+  }
+
+  return numerator / denominator
+}
+
+export function computeMedianDurationHours<T extends { createdAt: string }>(
+  nodes: Array<T & Record<string, string | null>> | undefined,
+  endField: string,
+): number | Unavailable {
+  if (!nodes?.length) {
+    return 'unavailable'
+  }
+
+  const durations = nodes
+    .map((node) => {
+      const createdAt = new Date(node.createdAt)
+      const endValue = node[endField]
+      const endedAt = typeof endValue === 'string' ? new Date(endValue) : null
+
+      if (Number.isNaN(createdAt.getTime()) || !endedAt || Number.isNaN(endedAt.getTime()) || endedAt < createdAt) {
+        return null
+      }
+
+      return (endedAt.getTime() - createdAt.getTime()) / (1000 * 60 * 60)
+    })
+    .filter((value): value is number => value != null)
+    .sort((left, right) => left - right)
+
+  if (durations.length === 0) {
+    return 'unavailable'
+  }
+
+  const middle = Math.floor(durations.length / 2)
+  if (durations.length % 2 === 1) {
+    return durations[middle] ?? 'unavailable'
+  }
+
+  const lower = durations[middle - 1]
+  const upper = durations[middle]
+  if (lower == null || upper == null) {
+    return 'unavailable'
+  }
+
+  return (lower + upper) / 2
+}
+
+export function computeMedianDurationHoursWithinWindow<T extends { createdAt: string }>(
+  nodes: Array<T & Record<string, string | null>>,
+  endField: string,
+  now: Date,
+  windowDays: ActivityWindowDays,
+): number | Unavailable {
+  const cutoff = new Date(now)
+  cutoff.setDate(cutoff.getDate() - windowDays)
+
+  const windowNodes = nodes.filter((node) => {
+    const endValue = node[endField]
+    if (typeof endValue !== 'string') {
+      return false
+    }
+
+    const endDate = new Date(endValue)
+    return !Number.isNaN(endDate.getTime()) && endDate >= cutoff
+  })
+
+  return computeMedianDurationHours(windowNodes, endField)
+}
+
+export function getWindowCutoffTime(windowDays: ActivityWindowDays) {
+  return Date.now() - windowDays * 24 * 60 * 60 * 1000
+}
+
+export function filterNodesByStartDate<T extends { createdAt: string }>(nodes: T[], windowDays: ActivityWindowDays) {
+  const cutoffTime = getWindowCutoffTime(windowDays)
+
+  return nodes.filter((node) => {
+    const createdAt = new Date(node.createdAt).getTime()
+    return !Number.isNaN(createdAt) && createdAt >= cutoffTime
+  })
+}
+
+export function filterNodesByEndDate<T extends object, K extends keyof T>(
+  nodes: T[],
+  endField: K,
+  windowDays: ActivityWindowDays,
+) {
+  const cutoffTime = getWindowCutoffTime(windowDays)
+
+  return nodes.filter((node) => {
+    const endValue = node[endField]
+    if (typeof endValue !== 'string') {
+      return false
+    }
+
+    const endedAt = new Date(endValue).getTime()
+    return !Number.isNaN(endedAt) && endedAt >= cutoffTime
+  })
+}
+
+export function isBotLogin(login: string | null) {
+  if (!login) {
+    return false
+  }
+
+  return login.includes('[bot]') || login.endsWith('-bot')
+}
+
+export function getFirstNonAuthorInteraction<T extends { createdAt: string; author: SearchActorNode | null }>(
+  authorLogin: string | null,
+  interactions: T[],
+): T | null {
+  const createdAtSorted = [...interactions].sort(
+    (left, right) => new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+  )
+
+  for (const interaction of createdAtSorted) {
+    const responderLogin = interaction.author?.login ?? null
+    if (!responderLogin || responderLogin === authorLogin) {
+      continue
+    }
+
+    return interaction
+  }
+
+  return null
+}
+
+export function getDurationHours(start: string, end: string | null): number | null {
+  if (!end) {
+    return null
+  }
+
+  const startedAt = new Date(start)
+  const endedAt = new Date(end)
+
+  if (Number.isNaN(startedAt.getTime()) || Number.isNaN(endedAt.getTime()) || endedAt < startedAt) {
+    return null
+  }
+
+  return (endedAt.getTime() - startedAt.getTime()) / (1000 * 60 * 60)
+}
+
+export function getIssueFirstResponseDurationHours(issue: ResponsivenessIssueNode): number | null {
+  return getDurationHours(issue.createdAt, getFirstNonAuthorInteraction(issue.author?.login ?? null, issue.comments.nodes)?.createdAt ?? null)
+}
+
+export function getPullRequestFirstReviewDurationHours(pullRequest: { createdAt: string; author: SearchActorNode | null; reviews: { nodes: Array<{ createdAt: string; author: SearchActorNode | null }> } }): number | null {
+  const firstReview = getFirstNonAuthorInteraction(pullRequest.author?.login ?? null, pullRequest.reviews.nodes)
+  return getDurationHours(pullRequest.createdAt, firstReview?.createdAt ?? null)
+}
+
+export function getResponseSignal(
+  authorLogin: string | null,
+  interactions: Array<{ createdAt: string; author: SearchActorNode | null }>,
+): ResponseSignal | null {
+  const firstResponse = getFirstNonAuthorInteraction(authorLogin, interactions)
+  if (!firstResponse) {
+    return {
+      firstResponderKind: null,
+      firstHumanResponseAt: null,
+    }
+  }
+
+  return {
+    firstResponderKind: isBotLogin(firstResponse.author?.login ?? null) ? 'bot' : 'human',
+    firstHumanResponseAt: isBotLogin(firstResponse.author?.login ?? null) ? null : firstResponse.createdAt,
+  }
+}
+
+export function collectIssueFirstResponseTimestamps(issues: ResponsivenessIssueNode[], windowDays: ActivityWindowDays): string[] | Unavailable {
+  const timestamps = filterNodesByStartDate(issues, windowDays)
+    .map((issue) => getFirstNonAuthorInteraction(issue.author?.login ?? null, issue.comments.nodes)?.createdAt ?? null)
+    .filter((value): value is string => Boolean(value))
+
+  return timestamps.length > 0 ? timestamps : 'unavailable'
+}
+
+export function collectIssueCloseTimestamps(issues: ResponsivenessIssueNode[], windowDays: ActivityWindowDays): string[] | Unavailable {
+  const timestamps = filterNodesByEndDate(issues, 'closedAt', windowDays)
+    .map((issue) => issue.closedAt)
+    .filter((value): value is string => Boolean(value))
+  return timestamps.length > 0 ? timestamps : 'unavailable'
+}
+
+export function collectPullRequestMergeTimestamps(
+  pullRequests: Array<{
+    createdAt: string
+    mergedAt: string | null
+  }>,
+  windowDays: ActivityWindowDays,
+): string[] | Unavailable {
+  const timestamps = filterNodesByEndDate(pullRequests, 'mergedAt', windowDays)
+    .map((pullRequest) => pullRequest.mergedAt)
+    .filter((value): value is string => Boolean(value))
+  return timestamps.length > 0 ? timestamps : 'unavailable'
+}
+
+export function computeStaleIssueRatio(staleIssueCount: number | undefined, openIssueCount: number | undefined): number | Unavailable {
+  if (typeof staleIssueCount !== 'number' || typeof openIssueCount !== 'number' || openIssueCount <= 0) {
+    return 'unavailable'
+  }
+
+  return staleIssueCount / openIssueCount
+}
+
+export function computeStaleItemRatio(staleItemCount: number | undefined, openItemCount: number | undefined): number | Unavailable {
+  if (typeof staleItemCount !== 'number' || typeof openItemCount !== 'number' || openItemCount <= 0) {
+    return 'unavailable'
+  }
+
+  return staleItemCount / openItemCount
+}
+
+export function countReleaseDatesWithinWindow(releaseDates: string[], now: Date, windowDays: ActivityWindowDays): number | Unavailable {
+  if (releaseDates.length === 0) {
+    return 0
+  }
+
+  const cutoff = new Date(now)
+  cutoff.setDate(cutoff.getDate() - windowDays)
+
+  return releaseDates.filter((value) => {
+    const date = new Date(value)
+    return !Number.isNaN(date.getTime()) && date >= cutoff
+  }).length
+}
+
+// Types re-exported for convenience — domain modules only need one import
+export type { SearchCommentNode, SearchReviewNode }

--- a/lib/analyzer/extract-activity.test.ts
+++ b/lib/analyzer/extract-activity.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildActivityCadenceByWindow,
+  buildActivityMetricsByWindow,
+  buildUnavailableActivityCounts,
+} from './extract-activity'
+import type { RepoActivityResponse } from './types'
+
+function makeActivity(overrides: Partial<RepoActivityResponse> = {}): RepoActivityResponse {
+  return {
+    repository: null,
+    prsOpened30: { issueCount: 0 },
+    prsOpened60: { issueCount: 0 },
+    prsOpened90: { issueCount: 0 },
+    prsOpened180: { issueCount: 0 },
+    prsOpened365: { issueCount: 0 },
+    prsMerged30: { issueCount: 0 },
+    prsMerged60: { issueCount: 0 },
+    prsMerged90: { issueCount: 0 },
+    prsMerged180: { issueCount: 0 },
+    prsMerged365: { issueCount: 0 },
+    issuesOpened30: { issueCount: 0 },
+    issuesOpened60: { issueCount: 0 },
+    issuesOpened90: { issueCount: 0 },
+    issuesOpened180: { issueCount: 0 },
+    issuesOpened365: { issueCount: 0 },
+    issuesClosed30: { issueCount: 0 },
+    issuesClosed60: { issueCount: 0 },
+    issuesClosed90: { issueCount: 0 },
+    issuesClosed180: { issueCount: 0 },
+    issuesClosed365: { issueCount: 0 },
+    staleIssues30: { issueCount: 0 },
+    staleIssues60: { issueCount: 0 },
+    staleIssues90: { issueCount: 0 },
+    staleIssues180: { issueCount: 0 },
+    staleIssues365: { issueCount: 0 },
+    recentMergedPullRequests: { nodes: [] },
+    recentClosedIssues: { nodes: [] },
+    ...overrides,
+  } as unknown as RepoActivityResponse
+}
+
+describe('buildUnavailableActivityCounts', () => {
+  it('returns zero issueCount for all windows', () => {
+    const counts = buildUnavailableActivityCounts()
+    expect(counts.prsOpened30.issueCount).toBe(0)
+    expect(counts.prsOpened365.issueCount).toBe(0)
+    expect(counts.recentMergedPullRequests.nodes).toHaveLength(0)
+  })
+
+  it('includes all expected count fields', () => {
+    const counts = buildUnavailableActivityCounts()
+    expect(counts).toHaveProperty('prsOpened30')
+    expect(counts).toHaveProperty('prsMerged365')
+    expect(counts).toHaveProperty('staleIssues90')
+    expect(counts).toHaveProperty('goodFirstIssues')
+  })
+})
+
+describe('buildActivityCadenceByWindow', () => {
+  it('returns undefined when commitTimestamps is unavailable', () => {
+    expect(buildActivityCadenceByWindow('unavailable', new Date())).toBeUndefined()
+  })
+
+  it('returns cadence metrics for all windows when timestamps provided', () => {
+    const now = new Date()
+    const timestamps = [
+      new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+      new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000).toISOString(),
+    ]
+    const result = buildActivityCadenceByWindow(timestamps, now)
+    expect(result).toBeDefined()
+    expect(result![30]).toBeDefined()
+    expect(result![90]).toBeDefined()
+    expect(result![365]).toBeDefined()
+  })
+})
+
+describe('buildActivityMetricsByWindow', () => {
+  it('returns unavailable for all metrics when activity is empty', () => {
+    const result = buildActivityMetricsByWindow(makeActivity(), new Date(), [], undefined)
+    expect(result[90].commits).toBe('unavailable')
+    expect(result[90].prsOpened).toBe(0)
+    expect(result[90].staleIssueRatio).toBe('unavailable')
+  })
+
+  it('uses prsOpened90 count from activity data', () => {
+    const activity = makeActivity({ prsOpened90: { issueCount: 42 } })
+    const result = buildActivityMetricsByWindow(activity, new Date(), [], undefined)
+    expect(result[90].prsOpened).toBe(42)
+  })
+
+  it('uses commit node count for 365d window', () => {
+    const now = new Date()
+    const nodes = [
+      { authoredDate: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString(), author: null },
+      { authoredDate: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString(), author: null },
+    ]
+    const result = buildActivityMetricsByWindow(makeActivity(), now, nodes, undefined)
+    expect(result[365].commits).toBe(2)
+  })
+
+  it('computes stale issue ratio from activity counts', () => {
+    const activity = makeActivity({ staleIssues90: { issueCount: 5 } })
+    const result = buildActivityMetricsByWindow(activity, new Date(), [], 20)
+    expect(result[90].staleIssueRatio).toBe(0.25)
+  })
+
+  it('counts releases within each window', () => {
+    const now = new Date()
+    const recentRelease = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const oldRelease = new Date(now.getTime() - 200 * 24 * 60 * 60 * 1000).toISOString()
+
+    const activity = makeActivity({
+      repository: {
+        releases: {
+          totalCount: 2,
+          nodes: [
+            { tagName: 'v1.1', name: null, description: null, isPrerelease: false, createdAt: recentRelease, publishedAt: recentRelease },
+            { tagName: 'v1.0', name: null, description: null, isPrerelease: false, createdAt: oldRelease, publishedAt: oldRelease },
+          ],
+        },
+        refs: null,
+        defaultBranchRef: null,
+      },
+    } as unknown as Partial<RepoActivityResponse>)
+
+    const result = buildActivityMetricsByWindow(activity, now, [], undefined)
+    expect(result[30].releases).toBe(1)
+    expect(result[365].releases).toBe(2)
+  })
+})
+

--- a/lib/analyzer/extract-activity.ts
+++ b/lib/analyzer/extract-activity.ts
@@ -1,0 +1,231 @@
+import type { ActivityCadenceMetrics, ActivityWindowDays, ActivityWindowMetrics, AnalysisResult, RateLimitState, Unavailable } from './analysis-result'
+import { ACTIVITY_WINDOW_DAYS } from './analysis-result'
+import { buildActivityCadenceMetrics } from '@/lib/activity/cadence'
+import { detectReleaseHealth } from '@/lib/release-health/detect'
+import { queryGitHubGraphQL } from './github-graphql'
+import { REPO_DISCUSSIONS_PAGE_QUERY } from './queries'
+import type { CommitNode, LegacyRepoActivityResponse, RepoActivityResponse, RepoActivityCountsResponse, RepoOverviewResponse } from './types'
+import {
+  computeMedianDurationHoursWithinWindow,
+  computeStaleIssueRatio,
+  countReleaseDatesWithinWindow,
+} from './analyzer-utils'
+
+// Cap discussions pagination. Discussions pages are small and cheap, but
+// we still bound worst-case cost for hyperactive forums (e.g. vercel/next.js
+// which has thousands). 20 pages × 100 = 2,000 within-year discussions —
+// comfortably above the saturation point while preventing runaway cost.
+export const MAX_DISCUSSION_PAGES = 20
+export const DISCUSSION_WINDOW_CAP_DAYS = 365
+
+// Cap commit history pagination to avoid extremely long analysis times
+// for repos like torvalds/linux (50,000+ commits/year). 2,000 commits
+// is enough to identify unique contributors and compute accurate ratios.
+export const MAX_COMMIT_HISTORY_NODES = 2000
+
+export async function collectRecentDiscussionTimestamps({
+  token,
+  owner,
+  name,
+  initialConnection,
+}: {
+  token: string
+  owner: string
+  name: string
+  initialConnection: NonNullable<RepoOverviewResponse['repository']>['commDiscussionsRecent'] | null | undefined
+}): Promise<{ createdAt: string[]; truncated: boolean; rateLimit: RateLimitState | null }> {
+  if (!initialConnection) {
+    return { createdAt: [], truncated: false, rateLimit: null }
+  }
+
+  const createdAt: string[] = initialConnection.nodes.map((n) => n.createdAt)
+  const cutoffMs = Date.now() - DISCUSSION_WINDOW_CAP_DAYS * 24 * 60 * 60 * 1000
+  let rateLimit: RateLimitState | null = null
+  let hasNextPage = initialConnection.pageInfo?.hasNextPage ?? false
+  let cursor = initialConnection.pageInfo?.endCursor ?? null
+
+  // Short-circuit: if the first page already crossed the 365d cutoff,
+  // everything we care about is in hand.
+  const crossedCutoff = (nodes: string[]): boolean => {
+    if (nodes.length === 0) return false
+    const oldestMs = Date.parse(nodes[nodes.length - 1]!)
+    return Number.isFinite(oldestMs) && oldestMs < cutoffMs
+  }
+  if (crossedCutoff(createdAt)) {
+    return { createdAt, truncated: false, rateLimit }
+  }
+
+  let pagesFetched = 1 // the initial overview page counts as page 1
+  while (
+    hasNextPage &&
+    cursor &&
+    pagesFetched < MAX_DISCUSSION_PAGES
+  ) {
+    const response = await queryGitHubGraphQL<{
+      repository: { discussions: { pageInfo: { hasNextPage: boolean; endCursor: string | null }; nodes: Array<{ createdAt: string }> } } | null
+    }>(token, REPO_DISCUSSIONS_PAGE_QUERY, { owner, name, after: cursor })
+    rateLimit = response.rateLimit ?? rateLimit
+    const connection = response.data.repository?.discussions
+    if (!connection) break
+    const pageTimestamps = connection.nodes.map((n) => n.createdAt)
+    createdAt.push(...pageTimestamps)
+    pagesFetched += 1
+    if (crossedCutoff(pageTimestamps)) {
+      return { createdAt, truncated: false, rateLimit }
+    }
+    hasNextPage = connection.pageInfo.hasNextPage
+    cursor = connection.pageInfo.endCursor
+  }
+
+  // Truncated only when we hit the page cap while still inside the window.
+  const truncated = hasNextPage && pagesFetched >= MAX_DISCUSSION_PAGES
+  return { createdAt, truncated, rateLimit }
+}
+
+export function buildActivityCadenceByWindow(
+  commitTimestamps365d: string[] | Unavailable,
+  now: Date,
+): Record<ActivityWindowDays, ActivityCadenceMetrics> | undefined {
+  if (!Array.isArray(commitTimestamps365d)) {
+    return undefined
+  }
+
+  return Object.fromEntries(
+    ACTIVITY_WINDOW_DAYS.map((windowDays) => [
+      windowDays,
+      buildActivityCadenceMetrics({
+        commitTimestamps: commitTimestamps365d,
+        now,
+        windowDays,
+      }),
+    ]),
+  ) as Record<ActivityWindowDays, ActivityCadenceMetrics>
+}
+
+export function buildActivityMetricsByWindow(
+  activity: RepoActivityResponse,
+  now: Date,
+  recentCommitNodes: CommitNode[],
+  openIssueCount: number | undefined,
+): Record<ActivityWindowDays, ActivityWindowMetrics> {
+  const legacyActivity = activity as RepoActivityResponse & LegacyRepoActivityResponse
+  const defaultBranchTarget = activity.repository?.defaultBranchRef?.target
+  const releaseDates =
+    activity.repository?.releases?.nodes?.map((release) => release.publishedAt ?? release.createdAt).filter((value): value is string => Boolean(value)) ??
+    []
+
+  const commitCountsByWindow: Record<ActivityWindowDays, number | Unavailable> = {
+    30: defaultBranchTarget?.recent30?.totalCount ?? 'unavailable',
+    60: defaultBranchTarget?.recent60?.totalCount ?? 'unavailable',
+    90: defaultBranchTarget?.recent90?.totalCount ?? 'unavailable',
+    180: defaultBranchTarget?.recent180?.totalCount ?? 'unavailable',
+    365: recentCommitNodes.length > 0 ? recentCommitNodes.length : defaultBranchTarget?.recent365Commits?.nodes.length ?? 'unavailable',
+  }
+
+  const mergedPullRequestNodes = activity.recentMergedPullRequests?.nodes ?? []
+  const closedIssueNodes = activity.recentClosedIssues?.nodes ?? []
+
+  return {
+    30: {
+      commits: commitCountsByWindow[30],
+      prsOpened: activity.prsOpened30?.issueCount ?? 'unavailable',
+      prsMerged: activity.prsMerged30?.issueCount ?? 'unavailable',
+      issuesOpened: activity.issuesOpened30?.issueCount ?? 'unavailable',
+      issuesClosed: activity.issuesClosed30?.issueCount ?? 'unavailable',
+      releases: countReleaseDatesWithinWindow(releaseDates, now, 30),
+      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues30?.issueCount, openIssueCount),
+      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 30),
+      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 30),
+    },
+    60: {
+      commits: commitCountsByWindow[60],
+      prsOpened: activity.prsOpened60?.issueCount ?? 'unavailable',
+      prsMerged: activity.prsMerged60?.issueCount ?? 'unavailable',
+      issuesOpened: activity.issuesOpened60?.issueCount ?? 'unavailable',
+      issuesClosed: activity.issuesClosed60?.issueCount ?? 'unavailable',
+      releases: countReleaseDatesWithinWindow(releaseDates, now, 60),
+      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues60?.issueCount, openIssueCount),
+      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 60),
+      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 60),
+    },
+    90: {
+      commits: commitCountsByWindow[90],
+      prsOpened: activity.prsOpened90?.issueCount ?? legacyActivity.prsOpened?.issueCount ?? 'unavailable',
+      prsMerged: activity.prsMerged90?.issueCount ?? legacyActivity.prsMerged?.issueCount ?? 'unavailable',
+      issuesOpened: activity.issuesOpened90?.issueCount ?? 'unavailable',
+      issuesClosed: activity.issuesClosed90?.issueCount ?? legacyActivity.issuesClosed?.issueCount ?? 'unavailable',
+      releases: countReleaseDatesWithinWindow(releaseDates, now, 90),
+      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues90?.issueCount, openIssueCount),
+      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 90),
+      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 90),
+    },
+    180: {
+      commits: commitCountsByWindow[180],
+      prsOpened: activity.prsOpened180?.issueCount ?? 'unavailable',
+      prsMerged: activity.prsMerged180?.issueCount ?? 'unavailable',
+      issuesOpened: activity.issuesOpened180?.issueCount ?? 'unavailable',
+      issuesClosed: activity.issuesClosed180?.issueCount ?? 'unavailable',
+      releases: countReleaseDatesWithinWindow(releaseDates, now, 180),
+      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues180?.issueCount, openIssueCount),
+      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 180),
+      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 180),
+    },
+    365: {
+      commits: commitCountsByWindow[365],
+      prsOpened: activity.prsOpened365?.issueCount ?? 'unavailable',
+      prsMerged: activity.prsMerged365?.issueCount ?? 'unavailable',
+      issuesOpened: activity.issuesOpened365?.issueCount ?? 'unavailable',
+      issuesClosed: activity.issuesClosed365?.issueCount ?? 'unavailable',
+      releases: countReleaseDatesWithinWindow(releaseDates, now, 365),
+      staleIssueRatio: computeStaleIssueRatio(activity.staleIssues365?.issueCount, openIssueCount),
+      medianTimeToMergeHours: computeMedianDurationHoursWithinWindow(mergedPullRequestNodes, 'mergedAt', now, 365),
+      medianTimeToCloseHours: computeMedianDurationHoursWithinWindow(closedIssueNodes, 'closedAt', now, 365),
+    },
+  }
+}
+
+export function buildUnavailableActivityCounts(): RepoActivityCountsResponse {
+  const unavailable = { issueCount: 0 }
+  return {
+    prsOpened30: unavailable, prsOpened60: unavailable, prsOpened90: unavailable, prsOpened180: unavailable, prsOpened365: unavailable,
+    prsMerged30: unavailable, prsMerged60: unavailable, prsMerged90: unavailable, prsMerged180: unavailable, prsMerged365: unavailable,
+    issuesOpened30: unavailable, issuesOpened60: unavailable, issuesOpened90: unavailable, issuesOpened180: unavailable, issuesOpened365: unavailable,
+    issuesClosed30: unavailable, issuesClosed60: unavailable, issuesClosed90: unavailable, issuesClosed180: unavailable, issuesClosed365: unavailable,
+    staleIssues30: unavailable, staleIssues60: unavailable, staleIssues90: unavailable, staleIssues180: unavailable, staleIssues365: unavailable,
+    goodFirstIssues: unavailable,
+    goodFirstIssuesHyphenated: unavailable,
+    goodFirstIssuesBeginner: unavailable,
+    goodFirstIssuesStarter: unavailable,
+    recentMergedPullRequests: { nodes: [] },
+    recentClosedIssues: { nodes: [] },
+  }
+}
+
+export function extractReleaseHealthResult(
+  activity: RepoActivityResponse,
+  now: Date,
+): AnalysisResult['releaseHealthResult'] {
+  const repo = activity.repository
+  if (!repo) return 'unavailable'
+  const releasesConnection = repo.releases
+  const rawNodes = releasesConnection?.nodes ?? []
+  const totalReleasesAllTime = typeof releasesConnection?.totalCount === 'number'
+    ? releasesConnection.totalCount
+    : rawNodes.length
+  const totalTags: number | Unavailable = typeof repo.refs?.totalCount === 'number'
+    ? repo.refs.totalCount
+    : 'unavailable'
+  return detectReleaseHealth({
+    releases: rawNodes.map((r) => ({
+      tagName: r.tagName,
+      name: r.name,
+      body: r.description,
+      isPrerelease: r.isPrerelease,
+      createdAt: r.createdAt,
+      publishedAt: r.publishedAt,
+    })),
+    totalReleasesAllTime,
+    totalTags,
+    now,
+  })
+}

--- a/lib/analyzer/extract-contributors.test.ts
+++ b/lib/analyzer/extract-contributors.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildContributorMetrics,
+  buildEarliestContributionByAuthor,
+  buildExperimentalMetricsByWindow,
+  createUnavailableContributorWindowMetrics,
+  filterCommitNodesByWindow,
+  getCommitActorKey,
+} from './extract-contributors'
+import type { CommitNode } from './types'
+
+function makeCommit(login: string | null, email: string | null, daysAgo: number): CommitNode {
+  const d = new Date()
+  d.setDate(d.getDate() - daysAgo)
+  return {
+    authoredDate: d.toISOString(),
+    author: {
+      name: login ?? email ?? 'anon',
+      email,
+      user: login ? { login } : null,
+    },
+  }
+}
+
+describe('getCommitActorKey', () => {
+  it('prefers login over email over name', () => {
+    const node = makeCommit('user1', 'user1@example.com', 1)
+    expect(getCommitActorKey(node)).toBe('login:user1')
+  })
+
+  it('falls back to email when no login', () => {
+    const node = makeCommit(null, 'user@example.com', 1)
+    expect(getCommitActorKey(node)).toBe('email:user@example.com')
+  })
+
+  it('returns null when author is null', () => {
+    const node: CommitNode = { authoredDate: new Date().toISOString(), author: null }
+    expect(getCommitActorKey(node)).toBeNull()
+  })
+})
+
+describe('filterCommitNodesByWindow', () => {
+  it('keeps nodes within the window', () => {
+    const now = new Date()
+    const nodes = [makeCommit('user1', null, 5), makeCommit('user2', null, 100)]
+    const result = filterCommitNodesByWindow(nodes, now, 30)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.author?.user?.login).toBe('user1')
+  })
+
+  it('returns empty when no nodes are in range', () => {
+    const now = new Date()
+    const nodes = [makeCommit('user1', null, 200)]
+    expect(filterCommitNodesByWindow(nodes, now, 90)).toHaveLength(0)
+  })
+})
+
+describe('buildEarliestContributionByAuthor', () => {
+  it('returns unavailable for empty array', () => {
+    expect(buildEarliestContributionByAuthor([])).toBe('unavailable')
+  })
+
+  it('tracks earliest contribution per author', () => {
+    const now = new Date()
+    const d10 = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString()
+    const d5 = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    const nodes: CommitNode[] = [
+      { authoredDate: d10, author: { name: 'alice', email: null, user: { login: 'alice' } } },
+      { authoredDate: d5, author: { name: 'alice', email: null, user: { login: 'alice' } } },
+    ]
+    const result = buildEarliestContributionByAuthor(nodes)
+    expect(result).not.toBe('unavailable')
+    const map = result as Map<string, number>
+    expect(map.get('login:alice')).toBe(Date.parse(d10))
+  })
+})
+
+describe('buildContributorMetrics', () => {
+  it('returns zero counts for empty nodes', () => {
+    const metrics = buildContributorMetrics([], 'unavailable', new Date(), 90)
+    expect(metrics.uniqueCommitAuthors).toBe(0)
+    expect(metrics.commitCountsByAuthor).toEqual({})
+    expect(metrics.repeatContributors).toBe(0)
+    expect(metrics.newContributors).toBe(0)
+  })
+
+  it('counts unique authors and repeat contributors', () => {
+    const now = new Date()
+    const nodes = [
+      makeCommit('alice', null, 5),
+      makeCommit('alice', null, 4),
+      makeCommit('bob', null, 3),
+    ]
+    const earliest = buildEarliestContributionByAuthor(nodes)
+    const metrics = buildContributorMetrics(nodes, earliest, now, 90)
+    expect(metrics.uniqueCommitAuthors).toBe(2)
+    expect(metrics.repeatContributors).toBe(1)
+  })
+
+  it('identifies new contributors', () => {
+    const now = new Date()
+    const nodes = [
+      makeCommit('alice', null, 5),  // within 30d window
+      makeCommit('bob', null, 60),   // outside 30d window
+    ]
+    const allNodes = [...nodes, makeCommit('bob', null, 60)]
+    const earliest = buildEarliestContributionByAuthor(allNodes)
+    const metrics = buildContributorMetrics(nodes, earliest, now, 30)
+    // alice's first contribution is within window → new contributor
+    expect(metrics.newContributors).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('createUnavailableContributorWindowMetrics', () => {
+  it('returns unavailable for all window sizes', () => {
+    const result = createUnavailableContributorWindowMetrics()
+    for (const windowDays of [30, 60, 90, 180, 365]) {
+      expect(result[windowDays as 30 | 60 | 90 | 180 | 365].uniqueCommitAuthors).toBe('unavailable')
+    }
+  })
+})
+
+describe('buildExperimentalMetricsByWindow', () => {
+  it('returns unavailable when no nodes', () => {
+    const result = buildExperimentalMetricsByWindow([], new Map(), new Date())
+    expect(result[90].commitCountsByExperimentalOrg).toBe('unavailable')
+  })
+
+  it('attributes commits to organizations', () => {
+    const now = new Date()
+    const nodes = [makeCommit('alice', null, 5)]
+    const orgs = new Map([['alice', ['CNCF']]])
+    const result = buildExperimentalMetricsByWindow(nodes, orgs, now)
+    const w90 = result[90]
+    expect(w90.commitCountsByExperimentalOrg).not.toBe('unavailable')
+    const orgCounts = w90.commitCountsByExperimentalOrg as Record<string, number>
+    expect(orgCounts['CNCF']).toBe(1)
+  })
+
+  it('buckets unaffiliated authors separately', () => {
+    const now = new Date()
+    const nodes = [makeCommit('alice', null, 5)]
+    const orgs = new Map([['alice', [] as string[]]])
+    const result = buildExperimentalMetricsByWindow(nodes, orgs, now)
+    const w90 = result[90]
+    const orgCounts = w90.commitCountsByExperimentalOrg as Record<string, number>
+    expect(orgCounts['Unaffiliated']).toBe(1)
+  })
+})

--- a/lib/analyzer/extract-contributors.ts
+++ b/lib/analyzer/extract-contributors.ts
@@ -1,0 +1,341 @@
+import type { ContributorWindowDays, ContributorWindowMetrics, RateLimitState, Unavailable } from './analysis-result'
+import { CONTRIBUTOR_WINDOW_DAYS } from './analysis-result'
+import { queryGitHubGraphQL } from './github-graphql'
+import { fetchPublicUserOrganizations } from './github-rest'
+import { REPO_COMMIT_HISTORY_PAGE_QUERY } from './queries'
+import type { CommitHistoryConnection, CommitNode, RepoCommitHistoryPageResponse } from './types'
+import { extractRateLimitFromError } from './analyzer-utils'
+
+// Cap commit history pagination to avoid extremely long analysis times
+// for repos like torvalds/linux (50,000+ commits/year). 2,000 commits
+// is enough to identify unique contributors and compute accurate ratios.
+export const MAX_COMMIT_HISTORY_NODES = 2000
+
+export async function collectRecentCommitHistory({
+  token,
+  owner,
+  name,
+  since365,
+  initialConnection,
+}: {
+  token: string
+  owner: string
+  name: string
+  since365: string
+  initialConnection: CommitHistoryConnection | null
+}): Promise<{ nodes: CommitNode[]; rateLimit: RateLimitState | null }> {
+  if (!initialConnection) {
+    return { nodes: [], rateLimit: null }
+  }
+
+  const nodes = [...initialConnection.nodes]
+  let rateLimit: RateLimitState | null = null
+  let hasNextPage = initialConnection.pageInfo.hasNextPage
+  let cursor = initialConnection.pageInfo.endCursor
+
+  while (hasNextPage && cursor && nodes.length < MAX_COMMIT_HISTORY_NODES) {
+    const response = await queryGitHubGraphQL<RepoCommitHistoryPageResponse>(token, REPO_COMMIT_HISTORY_PAGE_QUERY, {
+      owner,
+      name,
+      since365,
+      after: cursor,
+    })
+
+    rateLimit = response.rateLimit ?? rateLimit
+
+    const connection = response.data.repository?.defaultBranchRef?.target?.recent365Commits
+    if (!connection) {
+      break
+    }
+
+    nodes.push(...connection.nodes)
+    hasNextPage = connection.pageInfo.hasNextPage
+    cursor = connection.pageInfo.endCursor
+  }
+
+  return { nodes, rateLimit }
+}
+
+export function buildContributorMetricsByWindow(
+  recentCommitNodes: CommitNode[],
+  now: Date,
+): Record<ContributorWindowDays, ContributorWindowMetrics> {
+  const earliestContributionByAuthor = buildEarliestContributionByAuthor(recentCommitNodes)
+
+  return Object.fromEntries(
+    CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => {
+      const windowNodes = filterCommitNodesByWindow(recentCommitNodes, now, windowDays)
+      const metrics = buildContributorMetrics(windowNodes, earliestContributionByAuthor, now, windowDays)
+
+      return [
+        windowDays,
+        {
+          ...metrics,
+          commitCountsByExperimentalOrg: 'unavailable',
+          experimentalAttributedAuthors: 'unavailable',
+          experimentalUnattributedAuthors: 'unavailable',
+        },
+      ]
+    }),
+  ) as Record<ContributorWindowDays, ContributorWindowMetrics>
+}
+
+export function buildContributorMetrics(
+  recentCommitNodes: CommitNode[],
+  earliestContributionByAuthor: Map<string, number> | Unavailable,
+  now: Date,
+  windowDays: ContributorWindowDays,
+): Pick<ContributorWindowMetrics, 'uniqueCommitAuthors' | 'commitCountsByAuthor' | 'repeatContributors' | 'newContributors'> {
+  if (recentCommitNodes.length === 0) {
+    return {
+      uniqueCommitAuthors: 0,
+      commitCountsByAuthor: {},
+      repeatContributors: 0,
+      newContributors: 0,
+    }
+  }
+
+  const commitCountsByAuthor = new Map<string, number>()
+
+  for (const node of recentCommitNodes) {
+    const actorKey = getCommitActorKey(node)
+
+    if (!actorKey) {
+      return {
+        uniqueCommitAuthors: 'unavailable',
+        commitCountsByAuthor: 'unavailable',
+        repeatContributors: 'unavailable',
+        newContributors: 'unavailable',
+      }
+    }
+
+    commitCountsByAuthor.set(actorKey, (commitCountsByAuthor.get(actorKey) ?? 0) + 1)
+  }
+
+  const repeatContributors = Array.from(commitCountsByAuthor.values()).filter((count) => count > 1).length
+  const newContributorCutoff = new Date(now)
+  newContributorCutoff.setDate(now.getDate() - windowDays)
+
+  const newContributors =
+    earliestContributionByAuthor === 'unavailable'
+      ? 'unavailable'
+      : Array.from(commitCountsByAuthor.keys()).filter((actorKey) => {
+          const firstSeenAt = earliestContributionByAuthor.get(actorKey)
+          return typeof firstSeenAt === 'number' && firstSeenAt >= newContributorCutoff.getTime()
+        }).length
+
+  return {
+    uniqueCommitAuthors: commitCountsByAuthor.size,
+    commitCountsByAuthor: Object.fromEntries(commitCountsByAuthor.entries()),
+    repeatContributors,
+    newContributors,
+  }
+}
+
+export function createUnavailableContributorWindowMetrics(): Record<ContributorWindowDays, ContributorWindowMetrics> {
+  return Object.fromEntries(
+    CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => [
+      windowDays,
+      {
+        uniqueCommitAuthors: 'unavailable',
+        commitCountsByAuthor: 'unavailable',
+        repeatContributors: 'unavailable',
+        newContributors: 'unavailable',
+        commitCountsByExperimentalOrg: 'unavailable',
+        experimentalAttributedAuthors: 'unavailable',
+        experimentalUnattributedAuthors: 'unavailable',
+      },
+    ]),
+  ) as Record<ContributorWindowDays, ContributorWindowMetrics>
+}
+
+export async function buildExperimentalOrganizationCommitCountsByWindow(
+  token: string,
+  recentCommitNodes: CommitNode[],
+  now: Date,
+): Promise<{
+  data: Record<ContributorWindowDays, ContributorWindowMetrics>
+  rateLimit: RateLimitState | null
+}> {
+  if (recentCommitNodes.length === 0) {
+    return {
+      data: createUnavailableContributorWindowMetrics(),
+      rateLimit: null,
+    }
+  }
+
+  const uniqueLogins = new Set<string>()
+  for (const node of recentCommitNodes) {
+    const login = node.author?.user?.login?.trim()
+    if (login) {
+      uniqueLogins.add(login)
+    }
+  }
+
+  let rateLimit: RateLimitState | null = null
+  const organizationsByLogin = new Map<string, string[]>()
+
+  for (const login of uniqueLogins) {
+    const response = await fetchPublicUserOrganizations(token, login).catch((error) => ({
+      data: 'unavailable' as const,
+      rateLimit: extractRateLimitFromError(error),
+    }))
+    rateLimit = response.rateLimit ?? rateLimit
+
+    if (response.data === 'unavailable') {
+      organizationsByLogin.set(login, [])
+      continue
+    }
+
+    organizationsByLogin.set(login, response.data)
+  }
+
+  return {
+    data: buildExperimentalMetricsByWindow(recentCommitNodes, organizationsByLogin, now),
+    rateLimit,
+  }
+}
+
+export function buildExperimentalMetricsByWindow(
+  recentCommitNodes: CommitNode[],
+  organizationsByLogin: Map<string, string[]>,
+  now: Date,
+): Record<ContributorWindowDays, ContributorWindowMetrics> {
+  return Object.fromEntries(
+    CONTRIBUTOR_WINDOW_DAYS.map((windowDays) => {
+      const windowNodes = filterCommitNodesByWindow(recentCommitNodes, now, windowDays)
+      if (windowNodes.length === 0) {
+        return [
+          windowDays,
+          {
+            uniqueCommitAuthors: 'unavailable',
+            commitCountsByAuthor: 'unavailable',
+            repeatContributors: 'unavailable',
+            newContributors: 'unavailable',
+            commitCountsByExperimentalOrg: 'unavailable',
+            experimentalAttributedAuthors: 'unavailable',
+            experimentalUnattributedAuthors: 'unavailable',
+          },
+        ]
+      }
+
+      const commitCountsByExperimentalOrg = new Map<string, number>()
+      const attributedAuthors = new Set<string>()
+      const unattributedAuthors = new Set<string>()
+      let sawResolvableAuthor = false
+
+      for (const node of windowNodes) {
+        const actorKey = getCommitActorKey(node)
+        if (!actorKey) {
+          continue
+        }
+        sawResolvableAuthor = true
+
+        const login = node.author?.user?.login?.trim()
+        if (!login) {
+          unattributedAuthors.add(actorKey)
+          continue
+        }
+
+        const orgs = organizationsByLogin.get(login) ?? []
+        if (orgs.length === 0) {
+          unattributedAuthors.add(actorKey)
+          continue
+        }
+
+        attributedAuthors.add(actorKey)
+        // Attribute commit to all public organizations the contributor belongs to
+        for (const org of orgs) {
+          commitCountsByExperimentalOrg.set(org, (commitCountsByExperimentalOrg.get(org) ?? 0) + 1)
+        }
+      }
+
+      // Include unaffiliated commits in the org map for transparent reporting
+      if (unattributedAuthors.size > 0 && sawResolvableAuthor) {
+        let unaffiliatedCommits = 0
+        for (const node of windowNodes) {
+          const actorKey = getCommitActorKey(node)
+          if (actorKey && unattributedAuthors.has(actorKey)) {
+            unaffiliatedCommits++
+          }
+        }
+        if (unaffiliatedCommits > 0) {
+          commitCountsByExperimentalOrg.set('Unaffiliated', unaffiliatedCommits)
+        }
+      }
+
+      return [
+        windowDays,
+        {
+          uniqueCommitAuthors: 'unavailable',
+          commitCountsByAuthor: 'unavailable',
+          repeatContributors: 'unavailable',
+          newContributors: 'unavailable',
+          commitCountsByExperimentalOrg:
+            sawResolvableAuthor && commitCountsByExperimentalOrg.size > 0
+              ? Object.fromEntries(commitCountsByExperimentalOrg.entries())
+              : 'unavailable',
+          experimentalAttributedAuthors: sawResolvableAuthor ? attributedAuthors.size : 'unavailable',
+          experimentalUnattributedAuthors: sawResolvableAuthor ? unattributedAuthors.size : 'unavailable',
+        },
+      ]
+    }),
+  ) as Record<ContributorWindowDays, ContributorWindowMetrics>
+}
+
+export function filterCommitNodesByWindow(recentCommitNodes: CommitNode[], now: Date, windowDays: ContributorWindowDays) {
+  const cutoff = new Date(now)
+  cutoff.setDate(now.getDate() - windowDays)
+
+  return recentCommitNodes.filter((node) => {
+    const authoredDate = Date.parse(node.authoredDate)
+    if (Number.isNaN(authoredDate)) {
+      return false
+    }
+
+    return authoredDate >= cutoff.getTime()
+  })
+}
+
+export function buildEarliestContributionByAuthor(recentCommitNodes: CommitNode[]): Map<string, number> | Unavailable {
+  if (recentCommitNodes.length === 0) {
+    return 'unavailable'
+  }
+
+  const earliestContributionByAuthor = new Map<string, number>()
+
+  for (const node of recentCommitNodes) {
+    const actorKey = getCommitActorKey(node)
+    const authoredAt = Date.parse(node.authoredDate)
+
+    if (!actorKey || Number.isNaN(authoredAt)) {
+      return 'unavailable'
+    }
+
+    const currentEarliest = earliestContributionByAuthor.get(actorKey)
+    if (currentEarliest == null || authoredAt < currentEarliest) {
+      earliestContributionByAuthor.set(actorKey, authoredAt)
+    }
+  }
+
+  return earliestContributionByAuthor
+}
+
+export function getCommitActorKey(node: CommitNode): string | null {
+  const login = node.author?.user?.login?.trim()
+  if (login) {
+    return `login:${login}`
+  }
+
+  const email = node.author?.email?.trim()
+  if (email) {
+    return `email:${email.toLowerCase()}`
+  }
+
+  const name = node.author?.name?.trim()
+  if (name) {
+    return `name:${name.toLowerCase()}`
+  }
+
+  return null
+}

--- a/lib/analyzer/extract-responsiveness.test.ts
+++ b/lib/analyzer/extract-responsiveness.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildResponsivenessMetricsForWindow,
+  createUnavailableResponsivenessResponse,
+  mergeResponsivenessData,
+} from './extract-responsiveness'
+import type { ActivityWindowMetrics } from './analysis-result'
+
+const EMPTY_ACTIVITY_METRICS: ActivityWindowMetrics = {
+  commits: 0,
+  prsOpened: 0,
+  prsMerged: 0,
+  issuesOpened: 0,
+  issuesClosed: 0,
+  releases: 0,
+  staleIssueRatio: 'unavailable',
+  medianTimeToMergeHours: 'unavailable',
+  medianTimeToCloseHours: 'unavailable',
+}
+
+describe('createUnavailableResponsivenessResponse', () => {
+  it('returns empty node arrays with zero stale counts', () => {
+    const resp = createUnavailableResponsivenessResponse()
+    expect(resp.recentCreatedIssues.nodes).toHaveLength(0)
+    expect(resp.staleOpenPullRequests30.issueCount).toBe(0)
+    expect(resp.staleOpenPullRequests365.issueCount).toBe(0)
+  })
+})
+
+describe('mergeResponsivenessData', () => {
+  it('uses metadata when detail map is empty', () => {
+    const metadata = {
+      recentCreatedIssues: {
+        nodes: [{ id: 'i1', createdAt: '2024-01-01T00:00:00Z', author: { login: 'user' }, comments: { totalCount: 0 } }],
+      },
+      recentClosedIssues: { nodes: [] },
+      recentCreatedPullRequests: { nodes: [] },
+      recentMergedPullRequests: { nodes: [] },
+      staleOpenPullRequests30: { issueCount: 0 },
+      staleOpenPullRequests60: { issueCount: 0 },
+      staleOpenPullRequests90: { issueCount: 0 },
+      staleOpenPullRequests180: { issueCount: 0 },
+      staleOpenPullRequests365: { issueCount: 0 },
+    }
+    const result = mergeResponsivenessData(metadata, new Map())
+    expect(result.recentCreatedIssues.nodes).toHaveLength(1)
+    expect(result.recentCreatedIssues.nodes[0]!.createdAt).toBe('2024-01-01T00:00:00Z')
+  })
+
+  it('enriches nodes from detail map', () => {
+    const metadata = {
+      recentCreatedIssues: {
+        nodes: [{ id: 'i1', createdAt: '2024-01-01T00:00:00Z', author: { login: 'user' }, comments: { totalCount: 1 } }],
+      },
+      recentClosedIssues: { nodes: [] },
+      recentCreatedPullRequests: { nodes: [] },
+      recentMergedPullRequests: { nodes: [] },
+      staleOpenPullRequests30: { issueCount: 0 },
+      staleOpenPullRequests60: { issueCount: 0 },
+      staleOpenPullRequests90: { issueCount: 0 },
+      staleOpenPullRequests180: { issueCount: 0 },
+      staleOpenPullRequests365: { issueCount: 0 },
+    }
+    const detailMap = new Map([
+      ['i1', {
+        id: 'i1',
+        createdAt: '2024-01-01T00:00:00Z',
+        author: { login: 'user' },
+        comments: {
+          totalCount: 1,
+          nodes: [{ createdAt: '2024-01-01T01:00:00Z', author: { login: 'responder' } }],
+        },
+      }],
+    ])
+    const result = mergeResponsivenessData(metadata, detailMap)
+    expect(result.recentCreatedIssues.nodes[0]!.comments.nodes).toHaveLength(1)
+  })
+})
+
+describe('buildResponsivenessMetricsForWindow', () => {
+  it('returns unavailable for all duration metrics when no nodes', () => {
+    const metrics = buildResponsivenessMetricsForWindow(
+      90,
+      [],
+      [],
+      [],
+      [],
+      EMPTY_ACTIVITY_METRICS,
+      undefined,
+      undefined,
+      undefined,
+    )
+    expect(metrics.issueFirstResponseMedianHours).toBe('unavailable')
+    expect(metrics.prMergeMedianHours).toBe('unavailable')
+    expect(metrics.issueResolutionMedianHours).toBe('unavailable')
+  })
+
+  it('computes correct issue first response median', () => {
+    const now = Date.now()
+    const twoHoursAgo = new Date(now - 2 * 60 * 60 * 1000).toISOString()
+    const oneHourAgo = new Date(now - 1 * 60 * 60 * 1000).toISOString()
+    const fourHoursAgo = new Date(now - 4 * 60 * 60 * 1000).toISOString()
+    const threeHoursAgo = new Date(now - 3 * 60 * 60 * 1000).toISOString()
+    const issues = [
+      {
+        createdAt: fourHoursAgo,
+        author: { login: 'opener' },
+        comments: { totalCount: 1, nodes: [{ createdAt: threeHoursAgo, author: { login: 'responder' } }] },
+      },
+      {
+        createdAt: twoHoursAgo,
+        author: { login: 'opener' },
+        comments: { totalCount: 1, nodes: [{ createdAt: oneHourAgo, author: { login: 'responder' } }] },
+      },
+    ]
+    const metrics = buildResponsivenessMetricsForWindow(
+      90,
+      issues,
+      [],
+      [],
+      [],
+      EMPTY_ACTIVITY_METRICS,
+      undefined,
+      undefined,
+      undefined,
+    )
+    expect(typeof metrics.issueFirstResponseMedianHours).toBe('number')
+    expect(metrics.issueFirstResponseMedianHours as number).toBeCloseTo(1, 0)
+  })
+
+  it('computes stale PR ratio', () => {
+    const metrics = buildResponsivenessMetricsForWindow(
+      90,
+      [],
+      [],
+      [],
+      [],
+      EMPTY_ACTIVITY_METRICS,
+      5,
+      undefined,
+      20,
+    )
+    expect(metrics.stalePrRatio).toBe(0.25)
+  })
+
+  it('returns correct openIssueCount and openPullRequestCount', () => {
+    const metrics = buildResponsivenessMetricsForWindow(
+      90,
+      [],
+      [],
+      [],
+      [],
+      EMPTY_ACTIVITY_METRICS,
+      undefined,
+      42,
+      17,
+    )
+    expect(metrics.openIssueCount).toBe(42)
+    expect(metrics.openPullRequestCount).toBe(17)
+  })
+})

--- a/lib/analyzer/extract-responsiveness.ts
+++ b/lib/analyzer/extract-responsiveness.ts
@@ -1,0 +1,310 @@
+import type { ActivityWindowDays, ActivityWindowMetrics, AnalysisDiagnostic, RateLimitState, ResponsivenessMetrics } from './analysis-result'
+import { queryGitHubGraphQL } from './github-graphql'
+import { REPO_RESPONSIVENESS_METADATA_QUERY, buildResponsivenessDetailQuery } from './queries'
+import type {
+  DetailNode,
+  MetadataIssueNode,
+  MetadataPullRequestNode,
+  RepoResponsivenessMetadataResponse,
+  RepoResponsivenessResponse,
+  ResponsivenessIssueNode,
+  ResponsivenessPullRequestNode,
+} from './types'
+import {
+  buildDiagnostic,
+  computeMedian,
+  computePercentile,
+  computeRatio,
+  computeStaleItemRatio,
+  filterNodesByEndDate,
+  filterNodesByStartDate,
+  getDurationHours,
+  getIssueFirstResponseDurationHours,
+  getPullRequestFirstReviewDurationHours,
+  getResponseSignal,
+} from './analyzer-utils'
+
+export const DETAIL_BATCH_SIZE = 10
+
+export async function fetchResponsivenessTwoPass(
+  token: string,
+  variables: Record<string, string>,
+  diagnostics: Array<{ repo: string; source: string; message: string }>,
+  repo: string,
+): Promise<{ data: RepoResponsivenessResponse; rateLimit: RateLimitState | null }> {
+  // Pass 1: Lightweight metadata query
+  const metadataResult = await queryGitHubGraphQL<RepoResponsivenessMetadataResponse>(
+    token,
+    REPO_RESPONSIVENESS_METADATA_QUERY,
+    variables,
+  ).catch((error) => {
+    diagnostics.push(buildDiagnostic(repo, 'github-graphql:responsiveness-metadata', error))
+    return null
+  })
+
+  if (!metadataResult) {
+    return { data: createUnavailableResponsivenessResponse(), rateLimit: null }
+  }
+
+  const metadata = metadataResult.data
+
+  // Collect node IDs that need detail fetching (issues with comments, PRs with comments/reviews)
+  const detailRequests: Array<{ id: string; type: 'issue' | 'pr' }> = []
+
+  for (const issue of metadata.recentCreatedIssues?.nodes ?? []) {
+    if (issue?.id && issue.comments?.totalCount > 0) {
+      detailRequests.push({ id: issue.id, type: 'issue' })
+    }
+  }
+  for (const issue of metadata.recentClosedIssues?.nodes ?? []) {
+    if (issue?.id && issue.comments?.totalCount > 0) {
+      detailRequests.push({ id: issue.id, type: 'issue' })
+    }
+  }
+  for (const pr of metadata.recentCreatedPullRequests?.nodes ?? []) {
+    if (pr?.id && (pr.comments?.totalCount > 0 || pr.reviews?.totalCount > 0)) {
+      detailRequests.push({ id: pr.id, type: 'pr' })
+    }
+  }
+
+  // Deduplicate by id
+  const seen = new Set<string>()
+  const uniqueRequests = detailRequests.filter((r) => {
+    if (seen.has(r.id)) return false
+    seen.add(r.id)
+    return true
+  })
+
+  // Pass 2: Fetch comment/review details in batches
+  const detailMap = new Map<string, DetailNode>()
+  let latestRateLimit = metadataResult.rateLimit
+
+  for (let i = 0; i < uniqueRequests.length; i += DETAIL_BATCH_SIZE) {
+    const batch = uniqueRequests.slice(i, i + DETAIL_BATCH_SIZE)
+    const detailQuery = buildResponsivenessDetailQuery(batch)
+
+    const detailResult = await queryGitHubGraphQL<Record<string, DetailNode | null>>(
+      token,
+      detailQuery,
+      {},
+    ).catch((error) => {
+      diagnostics.push(buildDiagnostic(repo, 'github-graphql:responsiveness-detail', error))
+      return null
+    })
+
+    if (detailResult) {
+      latestRateLimit = detailResult.rateLimit ?? latestRateLimit
+      for (let j = 0; j < batch.length; j++) {
+        const node = detailResult.data[`node${j}`]
+        if (node?.id) {
+          detailMap.set(node.id, node)
+        }
+      }
+    }
+  }
+
+  // Merge metadata + details into the full response shape
+  const response = mergeResponsivenessData(metadata, detailMap)
+
+  return { data: response, rateLimit: latestRateLimit }
+}
+
+export function mergeResponsivenessData(
+  metadata: RepoResponsivenessMetadataResponse,
+  detailMap: Map<string, DetailNode>,
+): RepoResponsivenessResponse {
+  function enrichIssue(meta: MetadataIssueNode): ResponsivenessIssueNode {
+    const detail = detailMap.get(meta.id)
+    return {
+      createdAt: meta.createdAt,
+      closedAt: meta.closedAt,
+      author: meta.author,
+      comments: detail?.comments ?? { totalCount: meta.comments.totalCount, nodes: [] },
+    }
+  }
+
+  function enrichPR(meta: MetadataPullRequestNode): ResponsivenessPullRequestNode {
+    const detail = detailMap.get(meta.id)
+    return {
+      createdAt: meta.createdAt,
+      author: meta.author,
+      comments: detail?.comments ?? { totalCount: meta.comments.totalCount, nodes: [] },
+      reviews: detail?.reviews ?? { totalCount: meta.reviews.totalCount, nodes: [] },
+    }
+  }
+
+  return {
+    recentCreatedIssues: {
+      nodes: (metadata.recentCreatedIssues?.nodes ?? []).filter(Boolean).map(enrichIssue),
+    },
+    recentClosedIssues: {
+      nodes: (metadata.recentClosedIssues?.nodes ?? []).filter(Boolean).map(enrichIssue),
+    },
+    recentCreatedPullRequests: {
+      nodes: (metadata.recentCreatedPullRequests?.nodes ?? []).filter(Boolean).map(enrichPR),
+    },
+    recentMergedPullRequests: metadata.recentMergedPullRequests,
+    staleOpenPullRequests30: metadata.staleOpenPullRequests30,
+    staleOpenPullRequests60: metadata.staleOpenPullRequests60,
+    staleOpenPullRequests90: metadata.staleOpenPullRequests90,
+    staleOpenPullRequests180: metadata.staleOpenPullRequests180,
+    staleOpenPullRequests365: metadata.staleOpenPullRequests365,
+  }
+}
+
+export function createUnavailableResponsivenessResponse(): RepoResponsivenessResponse {
+  return {
+    recentCreatedIssues: { nodes: [] },
+    recentClosedIssues: { nodes: [] },
+    recentCreatedPullRequests: { nodes: [] },
+    recentMergedPullRequests: { nodes: [] },
+    staleOpenPullRequests30: { issueCount: 0 },
+    staleOpenPullRequests60: { issueCount: 0 },
+    staleOpenPullRequests90: { issueCount: 0 },
+    staleOpenPullRequests180: { issueCount: 0 },
+    staleOpenPullRequests365: { issueCount: 0 },
+  }
+}
+
+export function buildResponsivenessMetricsByWindow(
+  responsiveness: RepoResponsivenessResponse,
+  activityMetricsByWindow: Record<ActivityWindowDays, ActivityWindowMetrics>,
+  openIssueCount: number | undefined,
+  openPullRequestCount: number | undefined,
+): Record<ActivityWindowDays, ResponsivenessMetrics> {
+  const recentCreatedIssues = responsiveness.recentCreatedIssues?.nodes ?? []
+  const recentClosedIssues = responsiveness.recentClosedIssues?.nodes ?? []
+  const recentCreatedPullRequests = responsiveness.recentCreatedPullRequests?.nodes ?? []
+  const recentMergedPullRequests = responsiveness.recentMergedPullRequests?.nodes ?? []
+
+  return {
+    30: buildResponsivenessMetricsForWindow(
+      30,
+      recentCreatedIssues,
+      recentClosedIssues,
+      recentCreatedPullRequests,
+      recentMergedPullRequests,
+      activityMetricsByWindow[30],
+      responsiveness.staleOpenPullRequests30?.issueCount,
+      openIssueCount,
+      openPullRequestCount,
+    ),
+    60: buildResponsivenessMetricsForWindow(
+      60,
+      recentCreatedIssues,
+      recentClosedIssues,
+      recentCreatedPullRequests,
+      recentMergedPullRequests,
+      activityMetricsByWindow[60],
+      responsiveness.staleOpenPullRequests60?.issueCount,
+      openIssueCount,
+      openPullRequestCount,
+    ),
+    90: buildResponsivenessMetricsForWindow(
+      90,
+      recentCreatedIssues,
+      recentClosedIssues,
+      recentCreatedPullRequests,
+      recentMergedPullRequests,
+      activityMetricsByWindow[90],
+      responsiveness.staleOpenPullRequests90?.issueCount,
+      openIssueCount,
+      openPullRequestCount,
+    ),
+    180: buildResponsivenessMetricsForWindow(
+      180,
+      recentCreatedIssues,
+      recentClosedIssues,
+      recentCreatedPullRequests,
+      recentMergedPullRequests,
+      activityMetricsByWindow[180],
+      responsiveness.staleOpenPullRequests180?.issueCount,
+      openIssueCount,
+      openPullRequestCount,
+    ),
+    365: buildResponsivenessMetricsForWindow(
+      365,
+      recentCreatedIssues,
+      recentClosedIssues,
+      recentCreatedPullRequests,
+      recentMergedPullRequests,
+      activityMetricsByWindow[365],
+      responsiveness.staleOpenPullRequests365?.issueCount,
+      openIssueCount,
+      openPullRequestCount,
+    ),
+  }
+}
+
+export function buildResponsivenessMetricsForWindow(
+  windowDays: ActivityWindowDays,
+  recentCreatedIssues: ResponsivenessIssueNode[],
+  recentClosedIssues: ResponsivenessIssueNode[],
+  recentCreatedPullRequests: ResponsivenessPullRequestNode[],
+  recentMergedPullRequests: Array<{ createdAt: string; mergedAt: string | null }>,
+  activityMetrics: ActivityWindowMetrics,
+  staleOpenPullRequestCount: number | undefined,
+  openIssueCount: number | undefined,
+  openPullRequestCount: number | undefined,
+): ResponsivenessMetrics {
+  const issueNodesInWindow = filterNodesByStartDate(recentCreatedIssues, windowDays)
+  const closedIssueNodesInWindow = filterNodesByEndDate(recentClosedIssues, 'closedAt', windowDays)
+  const createdPullRequestsInWindow = filterNodesByStartDate(recentCreatedPullRequests, windowDays)
+  const mergedPullRequestsInWindow = filterNodesByEndDate(recentMergedPullRequests, 'mergedAt', windowDays)
+
+  const issueFirstResponseDurations = issueNodesInWindow
+    .map((issue) => getIssueFirstResponseDurationHours(issue))
+    .filter((value): value is number => value != null)
+  const prFirstReviewDurations = createdPullRequestsInWindow
+    .map((pullRequest) => getPullRequestFirstReviewDurationHours(pullRequest))
+    .filter((value): value is number => value != null)
+  const issueResolutionDurations = closedIssueNodesInWindow
+    .map((issue) => getDurationHours(issue.createdAt, issue.closedAt ?? null))
+    .filter((value): value is number => value != null)
+  const prMergeDurations = mergedPullRequestsInWindow
+    .map((pullRequest) => getDurationHours(pullRequest.createdAt, pullRequest.mergedAt))
+    .filter((value): value is number => value != null)
+
+  const interactionSignals = [
+    ...issueNodesInWindow.map((issue) => getResponseSignal(issue.author?.login ?? null, issue.comments.nodes)),
+    ...createdPullRequestsInWindow.map((pullRequest) =>
+      getResponseSignal(pullRequest.author?.login ?? null, [...pullRequest.comments.nodes, ...pullRequest.reviews.nodes]),
+    ),
+  ].filter((signal): signal is NonNullable<typeof signal> => signal != null)
+
+  const itemsWithHumanResponse = interactionSignals.filter((signal) => signal.firstHumanResponseAt != null).length
+  const itemsWithBotFirstResponse = interactionSignals.filter((signal) => signal.firstResponderKind === 'bot').length
+  const itemsWithHumanFirstResponse = interactionSignals.filter((signal) => signal.firstResponderKind === 'human').length
+  const itemsWithAnyFirstResponse = interactionSignals.filter((signal) => signal.firstResponderKind != null).length
+
+  return {
+    issueFirstResponseMedianHours: computeMedian(issueFirstResponseDurations),
+    issueFirstResponseP90Hours: computePercentile(issueFirstResponseDurations, 0.9),
+    prFirstReviewMedianHours: computeMedian(prFirstReviewDurations),
+    prFirstReviewP90Hours: computePercentile(prFirstReviewDurations, 0.9),
+    issueResolutionMedianHours: computeMedian(issueResolutionDurations),
+    issueResolutionP90Hours: computePercentile(issueResolutionDurations, 0.9),
+    prMergeMedianHours: computeMedian(prMergeDurations),
+    prMergeP90Hours: computePercentile(prMergeDurations, 0.9),
+    issueResolutionRate: computeRatio(activityMetrics.issuesClosed, activityMetrics.issuesOpened),
+    contributorResponseRate:
+      interactionSignals.length > 0 ? itemsWithHumanResponse / interactionSignals.length : 'unavailable',
+    botResponseRatio: itemsWithAnyFirstResponse > 0 ? itemsWithBotFirstResponse / itemsWithAnyFirstResponse : 'unavailable',
+    humanResponseRatio: itemsWithAnyFirstResponse > 0 ? itemsWithHumanFirstResponse / itemsWithAnyFirstResponse : 'unavailable',
+    staleIssueRatio: activityMetrics.staleIssueRatio,
+    stalePrRatio: computeStaleItemRatio(staleOpenPullRequestCount, openPullRequestCount),
+    prReviewDepth:
+      createdPullRequestsInWindow.length > 0
+        ? createdPullRequestsInWindow.reduce((total, pullRequest) => total + pullRequest.reviews.totalCount, 0) /
+          createdPullRequestsInWindow.length
+        : 'unavailable',
+    issuesClosedWithoutCommentRatio:
+      closedIssueNodesInWindow.length > 0
+        ? closedIssueNodesInWindow.filter((issue) => issue.comments.totalCount === 0).length / closedIssueNodesInWindow.length
+        : 'unavailable',
+    openIssueCount: typeof openIssueCount === 'number' ? openIssueCount : 'unavailable',
+    openPullRequestCount: typeof openPullRequestCount === 'number' ? openPullRequestCount : 'unavailable',
+  }
+}
+
+export type { AnalysisDiagnostic }

--- a/lib/analyzer/types.ts
+++ b/lib/analyzer/types.ts
@@ -1,0 +1,347 @@
+import type { Unavailable } from './analysis-result'
+
+export interface DocBlob {
+  text?: string
+  oid?: string
+}
+
+export interface ResolvedReadme {
+  path: string
+  text: string | null
+}
+
+export interface RepoOverviewResponse {
+  repository: {
+    name: string
+    description: string | null
+    createdAt: string
+    primaryLanguage: { name: string } | null
+    stargazerCount: number
+    forkCount: number
+    watchers: { totalCount: number }
+    issues: { totalCount: number }
+    pullRequests?: { totalCount: number }
+    defaultBranchRef?: { name: string } | null
+    repositoryTopics?: { nodes: Array<{ topic: { name: string } }> } | null
+    licenseInfo?: { spdxId: string | null; name: string | null } | null
+    rootTree?: { entries: Array<{ name: string; type: string }> } | null
+    docLicense?: DocBlob | null
+    docLicenseLower?: DocBlob | null
+    docLicenseMd?: DocBlob | null
+    docLicenseMdLower?: DocBlob | null
+    docLicenseTxt?: DocBlob | null
+    docLicenseTxtLower?: DocBlob | null
+    docCopying?: DocBlob | null
+    docCopyingLower?: DocBlob | null
+    docLicenseMit?: DocBlob | null
+    docLicenseApache?: DocBlob | null
+    docLicenseBsd?: DocBlob | null
+    docContributing?: DocBlob | null
+    docContributingRst?: DocBlob | null
+    docContributingTxt?: DocBlob | null
+    docContributingLower?: DocBlob | null
+    docContributingDocs?: DocBlob | null
+    docContributingGithub?: DocBlob | null
+    docCodeOfConduct?: DocBlob | null
+    docCodeOfConductRst?: DocBlob | null
+    docCodeOfConductTxt?: DocBlob | null
+    docCodeOfConductHyphenLower?: DocBlob | null
+    docCodeOfConductUnderscoreLower?: DocBlob | null
+    docCodeOfConductDocs?: DocBlob | null
+    docCodeOfConductGithub?: DocBlob | null
+    cncfAdopters?: DocBlob | null
+    cncfAdoptersLower?: DocBlob | null
+    cncfAdoptersPlain?: DocBlob | null
+    cncfAdoptersDocs?: DocBlob | null
+    cncfRoadmap?: DocBlob | null
+    cncfRoadmapLower?: DocBlob | null
+    cncfRoadmapDocs?: DocBlob | null
+    cncfMaintainers?: DocBlob | null
+    cncfMaintainersMd?: DocBlob | null
+    cncfMaintainersMdLower?: DocBlob | null
+    cncfCodeowners?: DocBlob | null
+    cncfCodeownersGithub?: DocBlob | null
+    docLicenseRst?: DocBlob | null
+    docLicenseRstLower?: DocBlob | null
+    docSecurity?: DocBlob | null
+    docSecurityLower?: DocBlob | null
+    docSecurityRst?: DocBlob | null
+    docSecurityGithub?: DocBlob | null
+    docSecurityGithubLower?: DocBlob | null
+    docSecurityDocs?: DocBlob | null
+    docSecurityDocsLower?: DocBlob | null
+    docSecurityContacts?: DocBlob | null
+    docChangelog?: DocBlob | null
+    docChangelogPlain?: DocBlob | null
+    docChangelogDocs?: DocBlob | null
+    docChanges?: DocBlob | null
+    docChangesRst?: DocBlob | null
+    docHistory?: DocBlob | null
+    docNews?: DocBlob | null
+    secDependabot?: DocBlob | null
+    secDependabotYaml?: DocBlob | null
+    secRenovateRoot?: DocBlob | null
+    secRenovateGithub?: DocBlob | null
+    secRenovateConfig?: DocBlob | null
+    secRenovateRc?: DocBlob | null
+    hasDiscussionsEnabled?: boolean | null
+    commFunding?: { oid: string } | null
+    commIssueTemplateLegacyRoot?: { oid: string } | null
+    commIssueTemplateLegacyGithub?: { oid: string } | null
+    commIssueTemplateDir?: { entries: Array<{ name: string }> } | null
+    commPrTemplateRoot?: { oid: string } | null
+    commPrTemplateGithub?: { oid: string } | null
+    commPrTemplateDocs?: { oid: string } | null
+    commDiscussionsRecent?: {
+      totalCount?: number
+      pageInfo?: { hasNextPage: boolean; endCursor: string | null }
+      nodes: Array<{ createdAt: string }>
+    } | null
+    commGovernanceRoot?: { oid: string } | null
+    commGovernanceGithub?: { oid: string } | null
+    commGovernanceDocs?: { oid: string } | null
+    onbDevcontainerDir?: { entries: Array<{ name: string }> } | null
+    onbDevcontainerJson?: { oid: string } | null
+    onbDockerComposeYml?: { oid: string } | null
+    onbDockerComposeYaml?: { oid: string } | null
+    onbGitpod?: { oid: string } | null
+    workflowDir?: {
+      entries: Array<{
+        name: string
+        object: { text: string } | null
+      }>
+    } | null
+  } | null
+}
+
+export interface RepoCommitAndReleasesResponse {
+  repository: {
+    releases: {
+      totalCount: number
+      nodes: Array<{
+        tagName: string
+        name: string | null
+        description: string | null
+        isPrerelease: boolean
+        createdAt: string
+        publishedAt: string | null
+      }>
+    }
+    refs: { totalCount: number } | null
+    defaultBranchRef: {
+      target: {
+        lifetime?: { totalCount: number }
+        recent30: { totalCount: number }
+        recent60: { totalCount: number }
+        recent90: { totalCount: number }
+        recent180: { totalCount: number }
+        recent365?: { totalCount: number }
+        recent365Commits: CommitHistoryConnection | null
+      } | null
+    } | null
+  } | null
+}
+
+export interface SearchCount { issueCount: number }
+
+export interface RepoActivityCountsResponse {
+  prsOpened30: SearchCount
+  prsOpened60: SearchCount
+  prsOpened90: SearchCount
+  prsOpened180: SearchCount
+  prsOpened365: SearchCount
+  prsMerged30: SearchCount
+  prsMerged60: SearchCount
+  prsMerged90: SearchCount
+  prsMerged180: SearchCount
+  prsMerged365: SearchCount
+  issuesOpened30: SearchCount
+  issuesOpened60: SearchCount
+  issuesOpened90: SearchCount
+  issuesOpened180: SearchCount
+  issuesOpened365: SearchCount
+  issuesClosed30: SearchCount
+  issuesClosed60: SearchCount
+  issuesClosed90: SearchCount
+  issuesClosed180: SearchCount
+  issuesClosed365: SearchCount
+  staleIssues30: SearchCount
+  staleIssues60: SearchCount
+  staleIssues90: SearchCount
+  staleIssues180: SearchCount
+  staleIssues365: SearchCount
+  goodFirstIssues?: SearchCount
+  goodFirstIssuesHyphenated?: SearchCount
+  goodFirstIssuesBeginner?: SearchCount
+  goodFirstIssuesStarter?: SearchCount
+  recentMergedPullRequests: {
+    nodes: Array<{
+      createdAt: string
+      mergedAt: string | null
+      authorAssociation?: string | null
+    }>
+  }
+  recentClosedIssues: {
+    nodes: Array<{
+      createdAt: string
+      closedAt: string | null
+    }>
+  }
+}
+
+export type RepoActivityResponse = RepoCommitAndReleasesResponse & RepoActivityCountsResponse
+
+export interface SearchActorNode {
+  login: string | null
+}
+
+export interface SearchCommentNode {
+  createdAt: string
+  author: SearchActorNode | null
+}
+
+export interface SearchReviewNode {
+  createdAt: string
+  author: SearchActorNode | null
+}
+
+export interface ResponsivenessIssueNode {
+  createdAt: string
+  closedAt?: string | null
+  author: SearchActorNode | null
+  comments: {
+    totalCount: number
+    nodes: SearchCommentNode[]
+  }
+}
+
+export interface ResponsivenessPullRequestNode {
+  createdAt: string
+  author: SearchActorNode | null
+  comments: {
+    totalCount: number
+    nodes: SearchCommentNode[]
+  }
+  reviews: {
+    totalCount: number
+    nodes: SearchReviewNode[]
+  }
+}
+
+// Pass 1 metadata types — no nested comment/review nodes
+export interface MetadataIssueNode {
+  id: string
+  createdAt: string
+  closedAt?: string | null
+  author: SearchActorNode | null
+  comments: { totalCount: number }
+}
+
+export interface MetadataPullRequestNode {
+  id: string
+  createdAt: string
+  author: SearchActorNode | null
+  comments: { totalCount: number }
+  reviews: { totalCount: number }
+}
+
+export interface RepoResponsivenessMetadataResponse {
+  recentCreatedIssues: { nodes: MetadataIssueNode[] }
+  recentClosedIssues: { nodes: MetadataIssueNode[] }
+  recentCreatedPullRequests: { nodes: MetadataPullRequestNode[] }
+  recentMergedPullRequests: { nodes: Array<{ createdAt: string; mergedAt: string | null }> }
+  staleOpenPullRequests30: { issueCount: number }
+  staleOpenPullRequests60: { issueCount: number }
+  staleOpenPullRequests90: { issueCount: number }
+  staleOpenPullRequests180: { issueCount: number }
+  staleOpenPullRequests365: { issueCount: number }
+}
+
+// Pass 2 detail node — returned by node() queries
+export interface DetailNode {
+  id: string
+  createdAt: string
+  author: SearchActorNode | null
+  comments?: { totalCount: number; nodes: SearchCommentNode[] }
+  reviews?: { totalCount: number; nodes: SearchReviewNode[] }
+}
+
+export interface RepoResponsivenessResponse {
+  recentCreatedIssues: {
+    nodes: ResponsivenessIssueNode[]
+  }
+  recentClosedIssues: {
+    nodes: ResponsivenessIssueNode[]
+  }
+  recentCreatedPullRequests: {
+    nodes: ResponsivenessPullRequestNode[]
+  }
+  recentMergedPullRequests: {
+    nodes: Array<{
+      createdAt: string
+      mergedAt: string | null
+    }>
+  }
+  staleOpenPullRequests30: {
+    issueCount: number
+  }
+  staleOpenPullRequests60: {
+    issueCount: number
+  }
+  staleOpenPullRequests90: {
+    issueCount: number
+  }
+  staleOpenPullRequests180: {
+    issueCount: number
+  }
+  staleOpenPullRequests365: {
+    issueCount: number
+  }
+}
+
+export interface LegacyRepoActivityResponse {
+  prsOpened?: { issueCount: number }
+  prsMerged?: { issueCount: number }
+  issuesClosed?: { issueCount: number }
+}
+
+export interface RepoCommitHistoryPageResponse {
+  repository: {
+    defaultBranchRef: {
+      target: {
+        recent365Commits: CommitHistoryConnection | null
+      } | null
+    } | null
+  } | null
+}
+
+export interface CommitHistoryConnection {
+  pageInfo: {
+    hasNextPage: boolean
+    endCursor: string | null
+  }
+  nodes: CommitNode[]
+}
+
+export interface CommitNode {
+  authoredDate: string
+  message?: string
+  author: {
+    name: string | null
+    email: string | null
+    user: {
+      login: string
+    } | null
+  } | null
+}
+
+export interface ResponseSignal {
+  firstResponderKind: 'bot' | 'human' | null
+  firstHumanResponseAt: string | null
+}
+
+export interface AnalyzerError {
+  message?: string
+  status?: number
+  retryAfter?: number | Unavailable
+}


### PR DESCRIPTION
## Summary

- Extracts 5 new modules from the 2606-line `lib/analyzer/analyze.ts` god file
- `types.ts` — all internal GraphQL response interfaces (DocBlob, RepoOverviewResponse, CommitNode, etc.)
- `analyzer-utils.ts` — pure utility functions (computeMedian, filterNodes*, getDurationHours, isBotLogin, etc.)
- `extract-responsiveness.ts` — two-pass responsiveness fetch + metrics builders
- `extract-contributors.ts` — commit history pagination + contributor metrics builders
- `extract-activity.ts` — activity counts, cadence, discussion pagination, release health
- `analyze.ts` is now a thin orchestrator; `toAnalyzerError` re-exported for backward compatibility
- Adds **77 new tests** directly exercising previously-untestable internal functions (PAT-03 goal)

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm test` — 183 test files, 1784 tests, all pass (up from 179/1707 before this PR)
- [x] New test files pass: `analyzer-utils.test.ts`, `extract-responsiveness.test.ts`, `extract-contributors.test.ts`, `extract-activity.test.ts`
- [x] No changes to public API surface of `analyze.ts` (all exported symbols still present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)