### PR TITLE
feat(ci): scheduled daily tech-debt & DRY audit via GitHub Copilot

### DIFF
--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -1,0 +1,165 @@
+name: Daily Tech Debt Audit
+
+on:
+  # 08:00 UTC = midnight PDT / 01:00 AM PST
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download previous fingerprint artifact
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: daily-tech-debt-audit.yml
+          name: tech-debt-fingerprint
+          path: .prev-artifact/
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      - name: Run tech-debt analysis
+        env:
+          COPILOT_TOKEN: ${{ secrets.COPILOT_TOKEN }}
+          FINDINGS_OUTPUT: findings.json
+        run: npx tsx scripts/tech-debt-audit.ts
+
+      - name: Compute new findings
+        id: diff
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          echo "date=$TODAY" >> "$GITHUB_OUTPUT"
+
+          jq -r '.fingerprints[]' findings.json 2>/dev/null | sort > /tmp/today-fps.txt || touch /tmp/today-fps.txt
+
+          if [ -f .prev-artifact/fingerprint.json ]; then
+            jq -r '.[]' .prev-artifact/fingerprint.json 2>/dev/null | sort > /tmp/prev-fps.txt || touch /tmp/prev-fps.txt
+          else
+            touch /tmp/prev-fps.txt
+          fi
+
+          comm -23 /tmp/today-fps.txt /tmp/prev-fps.txt > /tmp/new-fps.txt
+          NEW_COUNT=$(wc -l < /tmp/new-fps.txt | tr -d ' ')
+          echo "new-count=$NEW_COUNT" >> "$GITHUB_OUTPUT"
+
+          PREV_ISSUE=""
+          if [ -f .prev-artifact/last-issue.txt ]; then
+            PREV_ISSUE=$(cat .prev-artifact/last-issue.txt)
+          fi
+          echo "prev-issue=$PREV_ISSUE" >> "$GITHUB_OUTPUT"
+
+          echo "New findings: $NEW_COUNT (previous issue: ${PREV_ISSUE:-none})"
+
+      - name: Format issue body
+        if: steps.diff.outputs.new-count != '0'
+        run: |
+          python3 - <<'PYEOF' > /tmp/issue-body.md
+          import json
+
+          with open('findings.json') as f:
+              data = json.load(f)
+
+          findings = data.get('findings', [])
+          date = data.get('date', '')
+          total = len(findings)
+
+          icons = {'fix-now': '🚨', 'fix-soon': '⚠️', 'low-priority': 'ℹ️'}
+          lines = [
+              f'Automated tech-debt audit — **{total} new finding{"s" if total != 1 else ""}** detected on {date}.',
+              '',
+              '_Grouped by severity, then category. New findings only (deduped via fingerprint)._',
+          ]
+
+          for sev in ['fix-now', 'fix-soon', 'low-priority']:
+              by_sev = [f for f in findings if f['severity'] == sev]
+              if not by_sev:
+                  continue
+              lines.append(f'\n## {icons.get(sev, "")} {sev} ({len(by_sev)})\n')
+              cats: dict[str, list] = {}
+              for item in by_sev:
+                  cats.setdefault(item['category'], []).append(item)
+              for cat, items in cats.items():
+                  lines.append(f'### {cat}\n')
+                  for item in items:
+                      lines.append(
+                          f'- **{item["id"]}** `{item["file"]}:{item["lineStart"]}` {item["description"]}'
+                      )
+                      lines.append(f'  > {item["recommendation"]}')
+                  lines.append('')
+
+          print('\n'.join(lines))
+          PYEOF
+
+      - name: Ensure labels exist
+        if: steps.diff.outputs.new-count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "techdebt" --color "#e4e669" --description "Technical debt" 2>/dev/null || true
+          gh label create "automated" --color "#0075ca" --description "Created by automated workflow" 2>/dev/null || true
+
+      - name: Create issue for new findings
+        if: steps.diff.outputs.new-count != '0'
+        id: create-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TODAY="${{ steps.diff.outputs.date }}"
+          COUNT="${{ steps.diff.outputs.new-count }}"
+          ISSUE_URL=$(gh issue create \
+            --title "[Tech Debt Audit] $TODAY — $COUNT new findings" \
+            --body-file /tmp/issue-body.md \
+            --label "techdebt" \
+            --label "automated")
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+          echo "issue-number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Created issue #$ISSUE_NUMBER: $ISSUE_URL"
+
+      - name: Comment on previous issue (no new findings)
+        if: steps.diff.outputs.new-count == '0' && steps.diff.outputs.prev-issue != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TODAY="${{ steps.diff.outputs.date }}"
+          PREV_ISSUE="${{ steps.diff.outputs.prev-issue }}"
+          gh issue comment "$PREV_ISSUE" --body "No new debt detected on $TODAY."
+
+      - name: Save artifact state
+        run: |
+          mkdir -p .artifact
+          jq '.fingerprints' findings.json > .artifact/fingerprint.json
+          ISSUE="${{ steps.create-issue.outputs.issue-number }}"
+          if [ -z "$ISSUE" ]; then
+            ISSUE="${{ steps.diff.outputs.prev-issue }}"
+          fi
+          echo "$ISSUE" > .artifact/last-issue.txt
+
+      - name: Upload fingerprint artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tech-debt-fingerprint
+          path: .artifact/
+          retention-days: 7

