### PR TITLE
feat(tech-debt): confidence field, confidence-aware dashboard, and capped auto-fix PRs

### DIFF
--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -17,7 +17,11 @@ env:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
+
+    outputs:
+      new-count: ${{ steps.diff.outputs.new-count }}
+      issue-number: ${{ steps.create-issue.outputs.issue-number }}
 
     steps:
       - name: Check out repository
@@ -75,40 +79,96 @@ jobs:
 
       - name: Format issue body
         if: steps.diff.outputs.new-count != '0'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          python3 - <<'PYEOF' > /tmp/issue-body.md
-          import json
+          python3 - "$RUN_URL" /tmp/new-fps.txt <<'PYEOF' > /tmp/issue-body.md
+          import json, sys
+
+          run_url = sys.argv[1]
+          new_fps_path = sys.argv[2]
 
           with open('findings.json') as f:
               data = json.load(f)
 
-          findings = data.get('findings', [])
+          all_findings = data.get('findings', [])
+          all_fingerprints = data.get('fingerprints', [])
           date = data.get('date', '')
-          total = len(findings)
+          total_all = len(all_findings)
 
-          icons = {'fix-now': '🚨', 'fix-soon': '⚠️', 'low-priority': 'ℹ️'}
+          # Filter to new findings only
+          try:
+              with open(new_fps_path) as nf:
+                  new_fps = set(line.strip() for line in nf if line.strip())
+          except FileNotFoundError:
+              new_fps = set(all_fingerprints)
+
+          fp_map = {fp: f for fp, f in zip(all_fingerprints, all_findings)}
+          findings = [fp_map[fp] for fp in new_fps if fp in fp_map]
+          new_count = len(findings)
+
+          SEVERITIES = ['fix-now', 'fix-soon', 'low-priority']
+          CONFIDENCES = ['high', 'medium', 'low']
+          ICONS = {'fix-now': '🚨', 'fix-soon': '⚠️', 'low-priority': 'ℹ️'}
+          TOP_N = 5
+
+          def conf(f): return f.get('confidence', 'low')
+          def sev(f): return f.get('severity', 'low-priority')
+
+          # Severity × confidence counts
+          sev_counts = {s: len([f for f in findings if sev(f) == s]) for s in SEVERITIES}
+          high_fix_now = [f for f in findings if sev(f) == 'fix-now' and conf(f) == 'high']
+
+          total_note = f' ({total_all} total across all runs)' if total_all != new_count else ''
           lines = [
-              f'Automated tech-debt audit — **{total} new finding{"s" if total != 1 else ""}** detected on {date}.',
+              f'Automated tech-debt audit — **{new_count} new finding{"s" if new_count != 1 else ""}** on {date}{total_note}.',
+              f'**{len(high_fix_now)}** are high-confidence fix-now — auto-fix PRs will be opened for the top 3.',
               '',
-              '_Grouped by severity, then category. New findings only (deduped via fingerprint)._',
+              '## Summary',
+              '',
+              '| Severity | Total new | 🔴 high conf | 🟡 medium conf | 🟢 low conf |',
+              '|---|---|---|---|---|',
           ]
+          for s in SEVERITIES:
+              by_sev = [f for f in findings if sev(f) == s]
+              h = sum(1 for f in by_sev if conf(f) == 'high')
+              m = sum(1 for f in by_sev if conf(f) == 'medium')
+              lo = sum(1 for f in by_sev if conf(f) == 'low')
+              lines.append(f'| {ICONS[s]} {s} | {len(by_sev)} | {h} | {m} | {lo} |')
 
