### PR TITLE
fix(foundation): replace accordion title link with plain text

### DIFF
--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -136,15 +136,9 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
                 <path d="M6 4l4 4-4 4" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
               <span className="flex items-center gap-2 min-w-0">
-                <a
-                  href={`https://github.com/${repoResult.repo}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  className="truncate text-sm font-medium text-slate-800 underline hover:no-underline dark:text-slate-200"
-                >
+                <span className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
                   {repoResult.repo}
-                </a>
+                </span>
                 {score !== undefined ? <ScoreBadge score={score} /> : null}
               </span>
             </button>


### PR DESCRIPTION
## Summary

- The repo name in the collapsed accordion header was a hyperlink to GitHub
- A nested `<a>` inside a `<button>` is invalid HTML and causes unexpected click behavior
- The GitHub link already exists inside the expanded panel body
- Replaced the `<a>` with a plain `<span>` — clicking the header now only expands/collapses

## Test plan

- [x] Click the accordion header row in the Foundation results — it expands/collapses without navigating
- [x] Open the expanded panel and confirm the GitHub link is present inside it
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)