### PR TITLE
feat(foundation): add Export to Markdown button

### DIFF
--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -6,6 +6,7 @@ import { CNCFCandidacyPanel } from '@/components/cncf-candidacy/CNCFCandidacyPan
 import type { AnalyzeResponse, AnalysisResult } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { SkippedIssue } from '@/lib/foundation/fetch-board-repos'
+import { downloadFoundationMarkdown } from '@/lib/export/foundation-markdown-export'
 
 export type FoundationResult =
   | { kind: 'repos'; results: AnalyzeResponse }
@@ -69,6 +70,21 @@ function ReanalyzeButton({ onClick }: { onClick: () => void }) {
         <path d="M10 2v3h3" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
       Re-analyze
+    </button>
+  )
+}
+
+function ExportMarkdownButton({ result }: { result: FoundationResult }) {
+  return (
+    <button
+      type="button"
+      onClick={() => downloadFoundationMarkdown(result)}
+      className="inline-flex shrink-0 items-center gap-1.5 rounded border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+    >
+      <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M3 2h10M3 14h10M8 2v12M5 5l3-3 3 3M5 11l3 3 3-3" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      Export to Markdown
     </button>
   )
 }
@@ -183,12 +199,11 @@ export function FoundationResultsView({ result, error, onReanalyze, shareableUrl
   if (result.kind === 'repos') {
     return (
       <div className="space-y-4">
-        {(onReanalyze || shareableUrl) ? (
-          <div className="flex justify-end gap-2">
-            {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
-            {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
-          </div>
-        ) : null}
+        <div className="flex justify-end gap-2">
+          {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
+          <ExportMarkdownButton result={result} />
+          {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
+        </div>
         {result.results.failures.length > 0 ? (
           <section className="rounded border border-amber-200 bg-amber-50 p-4 dark:bg-amber-900/20 dark:border-amber-800/60">
             <h2 className="font-semibold text-amber-900 dark:text-amber-200">Failed repositories</h2>
@@ -209,12 +224,11 @@ export function FoundationResultsView({ result, error, onReanalyze, shareableUrl
   if (result.kind === 'org') {
     return (
       <div className="space-y-4">
-        {(onReanalyze || shareableUrl) ? (
-          <div className="flex justify-end gap-2">
-            {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
-            {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
-          </div>
-        ) : null}
+        <div className="flex justify-end gap-2">
+          {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
+          <ExportMarkdownButton result={result} />
+          {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
+        </div>
         <CNCFCandidacyPanel
           org={result.inventory.org}
           repos={result.inventory.results}
@@ -259,6 +273,7 @@ export function FoundationResultsView({ result, error, onReanalyze, shareableUrl
           </div>
           <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
             {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
+            <ExportMarkdownButton result={result} />
             {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
           </div>
         </div>

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -3,15 +3,11 @@
 import { useState } from 'react'
 import { CNCFReadinessTab } from '@/components/cncf-readiness/CNCFReadinessTab'
 import { CNCFCandidacyPanel } from '@/components/cncf-candidacy/CNCFCandidacyPanel'
-import type { AnalyzeResponse, AnalysisResult } from '@/lib/analyzer/analysis-result'
-import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
-import type { SkippedIssue } from '@/lib/foundation/fetch-board-repos'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { FoundationResult } from '@/lib/foundation/types'
 import { downloadFoundationMarkdown } from '@/lib/export/foundation-markdown-export'
 
-export type FoundationResult =
-  | { kind: 'repos'; results: AnalyzeResponse }
-  | { kind: 'org'; inventory: OrgInventoryResponse }
-  | { kind: 'projects-board'; url: string; results: AnalyzeResponse; skipped: SkippedIssue[]; method: 'graphql' | 'labels' }
+export type { FoundationResult }
 
 interface FoundationResultsViewProps {
   result: FoundationResult | null

--- a/lib/export/foundation-markdown-export.test.ts
+++ b/lib/export/foundation-markdown-export.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from 'vitest'
+import { buildFoundationMarkdownExport } from './foundation-markdown-export'
+import type { FoundationResult } from '@/lib/foundation/types'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+
+const RESULT_BASE: AnalysisResult = {
+  repo: 'example/project',
+  name: 'project',
+  description: 'An example project',
+  createdAt: '2020-01-01T00:00:00Z',
+  primaryLanguage: 'Go',
+  stars: 1234,
+  forks: 56,
+  watchers: 78,
+  commits30d: 10,
+  commits90d: 30,
+  releases12mo: 4,
+  prsOpened90d: 20,
+  prsMerged90d: 18,
+  issuesOpen: 5,
+  issuesClosed90d: 12,
+  uniqueCommitAuthors90d: 6,
+  totalContributors: 20,
+  maintainerCount: 'unavailable',
+  commitCountsByAuthor: { alice: 10 },
+  commitCountsByExperimentalOrg: {},
+  experimentalAttributedAuthors90d: 1,
+  experimentalUnattributedAuthors90d: 5,
+  issueFirstResponseTimestamps: [],
+  issueCloseTimestamps: [],
+  prMergeTimestamps: [],
+  documentationResult: 'unavailable',
+  licensingResult: 'unavailable',
+  defaultBranchName: 'main',
+  topics: [],
+  inclusiveNamingResult: {
+    defaultBranchName: 'main',
+    branchCheck: { checkType: 'branch', term: 'main', passed: true, tier: null, severity: null, replacements: [], context: null },
+    metadataChecks: [],
+  },
+  securityResult: 'unavailable',
+  missingFields: [],
+}
+
+const ASPIRANT_RESULT = {
+  foundationTarget: 'cncf-sandbox' as const,
+  readinessScore: 72,
+  autoFields: [
+    { id: 'readme', label: 'README', status: 'ready' as const, weight: 10, pointsEarned: 10, evidence: 'Found at /README.md' },
+    { id: 'license', label: 'License', status: 'missing' as const, weight: 15, pointsEarned: 0, remediationHint: 'Add a LICENSE file' },
+    { id: 'coc', label: 'Code of Conduct', status: 'partial' as const, weight: 5, pointsEarned: 3 },
+  ],
+  humanOnlyFields: [],
+  readyCount: 1,
+  totalAutoCheckable: 3,
+  alreadyInLandscape: false,
+  tagRecommendation: { primaryTag: 'tag-security' as const, matchedSignals: [], fallbackNote: null },
+  sandboxApplication: null,
+}
+
+const MINIMAL_REPOS_RESULT: FoundationResult = {
+  kind: 'repos',
+  results: {
+    results: [{ ...RESULT_BASE, aspirantResult: ASPIRANT_RESULT }],
+    failures: [],
+    rateLimit: null,
+  },
+}
+
+describe('buildFoundationMarkdownExport — kind: repos', () => {
+  it('returns a blob with MIME type text/markdown', () => {
+    const { blob } = buildFoundationMarkdownExport(MINIMAL_REPOS_RESULT)
+    expect(blob.type).toBe('text/markdown')
+  })
+
+  it('filename matches foundation-scan-YYYY-MM-DD-HHMM.md pattern', () => {
+    const { filename } = buildFoundationMarkdownExport(MINIMAL_REPOS_RESULT)
+    expect(filename).toMatch(/^foundation-scan-\d{4}-\d{2}-\d{2}-\d{4}\.md$/)
+  })
+
+  it('includes top-level heading and generated timestamp', async () => {
+    const { blob } = buildFoundationMarkdownExport(MINIMAL_REPOS_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('# Foundation Scan Report')
+    expect(text).toMatch(/\*\*Generated:\*\* \d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('includes a summary table with repo row', async () => {
+    const { blob } = buildFoundationMarkdownExport(MINIMAL_REPOS_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('## Summary')
+    expect(text).toContain('| Repository | Score | Status |')
+    expect(text).toContain('example/project')
+    expect(text).toContain('72 / 100')
+    expect(text).toContain('🟡 Needs work')
+  })
+
+  it('uses 🟢 Ready for scores >= 80', async () => {
+    const highScore = { ...ASPIRANT_RESULT, readinessScore: 85 }
+    const result: FoundationResult = {
+      kind: 'repos',
+      results: { results: [{ ...RESULT_BASE, aspirantResult: highScore }], failures: [], rateLimit: null },
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).toContain('🟢 Ready')
+  })
+
+  it('uses 🔴 Not ready for scores < 50', async () => {
+    const lowScore = { ...ASPIRANT_RESULT, readinessScore: 30 }
+    const result: FoundationResult = {
+      kind: 'repos',
+      results: { results: [{ ...RESULT_BASE, aspirantResult: lowScore }], failures: [], rateLimit: null },
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).toContain('🔴 Not ready')
+  })
+
+  it('includes per-repo section with Needs Work and Ready fields', async () => {
+    const { blob } = buildFoundationMarkdownExport(MINIMAL_REPOS_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('## example/project')
+    expect(text).toContain('### Needs Work')
+    expect(text).toContain('❌ **License**')
+    expect(text).toContain('+15 pts if resolved')
+    expect(text).toContain('Add a LICENSE file')
+    expect(text).toContain('⚠️ **Code of Conduct**')
+    expect(text).toContain('### Ready')
+    expect(text).toContain('✅ **README**')
+    expect(text).toContain('Found at /README.md')
+  })
+
+  it('Needs Work fields appear in autoFields order (no reverse)', async () => {
+    const { blob } = buildFoundationMarkdownExport(MINIMAL_REPOS_RESULT)
+    const text = await blob.text()
+    const licensePos = text.indexOf('**License**')
+    const cocPos = text.indexOf('**Code of Conduct**')
+    expect(licensePos).toBeGreaterThan(0)
+    expect(cocPos).toBeGreaterThan(0)
+    // License comes before Code of Conduct in autoFields — should stay that way
+    expect(licensePos).toBeLessThan(cocPos)
+  })
+
+  it('includes TAG recommendation', async () => {
+    const { blob } = buildFoundationMarkdownExport(MINIMAL_REPOS_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('**Recommended TAG:** tag-security')
+  })
+
+  it('landscapeOverride with status renders "Already a CNCF sandbox project"', async () => {
+    const result: FoundationResult = {
+      kind: 'repos',
+      results: {
+        results: [{ ...RESULT_BASE, landscapeOverride: true, landscapeStatus: 'sandbox' }],
+        failures: [],
+        rateLimit: null,
+      },
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).toContain('Already a CNCF sandbox project')
+    // Should NOT contain the old awkward form
+    expect(text).not.toContain('Already CNCF sandbox')
+    expect(text).not.toContain('Already a CNCF CNCF')
+  })
+
+  it('landscapeOverride without status renders "Already a CNCF project"', async () => {
+    const result: FoundationResult = {
+      kind: 'repos',
+      results: {
+        results: [{ ...RESULT_BASE, landscapeOverride: true, landscapeStatus: undefined }],
+        failures: [],
+        rateLimit: null,
+      },
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    // Summary table
+    expect(text).toContain('Already a CNCF project')
+    expect(text).not.toContain('Already a CNCF CNCF')
+    // Per-repo section
+    expect(text).toContain('> Already a CNCF project — not evaluated for sandbox readiness.')
+  })
+
+  it('includes failed repositories section when failures exist', async () => {
+    const result: FoundationResult = {
+      kind: 'repos',
+      results: {
+        results: [],
+        failures: [{ repo: 'bad/repo', reason: 'Not found', code: 'NOT_FOUND' }],
+        rateLimit: null,
+      },
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).toContain('## Failed Repositories')
+    expect(text).toContain('**bad/repo**: Not found')
+  })
+
+  it('renders sandbox application link when present', async () => {
+    const arWithApp = {
+      ...ASPIRANT_RESULT,
+      sandboxApplication: {
+        issueNumber: 42,
+        issueUrl: 'https://github.com/cncf/sandbox/issues/42',
+        title: 'example/project sandbox application',
+        state: 'OPEN' as const,
+        createdAt: '2024-01-15T00:00:00Z',
+        labels: [],
+        approved: false,
+      },
+    }
+    const result: FoundationResult = {
+      kind: 'repos',
+      results: { results: [{ ...RESULT_BASE, aspirantResult: arWithApp }], failures: [], rateLimit: null },
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).toContain('[#42](https://github.com/cncf/sandbox/issues/42)')
+    expect(text).toContain('open, under review')
+  })
+})
+
+describe('buildFoundationMarkdownExport — kind: projects-board', () => {
+  it('includes board URL in header', async () => {
+    const result: FoundationResult = {
+      kind: 'projects-board',
+      url: 'https://github.com/orgs/cncf/projects/14',
+      method: 'graphql',
+      results: {
+        results: [{ ...RESULT_BASE, aspirantResult: ASPIRANT_RESULT }],
+        failures: [],
+        rateLimit: null,
+      },
+      skipped: [],
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).toContain('# Foundation Scan Report — CNCF Sandbox Board')
+    expect(text).toContain('**Source:** [CNCF Sandbox Board](https://github.com/orgs/cncf/projects/14)')
+  })
+
+  it('includes skipped issues section', async () => {
+    const result: FoundationResult = {
+      kind: 'projects-board',
+      url: 'https://github.com/orgs/cncf/projects/14',
+      method: 'graphql',
+      results: { results: [], failures: [], rateLimit: null },
+      skipped: [
+        { issueNumber: 7, issueUrl: 'https://github.com/cncf/sandbox/issues/7', title: 'bad issue', reason: 'no repo link found' },
+      ],
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).toContain('## Skipped Issues')
+    expect(text).toContain('[#7 bad issue](https://github.com/cncf/sandbox/issues/7): no repo link found')
+  })
+
+  it('omits skipped issues section when skipped list is empty', async () => {
+    const result: FoundationResult = {
+      kind: 'projects-board',
+      url: 'https://github.com/orgs/cncf/projects/14',
+      method: 'graphql',
+      results: { results: [], failures: [], rateLimit: null },
+      skipped: [],
+    }
+    const { blob } = buildFoundationMarkdownExport(result)
+    const text = await blob.text()
+    expect(text).not.toContain('## Skipped Issues')
+  })
+})
+
+describe('buildFoundationMarkdownExport — kind: org', () => {
+  const ORG_RESULT: FoundationResult = {
+    kind: 'org',
+    inventory: {
+      org: 'my-org',
+      summary: {
+        totalPublicRepos: 42,
+        totalStars: 9876,
+        mostStarredRepos: [],
+        mostRecentlyActiveRepos: [],
+        languageDistribution: [
+          { language: 'Go', repoCount: 20 },
+          { language: 'TypeScript', repoCount: 10 },
+        ],
+        archivedRepoCount: 3,
+        activeRepoCount: 39,
+      },
+      results: [
+        {
+          repo: 'my-org/alpha',
+          name: 'alpha',
+          description: 'Alpha project',
+          primaryLanguage: 'Go',
+          stars: 500,
+          forks: 10,
+          watchers: 25,
+          openIssues: 3,
+          pushedAt: '2024-06-01T00:00:00Z',
+          archived: false,
+          isFork: false,
+          url: 'https://github.com/my-org/alpha',
+        },
+        {
+          repo: 'my-org/beta',
+          name: 'beta',
+          description: 'unavailable',
+          primaryLanguage: 'unavailable',
+          stars: 'unavailable',
+          forks: 0,
+          watchers: 0,
+          openIssues: 0,
+          pushedAt: 'unavailable',
+          archived: true,
+          isFork: false,
+          url: 'https://github.com/my-org/beta',
+        },
+      ],
+      rateLimit: null,
+      failure: null,
+    },
+  }
+
+  it('includes org-level heading', async () => {
+    const { blob } = buildFoundationMarkdownExport(ORG_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('# Foundation Scan Report — my-org')
+    expect(text).toContain('**Organization:** [github.com/my-org](https://github.com/my-org)')
+  })
+
+  it('includes summary metrics table', async () => {
+    const { blob } = buildFoundationMarkdownExport(ORG_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('## Summary')
+    expect(text).toContain('| Total public repositories | 42 |')
+    expect(text).toContain('| Total stars | 9,876 |')
+    expect(text).toContain('| Active repositories | 39 |')
+    expect(text).toContain('| Archived repositories | 3 |')
+  })
+
+  it('includes language distribution', async () => {
+    const { blob } = buildFoundationMarkdownExport(ORG_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('### Language Distribution')
+    expect(text).toContain('| Go | 20 |')
+    expect(text).toContain('| TypeScript | 10 |')
+  })
+
+  it('includes repository inventory table', async () => {
+    const { blob } = buildFoundationMarkdownExport(ORG_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('## Repository Inventory')
+    expect(text).toContain('[alpha](https://github.com/my-org/alpha)')
+    expect(text).toContain('| Active |')
+  })
+
+  it('renders archived and unavailable values correctly', async () => {
+    const { blob } = buildFoundationMarkdownExport(ORG_RESULT)
+    const text = await blob.text()
+    expect(text).toContain('[beta](https://github.com/my-org/beta)')
+    expect(text).toContain('| Archived |')
+    // stars = 'unavailable' → '—'
+    const betaRow = text.split('\n').find((l) => l.includes('[beta]'))
+    expect(betaRow).toContain('| — |')
+  })
+
+  it('filename still matches foundation-scan-YYYY-MM-DD-HHMM.md', () => {
+    const { filename } = buildFoundationMarkdownExport(ORG_RESULT)
+    expect(filename).toMatch(/^foundation-scan-\d{4}-\d{2}-\d{2}-\d{4}\.md$/)
+  })
+})

--- a/lib/export/foundation-markdown-export.ts
+++ b/lib/export/foundation-markdown-export.ts
@@ -1,0 +1,199 @@
+import type { FoundationResult } from '@/components/foundation/FoundationResultsView'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { triggerDownload } from '@/lib/export/json-export'
+
+export interface FoundationMarkdownExportResult {
+  blob: Blob
+  filename: string
+}
+
+function fmt(value: unknown): string {
+  if (value === 'unavailable' || value === null || value === undefined) return '—'
+  if (typeof value === 'number') return new Intl.NumberFormat('en-US').format(value)
+  return String(value)
+}
+
+function buildRepoSection(repoResult: AnalysisResult): string {
+  const lines: string[] = [`## ${repoResult.repo}`, '']
+
+  if (repoResult.landscapeOverride) {
+    const status = repoResult.landscapeStatus ?? 'CNCF'
+    lines.push(`> Already a CNCF ${status} project — not evaluated for sandbox readiness.`, '')
+    return lines.join('\n')
+  }
+
+  const ar = repoResult.aspirantResult
+  if (!ar) {
+    lines.push('> No readiness data available.', '')
+    return lines.join('\n')
+  }
+
+  const { readinessScore, readyCount, totalAutoCheckable, autoFields, tagRecommendation, sandboxApplication } = ar
+  const icon = readinessScore >= 80 ? '🟢' : readinessScore >= 50 ? '🟡' : '🔴'
+  lines.push(`**${icon} Score:** ${readinessScore} / 100 — ${readyCount} of ${totalAutoCheckable} auto-checkable fields ready`, '')
+
+  if (sandboxApplication) {
+    const filedDate = new Date(sandboxApplication.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+    lines.push(
+      `**Application:** [#${sandboxApplication.issueNumber}](${sandboxApplication.issueUrl}) — ${sandboxApplication.state === 'OPEN' ? 'open, under review' : 'closed'} (filed ${filedDate})`,
+      '',
+    )
+  }
+
+  if (tagRecommendation.primaryTag) {
+    lines.push(`**Recommended TAG:** ${tagRecommendation.primaryTag}`, '')
+  }
+
+  const readyFields = autoFields.filter((f) => f.status === 'ready')
+  const needsWorkFields = [...autoFields.filter((f) => f.status !== 'ready')].reverse()
+
+  if (needsWorkFields.length > 0) {
+    lines.push('### Needs Work', '')
+    for (const f of needsWorkFields) {
+      const statusIcon = f.status === 'missing' ? '❌' : '⚠️'
+      const pts = f.weight > 0 ? ` (+${f.weight} pts if resolved)` : ''
+      lines.push(`- ${statusIcon} **${f.label}**${pts}${f.remediationHint ? ` — ${f.remediationHint}` : ''}`)
+    }
+    lines.push('')
+  }
+
+  if (readyFields.length > 0) {
+    lines.push('### Ready', '')
+    for (const f of readyFields) {
+      lines.push(`- ✅ **${f.label}**${f.evidence ? ` — ${f.evidence}` : ''}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+function buildReposMarkdown(result: Extract<FoundationResult, { kind: 'repos' | 'projects-board' }>): string {
+  const response = result.results
+  const isBoard = result.kind === 'projects-board'
+
+  const header = [
+    isBoard ? '# Foundation Scan Report — CNCF Sandbox Board' : '# Foundation Scan Report',
+    '',
+    `**Generated:** ${new Date().toISOString()}`,
+    ...(isBoard ? [`**Source:** [CNCF Sandbox Board](${(result as Extract<FoundationResult, { kind: 'projects-board' }>).url})`] : []),
+    '',
+  ]
+
+  const summaryRows = response.results.map((r) => {
+    if (r.landscapeOverride) {
+      return `| ${r.repo} | — | Already CNCF ${r.landscapeStatus ?? 'project'} |`
+    }
+    if (!r.aspirantResult) return `| ${r.repo} | — | No data |`
+    const { readinessScore } = r.aspirantResult
+    const status = readinessScore >= 80 ? '🟢 Ready' : readinessScore >= 50 ? '🟡 Needs work' : '🔴 Not ready'
+    return `| ${r.repo} | ${readinessScore} / 100 | ${status} |`
+  })
+
+  const summaryLines = [
+    '## Summary',
+    '',
+    '| Repository | Score | Status |',
+    '| --- | --- | --- |',
+    ...summaryRows,
+    '',
+  ]
+
+  const skippedLines: string[] = []
+  if (isBoard) {
+    const board = result as Extract<FoundationResult, { kind: 'projects-board' }>
+    if (board.skipped.length > 0) {
+      skippedLines.push('## Skipped Issues', '')
+      for (const s of board.skipped) {
+        skippedLines.push(`- [#${s.issueNumber} ${s.title}](${s.issueUrl}): ${s.reason}`)
+      }
+      skippedLines.push('')
+    }
+  }
+
+  const failureLines: string[] = []
+  if (response.failures.length > 0) {
+    failureLines.push('## Failed Repositories', '')
+    for (const f of response.failures) {
+      failureLines.push(`- **${f.repo}**: ${f.reason}`)
+    }
+    failureLines.push('')
+  }
+
+  const parts = [...header, ...summaryLines, ...skippedLines, ...failureLines]
+  for (const repoResult of response.results) {
+    parts.push('---', '', buildRepoSection(repoResult))
+  }
+
+  return parts.join('\n')
+}
+
+function buildOrgMarkdown(result: Extract<FoundationResult, { kind: 'org' }>): string {
+  const { org, summary, results } = result.inventory
+
+  const lines = [
+    `# Foundation Scan Report — ${org}`,
+    '',
+    `**Generated:** ${new Date().toISOString()}`,
+    `**Organization:** [github.com/${org}](https://github.com/${org})`,
+    '',
+    '## Summary',
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    `| Total public repositories | ${fmt(summary.totalPublicRepos)} |`,
+    `| Total stars | ${fmt(summary.totalStars)} |`,
+    `| Active repositories | ${fmt(summary.activeRepoCount)} |`,
+    `| Archived repositories | ${fmt(summary.archivedRepoCount)} |`,
+    '',
+  ]
+
+  if (summary.languageDistribution.length > 0) {
+    lines.push(
+      '### Language Distribution',
+      '',
+      '| Language | Repositories |',
+      '| --- | --- |',
+      ...summary.languageDistribution.slice(0, 10).map((l) => `| ${l.language} | ${l.repoCount} |`),
+      '',
+    )
+  }
+
+  lines.push(
+    '## Repository Inventory',
+    '',
+    '| Repository | Stars | Language | Last Push | Status |',
+    '| --- | --- | --- | --- | --- |',
+  )
+
+  for (const r of results) {
+    const push =
+      r.pushedAt !== 'unavailable'
+        ? new Date(r.pushedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+        : '—'
+    const status = r.archived ? 'Archived' : r.isFork ? `Fork of ${r.parentRepo ?? '?'}` : 'Active'
+    lines.push(`| [${r.name}](${r.url}) | ${fmt(r.stars)} | ${fmt(r.primaryLanguage)} | ${push} | ${status} |`)
+  }
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+export function buildFoundationMarkdownExport(result: FoundationResult): FoundationMarkdownExportResult {
+  let markdown: string
+  if (result.kind === 'repos' || result.kind === 'projects-board') {
+    markdown = buildReposMarkdown(result)
+  } else {
+    markdown = buildOrgMarkdown(result)
+  }
+
+  const blob = new Blob([markdown], { type: 'text/markdown' })
+  const now = new Date()
+  const ts = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}`
+  const filename = `foundation-scan-${ts}.md`
+  return { blob, filename }
+}
+
+export function downloadFoundationMarkdown(result: FoundationResult): void {
+  triggerDownload(buildFoundationMarkdownExport(result))
+}

--- a/lib/export/foundation-markdown-export.ts
+++ b/lib/export/foundation-markdown-export.ts
@@ -1,4 +1,4 @@
-import type { FoundationResult } from '@/components/foundation/FoundationResultsView'
+import type { FoundationResult } from '@/lib/foundation/types'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import { triggerDownload } from '@/lib/export/json-export'
 
@@ -17,8 +17,8 @@ function buildRepoSection(repoResult: AnalysisResult): string {
   const lines: string[] = [`## ${repoResult.repo}`, '']
 
   if (repoResult.landscapeOverride) {
-    const status = repoResult.landscapeStatus ?? 'CNCF'
-    lines.push(`> Already a CNCF ${status} project — not evaluated for sandbox readiness.`, '')
+    const statusText = repoResult.landscapeStatus ? ` ${repoResult.landscapeStatus}` : ''
+    lines.push(`> Already a CNCF${statusText} project — not evaluated for sandbox readiness.`, '')
     return lines.join('\n')
   }
 
@@ -45,7 +45,7 @@ function buildRepoSection(repoResult: AnalysisResult): string {
   }
 
   const readyFields = autoFields.filter((f) => f.status === 'ready')
-  const needsWorkFields = [...autoFields.filter((f) => f.status !== 'ready')].reverse()
+  const needsWorkFields = autoFields.filter((f) => f.status !== 'ready')
 
   if (needsWorkFields.length > 0) {
     lines.push('### Needs Work', '')
@@ -82,7 +82,7 @@ function buildReposMarkdown(result: Extract<FoundationResult, { kind: 'repos' | 
 
   const summaryRows = response.results.map((r) => {
     if (r.landscapeOverride) {
-      return `| ${r.repo} | — | Already CNCF ${r.landscapeStatus ?? 'project'} |`
+      return `| ${r.repo} | — | ${r.landscapeStatus ? `Already a CNCF ${r.landscapeStatus} project` : 'Already a CNCF project'} |`
     }
     if (!r.aspirantResult) return `| ${r.repo} | — | No data |`
     const { readinessScore } = r.aspirantResult

--- a/lib/foundation/types.ts
+++ b/lib/foundation/types.ts
@@ -1,4 +1,12 @@
 import type { FoundationTarget } from '@/lib/cncf-sandbox/types'
+import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
+import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
+import type { SkippedIssue } from '@/lib/foundation/fetch-board-repos'
+
+export type FoundationResult =
+  | { kind: 'repos'; results: AnalyzeResponse }
+  | { kind: 'org'; inventory: OrgInventoryResponse }
+  | { kind: 'projects-board'; url: string; results: AnalyzeResponse; skipped: SkippedIssue[]; method: 'graphql' | 'labels' }
 
 export type FoundationInputKind = 'repos' | 'org' | 'projects-board' | 'invalid'
 


### PR DESCRIPTION
## Summary

- Adds an **Export to Markdown** button to the Foundation Scan results view, consistent with the existing Copy Link and Re-analyze buttons
- New `lib/export/foundation-markdown-export.ts` handles all three result kinds:
  - **repos** — summary table + per-repo readiness score, Needs Work / Ready field lists, TAG recommendation
  - **projects-board** — same as repos, plus board URL header and skipped issues section
  - **org** — org summary stats, language distribution, full repo inventory table
- Downloaded file is named `foundation-scan-YYYY-MM-DD-HHMM.md`

## Test plan

- [ ] Run a Foundation Scan for one or more repos — click **Export to Markdown** and verify the downloaded `.md` file contains a summary table and per-repo readiness sections
- [ ] Run a Foundation Scan for an org — verify the export contains org summary stats and the repo inventory table
- [ ] Run a Foundation Scan via the CNCF Sandbox board — verify the export includes the board URL and any skipped issues
- [ ] Verify button renders alongside Copy Link and Re-analyze without layout issues (desktop + mobile widths)
- [ ] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)