### PR TITLE
fix(tech-debt-audit): strip JSON fences, truncate oversized files, increase rate-limit delay

### DIFF
--- a/scripts/tech-debt-audit.test.ts
+++ b/scripts/tech-debt-audit.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { buildChunks } from './tech-debt-audit'
+import { describe, expect, it, vi } from 'vitest'
+import { buildChunks, parseFindings } from './tech-debt-audit'
 
 // MAX_CHUNK_TOKENS = 6_000, TOKENS_PER_CHAR = 1/4
 // → maxBytes = 6_000 / 0.25 = 24_000 chars per chunk
@@ -102,5 +102,55 @@ describe('buildChunks', () => {
     const chunks = buildChunks(fileData)
     const totalFiles = chunks.reduce((sum, c) => sum + c.fileCount, 0)
     expect(totalFiles).toBe(5)
+  })
+})
+
+describe('parseFindings', () => {
+  const sampleFinding = {
+    id: 'DRY-1',
+    category: 'DRY',
+    file: 'lib/foo.ts',
+    lineStart: 1,
+    lineEnd: 10,
+    description: 'Duplicated logic',
+    severity: 'fix-soon',
+    recommendation: 'Extract a shared helper',
+  }
+
+  it('parses plain JSON array without fences', () => {
+    const raw = JSON.stringify([sampleFinding])
+    const result = parseFindings(raw)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('DRY-1')
+  })
+
+  it('strips ```json fences before parsing', () => {
+    const raw = '```json\n' + JSON.stringify([sampleFinding]) + '\n```'
+    const result = parseFindings(raw)
+    expect(result).toHaveLength(1)
+    expect(result[0].category).toBe('DRY')
+  })
+
+  it('strips plain ``` fences before parsing', () => {
+    const raw = '```\n' + JSON.stringify([sampleFinding]) + '\n```'
+    const result = parseFindings(raw)
+    expect(result).toHaveLength(1)
+    expect(result[0].file).toBe('lib/foo.ts')
+  })
+
+  it('returns empty array and emits a warning for malformed JSON', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const result = parseFindings('not valid json {{{')
+    expect(result).toEqual([])
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('could not parse findings JSON'))
+    stderrSpy.mockRestore()
+  })
+
+  it('returns empty array for malformed JSON wrapped in fences', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const raw = '```json\nbroken { json\n```'
+    const result = parseFindings(raw)
+    expect(result).toEqual([])
+    stderrSpy.mockRestore()
   })
 })

