### PR TITLE
fix(foundation): clicking board URL icon fills input instead of copying

### DIFF
--- a/components/foundation/FoundationInputSection.test.tsx
+++ b/components/foundation/FoundationInputSection.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FoundationInputSection } from './FoundationInputSection'
 
@@ -122,5 +122,83 @@ describe('FoundationInputSection — picker tooltips', () => {
     const tooltips = screen.getAllByRole('tooltip')
     const comingSoon = tooltips.filter((t) => /coming soon/i.test(t.textContent ?? ''))
     expect(comingSoon.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('FoundationInputSection — board URL button', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('clicking the board URL button calls onInputChange with the board URL', () => {
+    const onInputChange = vi.fn()
+    render(<FoundationInputSection {...defaultProps} onInputChange={onInputChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /use this board url/i }))
+    expect(onInputChange).toHaveBeenCalledWith('https://github.com/orgs/cncf/projects/14')
+  })
+
+  it('shows "Used" feedback immediately after clicking the board URL button', () => {
+    render(<FoundationInputSection {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /use this board url/i }))
+    expect(screen.getByText('Used')).toBeInTheDocument()
+  })
+
+  it('resets "Used" feedback after 1.5 seconds', () => {
+    render(<FoundationInputSection {...defaultProps} />)
+    fireEvent.click(screen.getByRole('button', { name: /use this board url/i }))
+    expect(screen.getByText('Used')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(screen.queryByText('Used')).not.toBeInTheDocument()
+  })
+
+  it('resets the timer when the button is clicked multiple times in quick succession', () => {
+    render(<FoundationInputSection {...defaultProps} />)
+    const btn = screen.getByRole('button', { name: /use this board url/i })
+    fireEvent.click(btn)
+    act(() => { vi.advanceTimersByTime(800) })
+    // Click again before the first timeout fires
+    fireEvent.click(btn)
+    act(() => { vi.advanceTimersByTime(800) })
+    // Should still show "Used" because the second click reset the timer
+    expect(screen.getByText('Used')).toBeInTheDocument()
+    act(() => { vi.advanceTimersByTime(700) })
+    // Now 1500ms after the second click, it should reset
+    expect(screen.queryByText('Used')).not.toBeInTheDocument()
+  })
+})
+
+describe('FoundationInputSection — verify repos checkbox', () => {
+  it('renders the verify repos checkbox', () => {
+    render(<FoundationInputSection {...defaultProps} />)
+    expect(screen.getByRole('checkbox', { name: /verify repos before analyzing/i })).toBeInTheDocument()
+  })
+
+  it('checkbox is unchecked by default', () => {
+    render(<FoundationInputSection {...defaultProps} />)
+    expect(screen.getByRole('checkbox', { name: /verify repos before analyzing/i })).not.toBeChecked()
+  })
+
+  it('checkbox is disabled when no onVerifyReposChange handler is provided', () => {
+    render(<FoundationInputSection {...defaultProps} />)
+    expect(screen.getByRole('checkbox', { name: /verify repos before analyzing/i })).toBeDisabled()
+  })
+
+  it('checkbox is enabled when onVerifyReposChange handler is provided', () => {
+    render(<FoundationInputSection {...defaultProps} onVerifyReposChange={vi.fn()} />)
+    expect(screen.getByRole('checkbox', { name: /verify repos before analyzing/i })).toBeEnabled()
+  })
+
+  it('calls onVerifyReposChange when the checkbox is toggled', async () => {
+    const onVerifyReposChange = vi.fn()
+    render(<FoundationInputSection {...defaultProps} onVerifyReposChange={onVerifyReposChange} />)
+    await userEvent.click(screen.getByRole('checkbox', { name: /verify repos before analyzing/i }))
+    expect(onVerifyReposChange).toHaveBeenCalledWith(true)
   })
 })

--- a/components/foundation/FoundationInputSection.test.tsx
+++ b/components/foundation/FoundationInputSection.test.tsx
@@ -161,15 +161,17 @@ describe('FoundationInputSection — board URL button', () => {
   it('resets the timer when the button is clicked multiple times in quick succession', () => {
     render(<FoundationInputSection {...defaultProps} />)
     const btn = screen.getByRole('button', { name: /use this board url/i })
+
+    // t=0: first click
     fireEvent.click(btn)
+    // t=800ms: halfway through the 1500ms timeout — click again to reset
     act(() => { vi.advanceTimersByTime(800) })
-    // Click again before the first timeout fires
     fireEvent.click(btn)
+    // t=1600ms (800ms after second click): original timeout would have fired but second click cancelled it
     act(() => { vi.advanceTimersByTime(800) })
-    // Should still show "Used" because the second click reset the timer
     expect(screen.getByText('Used')).toBeInTheDocument()
+    // t=2300ms (1500ms after second click): new timeout fires and resets the label
     act(() => { vi.advanceTimersByTime(700) })
-    // Now 1500ms after the second click, it should reset
     expect(screen.queryByText('Used')).not.toBeInTheDocument()
   })
 })

--- a/components/foundation/FoundationInputSection.tsx
+++ b/components/foundation/FoundationInputSection.tsx
@@ -21,13 +21,12 @@ export function FoundationInputSection({
 }: FoundationInputSectionProps) {
   const [tooltipOpen, setTooltipOpen] = useState(false)
   const tooltipRef = useRef<HTMLDivElement | null>(null)
-  const [boardCopied, setBoardCopied] = useState(false)
+  const [boardFilled, setBoardFilled] = useState(false)
 
-  function handleCopyBoardUrl() {
-    void navigator.clipboard.writeText('https://github.com/orgs/cncf/projects/14').then(() => {
-      setBoardCopied(true)
-      setTimeout(() => setBoardCopied(false), 1500)
-    })
+  function handleUseBoardUrl() {
+    onInputChange('https://github.com/orgs/cncf/projects/14')
+    setBoardFilled(true)
+    setTimeout(() => setBoardFilled(false), 1500)
   }
 
   useEffect(() => {
@@ -98,21 +97,21 @@ export function FoundationInputSection({
             </a>
             <button
               type="button"
-              onClick={handleCopyBoardUrl}
-              aria-label="Copy board URL"
-              title="Copy board URL"
+              onClick={handleUseBoardUrl}
+              aria-label="Use this board URL"
+              title="Use this board URL"
               className="ml-1 inline-flex items-center rounded px-1 py-0.5 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
             >
-              {boardCopied ? (
+              {boardFilled ? (
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 text-emerald-500" aria-hidden="true">
                   <path fillRule="evenodd" d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207Z" clipRule="evenodd" />
                 </svg>
               ) : (
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3" aria-hidden="true">
-                  <path fillRule="evenodd" d="M11.013 2.513a1.75 1.75 0 0 0-2.475 0L6.226 4.837A1.75 1.75 0 0 0 6 5.89V9.75a.75.75 0 0 0 .75.75h3.86c.38 0 .745-.14 1.03-.392l2.323-2.132a1.75 1.75 0 0 0 .537-1.265V5.29a1.75 1.75 0 0 0-.513-1.24l-1.974-1.537ZM4.75 6.5A.25.25 0 0 1 5 6.25h.5a.75.75 0 0 0 0-1.5H5a1.75 1.75 0 0 0-1.75 1.75v5.75c0 .966.784 1.75 1.75 1.75h5A1.75 1.75 0 0 0 11.75 12.5v-.5a.75.75 0 0 0-1.5 0v.5a.25.25 0 0 1-.25.25h-5a.25.25 0 0 1-.25-.25V6.5Z" clipRule="evenodd" />
+                  <path d="M7.25 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8v4.25a.75.75 0 0 1-1.5 0V8.5H2.25a.75.75 0 0 1 0-1.5H6.5V2.75A.75.75 0 0 1 7.25 2Z" />
                 </svg>
               )}
-              <span className="ml-0.5 text-xs">{boardCopied ? 'Copied' : ''}</span>
+              <span className="ml-0.5 text-xs">{boardFilled ? 'Used' : ''}</span>
             </button>
           </p>
           <div ref={tooltipRef} className="relative">

--- a/components/foundation/FoundationInputSection.tsx
+++ b/components/foundation/FoundationInputSection.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from 'react'
 import { FOUNDATION_REGISTRY } from '@/lib/foundation/types'
 import type { FoundationTarget } from '@/lib/cncf-sandbox/types'
 
+const CNCF_BOARD_URL = 'https://github.com/orgs/cncf/projects/14'
+
 interface FoundationInputSectionProps {
   foundationTarget: FoundationTarget
   onFoundationTargetChange: (target: FoundationTarget) => void
@@ -26,12 +28,27 @@ export function FoundationInputSection({
   const [tooltipOpen, setTooltipOpen] = useState(false)
   const tooltipRef = useRef<HTMLDivElement | null>(null)
   const [boardFilled, setBoardFilled] = useState(false)
+  const boardTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   function handleUseBoardUrl() {
-    onInputChange('https://github.com/orgs/cncf/projects/14')
+    onInputChange(CNCF_BOARD_URL)
     setBoardFilled(true)
-    setTimeout(() => setBoardFilled(false), 1500)
+    if (boardTimeoutRef.current !== null) {
+      clearTimeout(boardTimeoutRef.current)
+    }
+    boardTimeoutRef.current = setTimeout(() => {
+      setBoardFilled(false)
+      boardTimeoutRef.current = null
+    }, 1500)
   }
+
+  useEffect(() => {
+    return () => {
+      if (boardTimeoutRef.current !== null) {
+        clearTimeout(boardTimeoutRef.current)
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (!tooltipOpen) return
@@ -92,7 +109,7 @@ export function FoundationInputSection({
             <span className="mx-2 text-slate-300 dark:text-slate-600">·</span>
             <span className="font-medium text-slate-700 dark:text-slate-300">Board:</span>{' '}
             <a
-              href="https://github.com/orgs/cncf/projects/14"
+              href={CNCF_BOARD_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="font-mono underline decoration-dotted hover:decoration-solid"
@@ -104,7 +121,7 @@ export function FoundationInputSection({
               onClick={handleUseBoardUrl}
               aria-label="Use this board URL"
               title="Use this board URL"
-              className="ml-1 inline-flex items-center rounded px-1 py-0.5 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
+              className="ml-1 inline-flex items-center rounded px-1 py-0.5 text-slate-400 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:ring-offset-white dark:text-slate-500 dark:hover:text-slate-300 dark:focus-visible:ring-offset-slate-900"
             >
               {boardFilled ? (
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 text-emerald-500" aria-hidden="true">
@@ -178,11 +195,12 @@ export function FoundationInputSection({
         />
       </div>
 
-      <label className="flex cursor-pointer items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+      <label className={`flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400 ${onVerifyReposChange ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}`}>
         <input
           type="checkbox"
           checked={verifyRepos}
           onChange={(e) => onVerifyReposChange?.(e.target.checked)}
+          disabled={!onVerifyReposChange}
           className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600"
         />
         Verify repos before analyzing

--- a/components/foundation/FoundationInputSection.tsx
+++ b/components/foundation/FoundationInputSection.tsx
@@ -10,6 +10,8 @@ interface FoundationInputSectionProps {
   inputValue: string
   onInputChange: (value: string) => void
   error: string | null
+  verifyRepos?: boolean
+  onVerifyReposChange?: (v: boolean) => void
 }
 
 export function FoundationInputSection({
@@ -18,6 +20,8 @@ export function FoundationInputSection({
   inputValue,
   onInputChange,
   error,
+  verifyRepos = false,
+  onVerifyReposChange,
 }: FoundationInputSectionProps) {
   const [tooltipOpen, setTooltipOpen] = useState(false)
   const tooltipRef = useRef<HTMLDivElement | null>(null)
@@ -173,6 +177,16 @@ export function FoundationInputSection({
           aria-describedby={error ? 'foundation-input-error' : undefined}
         />
       </div>
+
+      <label className="flex cursor-pointer items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+        <input
+          type="checkbox"
+          checked={verifyRepos}
+          onChange={(e) => onVerifyReposChange?.(e.target.checked)}
+          className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500 dark:border-slate-600"
+        />
+        Verify repos before analyzing
+      </label>
 
       {error ? (
         <p id="foundation-input-error" role="alert" data-testid="foundation-error" className="mt-1 text-sm text-red-600 dark:text-red-300">

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -10,6 +10,14 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => mockUseSearchParams(),
 }))
 
+vi.mock('@/lib/foundation/fetch-board-repos', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/lib/foundation/fetch-board-repos')>()
+  return {
+    ...original,
+    fetchBoardRepos: vi.fn(),
+  }
+})
+
 const TEST_SESSION = { token: 'gho_test_token', username: 'test-user' }
 
 function renderWithAuth(ui: React.ReactElement) {
@@ -609,6 +617,64 @@ describe('RepoInputClient', () => {
 
     await userEvent.clear(searchInput)
     expect(screen.queryByText(/Corporate contributions for/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('RepoInputClient — Foundation board verify-before-analyze', () => {
+  const BOARD_URL = 'https://github.com/orgs/cncf/projects/14'
+  const MOCK_REPOS = ['org/repo-alpha', 'org/repo-beta']
+
+  async function switchToFoundationMode() {
+    await userEvent.click(screen.getByRole('button', { name: /foundation/i }))
+  }
+
+  it('goes straight to analysis (skips review panel) when verifyRepos is unchecked', async () => {
+    const { fetchBoardRepos } = await import('@/lib/foundation/fetch-board-repos')
+    vi.mocked(fetchBoardRepos).mockResolvedValue({
+      repos: MOCK_REPOS,
+      skipped: [],
+      method: 'graphql',
+      issueMap: {},
+    })
+
+    const onAnalyze = vi.fn().mockResolvedValue({ results: [], failures: [], rateLimit: null })
+    renderWithAuth(<RepoInputClient onAnalyze={onAnalyze} />)
+
+    await switchToFoundationMode()
+    await userEvent.type(screen.getByRole('textbox', { name: /foundation input/i }), BOARD_URL)
+    // Checkbox is unchecked by default — go straight to analysis
+    await userEvent.click(screen.getByRole('button', { name: /^analyze$/i }))
+
+    await vi.waitFor(() => {
+      expect(onAnalyze).toHaveBeenCalledWith(MOCK_REPOS, TEST_SESSION.token)
+    })
+    expect(screen.queryByText(/repositories found/i)).not.toBeInTheDocument()
+  })
+
+  it('shows the repo review panel when verifyRepos is checked', async () => {
+    const { fetchBoardRepos } = await import('@/lib/foundation/fetch-board-repos')
+    vi.mocked(fetchBoardRepos).mockResolvedValue({
+      repos: MOCK_REPOS,
+      skipped: [],
+      method: 'graphql',
+      issueMap: {},
+    })
+
+    const onAnalyze = vi.fn()
+    renderWithAuth(<RepoInputClient onAnalyze={onAnalyze} />)
+
+    await switchToFoundationMode()
+
+    // Check the "Verify repos before analyzing" checkbox to enable review panel
+    const verifyCheckbox = screen.getByRole('checkbox', { name: /verify repos before analyzing/i })
+    await userEvent.click(verifyCheckbox)
+
+    await userEvent.type(screen.getByRole('textbox', { name: /foundation input/i }), BOARD_URL)
+    await userEvent.click(screen.getByRole('button', { name: /^analyze$/i }))
+
+    // Review panel should be visible — onAnalyze should NOT have been called yet
+    expect(await screen.findByText(/2 repositories found/i)).toBeInTheDocument()
+    expect(onAnalyze).not.toHaveBeenCalled()
   })
 })
 

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AuthProvider } from '@/components/auth/AuthContext'
 import { RepoInputClient } from './RepoInputClient'
+import { fetchBoardRepos } from '@/lib/foundation/fetch-board-repos'
 
 const mockUseSearchParams = vi.fn(() => new URLSearchParams())
 
@@ -629,7 +630,6 @@ describe('RepoInputClient — Foundation board verify-before-analyze', () => {
   }
 
   it('goes straight to analysis (skips review panel) when verifyRepos is unchecked', async () => {
-    const { fetchBoardRepos } = await import('@/lib/foundation/fetch-board-repos')
     vi.mocked(fetchBoardRepos).mockResolvedValue({
       repos: MOCK_REPOS,
       skipped: [],
@@ -652,7 +652,6 @@ describe('RepoInputClient — Foundation board verify-before-analyze', () => {
   })
 
   it('shows the repo review panel when verifyRepos is checked', async () => {
-    const { fetchBoardRepos } = await import('@/lib/foundation/fetch-board-repos')
     vi.mocked(fetchBoardRepos).mockResolvedValue({
       repos: MOCK_REPOS,
       skipped: [],

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -81,6 +81,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [loadingFoundation, setLoadingFoundation] = useState(false)
   const [foundationLoadingItems, setFoundationLoadingItems] = useState<string[]>([])
   const [foundationError, setFoundationError] = useState<string | null>(null)
+  const [verifyRepos, setVerifyRepos] = useState(false)
   const [pendingBoardScan, setPendingBoardScan] = useState<{
     repos: string[]
     skipped: SkippedIssue[]
@@ -334,7 +335,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setLoadingFoundation(true)
 
     if (parsed.kind === 'projects-board') {
-      // Phase 1: resolve repos (fast) — then pause for user review
       setFoundationLoadingItems(['Resolving repositories from board…'])
       try {
         const { repos, skipped, method, issueMap } = await fetchBoardRepos(session.token, parsed.url)
@@ -348,8 +348,20 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
           return
         }
 
-        // Pause here — show review panel so user can confirm before analysis
-        setPendingBoardScan({ repos, skipped, method, url: parsed.url, issueMap })
+        if (verifyRepos) {
+          // Pause here — show review panel so user can confirm before analysis
+          setPendingBoardScan({ repos, skipped, method, url: parsed.url, issueMap })
+          return
+        }
+
+        // Go straight into analysis without review
+        setFoundationLoadingItems(repos)
+        const response = onAnalyze
+          ? await onAnalyze(repos, session.token)
+          : await submitAnalysisRequest(repos, session.token, 'cncf-sandbox', controller.signal, issueMap)
+        if (response && !controller.signal.aborted) {
+          setFoundationResult({ kind: 'projects-board', url: parsed.url, results: response, skipped, method })
+        }
       } catch (error) {
         if (controller.signal.aborted) return
         setFoundationError(error instanceof Error ? error.message : 'Board scan failed.')
@@ -621,6 +633,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       foundationInputValue={foundationInput}
       onFoundationInputChange={setFoundationInput}
       foundationError={foundationError}
+      verifyRepos={verifyRepos}
+      onVerifyReposChange={setVerifyRepos}
     />
   )
 

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -18,6 +18,8 @@ interface RepoInputFormProps {
   foundationInputValue?: string
   onFoundationInputChange?: (value: string) => void
   foundationError?: string | null
+  verifyRepos?: boolean
+  onVerifyReposChange?: (v: boolean) => void
 }
 
 export function RepoInputForm({
@@ -32,6 +34,8 @@ export function RepoInputForm({
   foundationInputValue = '',
   onFoundationInputChange,
   foundationError = null,
+  verifyRepos = false,
+  onVerifyReposChange,
 }: RepoInputFormProps) {
   const [uncontrolledMode, setUncontrolledMode] = useState<'repos' | 'org' | 'foundation'>('repos')
   const [repoValue, setRepoValue] = useState(initialRepoValue)
@@ -122,6 +126,8 @@ export function RepoInputForm({
           inputValue={foundationInputValue}
           onInputChange={(v) => onFoundationInputChange?.(v)}
           error={foundationError}
+          verifyRepos={verifyRepos}
+          onVerifyReposChange={onVerifyReposChange}
         />
       ) : mode === 'repos' ? (
         <div className="relative">


### PR DESCRIPTION
## Summary
- The clipboard icon next to the **Board** link previously copied the URL to the clipboard, requiring a manual paste step — now it directly populates the textarea (one click instead of two)
- Adds a **"Verify repos before analyzing"** checkbox (unchecked by default): when unchecked, a board URL goes straight from fetch → analysis; when checked, the existing review panel appears so the user can confirm the resolved repo list first
- Checkbox is Foundation-tab-only; Repositories and Organization tabs are unaffected

## Test plan
- [ ] Open Foundation tab → CNCF Sandbox
- [ ] Click the icon next to `Board: github.com/orgs/cncf/projects/14` — verify textarea is immediately populated with the URL
- [ ] With checkbox **unchecked**: click Analyze — verify it goes straight to analysis (no review panel)
- [ ] With checkbox **checked**: click Analyze — verify the repo review panel appears before analysis starts
- [ ] Verify the icon shows a checkmark + "Used" for ~1.5 s then resets
- [ ] Verify Repositories and Organization tabs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)