### PR TITLE
fix(ci): switch to gpt-4o-mini, bail gracefully on daily token budget exhaustion

### DIFF
--- a/scripts/tech-debt-audit.test.ts
+++ b/scripts/tech-debt-audit.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
-import { buildChunks, parseFindings } from './tech-debt-audit'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { buildChunks, parseFindings, callCopilot, DailyBudgetExhaustedError, MAX_RETRY_WAIT_S } from './tech-debt-audit'
 
 // MAX_CHUNK_TOKENS = 6_000, TOKENS_PER_CHAR = 1/4
 // → maxBytes = 6_000 / 0.25 = 24_000 chars per chunk
@@ -152,5 +152,171 @@ describe('parseFindings', () => {
     const result = parseFindings(raw)
     expect(result).toEqual([])
     stderrSpy.mockRestore()
+  })
+})
+
+describe('callCopilot rate-limiting', () => {
+  const FAKE_PAT = 'test-pat'
+  const FAKE_PAYLOAD = 'const x = 1'
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('throws DailyBudgetExhaustedError when Retry-After exceeds MAX_RETRY_WAIT_S', async () => {
+    const largeWait = MAX_RETRY_WAIT_S + 1
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (h: string) => (h === 'Retry-After' ? String(largeWait) : null) },
+        text: async () => 'rate limited',
+      }),
+    )
+
+    await expect(callCopilot(FAKE_PAT, FAKE_PAYLOAD)).rejects.toBeInstanceOf(DailyBudgetExhaustedError)
+  })
+
+  it('DailyBudgetExhaustedError message says "will write partial results"', async () => {
+    const largeWait = MAX_RETRY_WAIT_S + 3600
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (h: string) => (h === 'Retry-After' ? String(largeWait) : null) },
+        text: async () => 'rate limited',
+      }),
+    )
+
+    let caught: unknown
+    try {
+      await callCopilot(FAKE_PAT, FAKE_PAYLOAD)
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(DailyBudgetExhaustedError)
+    expect((caught as Error).message).toContain('will write partial results')
+  })
+
+  it('throws DailyBudgetExhaustedError on 503 with large Retry-After', async () => {
+    const largeWait = MAX_RETRY_WAIT_S + 1
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        headers: { get: (h: string) => (h === 'Retry-After' ? String(largeWait) : null) },
+        text: async () => 'service unavailable',
+      }),
+    )
+
+    await expect(callCopilot(FAKE_PAT, FAKE_PAYLOAD)).rejects.toBeInstanceOf(DailyBudgetExhaustedError)
+  })
+
+  it('does not throw DailyBudgetExhaustedError when Retry-After is within the normal limit', async () => {
+    vi.useFakeTimers()
+    const smallWait = MAX_RETRY_WAIT_S - 1
+    const findingPayload = JSON.stringify([
+      {
+        id: 'DRY-1',
+        category: 'DRY',
+        file: 'lib/foo.ts',
+        lineStart: 1,
+        lineEnd: 5,
+        description: 'test',
+        severity: 'fix-soon',
+        confidence: 'high',
+        recommendation: 'fix it',
+      },
+    ])
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: { get: (h: string) => (h === 'Retry-After' ? String(smallWait) : null) },
+          text: async () => 'rate limited',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          json: async () => ({ choices: [{ message: { content: findingPayload } }] }),
+        }),
+    )
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const callPromise = callCopilot(FAKE_PAT, FAKE_PAYLOAD)
+    // Advance time past the sleep duration so the retry fires
+    await vi.advanceTimersByTimeAsync(smallWait * 1000 + 100)
+    const results = await callPromise
+    stderrSpy.mockRestore()
+    vi.useRealTimers()
+
+    expect(results).toHaveLength(1)
+    expect(results[0].id).toBe('DRY-1')
+  })
+
+  it('DailyBudgetExhaustedError does not propagate — the chunk loop catches it and still returns accumulated findings', async () => {
+    // Simulate: first chunk succeeds, second chunk triggers daily budget exhaustion.
+    // The catch block in the loop should break out and the accumulated findings should be available.
+    const finding = {
+      id: 'DRY-1',
+      category: 'DRY',
+      file: 'lib/foo.ts',
+      lineStart: 1,
+      lineEnd: 5,
+      description: 'test',
+      severity: 'fix-soon',
+      confidence: 'high',
+      recommendation: 'fix it',
+    }
+    const largeWait = MAX_RETRY_WAIT_S + 3600
+
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        // First chunk succeeds
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          json: async () => ({ choices: [{ message: { content: JSON.stringify([finding]) } }] }),
+        })
+        // Second chunk exhausts daily budget
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: { get: (h: string) => (h === 'Retry-After' ? String(largeWait) : null) },
+          text: async () => 'rate limited',
+        }),
+    )
+
+    // Verify that DailyBudgetExhaustedError is catchable and accumulated findings from prior chunks survive
+    const accumulatedFindings: typeof finding[] = []
+    const chunks = [{ payload: 'chunk1', fileCount: 1, estimatedTokens: 100 }, { payload: 'chunk2', fileCount: 1, estimatedTokens: 100 }]
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    for (const chunk of chunks) {
+      try {
+        const findings = await callCopilot(FAKE_PAT, chunk.payload)
+        accumulatedFindings.push(...findings)
+      } catch (err) {
+        if (err instanceof DailyBudgetExhaustedError) {
+          break
+        }
+        throw err
+      }
+    }
+    stderrSpy.mockRestore()
+
+    expect(accumulatedFindings).toHaveLength(1)
+    expect(accumulatedFindings[0].id).toBe('DRY-1')
   })
 })