--- a/scripts/tech-debt-audit.ts
+++ b/scripts/tech-debt-audit.ts
@@ -133,7 +133,36 @@ Output ONLY a JSON array — no prose, no markdown fences:
   }
 ]`
 
-async function callCopilot(pat: string, payload: string): Promise<Finding[]> {
+const MAX_RETRIES = 3
+
+function parseRetryAfter(value: string | null): number {
+  if (!value) return 60
+  const seconds = Number(value)
+  if (!isNaN(seconds)) return seconds
+  // RFC 7231 HTTP-date format (e.g. "Wed, 21 Oct 2015 07:28:00 GMT")
+  const date = new Date(value)
+  if (!isNaN(date.getTime())) {
+    return Math.max(0, Math.ceil((date.getTime() - Date.now()) / 1000))
+  }
+  return 60
+}
+
+/**
+ * Strip optional markdown code fences and parse model output as a Finding array.
+ * Returns [] (with a warning) if the JSON is malformed.
+ */
+export function parseFindings(raw: string): Finding[] {
+  // Strip markdown code fences the model sometimes wraps around JSON
+  const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
+  try {
+    return JSON.parse(cleaned) as Finding[]
+  } catch {
+    process.stderr.write(`  Warning: could not parse findings JSON from model response; skipping chunk\n`)
+    return []
+  }
+}
+
+async function callCopilot(pat: string, payload: string, attempt = 0): Promise<Finding[]> {
   const res = await fetch('https://models.inference.ai.azure.com/chat/completions', {
     method: 'POST',
     headers: {
@@ -153,6 +182,14 @@ async function callCopilot(pat: string, payload: string): Promise<Finding[]> {
   })
 
   if (!res.ok) {
+    if ((res.status === 429 || res.status === 503) && attempt < MAX_RETRIES) {
+      const wait = parseRetryAfter(res.headers.get('Retry-After'))
+      process.stderr.write(
+        `  Rate limited (${res.status}). Waiting ${wait}s before retrying (attempt ${attempt + 1} of ${MAX_RETRIES})...\n`,
+      )
+      await sleep(wait * 1000)
+      return callCopilot(pat, payload, attempt + 1)
+    }
     throw new Error(`Copilot API error: ${res.status} ${await res.text()}`)
   }
 
@@ -160,14 +197,7 @@ async function callCopilot(pat: string, payload: string): Promise<Finding[]> {
     choices: Array<{ message: { content: string } }>
   }
   const raw = data.choices[0]?.message?.content?.trim() ?? '[]'
-  // Strip markdown code fences the model sometimes wraps around JSON
-  const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
-  try {
-    return JSON.parse(cleaned) as Finding[]
-  } catch {
-    process.stderr.write(`  Warning: could not parse findings JSON from model response; skipping chunk\n`)
-    return []
-  }
+  return parseFindings(raw)
 }
 
 function fingerprint(f: Finding): string {

--- a/scripts/tech-debt-audit.ts
+++ b/scripts/tech-debt-audit.ts
@@ -160,8 +160,10 @@ async function callCopilot(pat: string, payload: string): Promise<Finding[]> {
     choices: Array<{ message: { content: string } }>
   }
   const raw = data.choices[0]?.message?.content?.trim() ?? '[]'
+  // Strip markdown code fences the model sometimes wraps around JSON
+  const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()
   try {
-    return JSON.parse(raw) as Finding[]
+    return JSON.parse(cleaned) as Finding[]
   } catch {
     process.stderr.write(`  Warning: could not parse findings JSON from model response; skipping chunk\n`)
     return []
@@ -201,8 +203,9 @@ async function main(): Promise<void> {
     process.stderr.write(`  Chunk ${i + 1}/${chunks.length}: ${fileCount} files, ~${estimatedTokens} tokens\n`)
 
     if (i > 0) {
-      // Small delay between requests to avoid 429 rate-limit errors
-      await sleep(500)
+      // GitHub Models free tier: 40 000 tokens/min. Each chunk is ~6 000 tokens in + prompt +
+      // response, so ~7 500 tokens/request → max ~5 requests/min → need ≥12 s between requests.
+      await sleep(12_000)
     }
 
     const findings = await callCopilot(pat, payload)


### PR DESCRIPTION
## Summary

Three fixes for the daily tech-debt audit workflow failures seen in runs #3 and #4:

**Fix 1 — 413 token limit:** A single file larger than the per-chunk budget was placed in its own chunk without truncation. Now any entry exceeding `maxBytes` is sliced to fit, with a truncation note appended.

**Fix 2 — JSON parse warnings:** `gpt-4o` sometimes wraps its response in ` ```json ``` ` fences even when the prompt says not to, causing findings to be silently dropped. Strip those fences before `JSON.parse`.

**Fix 3 — 429 rate limit:** GitHub Models free tier caps at 40,000 tokens/minute. Each request is ~7,500 tokens (6k content + prompt + response), allowing ~5 requests/minute max. Increased inter-chunk delay from 500ms → 12s.

> Note: 43 chunks × 12s ≈ 8.6 min total runtime — the cost of the free-tier rate limit with 145 files.

## Test plan

- [x] All 8 `buildChunks` unit tests pass (`npx vitest run scripts/tech-debt-audit.test.ts`)
- [ ] `workflow_dispatch` run on `main` after merge completes without a 4xx error
- [ ] No "could not parse findings JSON" warnings in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)