-          for sev in ['fix-now', 'fix-soon', 'low-priority']:
-              by_sev = [f for f in findings if f['severity'] == sev]
-              if not by_sev:
-                  continue
-              lines.append(f'\n## {icons.get(sev, "")} {sev} ({len(by_sev)})\n')
-              cats: dict[str, list] = {}
-              for item in by_sev:
-                  cats.setdefault(item['category'], []).append(item)
-              for cat, items in cats.items():
-                  lines.append(f'### {cat}\n')
-                  for item in items:
-                      lines.append(
-                          f'- **{item["id"]}** `{item["file"]}:{item["lineStart"]}` {item["description"]}'
-                      )
-                      lines.append(f'  > {item["recommendation"]}')
-                  lines.append('')
+          # Category breakdown (new, high-confidence only)
+          cats: dict[str, dict[str, int]] = {}
+          for f in [x for x in findings if conf(x) == 'high']:
+              cat = f.get('category', '?')
+              cats.setdefault(cat, {s: 0 for s in SEVERITIES})
+              cats[cat][sev(f)] = cats[cat].get(sev(f), 0) + 1
+
+          if cats:
+              lines += [
+                  '',
+                  '## High-confidence findings by category',
+                  '',
+                  '| Category | 🚨 fix-now | ⚠️ fix-soon | ℹ️ low-priority |',
+                  '|---|---|---|---|',
+              ]
+              for cat, sc in sorted(cats.items()):
+                  lines.append(f'| {cat} | {sc.get("fix-now",0)} | {sc.get("fix-soon",0)} | {sc.get("low-priority",0)} |')
+
+          # Top high-confidence fix-now items inline
+          if high_fix_now:
+              shown = high_fix_now[:TOP_N]
+              lines += ['', f'## 🚨 Top fix-now (high confidence — showing {len(shown)} of {len(high_fix_now)})', '']
+              for item in shown:
+                  lines.append(f'- **{item["id"]}** `{item["file"]}:{item["lineStart"]}` — {item["description"]}')
+                  lines.append(f'  > {item["recommendation"]}')
+              if len(high_fix_now) > TOP_N:
+                  lines.append(f'\n_...and {len(high_fix_now) - TOP_N} more in the artifact._')
+
+          lines += [
+              '',
+              '---',
+              f'📎 [Full findings.json]({run_url}) (workflow artifact, 7-day retention)',
+          ]
 
           print('\n'.join(lines))
           PYEOF
@@ -151,6 +211,7 @@ jobs:
         run: |
           mkdir -p .artifact
           jq '.fingerprints' findings.json > .artifact/fingerprint.json
+          cp findings.json .artifact/findings.json
           ISSUE="${{ steps.create-issue.outputs.issue-number }}"
           if [ -z "$ISSUE" ]; then
             ISSUE="${{ steps.diff.outputs.prev-issue }}"
@@ -163,3 +224,48 @@ jobs:
           name: tech-debt-fingerprint
           path: .artifact/
           retention-days: 7
