### PR TITLE
fix(tech-debt-autofix): use actions/download-artifact to get findings.json from current run

### DIFF
--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -231,6 +231,7 @@ jobs:
     if: needs.audit.outputs.new-count != '0'
 
     permissions:
+      actions: read
       contents: write
       pull-requests: write
       issues: read

--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -249,16 +249,13 @@ jobs:
         run: npm ci
 
       - name: Download findings artifact
-        uses: dawidd6/action-download-artifact@v9
+        uses: actions/download-artifact@v4
         with:
-          workflow: daily-tech-debt-audit.yml
           name: tech-debt-fingerprint
           path: .artifact/
-          if_no_artifact_found: warn
-        continue-on-error: true
 
       - name: Copy findings into working directory
-        run: cp .artifact/findings.json findings.json 2>/dev/null || echo "No findings.json in artifact"
+        run: cp .artifact/findings.json findings.json
 
       - name: Open auto-fix PRs for top high-confidence findings
         env:


### PR DESCRIPTION
## Summary

The `auto-fix` job was using `dawidd6/action-download-artifact` which downloads artifacts from a **previous** workflow run. Since `findings.json` is uploaded by the `audit` job in the **same** run, the file was never present and the script failed with `ENOENT: no such file or directory, open 'findings.json'`.

Fix: switch to `actions/download-artifact@v4` which downloads from the current run's artifacts. Also removed the `2>/dev/null || echo "..."` error-swallow on the `cp` step so failures surface immediately rather than appearing as a success.

## Test plan

- [x] Workflow file change is correct (no typecheck needed)
- [ ] `workflow_dispatch` run on `main` — `auto-fix` job downloads `findings.json` successfully and proceeds to open PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)