### PR TITLE
fix(tech-debt-autofix): upload findings.json as dedicated artifact for auto-fix job

### DIFF
--- a/.github/workflows/daily-tech-debt-audit.yml
+++ b/.github/workflows/daily-tech-debt-audit.yml
@@ -51,6 +51,13 @@ jobs:
           FINDINGS_OUTPUT: findings.json
         run: npx tsx scripts/tech-debt-audit.ts
 
+      - name: Upload findings for auto-fix job
+        uses: actions/upload-artifact@v4
+        with:
+          name: tech-debt-findings
+          path: findings.json
+          retention-days: 1
+
       - name: Compute new findings
         id: diff
         run: |
@@ -251,11 +258,7 @@ jobs:
       - name: Download findings artifact
         uses: actions/download-artifact@v4
         with:
-          name: tech-debt-fingerprint
-          path: .artifact/
-
-      - name: Copy findings into working directory
-        run: cp .artifact/findings.json findings.json
+          name: tech-debt-findings
 
       - name: Open auto-fix PRs for top high-confidence findings
         env:


### PR DESCRIPTION
## Summary

The `auto-fix` job failed with `Artifact not found for name: tech-debt-fingerprint` because it was trying to download the same artifact used for cross-run fingerprint persistence — but that artifact is also downloaded by `dawidd6/action-download-artifact` in the `audit` job (from a **previous** run), creating ambiguity about which version `actions/download-artifact@v4` resolves.

**Fix:** Upload `findings.json` as its own dedicated `tech-debt-findings` artifact (1-day retention) immediately after the analysis step completes, before any conditional logic. The `auto-fix` job downloads that artifact directly — no path remapping needed since `actions/download-artifact@v4` without a `path:` drops files into the working directory.

The `tech-debt-fingerprint` artifact is unchanged and continues to handle cross-run dedup.

## Test plan

- [x] Workflow YAML is valid (typecheck passes)
- [ ] `workflow_dispatch` on `main` — `auto-fix` job downloads `findings.json` successfully and opens PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)