### PR TITLE
fix(tech-debt-audit): replace full findings dump with dashboard issue body

### DIFF
--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -86,18 +86,31 @@ jobs:
           with open('findings.json') as f:
               data = json.load(f)
 
-          findings = data.get('findings', [])
+          all_findings = data.get('findings', [])
+          all_fingerprints = data.get('fingerprints', [])
           date = data.get('date', '')
-          total = len(findings)
+          total = len(all_findings)
+
+          # Filter to new findings only (fingerprints in /tmp/new-fps.txt)
+          try:
+              with open('/tmp/new-fps.txt') as nf:
+                  new_fps = set(line.strip() for line in nf if line.strip())
+          except FileNotFoundError:
+              new_fps = set(all_fingerprints)
+
+          fp_map = {fp: f for fp, f in zip(all_fingerprints, all_findings)}
+          findings = [fp_map[fp] for fp in new_fps if fp in fp_map]
+          new_count = len(findings)
 
           SEVERITIES = ['fix-now', 'fix-soon', 'low-priority']
           ICONS = {'fix-now': '🚨', 'fix-soon': '⚠️', 'low-priority': 'ℹ️'}
           TOP_N = 5  # fix-now items shown inline; rest in artifact
 
-          counts = {s: sum(1 for f in findings if f['severity'] == s) for s in SEVERITIES}
+          counts = {s: sum(1 for f in findings if f.get('severity') == s) for s in SEVERITIES}
 
