### PR TITLE
feat(metric-cards): add copy score to clipboard button

### DIFF
--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -273,6 +273,36 @@ describe('MetricCard', () => {
       expect(text).toMatch(/^RepoPulse: facebook\/react — /)
       expect(text).toMatch(/Activity:/)
       expect(text).toMatch(/Responsiveness:/)
+      // ecosystem section is included since stars/forks/watchers are available
+      expect(text).toMatch(/Ecosystem:/)
+      expect(text).toMatch(/Reach:/)
+      expect(text).toMatch(/Attention:/)
+      expect(text).toMatch(/Engagement:/)
+    })
+
+    it('includes maturity details in the copy string when available', async () => {
+      const card = buildMetricCardViewModels([buildResult({
+        primaryLanguage: 'TypeScript',
+        ageInDays: 365 * 5,
+        starsPerYear: 1200,
+        contributorsPerYear: 42,
+        commitsPerMonthLifetime: 25,
+        growthTrajectory: 'accelerating',
+      })])[0]!
+      render(<MetricCard card={card} />)
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /copy score to clipboard/i }))
+      })
+
+      expect(writeText).toHaveBeenCalledOnce()
+      const [text] = writeText.mock.calls[0] as [string]
+      expect(text).toMatch(/Primary language: TypeScript/)
+      expect(text).toMatch(/Age:/)
+      expect(text).toMatch(/Stars \/ year:/)
+      expect(text).toMatch(/Contributors \/ year:/)
+      expect(text).toMatch(/Commits \/ month:/)
+      expect(text).toMatch(/Growth trajectory: Accelerating/)
     })
 
     it('shows "Copied!" feedback after click and resets after 2s', async () => {

--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -277,18 +277,21 @@ describe('MetricCard', () => {
 
     it('shows "Copied!" feedback after click and resets after 2s', async () => {
       vi.useFakeTimers()
-      const card = buildMetricCardViewModels([buildResult()])[0]!
-      render(<MetricCard card={card} />)
+      try {
+        const card = buildMetricCardViewModels([buildResult()])[0]!
+        render(<MetricCard card={card} />)
 
-      await act(async () => {
-        fireEvent.click(screen.getByRole('button', { name: /copy score to clipboard/i }))
-      })
+        await act(async () => {
+          fireEvent.click(screen.getByRole('button', { name: /copy score to clipboard/i }))
+        })
 
-      expect(screen.getByText('Copied!')).toBeInTheDocument()
+        expect(screen.getByText('Copied!')).toBeInTheDocument()
 
-      await act(async () => { vi.advanceTimersByTime(2000) })
-      expect(screen.queryByText('Copied!')).not.toBeInTheDocument()
-      vi.useRealTimers()
+        await act(async () => { vi.advanceTimersByTime(2000) })
+        expect(screen.queryByText('Copied!')).not.toBeInTheDocument()
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('omits hidden buckets from the copy string for solo repos', async () => {

--- a/components/metric-cards/MetricCard.test.tsx
+++ b/components/metric-cards/MetricCard.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { buildMetricCardViewModels } from '@/lib/metric-cards/view-model'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { buildResult as _buildResult, INCLUSIVE_NAMING_CLEAN } from '@/lib/testing/fixtures'
@@ -240,6 +240,75 @@ describe('MetricCard', () => {
     expect(screen.queryByText(/^Reach$/)).not.toBeInTheDocument()
     expect(screen.queryByText(/^Engagement$/)).not.toBeInTheDocument()
     expect(screen.queryByText(/^Attention$/)).not.toBeInTheDocument()
+  })
+
+  describe('copy score to clipboard (#90)', () => {
+    let writeText: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      writeText = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      })
+    })
+
+    it('renders a copy button on the OSS Health Score banner', () => {
+      const card = buildMetricCardViewModels([buildResult()])[0]!
+      render(<MetricCard card={card} />)
+      expect(screen.getByTestId(`copy-score-${card.repo}`)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /copy score to clipboard/i })).toBeInTheDocument()
+    })
+
+    it('copies a formatted score string to clipboard on click', async () => {
+      const card = buildMetricCardViewModels([buildResult()])[0]!
+      render(<MetricCard card={card} />)
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /copy score to clipboard/i }))
+      })
+
+      expect(writeText).toHaveBeenCalledOnce()
+      const [text] = writeText.mock.calls[0] as [string]
+      expect(text).toMatch(/^RepoPulse: facebook\/react — /)
+      expect(text).toMatch(/Activity:/)
+      expect(text).toMatch(/Responsiveness:/)
+    })
+
+    it('shows "Copied!" feedback after click and resets after 2s', async () => {
+      vi.useFakeTimers()
+      const card = buildMetricCardViewModels([buildResult()])[0]!
+      render(<MetricCard card={card} />)
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /copy score to clipboard/i }))
+      })
+
+      expect(screen.getByText('Copied!')).toBeInTheDocument()
+
+      await act(async () => { vi.advanceTimersByTime(2000) })
+      expect(screen.queryByText('Copied!')).not.toBeInTheDocument()
+      vi.useRealTimers()
+    })
+
+    it('omits hidden buckets from the copy string for solo repos', async () => {
+      const card = buildMetricCardViewModels([buildResult({
+        totalContributors: 1,
+        uniqueCommitAuthors90d: 1,
+        maintainerCount: 'unavailable',
+        documentationResult: 'unavailable',
+      })])[0]!
+      render(<MetricCard card={card} />)
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /copy score to clipboard/i }))
+      })
+
+      expect(writeText).toHaveBeenCalledOnce()
+      const [text] = writeText.mock.calls[0] as [string]
+      expect(text).not.toMatch(/Responsiveness:/)
+      expect(text).not.toMatch(/Contributors:/)
+    })
   })
 })
 

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -20,12 +20,23 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
   }
 
   const [paneCollapsed, setPaneCollapsed] = useState(false)