+
+  auto-fix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: audit
+    if: needs.audit.outputs.new-count != '0'
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download findings artifact
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: daily-tech-debt-audit.yml
+          name: tech-debt-fingerprint
+          path: .artifact/
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      - name: Copy findings into working directory
+        run: cp .artifact/findings.json findings.json 2>/dev/null || echo "No findings.json in artifact"
+
+      - name: Open auto-fix PRs for top high-confidence findings
+        env:
+          COPILOT_TOKEN: ${{ secrets.COPILOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FINDINGS_OUTPUT: findings.json
+          TECH_DEBT_ISSUE: ${{ needs.audit.outputs.issue-number }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: npx tsx scripts/tech-debt-fix.ts

--- a/scripts/tech-debt-audit.ts
+++ b/scripts/tech-debt-audit.ts
@@ -24,6 +24,7 @@ interface Finding {
   lineEnd: number
   description: string
   severity: 'fix-now' | 'fix-soon' | 'low-priority'
+  confidence: 'high' | 'medium' | 'low'
   recommendation: string
 }
 
@@ -119,6 +120,13 @@ Detection categories:
 - OPTIMIZATIONS: synchronous chart imports, O(n²) patterns, unused GraphQL fields
 - MISSING_TESTS: API routes with zero unit tests, scoring modules with no boundary tests
 
+Confidence guidance — be conservative:
+- high: the issue is unambiguous AND the fix is fully mechanical (extract function, deduplicate constant, add missing null-check). A reviewer could approve the diff in under 2 minutes without reading surrounding code.
+- medium: the issue is likely real but the correct fix requires understanding broader context or business logic.
+- low: stylistic, speculative, or the evidence in the visible code is thin.
+
+Only emit a finding if you are at least medium confidence. Prefer fewer, higher-signal findings over an exhaustive list.
+
 Output ONLY a JSON array — no prose, no markdown fences:
 [
   {
@@ -129,6 +137,7 @@ Output ONLY a JSON array — no prose, no markdown fences:
     "lineEnd": 40,
     "description": "one sentence",
     "severity": "fix-now|fix-soon|low-priority",
+    "confidence": "high|medium|low",
     "recommendation": "one sentence"
   }
 ]`

--- a/scripts/tech-debt-fix.ts
+++ b/scripts/tech-debt-fix.ts
@@ -1,0 +1,231 @@
+/**
+ * Auto-fix script for high-confidence fix-now tech-debt findings.
+ *
+ * Usage (in CI):
+ *   COPILOT_TOKEN=<pat> TECH_DEBT_ISSUE=<issue#> npx tsx scripts/tech-debt-fix.ts
+ *
+ * Reads findings.json, picks the top MAX_FIX_PRS files with high-confidence
+ * fix-now findings, asks the model to patch each file, then commits and opens
+ * a draft PR per file referencing the tech-debt issue.
+ */
+
+import { execSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+const ROOT = process.cwd()
+const MAX_FIX_PRS = 3
+const MAX_FILE_CHARS = 24_000 // stay within model token budget
+
+interface Finding {
+  id: string
+  category: string
+  file: string
+  lineStart: number
+  lineEnd: number
+  description: string
+  severity: string
+  confidence: string
+  recommendation: string
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function run(cmd: string): string {
+  return execSync(cmd, { cwd: ROOT, encoding: 'utf8' }).trim()
+}
+
+function stripFences(raw: string): string {
+  return raw.replace(/^```[^\n]*\n?/m, '').replace(/\n?```$/m, '').trim()
+}
+
+async function generateFix(
+  pat: string,
+  filePath: string,
+  findings: Finding[],
+): Promise<string | null> {
+  let content: string
+  try {
+    content = readFileSync(filePath, 'utf8')
+  } catch {
+    process.stderr.write(`  Cannot read ${filePath}\n`)
+    return null
+  }
+
+  if (content.length > MAX_FILE_CHARS) {
+    content = content.slice(0, MAX_FILE_CHARS) + '\n// [file truncated for context window]'
+  }
+
+  const findingsList = findings
+    .map(
+      f =>
+        `  - ${f.id} (lines ${f.lineStart}–${f.lineEnd}): ${f.description}\n    Fix: ${f.recommendation}`,
+    )
+    .join('\n')
+
+  const prompt = `You are a TypeScript/Next.js engineer applying a targeted tech-debt fix.
+
+File: ${filePath}
+Findings to fix:
+${findingsList}
+
+Rules:
+- Apply ONLY the listed fixes. Do not refactor anything else.
+- Preserve all existing behaviour, exports, and types.
+- Return ONLY the complete corrected file content — no markdown fences, no commentary.
+
+File content:
+${content}`
+
+  const res = await fetch('https://models.inference.ai.azure.com/chat/completions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${pat}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0,
+    }),
+  })
+
+  if (!res.ok) {
+    process.stderr.write(`  Fix API error ${res.status} for ${filePath}\n`)
+    return null
+  }
+
+  const data = (await res.json()) as { choices: Array<{ message: { content: string } }> }
+  const raw = data.choices[0]?.message?.content?.trim() ?? ''
+  return stripFences(raw) || null
+}
+
+async function main(): Promise<void> {
+  const pat = process.env.COPILOT_TOKEN
+  if (!pat) {
+    process.stderr.write('COPILOT_TOKEN not set\n')
+    process.exit(1)
+  }
+
+  const issueNumber = process.env.TECH_DEBT_ISSUE ?? ''
+  const findingsPath = process.env.FINDINGS_OUTPUT ?? 'findings.json'
+  const baseBranch = process.env.GITHUB_REF_NAME ?? 'main'
+  const date = new Date().toISOString().slice(0, 10)
+
+  const data = JSON.parse(readFileSync(findingsPath, 'utf8')) as {
+    findings: Finding[]
+  }
+
+  const candidates = (data.findings ?? []).filter(
+    f => f.confidence === 'high' && f.severity === 'fix-now',
+  )
+
+  process.stderr.write(`  ${candidates.length} high-confidence fix-now candidates\n`)
+
+  if (candidates.length === 0) {
+    process.stderr.write('  Nothing to auto-fix.\n')
+    return
+  }
+
+  // Group by file; take top MAX_FIX_PRS files (most findings first)
+  const byFile = new Map<string, Finding[]>()
+  for (const f of candidates) {
+    const existing = byFile.get(f.file) ?? []
+    existing.push(f)
+    byFile.set(f.file, existing)
+  }
+
+  const topFiles = [...byFile.entries()]
+    .sort((a, b) => b[1].length - a[1].length)
+    .slice(0, MAX_FIX_PRS)
+
+  // Configure git identity for CI commits
+  run('git config user.email "github-actions[bot]@users.noreply.github.com"')
+  run('git config user.name "github-actions[bot]"')
+
+  for (let i = 0; i < topFiles.length; i++) {
+    const [filePath, findings] = topFiles[i]
+    const primaryId = findings[0].id.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+    const branch = `tech-debt-autofix/${date}-${primaryId}`
+
+    process.stderr.write(`\n  [${i + 1}/${topFiles.length}] ${filePath} (${findings.length} finding(s))\n`)
+
+    if (i > 0) await sleep(12_000) // respect rate limit between API calls
+
+    const fixedContent = await generateFix(pat, filePath, findings)
+    if (!fixedContent) {
+      process.stderr.write(`  Skipping ${filePath} — no fix generated\n`)
+      continue
+    }
+
+    const original = readFileSync(filePath, 'utf8')
+    if (fixedContent === original) {
+      process.stderr.write(`  Skipping ${filePath} — model returned identical content\n`)
+      continue
+    }
+
+    // Check if branch already exists remotely
+    try {
+      run(`git ls-remote --exit-code origin refs/heads/${branch}`)
+      process.stderr.write(`  Branch ${branch} already exists, skipping\n`)
+      continue
+    } catch {
+      // Branch doesn't exist — proceed
+    }
+
+    try {
+      run(`git checkout -b ${branch}`)
+      writeFileSync(filePath, fixedContent, 'utf8')
+      run(`git add "${filePath}"`)
+
+      const shortDesc = findings[0].description.slice(0, 60)
+      run(`git commit -m "fix(tech-debt): ${findings[0].id} — ${shortDesc}"`)
+      run(`git push origin ${branch}`)
+
+      const findingLines = findings
+        .map(f => `- **${f.id}** \`${f.file}:${f.lineStart}\` — ${f.description}`)
+        .join('\n')
+
+      const issueRef = issueNumber ? `\nCloses part of #${issueNumber}` : ''
+      const prBody = [
+        `Automated fix for **${findings.length}** high-confidence tech-debt finding(s) in \`${filePath}\`.`,
+        '',
+        findingLines,
+        issueRef,
+        '',
+        '> ⚠️ Auto-generated — review the diff carefully before merging.',
+        '',
+        '🤖 Generated with [Claude Code](https://claude.com/claude-code)',
+      ]
+        .join('\n')
+        .trim()
+
+      execSync(
+        `gh pr create \
+          --title "fix(tech-debt): ${findings[0].id} — ${shortDesc}" \
+          --body-file - \
+          --label techdebt \
+          --label automated \
+          --base ${baseBranch}`,
+        { cwd: ROOT, input: prBody, stdio: ['pipe', 'inherit', 'inherit'], encoding: 'utf8' },
+      )
+
+      process.stderr.write(`  PR opened for ${filePath}\n`)
+    } catch (err) {
+      process.stderr.write(`  Error processing ${filePath}: ${String(err)}\n`)
+    } finally {
+      // Return to base branch for next iteration
+      try {
+        run(`git checkout ${baseBranch}`)
+      } catch {
+        run(`git checkout -f ${baseBranch}`)
+      }
+    }
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch(err => {
+    process.stderr.write(`${String(err)}\n`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary

Three interlocking changes to make the daily audit report actionable without creating a PR avalanche.

### 1 — Confidence field in the audit

The audit prompt now asks the model to rate each finding `high | medium | low`:
- **high**: unambiguous issue, fully mechanical fix — a reviewer can approve the diff in <2 minutes
- **medium**: likely real but fix requires understanding broader context
- **low**: stylistic or speculative

The prompt also instructs the model to prefer fewer, higher-signal findings over exhaustive lists, which should significantly reduce noise from the current 414/run.

### 2 — Confidence-aware issue dashboard

The summary table now shows a confidence breakdown per severity row. The top fix-now section only shows **high-confidence** items. The issue header notes how many high-confidence fix-now findings exist and that auto-fix PRs will be opened for the top 3.

### 3 — Auto-fix job (capped at 3 PRs/run)

New `auto-fix` job runs after `audit` in the same workflow. It:
- Downloads `findings.json` from the artifact
- Filters to `confidence: high` + `severity: fix-now`
- Groups by file, takes the top 3 files (most findings first)
- Calls the model with the file content + specific findings → generates a targeted patch
- Creates a branch, commits, pushes, opens a PR per file referencing the tech-debt issue
- Skips if the branch already exists (no duplicate PRs across runs)
- 12s inter-request delay to respect the rate limit

New file: `scripts/tech-debt-fix.ts`

## Test plan

### Pre-merge (auto-verified)
- [x] All 13 unit tests pass (`npx vitest run scripts/tech-debt-audit.test.ts`)
- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] Lint clean (`npm run lint`)

### Post-merge (verify via `workflow_dispatch` on `main`)
- [ ] Issue dashboard shows confidence breakdown column in the summary table
- [ ] Auto-fix job runs and opens ≤3 PRs for high-confidence fix-now findings
- [ ] Each auto-fix PR references the tech-debt issue number
- [ ] No duplicate PRs opened on re-run (branch-exists check works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)