+          total_note = f' ({total} total across all runs)' if total != new_count else ''
           lines = [
-              f'Automated tech-debt audit — **{total} finding{"s" if total != 1 else ""}** detected on {date}.',
+              f'Automated tech-debt audit — **{new_count} new finding{"s" if new_count != 1 else ""}** detected on {date}{total_note}.',
               '',
               '## Summary',
               '',
@@ -127,7 +140,7 @@ jobs:
               lines.append(f'| {cat} | {sev_counts["fix-now"]} | {sev_counts["fix-soon"]} | {sev_counts["low-priority"]} |')
 
           # Top fix-now items inline
-          fix_now = [f for f in findings if f['severity'] == 'fix-now']
+          fix_now = [f for f in findings if f.get('severity') == 'fix-now']
           if fix_now:
               shown = fix_now[:TOP_N]
               lines += ['', f'## 🚨 Top fix-now (showing {len(shown)} of {len(fix_now)})', '']
@@ -140,7 +153,7 @@ jobs:
           lines += [
               '',
               '---',
-              f'📎 [Workflow run artifacts]({run_url}) (includes findings.json, 7-day retention)',
+              f'📎 [View workflow run & artifacts]({run_url}) (includes findings.json, 7-day retention)',
           ]
 
           print('\n'.join(lines))

--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -140,7 +140,7 @@ jobs:
           lines += [
               '',
               '---',
-              f'📎 [Full findings.json]({run_url}) (workflow artifact, 7-day retention)',
+              f'📎 [Workflow run artifacts]({run_url}) (includes findings.json, 7-day retention)',
           ]
 
           print('\n'.join(lines))

--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -110,8 +110,11 @@ jobs:
           # Category breakdown table
           cats: dict[str, dict[str, int]] = {}
           for f in findings:
+              severity = f.get('severity')
+              if severity not in SEVERITIES:
+                  continue
               cats.setdefault(f['category'], {s: 0 for s in SEVERITIES})
-              cats[f['category']][f['severity']] += 1
+              cats[f['category']][severity] += 1
 
           lines += [
               '',

--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Check out repository
@@ -75,9 +75,13 @@ jobs:
 
       - name: Format issue body
         if: steps.diff.outputs.new-count != '0'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          python3 - <<'PYEOF' > /tmp/issue-body.md
-          import json
+          python3 - "$RUN_URL" <<'PYEOF' > /tmp/issue-body.md
+          import json, sys
+
+          run_url = sys.argv[1]
 
           with open('findings.json') as f:
               data = json.load(f)
@@ -86,29 +90,55 @@ jobs:
           date = data.get('date', '')
           total = len(findings)
 
-          icons = {'fix-now': '🚨', 'fix-soon': '⚠️', 'low-priority': 'ℹ️'}
-          lines = [
-              f'Automated tech-debt audit — **{total} new finding{"s" if total != 1 else ""}** detected on {date}.',
-              '',
-              '_Grouped by severity, then category. New findings only (deduped via fingerprint)._',
-          ]
+          SEVERITIES = ['fix-now', 'fix-soon', 'low-priority']
+          ICONS = {'fix-now': '🚨', 'fix-soon': '⚠️', 'low-priority': 'ℹ️'}
+          TOP_N = 5  # fix-now items shown inline; rest in artifact
 
-          for sev in ['fix-now', 'fix-soon', 'low-priority']:
-              by_sev = [f for f in findings if f['severity'] == sev]
-              if not by_sev:
-                  continue
-              lines.append(f'\n## {icons.get(sev, "")} {sev} ({len(by_sev)})\n')
-              cats: dict[str, list] = {}
-              for item in by_sev:
-                  cats.setdefault(item['category'], []).append(item)
-              for cat, items in cats.items():
-                  lines.append(f'### {cat}\n')
-                  for item in items:
-                      lines.append(
-                          f'- **{item["id"]}** `{item["file"]}:{item["lineStart"]}` {item["description"]}'
-                      )
-                      lines.append(f'  > {item["recommendation"]}')
-                  lines.append('')
+          counts = {s: sum(1 for f in findings if f['severity'] == s) for s in SEVERITIES}
+
+          lines = [
+              f'Automated tech-debt audit — **{total} finding{"s" if total != 1 else ""}** detected on {date}.',
+              '',
+              '## Summary',
+              '',
+              '| Severity | Count |',
+              '|---|---|',
+          ]
+          for sev in SEVERITIES:
+              lines.append(f'| {ICONS[sev]} {sev} | {counts[sev]} |')
+
+          # Category breakdown table
+          cats: dict[str, dict[str, int]] = {}
+          for f in findings:
+              cats.setdefault(f['category'], {s: 0 for s in SEVERITIES})
+              cats[f['category']][f['severity']] += 1
+
+          lines += [
+              '',
+              '## By category',
+              '',
+              '| Category | 🚨 fix-now | ⚠️ fix-soon | ℹ️ low-priority |',
+              '|---|---|---|---|',
+          ]
+          for cat, sev_counts in sorted(cats.items()):
+              lines.append(f'| {cat} | {sev_counts["fix-now"]} | {sev_counts["fix-soon"]} | {sev_counts["low-priority"]} |')
+
+          # Top fix-now items inline
+          fix_now = [f for f in findings if f['severity'] == 'fix-now']
+          if fix_now:
+              shown = fix_now[:TOP_N]
+              lines += ['', f'## 🚨 Top fix-now (showing {len(shown)} of {len(fix_now)})', '']
+              for item in shown:
+                  lines.append(f'- **{item["id"]}** `{item["file"]}:{item["lineStart"]}` — {item["description"]}')
+                  lines.append(f'  > {item["recommendation"]}')
+              if len(fix_now) > TOP_N:
+                  lines.append(f'\n_...and {len(fix_now) - TOP_N} more. See the full findings in the workflow artifact._')
+
+          lines += [
+              '',
+              '---',
+              f'📎 [Full findings.json]({run_url}) (workflow artifact, 7-day retention)',
+          ]
 
           print('\n'.join(lines))
           PYEOF
@@ -151,6 +181,7 @@ jobs:
         run: |
           mkdir -p .artifact
           jq '.fingerprints' findings.json > .artifact/fingerprint.json
+          cp findings.json .artifact/findings.json
           ISSUE="${{ steps.create-issue.outputs.issue-number }}"
           if [ -z "$ISSUE" ]; then
             ISSUE="${{ steps.diff.outputs.prev-issue }}"


### PR DESCRIPTION
## Summary

The issue body was hitting GitHub's 65,536-character GraphQL limit when the audit produced hundreds of findings across 43 chunks.

**Root cause:** The old formatter dumped every finding as bullet points — unbounded output.

**Fix:** Issue body is now a compact dashboard:

| Section | Content |
|---|---|
| Summary table | Finding count by severity |
| Category breakdown | Count per category × severity |
| Top fix-now | Up to 5 inline with recommendation |
| Artifact link | URL to workflow run → full `findings.json` |

Full `findings.json` is now also saved into the `tech-debt-fingerprint` artifact (alongside the existing `fingerprint.json`) and linked from the issue body. Timeout bumped 15 → 30 min to accommodate 43 chunks × 12s inter-chunk delay.

## Test plan

### Pre-merge (auto-verified)
- [x] All 1,752 unit tests pass (`npm test`)
- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] Lint clean — 0 errors, 2 pre-existing warnings (`npm run lint`)
- [x] Build passes (`npm run build`)

### Post-merge (verify via `workflow_dispatch` on `main`)
- [ ] Workflow run completes without the 65,536-char GraphQL error on `Create issue for new findings`
- [ ] Issue body contains the summary table, category breakdown table, and top fix-now items
- [ ] `findings.json` appears in the `tech-debt-fingerprint` workflow artifact
- [ ] Issue body contains a link to the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)