### PR TITLE
fix(#272): responsiveness rollup panel respects selected time window

### DIFF
--- a/components/org-summary/panels/ResponsivenessRollupPanel.tsx
+++ b/components/org-summary/panels/ResponsivenessRollupPanel.tsx
@@ -32,7 +32,11 @@ export function ResponsivenessRollupPanel({ panel, externalWindow }: Props) {
       panel={panel}
       noDataMessage="No responsiveness data available across this run."
     >
-      {windowValue && windowValue.contributingReposCount > 0 ? (
+      {!windowValue || windowValue.contributingReposCount === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          No responsiveness data for the selected window.
+        </p>
+      ) : (
         <dl className="grid grid-cols-2 gap-3">
           <div>
             <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -61,7 +65,7 @@ export function ResponsivenessRollupPanel({ panel, externalWindow }: Props) {
             </dd>
           </div>
         </dl>
-      ) : null}
+      )}
     </PanelShell>
   )
 }

--- a/components/org-summary/panels/ResponsivenessRollupPanel.tsx
+++ b/components/org-summary/panels/ResponsivenessRollupPanel.tsx
@@ -1,12 +1,16 @@
 'use client'
 
 import type { AggregatePanel } from '@/lib/org-aggregation/types'
-import type { ResponsivenessRollupValue } from '@/lib/org-aggregation/aggregators/types'
+import type {
+  ContributorDiversityWindow,
+  ResponsivenessRollupValue,
+} from '@/lib/org-aggregation/aggregators/types'
 import { HelpLabel } from '@/components/shared/HelpLabel'
 import { PanelShell } from '../PanelShell'
 
 interface Props {
   panel: AggregatePanel<ResponsivenessRollupValue>
+  externalWindow?: ContributorDiversityWindow
 }
 
 function formatHours(hours: number): string {
@@ -16,7 +20,11 @@ function formatHours(hours: number): string {
   return `${days.toFixed(1)}d`
 }
 
-export function ResponsivenessRollupPanel({ panel }: Props) {
+export function ResponsivenessRollupPanel({ panel, externalWindow }: Props) {
+  const selectedWindow: ContributorDiversityWindow =
+    externalWindow ?? panel.value?.defaultWindow ?? 90
+  const windowValue = panel.value?.byWindow[selectedWindow]
+
   return (
     <PanelShell
       label="Responsiveness"
@@ -24,7 +32,7 @@ export function ResponsivenessRollupPanel({ panel }: Props) {
       panel={panel}
       noDataMessage="No responsiveness data available across this run."
     >
-      {panel.value ? (
+      {windowValue && windowValue.contributingReposCount > 0 ? (
         <dl className="grid grid-cols-2 gap-3">
           <div>
             <dt className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -34,8 +42,8 @@ export function ResponsivenessRollupPanel({ panel }: Props) {
               />
             </dt>
             <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-              {panel.value.weightedMedianFirstResponseHours !== null
-                ? formatHours(panel.value.weightedMedianFirstResponseHours)
+              {windowValue.weightedMedianFirstResponseHours !== null
+                ? formatHours(windowValue.weightedMedianFirstResponseHours)
                 : '—'}
             </dd>
           </div>
@@ -47,8 +55,8 @@ export function ResponsivenessRollupPanel({ panel }: Props) {
               />
             </dt>
             <dd className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-              {panel.value.weightedMedianPrMergeHours !== null
-                ? formatHours(panel.value.weightedMedianPrMergeHours)
+              {windowValue.weightedMedianPrMergeHours !== null
+                ? formatHours(windowValue.weightedMedianPrMergeHours)
                 : '—'}
             </dd>
           </div>

--- a/components/org-summary/panels/registry.tsx
+++ b/components/org-summary/panels/registry.tsx
@@ -169,6 +169,9 @@ export function renderPanel(panelId: PanelId, panel: AggregatePanel<unknown>, se
   if (panelId === 'contributor-diversity') {
     return <ContributorDiversityPanel panel={panel as AggregatePanel<never>} externalWindow={selectedWindow as ContributorDiversityWindow | undefined} />
   }
+  if (panelId === 'responsiveness-rollup') {
+    return <ResponsivenessRollupPanel panel={panel as AggregatePanel<never>} externalWindow={selectedWindow as ContributorDiversityWindow | undefined} />
+  }
   const Real = REAL_PANELS[panelId]
   if (Real) {
     return <Real panel={panel as AggregatePanel<never>} />

--- a/lib/org-aggregation/aggregators/responsiveness-rollup.test.ts
+++ b/lib/org-aggregation/aggregators/responsiveness-rollup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { AnalysisResult, ResponsivenessMetrics } from '@/lib/analyzer/analysis-result'
+import type { AnalysisResult, ResponsivenessMetrics, ActivityWindowDays } from '@/lib/analyzer/analysis-result'
 import { responsivenessRollupAggregator, weightedMedian } from './responsiveness-rollup'
 import { buildResult } from '@/lib/testing/fixtures'
 
@@ -34,7 +34,7 @@ function stubMetrics(partial: Partial<ResponsivenessMetrics>): ResponsivenessMet
 const CONTEXT = { totalReposInRun: 3, flagshipRepos: [], inactiveRepoWindowMonths: 12 }
 
 describe('responsivenessRollupAggregator — FR-021', () => {
-  it('typical: computes weighted medians from multiple repos', () => {
+  it('typical: computes weighted medians from multiple repos (legacy fallback fields, 90d window)', () => {
     const results = [
       partialResult('o/alpha', {
         responsivenessMetrics: stubMetrics({ issueFirstResponseMedianHours: 4, prMergeMedianHours: 24 }),
@@ -60,13 +60,16 @@ describe('responsivenessRollupAggregator — FR-021', () => {
     expect(panel.contributingReposCount).toBe(3)
     expect(panel.panelId).toBe('responsiveness-rollup')
     expect(panel.value).not.toBeNull()
+    const w90 = panel.value!.byWindow[90]
     // Weighted median: sorted by value, walk until cumulative >= total/2
     // First response: (4,50), (8,30), (12,100) => total=180, half=90
     //   cumulative: 50 < 90, 50+30=80 < 90, 80+100=180 >= 90 => 12
-    expect(panel.value!.weightedMedianFirstResponseHours).toBe(12)
+    expect(w90.weightedMedianFirstResponseHours).toBe(12)
     // PR merge: (24,10), (36,5), (48,20) => total=35, half=17.5
     //   cumulative: 10 < 17.5, 10+5=15 < 17.5, 15+20=35 >= 17.5 => 48
-    expect(panel.value!.weightedMedianPrMergeHours).toBe(48)
+    expect(w90.weightedMedianPrMergeHours).toBe(48)
+    expect(w90.contributingReposCount).toBe(3)
+    expect(panel.value!.defaultWindow).toBe(90)
   })
 
   it('all-unavailable: every repo lacks responsiveness data -> panel is unavailable', () => {
@@ -97,8 +100,9 @@ describe('responsivenessRollupAggregator — FR-021', () => {
     const panel = responsivenessRollupAggregator(results, CONTEXT)
     expect(panel.status).toBe('final')
     expect(panel.contributingReposCount).toBe(1)
-    expect(panel.value!.weightedMedianFirstResponseHours).toBe(6)
-    expect(panel.value!.weightedMedianPrMergeHours).toBe(30)
+    const w90 = panel.value!.byWindow[90]
+    expect(w90.weightedMedianFirstResponseHours).toBe(6)
+    expect(w90.weightedMedianPrMergeHours).toBe(30)
   })
 
   it('empty: results array is empty -> in-progress with null value', () => {
@@ -147,8 +151,64 @@ describe('responsivenessRollupAggregator — FR-021', () => {
     const panel = responsivenessRollupAggregator(results, { ...CONTEXT, totalReposInRun: 1 })
     expect(panel.status).toBe('final')
     expect(panel.contributingReposCount).toBe(1)
+    const w90 = panel.value!.byWindow[90]
     // With default weight of 1, the single value is the median
-    expect(panel.value!.weightedMedianFirstResponseHours).toBe(10)
-    expect(panel.value!.weightedMedianPrMergeHours).toBe(20)
+    expect(w90.weightedMedianFirstResponseHours).toBe(10)
+    expect(w90.weightedMedianPrMergeHours).toBe(20)
+  })
+
+  it('windowed: uses responsivenessMetricsByWindow when available, different windows return different values', () => {
+    const makeWindowedMetrics = (
+      firstResponseHours: number,
+      prMergeHours: number,
+      openIssueCount: number,
+    ): ResponsivenessMetrics => stubMetrics({
+      issueFirstResponseMedianHours: firstResponseHours,
+      prMergeMedianHours: prMergeHours,
+      openIssueCount,
+    })
+
+    const results = [
+      partialResult('o/alpha', {
+        responsivenessMetricsByWindow: {
+          30: makeWindowedMetrics(2, 10, 40),
+          60: makeWindowedMetrics(3, 15, 45),
+          90: makeWindowedMetrics(4, 20, 50),
+          180: makeWindowedMetrics(6, 30, 60),
+          365: makeWindowedMetrics(10, 48, 80),
+        } as Record<ActivityWindowDays, ResponsivenessMetrics>,
+        issuesOpen: 50,
+        prsMerged90d: 10,
+      }),
+    ]
+    const panel = responsivenessRollupAggregator(results, { ...CONTEXT, totalReposInRun: 1 })
+    expect(panel.status).toBe('final')
+    expect(panel.value!.byWindow[30].weightedMedianFirstResponseHours).toBe(2)
+    expect(panel.value!.byWindow[30].weightedMedianPrMergeHours).toBe(10)
+    expect(panel.value!.byWindow[90].weightedMedianFirstResponseHours).toBe(4)
+    expect(panel.value!.byWindow[90].weightedMedianPrMergeHours).toBe(20)
+    expect(panel.value!.byWindow[365].weightedMedianFirstResponseHours).toBe(10)
+    expect(panel.value!.byWindow[365].weightedMedianPrMergeHours).toBe(48)
+  })
+
+  it('windowed: non-90d windows return null when responsivenessMetricsByWindow is absent', () => {
+    const results = [
+      partialResult('o/alpha', {
+        // Only legacy fields, no responsivenessMetricsByWindow
+        responsivenessMetrics: stubMetrics({ issueFirstResponseMedianHours: 8, prMergeMedianHours: 24 }),
+        issuesOpen: 20,
+        medianTimeToMergeHours: 24,
+        prsMerged90d: 5,
+      }),
+    ]
+    const panel = responsivenessRollupAggregator(results, { ...CONTEXT, totalReposInRun: 1 })
+    expect(panel.status).toBe('final')
+    // 90d falls back to legacy fields
+    expect(panel.value!.byWindow[90].weightedMedianFirstResponseHours).toBe(8)
+    expect(panel.value!.byWindow[90].weightedMedianPrMergeHours).toBe(24)
+    // Other windows have no data
+    expect(panel.value!.byWindow[30].weightedMedianFirstResponseHours).toBeNull()
+    expect(panel.value!.byWindow[30].weightedMedianPrMergeHours).toBeNull()
+    expect(panel.value!.byWindow[180].weightedMedianFirstResponseHours).toBeNull()
   })
 })

--- a/lib/org-aggregation/aggregators/responsiveness-rollup.ts
+++ b/lib/org-aggregation/aggregators/responsiveness-rollup.ts
@@ -36,7 +36,7 @@ export function weightedMedian(pairs: { value: number; weight: number }[]): numb
 
 function computeWindow(
   results: AnalysisResult[],
-  window: ContributorDiversityWindow,
+  window: ActivityWindowDays,
 ): ResponsivenessRollupWindowValue {
   const firstResponsePairs: { value: number; weight: number }[] = []
   const prMergePairs: { value: number; weight: number }[] = []
@@ -46,7 +46,7 @@ function computeWindow(
     const ar = r as AnalysisResult
     let contributes = false
 
-    const windowedMetrics = ar.responsivenessMetricsByWindow?.[window as ActivityWindowDays]
+    const windowedMetrics = ar.responsivenessMetricsByWindow?.[window]
 
     // First response hours from windowed metrics; fall back to legacy field at 90d.
     const firstResponse =
@@ -70,7 +70,7 @@ function computeWindow(
       (window === 90 ? ar.medianTimeToMergeHours : undefined)
 
     if (typeof mergeHours === 'number') {
-      const activityMetrics = ar.activityMetricsByWindow?.[window as ActivityWindowDays]
+      const activityMetrics = ar.activityMetricsByWindow?.[window]
       const prsMerged =
         typeof activityMetrics?.prsMerged === 'number' && activityMetrics.prsMerged > 0
           ? activityMetrics.prsMerged

--- a/lib/org-aggregation/aggregators/responsiveness-rollup.ts
+++ b/lib/org-aggregation/aggregators/responsiveness-rollup.ts
@@ -1,13 +1,19 @@
-import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { AnalysisResult, ActivityWindowDays } from '@/lib/analyzer/analysis-result'
 import type { AggregatePanel } from '../types'
-import type { Aggregator, ResponsivenessRollupValue } from './types'
+import type {
+  Aggregator,
+  ContributorDiversityWindow,
+  ResponsivenessRollupValue,
+  ResponsivenessRollupWindowValue,
+} from './types'
+import { CONTRIBUTOR_DIVERSITY_WINDOWS } from './types'
 
 /**
  * FR-021: Weighted-median responsiveness rollup across all repos in the org.
  *
  * Two metrics:
- *   - weightedMedianFirstResponseHours: weighted by issuesOpen (repo issue volume)
- *   - weightedMedianPrMergeHours: weighted by prsMerged90d (repo merge volume)
+ *   - weightedMedianFirstResponseHours: weighted by openIssueCount (from windowed metrics)
+ *   - weightedMedianPrMergeHours: weighted by windowed prsMerged count
  *
  * Weighted median per research R6: sort pairs by value, walk until
  * cumulative weight >= totalWeight / 2.
@@ -28,6 +34,63 @@ export function weightedMedian(pairs: { value: number; weight: number }[]): numb
   return sorted[sorted.length - 1].value
 }
 
+function computeWindow(
+  results: AnalysisResult[],
+  window: ContributorDiversityWindow,
+): ResponsivenessRollupWindowValue {
+  const firstResponsePairs: { value: number; weight: number }[] = []
+  const prMergePairs: { value: number; weight: number }[] = []
+  let contributingReposCount = 0
+
+  for (const r of results) {
+    const ar = r as AnalysisResult
+    let contributes = false
+
+    const windowedMetrics = ar.responsivenessMetricsByWindow?.[window as ActivityWindowDays]
+
+    // First response hours from windowed metrics; fall back to legacy field at 90d.
+    const firstResponse =
+      windowedMetrics?.issueFirstResponseMedianHours ??
+      (window === 90 ? ar.responsivenessMetrics?.issueFirstResponseMedianHours : undefined)
+
+    if (typeof firstResponse === 'number') {
+      const openIssues =
+        typeof windowedMetrics?.openIssueCount === 'number' && windowedMetrics.openIssueCount > 0
+          ? windowedMetrics.openIssueCount
+          : typeof ar.issuesOpen === 'number' && ar.issuesOpen > 0
+            ? ar.issuesOpen
+            : 1
+      firstResponsePairs.push({ value: firstResponse, weight: openIssues })
+      contributes = true
+    }
+
+    // PR merge hours from windowed metrics; fall back to legacy top-level field at 90d.
+    const mergeHours =
+      windowedMetrics?.prMergeMedianHours ??
+      (window === 90 ? ar.medianTimeToMergeHours : undefined)
+
+    if (typeof mergeHours === 'number') {
+      const activityMetrics = ar.activityMetricsByWindow?.[window as ActivityWindowDays]
+      const prsMerged =
+        typeof activityMetrics?.prsMerged === 'number' && activityMetrics.prsMerged > 0
+          ? activityMetrics.prsMerged
+          : typeof ar.prsMerged90d === 'number' && ar.prsMerged90d > 0
+            ? ar.prsMerged90d
+            : 1
+      prMergePairs.push({ value: mergeHours, weight: prsMerged })
+      contributes = true
+    }
+
+    if (contributes) contributingReposCount++
+  }
+
+  return {
+    weightedMedianFirstResponseHours: weightedMedian(firstResponsePairs),
+    weightedMedianPrMergeHours: weightedMedian(prMergePairs),
+    contributingReposCount,
+  }
+}
+
 export const responsivenessRollupAggregator: Aggregator<ResponsivenessRollupValue> = (
   results,
   context,
@@ -42,34 +105,15 @@ export const responsivenessRollupAggregator: Aggregator<ResponsivenessRollupValu
     }
   }
 
-  const firstResponsePairs: { value: number; weight: number }[] = []
-  const prMergePairs: { value: number; weight: number }[] = []
-  let contributingReposCount = 0
+  const byWindow = Object.fromEntries(
+    CONTRIBUTOR_DIVERSITY_WINDOWS.map((w) => [w, computeWindow(results, w)]),
+  ) as Record<ContributorDiversityWindow, ResponsivenessRollupWindowValue>
 
-  for (const r of results) {
-    const ar = r as AnalysisResult
-    let contributes = false
+  const maxContributing = Math.max(
+    ...CONTRIBUTOR_DIVERSITY_WINDOWS.map((w) => byWindow[w].contributingReposCount),
+  )
 
-    // First response hours — weighted by issuesOpen
-    const firstResponse = ar.responsivenessMetrics?.issueFirstResponseMedianHours
-    if (typeof firstResponse === 'number') {
-      const issuesOpen = typeof ar.issuesOpen === 'number' && ar.issuesOpen > 0 ? ar.issuesOpen : 1
-      firstResponsePairs.push({ value: firstResponse, weight: issuesOpen })
-      contributes = true
-    }
-
-    // PR merge hours — weighted by prsMerged90d
-    const mergeHours = ar.medianTimeToMergeHours
-    if (typeof mergeHours === 'number') {
-      const prsMerged = typeof ar.prsMerged90d === 'number' && ar.prsMerged90d > 0 ? ar.prsMerged90d : 1
-      prMergePairs.push({ value: mergeHours, weight: prsMerged })
-      contributes = true
-    }
-
-    if (contributes) contributingReposCount++
-  }
-
-  if (contributingReposCount === 0) {
+  if (maxContributing === 0) {
     return {
       panelId: 'responsiveness-rollup',
       contributingReposCount: 0,
@@ -81,12 +125,12 @@ export const responsivenessRollupAggregator: Aggregator<ResponsivenessRollupValu
 
   return {
     panelId: 'responsiveness-rollup',
-    contributingReposCount,
+    contributingReposCount: maxContributing,
     totalReposInRun: context.totalReposInRun,
     status: 'final',
     value: {
-      weightedMedianFirstResponseHours: weightedMedian(firstResponsePairs),
-      weightedMedianPrMergeHours: weightedMedian(prMergePairs),
+      defaultWindow: 90,
+      byWindow,
     },
   }
 }

--- a/lib/org-aggregation/aggregators/types.ts
+++ b/lib/org-aggregation/aggregators/types.ts
@@ -100,9 +100,15 @@ export type ActivityRollupValue = {
   leastActiveRepo: { repo: string; commits: number } | null
 }
 
-export type ResponsivenessRollupValue = {
+export type ResponsivenessRollupWindowValue = {
   weightedMedianFirstResponseHours: number | null
   weightedMedianPrMergeHours: number | null
+  contributingReposCount: number
+}
+
+export type ResponsivenessRollupValue = {
+  defaultWindow: ContributorDiversityWindow
+  byWindow: Record<ContributorDiversityWindow, ResponsivenessRollupWindowValue>
 }
 
 export type LicenseConsistencyValue = {

--- a/specs/231-org-aggregation/contracts/aggregator-contracts.ts
+++ b/specs/231-org-aggregation/contracts/aggregator-contracts.ts
@@ -75,9 +75,18 @@ export type ActivityRollupValue = {
   leastActiveRepo: { repo: string; commits: number } | null
 }
 
-export type ResponsivenessRollupValue = {
+export const CONTRIBUTOR_DIVERSITY_WINDOWS = [30, 60, 90, 180, 365] as const
+export type ContributorDiversityWindow = (typeof CONTRIBUTOR_DIVERSITY_WINDOWS)[number]
+
+export type ResponsivenessRollupWindowValue = {
   weightedMedianFirstResponseHours: number | null
   weightedMedianPrMergeHours: number | null
+  contributingReposCount: number
+}
+
+export type ResponsivenessRollupValue = {
+  defaultWindow: ContributorDiversityWindow
+  byWindow: Record<ContributorDiversityWindow, ResponsivenessRollupWindowValue>
 }
 
 export type LicenseConsistencyValue = {


### PR DESCRIPTION
## Summary

- Pre-compute all five time windows (30/60/90/180/365d) in `responsivenessRollupAggregator` by reading from `responsivenessMetricsByWindow[window]` (with 90d fallback to legacy `responsivenessMetrics` / `medianTimeToMergeHours` fields for backward compatibility)
- `ResponsivenessRollupValue` now stores `byWindow: Record<ContributorDiversityWindow, ResponsivenessRollupWindowValue>` instead of flat fields, matching the `ContributorDiversityValue` pattern
- `ResponsivenessRollupPanel` accepts `externalWindow` prop and renders the selected window's weighted medians
- `registry.tsx` `renderPanel` passes `selectedWindow` to `ResponsivenessRollupPanel` (same wiring as `ContributorDiversityPanel`)

## Test plan

- [x] `npx vitest run lib/org-aggregation/aggregators/responsiveness-rollup.test.ts` — all 8 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] Open the demo org view, navigate to the **Responsiveness** tab, and change the time window selector — the "First response (median)" and "PR merge (median)" values update with each window change
- [x] Verify the 90d window still shows the same values as before the fix (backward compat via fallback fields)

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)