### PR TITLE
fix(tech-debt-audit): truncate oversized files to stay within per-chunk token budget

### DIFF
--- a/scripts/tech-debt-audit.test.ts
+++ b/scripts/tech-debt-audit.test.ts
@@ -67,8 +67,7 @@ describe('buildChunks', () => {
   })
 
   it('places an oversized file alone when it is the first file', () => {
-    // If the oversized file is first, the parts.length > 0 guard skips the flush,
-    // so it begins a new chunk implicitly — it should still appear in its own chunk
+    // Oversized file gets truncated to maxBytes then placed alone; small file goes in its own chunk
     const hugeContent = 'y'.repeat(30_000)
     const smallContent = 'z'.repeat(100)
     const fileData = [
@@ -77,12 +76,20 @@ describe('buildChunks', () => {
     ]
     const chunks = buildChunks(fileData)
     expect(chunks.length).toBeGreaterThanOrEqual(2)
-    // huge.ts must appear in one chunk, small.ts in another
     const hugeChunk = chunks.find(c => c.payload.includes('// --- huge.ts ---'))
     const smallChunk = chunks.find(c => c.payload.includes('// --- small.ts ---'))
     expect(hugeChunk).toBeDefined()
     expect(smallChunk).toBeDefined()
     expect(hugeChunk).not.toBe(smallChunk)
+  })
+
+  it('truncates a single file that exceeds maxBytes and keeps estimatedTokens within budget', () => {
+    // A 100_000-char file (25_000 tokens) must be truncated to ≤24_000 chars before sending
+    const hugeContent = 'x'.repeat(100_000)
+    const chunks = buildChunks([{ relPath: 'big.ts', content: hugeContent, size: 100_000 }])
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].estimatedTokens).toBeLessThanOrEqual(6_000)
+    expect(chunks[0].payload).toContain('// [truncated')
   })
 
   it('fileCount matches the number of files in each chunk', () => {

--- a/scripts/tech-debt-audit.ts
+++ b/scripts/tech-debt-audit.ts
@@ -85,8 +85,12 @@ export function buildChunks(fileData: FileData[]): Array<{ payload: string; file
   let chunkBytes = 0
 
   for (const { relPath, content } of fileData) {
-    const entry = `// --- ${relPath} ---\n${content}`
-    // If this single file already exceeds the budget, send it alone
+    let entry = `// --- ${relPath} ---\n${content}`
+    // Truncate files that would exceed the per-chunk budget even alone
+    if (entry.length > maxBytes) {
+      const note = '\n// [truncated — file exceeds per-chunk token budget]'
+      entry = entry.slice(0, maxBytes - note.length) + note
+    }
     if (parts.length > 0 && chunkBytes + entry.length > maxBytes) {
       const payload = parts.join('\n\n')
       chunks.push({ payload, fileCount: parts.length, estimatedTokens: Math.round(payload.length * TOKENS_PER_CHAR) })


### PR DESCRIPTION
## Summary

Three fixes for the daily tech-debt audit workflow failures:

**Fix 1 — 413 token limit (original):** A single file larger than the per-chunk budget was placed in its own chunk without truncation. Now any entry exceeding \`maxBytes\` is sliced to fit, with a truncation note appended.

**Fix 2 — JSON parse warnings:** \`gpt-4o\` sometimes wraps its response in \` ```json ``` \` fences even when the prompt says not to. Strip those fences before \`JSON.parse\` so findings aren't silently dropped.

**Fix 3 — 429 rate limit:** GitHub Models free tier caps at 40,000 tokens/minute. Each request is ~7,500 tokens (6k content + prompt + response), allowing ~5 requests/minute max. Increased inter-chunk delay from 500ms → 12s.

> Note: 43 chunks × 12s ≈ 8.6 min total runtime. This is the cost of the free-tier rate limit with 145 files.

## Test plan

- [x] All 8 `buildChunks` unit tests pass (`npx vitest run scripts/tech-debt-audit.test.ts`)
- [ ] `workflow_dispatch` run on `main` after merge completes without a 4xx error
- [ ] No "could not parse findings JSON" warnings in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)