--- a/scripts/tech-debt-audit.ts
+++ b/scripts/tech-debt-audit.ts
@@ -144,11 +144,11 @@ Output ONLY a JSON array — no prose, no markdown fences:
 
 const MAX_RETRIES = 3
 // If Retry-After exceeds this, the daily token budget is exhausted — no point waiting.
-const MAX_RETRY_WAIT_S = 120
+export const MAX_RETRY_WAIT_S = 120
 
-class DailyBudgetExhaustedError extends Error {
+export class DailyBudgetExhaustedError extends Error {
   constructor(waitSeconds: number) {
-    super(`Daily token budget exhausted (Retry-After: ${waitSeconds}s) — writing partial results`)
+    super(`Daily token budget exhausted (Retry-After: ${waitSeconds}s) — will write partial results`)
   }
 }
 
@@ -179,7 +179,7 @@ export function parseFindings(raw: string): Finding[] {
   }
 }
 
-async function callCopilot(pat: string, payload: string, attempt = 0): Promise<Finding[]> {
+export async function callCopilot(pat: string, payload: string, attempt = 0): Promise<Finding[]> {
   const res = await fetch('https://models.inference.ai.azure.com/chat/completions', {
     method: 'POST',
     headers: {

--- a/scripts/tech-debt-audit.ts
+++ b/scripts/tech-debt-audit.ts
@@ -143,6 +143,14 @@ Output ONLY a JSON array — no prose, no markdown fences:
 ]`
 
 const MAX_RETRIES = 3
+// If Retry-After exceeds this, the daily token budget is exhausted — no point waiting.
+const MAX_RETRY_WAIT_S = 120
+
+class DailyBudgetExhaustedError extends Error {
+  constructor(waitSeconds: number) {
+    super(`Daily token budget exhausted (Retry-After: ${waitSeconds}s) — writing partial results`)
+  }
+}
 
 function parseRetryAfter(value: string | null): number {
   if (!value) return 60
@@ -179,7 +187,7 @@ async function callCopilot(pat: string, payload: string, attempt = 0): Promise<F
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      model: 'gpt-4o',
+      model: 'gpt-4o-mini',
       messages: [
         {
           role: 'user',
@@ -193,6 +201,9 @@ async function callCopilot(pat: string, payload: string, attempt = 0): Promise<F
   if (!res.ok) {
     if ((res.status === 429 || res.status === 503) && attempt < MAX_RETRIES) {
       const wait = parseRetryAfter(res.headers.get('Retry-After'))
+      if (wait > MAX_RETRY_WAIT_S) {
+        throw new DailyBudgetExhaustedError(wait)
+      }
       process.stderr.write(
         `  Rate limited (${res.status}). Waiting ${wait}s before retrying (attempt ${attempt + 1} of ${MAX_RETRIES})...\n`,
       )
@@ -248,7 +259,16 @@ async function main(): Promise<void> {
     process.stderr.write(`  Chunk ${i + 1}/${chunks.length}: ${fileCount} files, ~${estimatedTokens} tokens\n`)
 
     const callStart = Date.now()
-    const findings = await callCopilot(pat, payload)
+    let findings: Finding[]
+    try {
+      findings = await callCopilot(pat, payload)
+    } catch (err) {
+      if (err instanceof DailyBudgetExhaustedError) {
+        process.stderr.write(`  ${err.message}\n`)
+        break
+      }
+      throw err
+    }
     process.stderr.write(`    ${findings.length} findings returned\n`)
 
     for (const f of findings) {


### PR DESCRIPTION
## Problem

The audit job hits the GitHub Models daily token cap (~150k tokens free tier) around chunk 20 of 44. The API returns `Retry-After: ~60000s` (~16.6 hours). The existing retry loop waited for that duration and hit the 60-minute job timeout with no output.

## Fix

- **Switch `gpt-4o` → `gpt-4o-mini`** — higher daily token budget on the free tier, adequate for code quality analysis
- **`DailyBudgetExhaustedError`** — if `Retry-After > 120s`, break out of the chunk loop and write partial results to `findings.json` instead of timing out with nothing. Findings from completed chunks are still usable.

## Behaviour after this PR

| Scenario | Before | After |
|---|---|---|
| Daily budget hit mid-run | Waits 16h, times out, no output | Breaks loop, writes partial findings, continues to issue/auto-fix steps |
| Per-minute rate limit (≤60s wait) | Retries correctly | Unchanged |

## Test plan

- [ ] Audit run completes without timing out
- [ ] If daily budget is hit, partial findings are still written and uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)