+  const [copied, setCopied] = useState(false)
   // Session-scoped override for the solo-project scoring surface. null =
   // use the auto-detected profile from the precomputed health score.
   const [profileOverride, setProfileOverride] = useState<HealthScoreProfile | null>(null)
   const hs = profileOverride === null
     ? card.healthScore
     : getHealthScore(card.analysisResult, { mode: profileOverride })
+
+  const handleCopyScore = () => {
+    const visibleBuckets = hs.buckets.filter((b) => !b.hidden && b.percentile !== null)
+    const bucketStr = visibleBuckets.map((b) => `${b.name}: ${b.label.replace(' percentile', '')}`).join(', ')
+    const text = `RepoPulse: ${card.repo} — ${hs.label}${bucketStr ? ` (${bucketStr})` : ''}`
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }).catch(() => {/* clipboard unavailable */})
+  }
   const isSolo = hs.profile === 'solo'
   const autoSolo = card.healthScore.soloDetection.isSolo
   const showOverrideToggle = autoSolo || profileOverride !== null
@@ -111,7 +122,26 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
           <p className="text-xs font-medium uppercase tracking-wide">OSS Health Score</p>
           {hs.bracketLabel ? <p className="text-[10px] opacity-60">{hs.bracketLabel}</p> : null}
         </div>
