### PR TITLE
feat(quotes): add Jensen Huang open source quote

### DIFF
--- a/lib/loading-quotes.ts
+++ b/lib/loading-quotes.ts
@@ -230,6 +230,11 @@ export const LOADING_QUOTES: LoadingQuote[] = [
 
   // AI & open source
   {
+    text: 'Researchers need open source. Developers need open source. Companies around the world — we need open source.',
+    author: 'Jensen Huang',
+    context: 'CEO, NVIDIA; GTC keynote',
+  },
+  {
     text: 'I think open source AI is going to be incredibly important for the world.',
     author: 'Dario Amodei',
     context: 'CEO, Anthropic',


### PR DESCRIPTION
## Summary

- Adds Jensen Huang (CEO, NVIDIA) quote to the loading quotes pool
- Source: NVIDIA GTC keynote, shared via [NVIDIA AI LinkedIn](https://www.linkedin.com/posts/nvidia-ai_researchers-need-open-source-developers-activity-7389028427682541568-DUMa/)

> "Researchers need open source. Developers need open source. Companies around the world — we need open source."

## Test plan

- [ ] Verify the quote appears in the loading rotation during repo analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)