### PR TITLE
fix(repos-tab): default foundationTarget to 'none' to ensure full analysis

### DIFF
--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -56,7 +56,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   })()
   const initialRepoValue = initialRawRepos.join('\n')
   const initialFoundationState = decodeFoundationUrl(searchParams.toString())
-  const initialFoundationTarget = (initialFoundationState?.foundation ?? 'cncf-sandbox') as FoundationTarget
+  const initialFoundationTarget = (initialFoundationState?.foundation ?? 'none') as FoundationTarget
   const initialTab = (searchParams.get('tab') ?? 'overview') as ResultTabId
   const autoTriggeredRef = useRef(false)
   const foundationAutoTriggeredRef = useRef(false)


### PR DESCRIPTION
## Summary

- The Repositories tab has no foundation selector, but `foundationTarget` was defaulting to `'cncf-sandbox'`
- This silently triggered the CNCF landscape pre-filter, replacing already-CNCF repos with lightweight stubs (all fields `'unavailable'`) instead of running full GitHub analysis
- Result: broken metric cards showing "Insufficient data", no description, no scores (as seen with `kai-scheduler/KAI-Scheduler`)
- Fix: change the fallback default from `'cncf-sandbox'` to `'none'` in `RepoInputClient.tsx:59`

CNCF Sandbox Readiness scores are still computed and displayed — they derive from the full analysis data, not from the foundation target.

Closes #487

## Test plan

- [ ] Analyze a list that includes an existing CNCF project (e.g. `kai-scheduler/KAI-Scheduler`) from the Repositories tab — verify it renders a full metric card with real data, not "Insufficient data"
- [ ] Analyze a list with no CNCF projects — verify results are unchanged
- [ ] Confirm Foundation tab still works correctly with `cncf-sandbox` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)