### PR TITLE
fix(foundation): show meaningful message for already-CNCF projects

### DIFF
--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -155,6 +155,10 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
                     aspirantResult={repoResult.aspirantResult}
                     repoSlug={repoResult.repo}
                   />
+                ) : repoResult.landscapeOverride ? (
+                  <p className="text-sm text-slate-500 dark:text-slate-400">
+                    This project is already a CNCF{repoResult.landscapeStatus ? ` ${repoResult.landscapeStatus}` : ''} project and is not evaluated for sandbox readiness.
+                  </p>
                 ) : (
                   <p className="text-sm text-slate-500 dark:text-slate-400">
                     No foundation readiness data available for {repoResult.repo}.


### PR DESCRIPTION
## Summary

- `kai-scheduler/KAI-Scheduler` (and any other already-CNCF project) was showing "No foundation readiness data available" when expanded in the Foundation tab
- Root cause: the API correctly sets `landscapeOverride: true` and `aspirantResult: null` for projects already in the CNCF landscape, but the UI only checked `aspirantResult` and fell through to the generic no-data message
- Fix: check `landscapeOverride` first and render a specific message — "This project is already a CNCF sandbox/incubating/graduated project and is not evaluated for sandbox readiness."

## Test plan

- [x] Analyze `kai-scheduler/KAI-Scheduler` in the Foundation → CNCF Sandbox tab and confirm the expanded panel shows the CNCF landscape membership message instead of "No foundation readiness data available"
- [x] Analyze a non-CNCF repo and confirm it still shows the readiness checklist as before
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)