--- a/scripts/tech-debt-audit.ts
+++ b/scripts/tech-debt-audit.ts
@@ -1,0 +1,190 @@
+/**
+ * Daily tech-debt and DRY-violation audit via GitHub Copilot API.
+ *
+ * Usage: COPILOT_TOKEN=<pat> npx tsx scripts/tech-debt-audit.ts
+ *
+ * Writes findings to the path in FINDINGS_OUTPUT env var (default: findings.json).
+ */
+
+import { createHash } from 'crypto'
+import { readdirSync, readFileSync, writeFileSync } from 'fs'
+import { join, relative } from 'path'
+
+const ROOT = process.cwd()
+const MAX_PAYLOAD_BYTES = 200 * 1024
+
+interface Finding {
+  id: string
+  category: 'DRY' | 'CONSISTENCY' | 'PATTERNS' | 'OPTIMIZATIONS' | 'MISSING_TESTS'
+  file: string
+  lineStart: number
+  lineEnd: number
+  description: string
+  severity: 'fix-now' | 'fix-soon' | 'low-priority'
+  recommendation: string
+}
+
+const SOURCE_DIRS = ['app', 'lib', 'scripts']
+const INCLUDE_EXTS = new Set(['.ts', '.tsx'])
+const EXCLUDE_RE = /\.test\.|\.spec\.|node_modules|\.next/
+
+function walkDir(dir: string, results: string[] = []): string[] {
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return results
+  }
+  for (const entry of entries) {
+    if (EXCLUDE_RE.test(entry.name)) continue
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walkDir(fullPath, results)
+    } else if (entry.isFile()) {
+      const dot = entry.name.lastIndexOf('.')
+      if (dot !== -1 && INCLUDE_EXTS.has(entry.name.slice(dot))) {
+        results.push(fullPath)
+      }
+    }
+  }
+  return results
+}
+
+function collectFiles(): string[] {
+  return SOURCE_DIRS.flatMap(dir => walkDir(join(ROOT, dir)))
+}
+
+function buildPayload(files: string[]): string {
+  const fileData = files.flatMap(filePath => {
+    try {
+      const content = readFileSync(filePath, 'utf8')
+      return [{ relPath: relative(ROOT, filePath), content, size: content.length }]
+    } catch {
+      return []
+    }
+  })
+
+  // Largest files first — biggest debt risk and god-module signal
+  fileData.sort((a, b) => b.size - a.size)
+
+  const parts: string[] = []
+  let total = 0
+  for (const { relPath, content, size } of fileData) {
+    if (total + size > MAX_PAYLOAD_BYTES) break
+    parts.push(`// --- ${relPath} ---\n${content}`)
+    total += size
+  }
+  return parts.join('\n\n')
+}
+
+async function exchangeToken(pat: string): Promise<string> {
+  const res = await fetch('https://api.github.com/copilot_internal/v2/token', {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${pat}`,
+      'Content-Type': 'application/json',
+      'Editor-Version': 'Neovim/0.9.0',
+      'Editor-Plugin-Version': 'copilot.vim/1.10.0',
+    },
+  })
+  if (!res.ok) {
+    throw new Error(`Token exchange failed: ${res.status} ${await res.text()}`)
+  }
+  const { token } = (await res.json()) as { token: string }
+  return token
+}
+
+const AUDIT_PROMPT = `You are a senior TypeScript/Next.js code quality auditor.
+Analyse the source files below and identify technical debt.
+
+Detection categories:
+- DRY: copy-pasted logic, duplicated literals, repeated structural patterns
+- CONSISTENCY: hardcoded thresholds, diverging error shapes, mixed null/undefined/unavailable patterns
+- PATTERNS: god modules (>500 lines), stale-closure eslint-disable suppressions, unsafe \`as unknown as\` casts, missing useMemo on expensive derivations
+- OPTIMIZATIONS: synchronous chart imports, O(n²) patterns, unused GraphQL fields
+- MISSING_TESTS: API routes with zero unit tests, scoring modules with no boundary tests
+
+Output ONLY a JSON array — no prose, no markdown fences:
+[
+  {
+    "id": "DRY-<n>",
+    "category": "DRY|CONSISTENCY|PATTERNS|OPTIMIZATIONS|MISSING_TESTS",
+    "file": "relative/path.ts",
+    "lineStart": 10,
+    "lineEnd": 40,
+    "description": "one sentence",
+    "severity": "fix-now|fix-soon|low-priority",
+    "recommendation": "one sentence"
+  }
+]`
+
+async function callCopilot(sessionToken: string, payload: string): Promise<Finding[]> {
+  const res = await fetch('https://api.githubcopilot.com/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${sessionToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'user',
+          content: `${AUDIT_PROMPT}\n\n<files>\n${payload}\n</files>`,
+        },
+      ],
+      temperature: 0,
+    }),
+  })
+
+  if (!res.ok) {
+    throw new Error(`Copilot API error: ${res.status} ${await res.text()}`)
+  }
+
+  const data = (await res.json()) as {
+    choices: Array<{ message: { content: string } }>
+  }
+  const raw = data.choices[0]?.message?.content?.trim() ?? '[]'
+  return JSON.parse(raw) as Finding[]
+}
+
+function fingerprint(f: Finding): string {
+  return createHash('sha256').update(f.file + f.lineStart + f.category).digest('hex')
+}
+
+async function main(): Promise<void> {
+  const pat = process.env.COPILOT_TOKEN
+  if (!pat) {
+    process.stderr.write('Error: COPILOT_TOKEN environment variable is required\n')
+    process.exit(1)
+  }
+
+  process.stderr.write('Collecting source files...\n')
+  const files = collectFiles()
+  process.stderr.write(`  ${files.length} files found\n`)
+
+  const payload = buildPayload(files)
+  process.stderr.write(`  Payload: ${payload.length} bytes\n`)
+
+  process.stderr.write('Exchanging COPILOT_TOKEN for session token...\n')
+  const sessionToken = await exchangeToken(pat)
+
+  process.stderr.write('Running Copilot analysis...\n')
+  const findings = await callCopilot(sessionToken, payload)
+  process.stderr.write(`  ${findings.length} findings returned\n`)
+
+  const output = {
+    date: new Date().toISOString().slice(0, 10),
+    findings,
+    fingerprints: findings.map(fingerprint),
+  }
+
+  const outputPath = process.env.FINDINGS_OUTPUT ?? 'findings.json'
+  writeFileSync(outputPath, JSON.stringify(output, null, 2))
+  process.stderr.write(`Wrote ${findings.length} findings to ${outputPath}\n`)
+}
+
+main().catch(err => {
+  process.stderr.write(`${String(err)}\n`)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Adds `scripts/tech-debt-audit.ts`: globs `app/**`, `lib/**`, `scripts/**` TypeScript sources (excluding test files), builds a capped 200 KB payload sorted by file size (largest debt risk first), exchanges `COPILOT_TOKEN` for a Copilot session token, calls `/chat/completions` with a structured prompt covering DRY / CONSISTENCY / PATTERNS / OPTIMIZATIONS / MISSING_TESTS, and writes `findings.json` with sha256 fingerprints.
- Adds `.github/workflows/daily-tech-debt-audit.yml`: runs on `cron: '0 8 * * *'` (midnight PT) + `workflow_dispatch`; downloads the previous `tech-debt-fingerprint` artifact, diffs fingerprints to find net-new findings, creates a labeled GitHub issue (`techdebt` + `automated`) when there are new findings, comments on the previous issue otherwise; uploads the updated fingerprint artifact with 7-day retention.

Closes #453

## Test plan

- [ ] `COPILOT_TOKEN=<pat> npx tsx scripts/tech-debt-audit.ts` runs locally and writes `findings.json`
- [x] `npm run typecheck` passes (no new TS errors)
- [ ] Workflow appears in Actions UI under "Daily Tech Debt Audit"
- [ ] Manual `workflow_dispatch` run completes without errors
- [ ] Second consecutive `workflow_dispatch` run (no code changes) posts "No new debt detected" comment instead of opening a new issue
- [ ] New-findings issue is labeled `techdebt` + `automated`
- [ ] `COPILOT_TOKEN` secret configured in repo Settings → Secrets → Actions (manual step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)