### PR TITLE
refactor(PAT-04): replace 12 named ResultsShell slot props with slots record

### DIFF
--- a/components/app-shell/ResultsShell.test.tsx
+++ b/components/app-shell/ResultsShell.test.tsx
@@ -3,19 +3,23 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { ResultsShell } from './ResultsShell'
 
+const BASE_SLOTS = {
+  overview: <div>Overview content</div>,
+  contributors: <div>Contributors coming soon</div>,
+  activity: <div>Activity coming soon</div>,
+  responsiveness: <div>Responsiveness coming soon</div>,
+  documentation: <div>Documentation coming soon</div>,
+  security: <div>Security coming soon</div>,
+  recommendations: <div>Recommendations coming soon</div>,
+  comparison: <div>Comparison coming soon</div>,
+}
+
 describe('ResultsShell', () => {
   it('keeps the analysis panel visible while switching tabs', async () => {
     render(
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
-        overview={<div>Overview content</div>}
-        contributors={<div>Contributors coming soon</div>}
-        activity={<div>Activity coming soon</div>}
-        responsiveness={<div>Responsiveness coming soon</div>}
-        documentation={<div>Documentation coming soon</div>}
-        security={<div>Security coming soon</div>}
-        recommendations={<div>Recommendations coming soon</div>}
-        comparison={<div>Comparison coming soon</div>}
+        slots={BASE_SLOTS}
       />,
     )
 
@@ -32,14 +36,7 @@ describe('ResultsShell', () => {
     render(
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
-        overview={<div>Overview content</div>}
-        contributors={<div>Contributors coming soon</div>}
-        activity={<div>Activity coming soon</div>}
-        responsiveness={<div>Responsiveness coming soon</div>}
-        documentation={<div>Documentation coming soon</div>}
-        security={<div>Security coming soon</div>}
-        recommendations={<div>Recommendations coming soon</div>}
-        comparison={<div>Comparison coming soon</div>}
+        slots={BASE_SLOTS}
       />,
     )
 
@@ -51,14 +48,7 @@ describe('ResultsShell', () => {
     render(
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
-        overview={<div>Overview content</div>}
-        contributors={<div>Contributors coming soon</div>}
-        activity={<div>Activity coming soon</div>}
-        responsiveness={<div>Responsiveness coming soon</div>}
-        documentation={<div>Documentation coming soon</div>}
-        security={<div>Security coming soon</div>}
-        recommendations={<div>Recommendations coming soon</div>}
-        comparison={<div>Comparison coming soon</div>}
+        slots={BASE_SLOTS}
       />,
     )
 
@@ -71,14 +61,7 @@ describe('ResultsShell', () => {
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
         tabs={[{ id: 'overview', label: 'Organization', status: 'implemented', description: 'Org inventory' }]}
-        overview={<div>Organization content</div>}
-        contributors={<div>Contributors coming soon</div>}
-        activity={<div>Activity coming soon</div>}
-        responsiveness={<div>Responsiveness coming soon</div>}
-        documentation={<div>Documentation coming soon</div>}
-        security={<div>Security coming soon</div>}
-        recommendations={<div>Recommendations coming soon</div>}
-        comparison={<div>Comparison coming soon</div>}
+        slots={{ ...BASE_SLOTS, overview: <div>Organization content</div> }}
       />,
     )
 
@@ -91,41 +74,27 @@ describe('ResultsShell', () => {
     const { rerender } = render(
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
-        overview={<div>Overview content</div>}
-        contributors={<div>Contributors content</div>}
-        activity={<div>Activity content</div>}
-        responsiveness={<div>Responsiveness content</div>}
-        documentation={<div>Documentation content</div>}
-        security={<div>Security content</div>}
-        recommendations={<div>Recommendations content</div>}
-        comparison={<div>Comparison content</div>}
+        slots={BASE_SLOTS}
       />,
     )
 
     // Comparison is in the overflow menu
     await userEvent.click(screen.getByRole('button', { name: /More/ }))
     await userEvent.click(screen.getByRole('tab', { name: 'Comparison' }))
-    expect(screen.getByText('Comparison content')).toBeInTheDocument()
+    expect(screen.getByText('Comparison coming soon')).toBeInTheDocument()
 
     rerender(
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
         tabs={[{ id: 'overview', label: 'Overview', status: 'implemented', description: 'Org inventory' }]}
-        overview={<div>Organization content</div>}
-        contributors={<div>Contributors content</div>}
-        activity={<div>Activity content</div>}
-        responsiveness={<div>Responsiveness content</div>}
-        documentation={<div>Documentation content</div>}
-        security={<div>Security content</div>}
-        recommendations={<div>Recommendations content</div>}
-        comparison={<div>Comparison content</div>}
+        slots={{ ...BASE_SLOTS, overview: <div>Organization content</div> }}
       />,
     )
 
     expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByText('Organization content')).toBeInTheDocument()
     // Comparison content is in the DOM but hidden (parent has display: none)
-    expect(screen.getByText('Comparison content').closest('[data-tab-content="comparison"]')).toHaveStyle('display: none')
+    expect(screen.getByText('Comparison coming soon').closest('[data-tab-content="comparison"]')).toHaveStyle('display: none')
   })
 
   it('supports opening on an initial active tab', async () => {
@@ -133,24 +102,17 @@ describe('ResultsShell', () => {
       <ResultsShell
         initialActiveTab="comparison"
         analysisPanel={<div>Analysis panel</div>}
-        overview={<div>Overview content</div>}
-        contributors={<div>Contributors content</div>}
-        activity={<div>Activity content</div>}
-        responsiveness={<div>Responsiveness content</div>}
-        documentation={<div>Documentation content</div>}
-        security={<div>Security content</div>}
-        recommendations={<div>Recommendations content</div>}
-        comparison={<div>Comparison content</div>}
+        slots={BASE_SLOTS}
       />,
     )
 
     // Comparison is in the overflow — button shows "Comparison" when active
     await userEvent.click(screen.getByRole('button', { name: /Comparison/ }))
     expect(screen.getByRole('tab', { name: 'Comparison' })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByText('Comparison content')).toBeInTheDocument()
+    expect(screen.getByText('Comparison coming soon')).toBeInTheDocument()
   })
 
-  it('renders a governance tab body when the governance tab is provided (#303)', async () => {
+  it('renders a governance tab body when the governance slot is provided (#303)', async () => {
     render(
       <ResultsShell
         analysisPanel={<div>Analysis panel</div>}
@@ -160,20 +122,30 @@ describe('ResultsShell', () => {
           { id: 'governance', label: 'Governance', status: 'implemented', description: 'Org-level hygiene and policy' },
           { id: 'security', label: 'Security', status: 'implemented', description: 'Org security' },
         ]}
-        overview={<div>Org overview</div>}
-        contributors={null}
-        activity={null}
-        responsiveness={null}
-        documentation={<div>Org documentation</div>}
-        governance={<div>Org governance content</div>}
-        security={<div>Org security</div>}
-        recommendations={null}
-        comparison={null}
+        slots={{
+          overview: <div>Org overview</div>,
+          documentation: <div>Org documentation</div>,
+          governance: <div>Org governance content</div>,
+          security: <div>Org security</div>,
+        }}
       />,
     )
 
     await userEvent.click(screen.getByRole('tab', { name: 'Governance' }))
     expect(screen.getByText('Org governance content')).toBeInTheDocument()
     expect(screen.getByText('Org governance content').closest('[data-tab-content="governance"]')).not.toHaveStyle('display: none')
+  })
+
+  it('renders a slot in its matching tab container', async () => {
+    render(
+      <ResultsShell
+        analysisPanel={<div>Analysis panel</div>}
+        slots={{ ...BASE_SLOTS, security: <div>Security tab body</div> }}
+      />,
+    )
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Security' }))
+    const container = screen.getByText('Security tab body').closest('[data-tab-content="security"]')
+    expect(container).not.toHaveStyle('display: none')
   })
 })

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -15,16 +15,7 @@ import { ResultsTabs } from './ResultsTabs'
 
 interface ResultsShellProps {
   analysisPanel: React.ReactNode
-  overview: React.ReactNode
-  contributors: React.ReactNode
-  activity: React.ReactNode
-  responsiveness: React.ReactNode
-  documentation: React.ReactNode
-  governance?: React.ReactNode
-  security: React.ReactNode
-  recommendations: React.ReactNode
-  comparison: React.ReactNode
-  cncfCandidacy?: React.ReactNode
+  slots: Partial<Record<ResultTabId, React.ReactNode>>
   hideTabs?: boolean
   tabs?: ResultTabDefinition[]
   initialActiveTab?: ResultTabId
@@ -38,16 +29,7 @@ interface ResultsShellProps {
 
 export function ResultsShell({
   analysisPanel,
-  overview,
-  contributors,
-  activity,
-  responsiveness,
-  documentation,
-  governance,
-  security,
-  recommendations,
-  comparison,
-  cncfCandidacy,
+  slots,
   hideTabs = false,
   tabs = resultTabs,
   initialActiveTab = 'overview',
@@ -88,7 +70,7 @@ export function ResultsShell({
 
   const effectiveTabs = useMemo(() => {
     let result = tabs
-    if (cncfCandidacy) {
+    if (slots['cncf-candidacy']) {
       const hasCandidacyTab = result.some((t) => t.id === 'cncf-candidacy')
       if (!hasCandidacyTab) {
         result = [
@@ -98,7 +80,7 @@ export function ResultsShell({
       }
     }
     return result
-  }, [tabs, cncfCandidacy])
+  }, [tabs, slots])
 
   const currentActiveTab = useMemo(
     () => (effectiveTabs.some((tab) => tab.id === activeTab) ? activeTab : effectiveTabs[0]?.id ?? 'overview'),
@@ -238,7 +220,7 @@ export function ResultsShell({
           <section aria-label="Result workspace" className="overflow-hidden rounded-3xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900 sm:p-6">
             {toolbar ? <div className="mb-4">{toolbar}</div> : null}
             {hideTabs ? (
-              <div ref={containerRef}>{overview}</div>
+              <div ref={containerRef}>{slots.overview}</div>
             ) : (
               <>
                 <ResultsTabs
@@ -248,20 +230,11 @@ export function ResultsShell({
                   matchCounts={searchQuery.trim() ? domMatchCounts : tagMatchCounts}
                 />
                 <div className="mt-6" ref={containerRef}>
-                  <div data-tab-content="overview" style={{ display: currentActiveTab === 'overview' ? 'contents' : 'none' }}>
-                    {overview}
-                  </div>
-                  <div data-tab-content="contributors" style={{ display: currentActiveTab === 'contributors' ? 'contents' : 'none' }}>{contributors}</div>
-                  <div data-tab-content="activity" style={{ display: currentActiveTab === 'activity' ? 'contents' : 'none' }}>{activity}</div>
-                  <div data-tab-content="responsiveness" style={{ display: currentActiveTab === 'responsiveness' ? 'contents' : 'none' }}>{responsiveness}</div>
-                  <div data-tab-content="documentation" style={{ display: currentActiveTab === 'documentation' ? 'contents' : 'none' }}>{documentation}</div>
-                  <div data-tab-content="governance" style={{ display: currentActiveTab === 'governance' ? 'contents' : 'none' }}>{governance}</div>
-                  <div data-tab-content="security" style={{ display: currentActiveTab === 'security' ? 'contents' : 'none' }}>{security}</div>
-                  <div data-tab-content="recommendations" style={{ display: currentActiveTab === 'recommendations' ? 'contents' : 'none' }}>{recommendations}</div>
-                  <div data-tab-content="comparison" style={{ display: currentActiveTab === 'comparison' ? 'contents' : 'none' }}>{comparison}</div>
-                  <div data-tab-content="cncf-candidacy" style={{ display: currentActiveTab === 'cncf-candidacy' ? 'contents' : 'none' }}>
-                    {cncfCandidacy}
-                  </div>
+                  {(Object.entries(slots) as [ResultTabId, React.ReactNode][]).map(([tabId, content]) => (
+                    <div key={tabId} data-tab-content={tabId} style={{ display: currentActiveTab === tabId ? 'contents' : 'none' }}>
+                      {content}
+                    </div>
+                  ))}
                 </div>
               </>
             )}

--- a/components/demo/DemoOrganizationClient.tsx
+++ b/components/demo/DemoOrganizationClient.tsx
@@ -198,50 +198,50 @@ export function DemoOrganizationClient({ response, governance, topReposAnalyzed 
             {view ? <OrgWindowSelector selected={orgWindow} onChange={setOrgWindow} /> : null}
           </div>
         }
-        overview={
-          <OrgInventoryView
-            org={response.org}
-            summary={response.summary}
-            results={response.results}
-            rateLimit={response.rateLimit}
-            onAnalyzeRepo={(repo) => setSignInDialogRepos([repo])}
-            onAnalyzeSelected={(repos) => setSignInDialogRepos(repos)}
-            onAnalyzeAllActive={(repos) => setSignInDialogRepos(repos)}
-          />
-        }
-        contributors={view ? withNote(
-          <OrgBucketContent bucketId="contributors" view={view} selectedWindow={orgWindow} />,
-        ) : emptyPanel}
-        activity={view ? withNote(
-          <OrgBucketContent bucketId="activity" view={view} selectedWindow={orgWindow} />,
-        ) : emptyPanel}
-        responsiveness={view ? withNote(
-          <OrgBucketContent bucketId="responsiveness" view={view} selectedWindow={orgWindow} />,
-        ) : emptyPanel}
-        documentation={view ? withNote(
-          <OrgBucketContent bucketId="documentation" view={view} selectedWindow={orgWindow} />,
-        ) : emptyPanel}
-        governance={withNote(
-          <OrgBucketContent
-            bucketId="governance"
-            view={view}
-            selectedWindow={orgWindow}
-            org={response.org}
-            twoFactorOverride={governance.twoFactor}
-            staleAdminsOverride={governance.staleAdmins}
-            memberPermissionOverride={governance.memberPermission}
-          />,
-        )}
-        security={view ? withNote(
-          <OrgBucketContent bucketId="security" view={view} selectedWindow={orgWindow} />,
-        ) : emptyPanel}
-        recommendations={emptyPanel}
-        comparison={emptyPanel}
-        cncfCandidacy={
-          response.results.length > 0 ? (
+        slots={{
+          overview: (
+            <OrgInventoryView
+              org={response.org}
+              summary={response.summary}
+              results={response.results}
+              rateLimit={response.rateLimit}
+              onAnalyzeRepo={(repo) => setSignInDialogRepos([repo])}
+              onAnalyzeSelected={(repos) => setSignInDialogRepos(repos)}
+              onAnalyzeAllActive={(repos) => setSignInDialogRepos(repos)}
+            />
+          ),
+          contributors: view ? withNote(
+            <OrgBucketContent bucketId="contributors" view={view} selectedWindow={orgWindow} />,
+          ) : emptyPanel,
+          activity: view ? withNote(
+            <OrgBucketContent bucketId="activity" view={view} selectedWindow={orgWindow} />,
+          ) : emptyPanel,
+          responsiveness: view ? withNote(
+            <OrgBucketContent bucketId="responsiveness" view={view} selectedWindow={orgWindow} />,
+          ) : emptyPanel,
+          documentation: view ? withNote(
+            <OrgBucketContent bucketId="documentation" view={view} selectedWindow={orgWindow} />,
+          ) : emptyPanel,
+          governance: withNote(
+            <OrgBucketContent
+              bucketId="governance"
+              view={view}
+              selectedWindow={orgWindow}
+              org={response.org}
+              twoFactorOverride={governance.twoFactor}
+              staleAdminsOverride={governance.staleAdmins}
+              memberPermissionOverride={governance.memberPermission}
+            />,
+          ),
+          security: view ? withNote(
+            <OrgBucketContent bucketId="security" view={view} selectedWindow={orgWindow} />,
+          ) : emptyPanel,
+          recommendations: emptyPanel,
+          comparison: emptyPanel,
+          'cncf-candidacy': response.results.length > 0 ? (
             <CNCFCandidacyPanel org={response.org} repos={response.results} />
-          ) : emptyPanel
-        }
+          ) : emptyPanel,
+        }}
       />
     </SearchProvider>
   )

--- a/components/demo/DemoRepositoriesClient.tsx
+++ b/components/demo/DemoRepositoriesClient.tsx
@@ -79,52 +79,54 @@ export function DemoRepositoriesClient({ response }: DemoRepositoriesClientProps
         searchQuery={debouncedQuery}
         onDomMatchCounts={handleDomMatchCounts}
         tagMatchCounts={computeTabTagCounts(response.results, activeTag)}
-        overview={overviewContent}
-        contributors={
-          <ContributorsView
-            results={response.results}
-            activeTag={activeTag}
-            onTagChange={setActiveTag}
-          />
-        }
-        activity={
-          <ActivityView
-            results={response.results}
-            activeTag={activeTag}
-            onTagChange={setActiveTag}
-          />
-        }
-        responsiveness={
-          <ResponsivenessView
-            results={response.results}
-            activeTag={activeTag}
-            onTagChange={setActiveTag}
-          />
-        }
-        documentation={
-          <DocumentationView
-            results={response.results}
-            activeTag={activeTag}
-            onTagChange={setActiveTag}
-          />
-        }
-        security={
-          <SecurityView
-            results={response.results}
-            activeTag={activeTag}
-            onTagChange={setActiveTag}
-          />
-        }
-        recommendations={
-          <RecommendationsView
-            results={response.results}
-            activeTag={activeTag}
-            onTagChange={setActiveTag}
-          />
-        }
-        comparison={
-          <ComparisonView results={response.results} rateLimit={response.rateLimit} />
-        }
+        slots={{
+          overview: overviewContent,
+          contributors: (
+            <ContributorsView
+              results={response.results}
+              activeTag={activeTag}
+              onTagChange={setActiveTag}
+            />
+          ),
+          activity: (
+            <ActivityView
+              results={response.results}
+              activeTag={activeTag}
+              onTagChange={setActiveTag}
+            />
+          ),
+          responsiveness: (
+            <ResponsivenessView
+              results={response.results}
+              activeTag={activeTag}
+              onTagChange={setActiveTag}
+            />
+          ),
+          documentation: (
+            <DocumentationView
+              results={response.results}
+              activeTag={activeTag}
+              onTagChange={setActiveTag}
+            />
+          ),
+          security: (
+            <SecurityView
+              results={response.results}
+              activeTag={activeTag}
+              onTagChange={setActiveTag}
+            />
+          ),
+          recommendations: (
+            <RecommendationsView
+              results={response.results}
+              activeTag={activeTag}
+              onTagChange={setActiveTag}
+            />
+          ),
+          comparison: (
+            <ComparisonView results={response.results} rateLimit={response.rateLimit} />
+          ),
+        }}
       />
     </SearchProvider>
   )

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -1031,9 +1031,9 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       searchQuery={debouncedQuery}
       onDomMatchCounts={handleDomMatchCounts}
       tagMatchCounts={analysisResponse ? computeTabTagCounts(analysisResponse.results, activeTag) : undefined}
-      overview={overviewContent}
-      contributors={
-        inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
+      slots={{
+        overview: overviewContent,
+        contributors: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
           <OrgBucketContent bucketId="contributors" view={orgAggregation.view} selectedWindow={orgWindow} />
         ) : analysisResponse ? (
           <ContributorsView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} cncfBadges={cncfBadges} />
@@ -1041,10 +1041,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
-        )
-      }
-      activity={
-        inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
+        ),
+        activity: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
           <OrgBucketContent bucketId="activity" view={orgAggregation.view} selectedWindow={orgWindow} />
         ) : analysisResponse ? (
           <ActivityView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} cncfBadges={cncfBadges} />
@@ -1052,10 +1050,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
-        )
-      }
-      responsiveness={
-        inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
+        ),
+        responsiveness: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
           <OrgBucketContent bucketId="responsiveness" view={orgAggregation.view} selectedWindow={orgWindow} />
         ) : analysisResponse ? (
           <ResponsivenessView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
@@ -1063,10 +1059,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
-        )
-      }
-      documentation={
-        inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
+        ),
+        documentation: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
           <OrgBucketContent
             bucketId="documentation"
             view={orgAggregation.view}
@@ -1078,10 +1072,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
-        )
-      }
-      governance={
-        inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
+        ),
+        governance: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
           <OrgBucketContent
             bucketId="governance"
             view={orgAggregation.view}
@@ -1094,10 +1086,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
             view={null}
             org={orgInventoryResponse.org}
           />
-        ) : null
-      }
-      security={
-        inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
+        ) : undefined,
+        security: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
           <OrgBucketContent bucketId="security" view={orgAggregation.view} selectedWindow={orgWindow} />
         ) : analysisResponse ? (
           <SecurityView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} cncfBadges={cncfBadges} />
@@ -1105,10 +1095,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
-        )
-      }
-      recommendations={
-        inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
+        ),
+        recommendations: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (
           <OrgBucketContent bucketId="recommendations" view={orgAggregation.view} selectedWindow={orgWindow} />
         ) : analysisResponse ? (
           <RecommendationsView results={analysisResponse.results} activeTag={activeTag} onTagChange={setActiveTag} />
@@ -1116,10 +1104,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
-        )
-      }
-      comparison={
-        analysisResponse && successfulRepoCount >= 2 ? (
+        ),
+        comparison: analysisResponse && successfulRepoCount >= 2 ? (
           <ComparisonView results={analysisResponse.results} rateLimit={analysisResponse.rateLimit} />
         ) : loadingRepos.length >= 2 ? (
           <p className="text-sm text-slate-600 dark:text-slate-300">
@@ -1138,8 +1124,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Enter 2 or more repositories and click <span className="font-medium text-slate-700 dark:text-slate-200">Analyze</span> to get started.
           </p>
-        )
-      }
+        ),
+      }}
     />
     </SearchProvider>
   )


### PR DESCRIPTION
Closes part of #427 (Sub-PR G — PAT-04).

## Summary

- **Problem**: `ResultsShell` accepted 10 named `React.ReactNode` slot props (`overview`, `contributors`, `activity`, …, `cncfCandidacy`). Adding a new tab required three synchronized edits: add to the interface, add to destructuring, add a `data-tab-content` div.
- **Fix**: Replace all 10 slot props with `slots: Partial<Record<ResultTabId, ReactNode>>`. Now adding a tab is a single edit — pass `slots={{ 'new-tab': <Content /> }}` alongside a `tabs` entry.
- Tab content is rendered via `Object.entries(slots).map(...)` — one loop replaces 10 hardcoded divs.
- `cncf-candidacy` auto-add logic now keys off `slots['cncf-candidacy']` presence instead of a dedicated prop.
- `hideTabs` path uses `slots.overview` directly.

## Files changed

| File | Change |
|------|--------|
| `components/app-shell/ResultsShell.tsx` | Remove 10 named slot props; add `slots` record; render via loop |
| `components/app-shell/ResultsShell.test.tsx` | Migrate 6 existing tests to slots API; add 1 new regression test |
| `components/repo-input/RepoInputClient.tsx` | Convert named props → `slots={{ … }}` |
| `components/demo/DemoRepositoriesClient.tsx` | Convert named props → `slots={{ … }}` |
| `components/demo/DemoOrganizationClient.tsx` | Convert named props → `slots={{ … }}`; `cncfCandidacy` → `'cncf-candidacy'` key |

## Test plan

- [x] `npx vitest run components/app-shell/ResultsShell.test.tsx` — 8 tests pass
- [x] `npx tsc --noEmit` — zero errors
- [ ] Manual: load `/demo` — all tabs render correctly
- [ ] Manual: load `/demo/org` — all tabs (including CNCF Candidacy) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)