### PR TITLE
fix(analyze): restore repo report order to match input order

### DIFF
--- a/app/api/analyze/route.test.ts
+++ b/app/api/analyze/route.test.ts
@@ -1,12 +1,44 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { POST, MAX_REPOS_PER_REQUEST } from './route'
 import { analyze } from '@/lib/analyzer/analyze'
+import {
+  fetchCNCFLandscape,
+  fetchCNCFSandboxIssues,
+  getLandscapeProjectStatus,
+} from '@/lib/cncf-sandbox/landscape'
+import { evaluateAspirant } from '@/lib/cncf-sandbox/evaluate'
+import { buildApprovedCorpusSummary } from '@/lib/cncf-sandbox/approved-corpus'
 
 vi.mock('@/lib/analyzer/analyze', () => ({
   analyze: vi.fn(),
 }))
 
+vi.mock('@/lib/cncf-sandbox/landscape', () => ({
+  fetchCNCFLandscape: vi.fn(),
+  fetchCNCFSandboxIssues: vi.fn(),
+  fetchSandboxIssueBody: vi.fn(),
+  findSandboxApplication: vi.fn(),
+  getLandscapeProjectStatus: vi.fn(),
+}))
+
+vi.mock('@/lib/cncf-sandbox/evaluate', () => ({
+  evaluateAspirant: vi.fn(),
+}))
+
+vi.mock('@/lib/cncf-sandbox/approved-corpus', () => ({
+  buildApprovedCorpusSummary: vi.fn(),
+}))
+
+vi.mock('@/lib/cncf-sandbox/parse-application', () => ({
+  parseApplicationIssue: vi.fn(),
+}))
+
 const analyzeMock = vi.mocked(analyze)
+const fetchCNCFLandscapeMock = vi.mocked(fetchCNCFLandscape)
+const fetchCNCFSandboxIssuesMock = vi.mocked(fetchCNCFSandboxIssues)
+const getLandscapeProjectStatusMock = vi.mocked(getLandscapeProjectStatus)
+const evaluateAspirantMock = vi.mocked(evaluateAspirant)
+const buildApprovedCorpusSummaryMock = vi.mocked(buildApprovedCorpusSummary)
 
 describe('POST /api/analyze', () => {
   beforeEach(() => {
@@ -223,5 +255,55 @@ describe('POST /api/analyze', () => {
 
     expect(response.status).toBe(401)
     expect(body.error).toEqual({ message: 'Authentication required.', code: 'UNAUTHENTICATED' })
+  })
+
+  // Regression: landscape-override stubs must not be pushed to the tail
+  it('preserves original input order when the first repo is already in the CNCF landscape', async () => {
+    const fakeData = {} as never
+    fetchCNCFLandscapeMock.mockResolvedValue(fakeData)
+    fetchCNCFSandboxIssuesMock.mockResolvedValue([])
+    buildApprovedCorpusSummaryMock.mockResolvedValue(undefined as never)
+
+    // First repo is already in the landscape (sandbox); second needs analysis.
+    getLandscapeProjectStatusMock.mockImplementation((repo: string) => {
+      if (repo === 'cncf-org/existing-project') return 'sandbox'
+      return null
+    })
+
+    analyzeMock.mockResolvedValue({
+      results: [{ repo: 'my-org/new-repo', name: 'new-repo' } as never],
+      failures: [],
+      rateLimit: null,
+    })
+
+    evaluateAspirantMock.mockReturnValue({
+      foundationTarget: 'cncf-sandbox',
+      readinessScore: 0,
+      autoFields: [],
+      humanOnlyFields: [],
+      readyCount: 0,
+      totalAutoCheckable: 0,
+      alreadyInLandscape: false,
+      tagRecommendation: null,
+      sandboxApplication: null,
+    } as never)
+
+    const request = new Request('http://localhost/api/analyze', {
+      method: 'POST',
+      body: JSON.stringify({
+        repos: ['cncf-org/existing-project', 'my-org/new-repo'],
+        token: 'ghp_test',
+        foundationTarget: 'cncf-sandbox',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST(request)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.results).toHaveLength(2)
+    expect(body.results[0].repo).toBe('cncf-org/existing-project')
+    expect(body.results[1].repo).toBe('my-org/new-repo')
   })
 })

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -184,8 +184,22 @@ export async function POST(request: Request) {
 
     // Merge landscape-override stubs into results, then restore original input order.
     response.results.push(...landscapeOverrideResults)
-    const inputOrder = new Map(body.repos.map((repo, i) => [repo.toLowerCase(), i]))
-    response.results.sort((a, b) => (inputOrder.get(a.repo.toLowerCase()) ?? Infinity) - (inputOrder.get(b.repo.toLowerCase()) ?? Infinity))
+    const inputPositions = new Map<string, number[]>()
+    for (const [index, repo] of body.repos.entries()) {
+      const normalizedRepo = repo.toLowerCase()
+      const positions = inputPositions.get(normalizedRepo)
+      if (positions) {
+        positions.push(index)
+      } else {
+        inputPositions.set(normalizedRepo, [index])
+      }
+    }
+    const resultOrder = new Map<AnalysisResult, number>()
+    for (const result of response.results) {
+      const positions = inputPositions.get(result.repo.toLowerCase())
+      resultOrder.set(result, positions?.shift() ?? Infinity)
+    }
+    response.results.sort((a, b) => (resultOrder.get(a) ?? Infinity) - (resultOrder.get(b) ?? Infinity))
 
     const elapsed = ((Date.now() - start) / 1000).toFixed(1)
     console.log(`[analyze] Completed in ${elapsed}s — ${response.results.length} succeeded, ${response.failures.length} failed`)

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -182,8 +182,10 @@ export async function POST(request: Request) {
       }
     }
 
-    // Merge landscape-override stubs into results.
+    // Merge landscape-override stubs into results, then restore original input order.
     response.results.push(...landscapeOverrideResults)
+    const inputOrder = new Map(body.repos.map((repo, i) => [repo.toLowerCase(), i]))
+    response.results.sort((a, b) => (inputOrder.get(a.repo.toLowerCase()) ?? Infinity) - (inputOrder.get(b.repo.toLowerCase()) ?? Infinity))
 
     const elapsed = ((Date.now() - start) / 1000).toFixed(1)
     console.log(`[analyze] Completed in ${elapsed}s — ${response.results.length} succeeded, ${response.failures.length} failed`)


### PR DESCRIPTION
## Summary

- Repos already in the CNCF landscape were peeled off into a stub array and appended at the end of `response.results`, breaking report order
- This affected all Repositories-tab analyses because `foundationTarget` defaults to `'cncf-sandbox'` on the client, silently activating the landscape pre-filter
- After merging stubs back into results, the results are now re-sorted to match the original `body.repos` input order

## Root cause

`app/api/analyze/route.ts` — `landscapeOverrideResults` were appended at the tail without restoring input position:
```ts
response.results.push(...landscapeOverrideResults) // stubs always end up last
```

## Fix

```ts
const inputOrder = new Map(body.repos.map((repo, i) => [repo.toLowerCase(), i]))
response.results.sort((a, b) =>
  (inputOrder.get(a.repo.toLowerCase()) ?? Infinity) - (inputOrder.get(b.repo.toLowerCase()) ?? Infinity)
)
```

Closes #487

## Test plan

- [ ] Enter repos where the first entry is an existing CNCF project (e.g. `kai-scheduler/KAI-Scheduler`) — verify it appears first in the report
- [ ] Enter repos with no CNCF projects — verify order is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)