-        <p className="text-lg font-bold">{hs.label}</p>
+        <div className="flex items-center gap-2">
+          <p className="text-lg font-bold">{hs.label}</p>
+          <button
+            type="button"
+            onClick={handleCopyScore}
+            title="Copy score to clipboard"
+            aria-label="Copy score to clipboard"
+            data-testid={`copy-score-${card.repo}`}
+            className="rounded p-0.5 opacity-60 transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-current"
+          >
+            {copied ? (
+              <span className="text-[10px] font-medium">Copied!</span>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
+                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
 
       {(profileCells.length > 0 || scoreCells.length > 0) ? (

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -34,30 +34,32 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
 
   const handleCopyScore = () => {
     const lines: string[] = []
+    const stripPct = (label: string) => label.replace(' percentile', '')
 
     // Line 1: overall health score + health bucket breakdown
     const visibleBuckets = hs.buckets.filter((b) => !b.hidden && b.percentile !== null)
-    const bucketStr = visibleBuckets.map((b) => `${b.name}: ${b.label.replace(' percentile', '')}`).join(', ')
+    const bucketStr = visibleBuckets.map((b) => `${b.name}: ${stripPct(b.label)}`).join(', ')
     lines.push(`RepoPulse: ${card.repo} — ${hs.label}${bucketStr ? ` (${bucketStr})` : ''}`)
 
     // Line 2: ecosystem (Reach / Attention / Engagement) when available
     if (card.profile) {
       const eco = [
-        `Reach: ${card.profile.reachLabel.replace(' percentile', '')}`,
-        `Attention: ${card.profile.attentionLabel.replace(' percentile', '')}`,
-        `Engagement: ${card.profile.engagementLabel.replace(' percentile', '')}`,
+        `Reach: ${stripPct(card.profile.reachLabel)}`,
+        `Attention: ${stripPct(card.profile.attentionLabel)}`,
+        `Engagement: ${stripPct(card.profile.engagementLabel)}`,
       ]
       lines.push(`Ecosystem: ${eco.join(' · ')}`)
     }
 
-    // Line 3: lenses that have a numeric percentile
+    // Line 3: lenses with a numeric percentile (excludes '—' / 'Insufficient…' values)
     const scoredLenses = card.lenses.filter((l) => /^\d/.test(l.percentileLabel.trim()))
     if (scoredLenses.length > 0) {
-      const lensParts = scoredLenses.map((l) => `${l.label}: ${l.percentileLabel.replace(' percentile', '')}`)
+      const lensParts = scoredLenses.map((l) => `${l.label}: ${stripPct(l.percentileLabel)}`)
       lines.push(`Lenses: ${lensParts.join(' · ')}`)
     }
 
-    // Line 4: maturity / repo details — skip "Created" (shown in header) and unavailable values
+    // Line 4: maturity / repo details — skip 'Created' (shown in the card header) and
+    // values that are unavailable ('—') or unscored ('Insufficient…')
     const maturityDetails = card.details.filter(
       (d) => d.label !== 'Created' && d.value !== '—' && !d.value.includes('Insufficient'),
     )

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -33,9 +33,39 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
     : getHealthScore(card.analysisResult, { mode: profileOverride })
 
   const handleCopyScore = () => {
+    const lines: string[] = []
+
+    // Line 1: overall health score + health bucket breakdown
     const visibleBuckets = hs.buckets.filter((b) => !b.hidden && b.percentile !== null)
     const bucketStr = visibleBuckets.map((b) => `${b.name}: ${b.label.replace(' percentile', '')}`).join(', ')
-    const text = `RepoPulse: ${card.repo} — ${hs.label}${bucketStr ? ` (${bucketStr})` : ''}`
+    lines.push(`RepoPulse: ${card.repo} — ${hs.label}${bucketStr ? ` (${bucketStr})` : ''}`)
+
+    // Line 2: ecosystem (Reach / Attention / Engagement) when available
+    if (card.profile) {
+      const eco = [
+        `Reach: ${card.profile.reachLabel.replace(' percentile', '')}`,
+        `Attention: ${card.profile.attentionLabel.replace(' percentile', '')}`,
+        `Engagement: ${card.profile.engagementLabel.replace(' percentile', '')}`,
+      ]
+      lines.push(`Ecosystem: ${eco.join(' · ')}`)
+    }
+
+    // Line 3: lenses that have a numeric percentile
+    const scoredLenses = card.lenses.filter((l) => /^\d/.test(l.percentileLabel.trim()))
+    if (scoredLenses.length > 0) {
+      const lensParts = scoredLenses.map((l) => `${l.label}: ${l.percentileLabel.replace(' percentile', '')}`)
+      lines.push(`Lenses: ${lensParts.join(' · ')}`)
+    }
+
+    // Line 4: maturity / repo details — skip "Created" (shown in header) and unavailable values
+    const maturityDetails = card.details.filter(
+      (d) => d.label !== 'Created' && d.value !== '—' && !d.value.includes('Insufficient'),
+    )
+    if (maturityDetails.length > 0) {
+      lines.push(maturityDetails.map((d) => `${d.label}: ${d.value}`).join(' · '))
+    }
+
+    const text = lines.join('\n')
     try {
       if (!navigator.clipboard?.writeText) return
       navigator.clipboard.writeText(text).then(() => {

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { CollapseChevron } from '@/components/shared/CollapseChevron'
 import type { LensReadout, MetricCardViewModel } from '@/lib/metric-cards/view-model'
 import { formatPercentileLabel } from '@/lib/scoring/config-loader'
@@ -21,6 +21,8 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
 
   const [paneCollapsed, setPaneCollapsed] = useState(false)
   const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => () => { if (timeoutRef.current) clearTimeout(timeoutRef.current) }, [])
   // Session-scoped override for the solo-project scoring surface. null =
   // use the auto-detected profile from the precomputed health score.
   const [profileOverride, setProfileOverride] = useState<HealthScoreProfile | null>(null)
@@ -32,10 +34,16 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
     const visibleBuckets = hs.buckets.filter((b) => !b.hidden && b.percentile !== null)
     const bucketStr = visibleBuckets.map((b) => `${b.name}: ${b.label.replace(' percentile', '')}`).join(', ')
     const text = `RepoPulse: ${card.repo} — ${hs.label}${bucketStr ? ` (${bucketStr})` : ''}`
-    navigator.clipboard.writeText(text).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    }).catch(() => {/* clipboard unavailable */})
+    try {
+      if (!navigator.clipboard?.writeText) return
+      navigator.clipboard.writeText(text).then(() => {
+        setCopied(true)
+        if (timeoutRef.current) clearTimeout(timeoutRef.current)
+        timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+      }).catch(() => {/* clipboard unavailable */})
+    } catch {
+      /* clipboard unavailable */
+    }
   }
   const isSolo = hs.profile === 'solo'
   const autoSolo = card.healthScore.soloDetection.isSolo

--- a/components/metric-cards/MetricCard.tsx
+++ b/components/metric-cards/MetricCard.tsx
@@ -22,7 +22,9 @@ export function MetricCard({ card, activeTag, onTagChange }: MetricCardProps) {
   const [paneCollapsed, setPaneCollapsed] = useState(false)
   const [copied, setCopied] = useState(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => () => { if (timeoutRef.current) clearTimeout(timeoutRef.current) }, [])
+  useEffect(() => {
+    return () => { if (timeoutRef.current) clearTimeout(timeoutRef.current) }
+  }, [])
   // Session-scoped override for the solo-project scoring surface. null =
   // use the auto-detected profile from the precomputed health score.
   const [profileOverride, setProfileOverride] = useState<HealthScoreProfile | null>(null)


### PR DESCRIPTION
Closes #90

## Summary
- Adds a small copy icon button on the OSS Health Score banner in `MetricCard`
- On click, copies a formatted string like `RepoPulse: facebook/react — 70th percentile (Activity: 78th, Responsiveness: 61st)` to the clipboard via `navigator.clipboard.writeText()`
- Shows brief "Copied!" text feedback for 2 seconds, then reverts to the icon
- Hidden buckets (Responsiveness/Contributors for solo projects) are automatically excluded from the copy string

## Test plan
- [ ] Copy button is visible on the OSS Health Score banner
- [ ] Clicking copies a human-readable score summary to the clipboard
- [ ] "Copied!" feedback appears briefly after clicking, then disappears
- [ ] Solo-repo copy string excludes Responsiveness and Contributors buckets
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] All 16 MetricCard unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)