### PR TITLE
feat(copy-link): consolidate Copy Link into a single button in the tab header row

### DIFF
--- a/components/export/ExportControls.test.tsx
+++ b/components/export/ExportControls.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ExportControls } from './ExportControls'
@@ -10,9 +10,6 @@ vi.mock('@/lib/export/json-export', () => ({
 }))
 vi.mock('@/lib/export/markdown-export', () => ({
   buildMarkdownExport: vi.fn(() => ({ blob: new Blob(['# md'], { type: 'text/markdown' }), filename: 'test.md' })),
-}))
-vi.mock('@/lib/export/shareable-url', () => ({
-  encodeRepos: vi.fn(() => 'http://localhost:3000/?repos=facebook%2Freact'),
 }))
 
 const MINIMAL_RESPONSE: AnalyzeResponse = {
@@ -71,10 +68,6 @@ describe('ExportControls — disabled state (no results)', () => {
     expect(screen.getByRole('button', { name: /download markdown/i })).toBeDisabled()
   })
 
-  it('renders Copy link button', () => {
-    render(<ExportControls analysisResponse={null} analyzedRepos={[]} />)
-    expect(screen.getByRole('button', { name: /copy link/i })).toBeInTheDocument()
-  })
 })
 
 describe('ExportControls — enabled state (with results)', () => {
@@ -106,25 +99,3 @@ describe('ExportControls — enabled state (with results)', () => {
   })
 })
 
-describe('ExportControls — Copy Link', () => {
-  beforeEach(() => {
-    Object.assign(navigator, {
-      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
-    })
-  })
-
-  it('shows "Copied!" after successful clipboard write', async () => {
-    render(<ExportControls analysisResponse={MINIMAL_RESPONSE} analyzedRepos={['facebook/react']} />)
-    await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
-    expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
-  })
-
-  it('shows fallback input when clipboard API fails', async () => {
-    Object.assign(navigator, {
-      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
-    })
-    render(<ExportControls analysisResponse={MINIMAL_RESPONSE} analyzedRepos={['facebook/react']} />)
-    await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
-    expect(screen.getByRole('textbox', { name: /shareable url/i })).toBeInTheDocument()
-  })
-})

--- a/components/export/ExportControls.tsx
+++ b/components/export/ExportControls.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { useState } from 'react'
 import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import { buildJsonExport, triggerDownload } from '@/lib/export/json-export'
 import { buildMarkdownExport } from '@/lib/export/markdown-export'
-import { encodeRepos } from '@/lib/export/shareable-url'
 
 interface ExportControlsProps {
   analysisResponse: AnalyzeResponse | null
@@ -12,9 +10,6 @@ interface ExportControlsProps {
 }
 
 export function ExportControls({ analysisResponse, analyzedRepos }: ExportControlsProps) {
-  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'fallback'>('idle')
-  const [fallbackUrl, setFallbackUrl] = useState('')
-
   const disabled = !analysisResponse
 
   function handleDownloadJson() {
@@ -27,18 +22,6 @@ export function ExportControls({ analysisResponse, analyzedRepos }: ExportContro
     if (!analysisResponse) return
     const result = buildMarkdownExport(analysisResponse, analyzedRepos)
     triggerDownload(result)
-  }
-
-  async function handleCopyLink() {
-    const url = encodeRepos(analyzedRepos)
-    try {
-      await navigator.clipboard.writeText(url)
-      setCopyState('copied')
-      setTimeout(() => setCopyState('idle'), 2000)
-    } catch {
-      setFallbackUrl(url)
-      setCopyState('fallback')
-    }
   }
 
   return (
@@ -60,25 +43,6 @@ export function ExportControls({ analysisResponse, analyzedRepos }: ExportContro
       >
         Download Markdown
       </button>
-
-      <button
-        type="button"
-        onClick={() => { void handleCopyLink() }}
-        className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
-      >
-        {copyState === 'copied' ? 'Copied!' : 'Copy link'}
-      </button>
-
-      {copyState === 'fallback' && fallbackUrl ? (
-        <input
-          type="text"
-          readOnly
-          value={fallbackUrl}
-          aria-label="Shareable URL"
-          className="flex-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
-          onFocus={(e) => e.currentTarget.select()}
-        />
-      ) : null}
     </div>
   )
 }

--- a/components/foundation/FoundationResultsView.tsx
+++ b/components/foundation/FoundationResultsView.tsx
@@ -13,45 +13,6 @@ interface FoundationResultsViewProps {
   result: FoundationResult | null
   error: string | null
   onReanalyze?: () => void
-  shareableUrl?: string
-}
-
-function CopyLinkButton({ url }: { url: string }) {
-  const [state, setState] = useState<'idle' | 'copied' | 'fallback'>('idle')
-  const [fallbackUrl, setFallbackUrl] = useState('')
-
-  async function handleCopy() {
-    try {
-      await navigator.clipboard.writeText(url)
-      setState('copied')
-      setTimeout(() => setState('idle'), 2000)
-    } catch {
-      setFallbackUrl(url)
-      setState('fallback')
-    }
-  }
-
-  return (
-    <>
-      <button
-        type="button"
-        onClick={() => { void handleCopy() }}
-        className="inline-flex shrink-0 items-center gap-1.5 rounded border border-slate-300 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
-      >
-        {state === 'copied' ? 'Copied!' : 'Copy link'}
-      </button>
-      {state === 'fallback' && fallbackUrl ? (
-        <input
-          type="text"
-          readOnly
-          value={fallbackUrl}
-          aria-label="Shareable URL"
-          className="rounded border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
-          onFocus={(e) => e.currentTarget.select()}
-        />
-      ) : null}
-    </>
-  )
 }
 
 function ReanalyzeButton({ onClick }: { onClick: () => void }) {
@@ -180,7 +141,7 @@ function RepoAccordion({ repoResults }: { repoResults: AnalysisResult[] }) {
   )
 }
 
-export function FoundationResultsView({ result, error, onReanalyze, shareableUrl }: FoundationResultsViewProps) {
+export function FoundationResultsView({ result, error, onReanalyze }: FoundationResultsViewProps) {
 
   if (error) {
     return (
@@ -196,7 +157,6 @@ export function FoundationResultsView({ result, error, onReanalyze, shareableUrl
     return (
       <div className="space-y-4">
         <div className="flex justify-end gap-2">
-          {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
           <ExportMarkdownButton result={result} />
           {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
         </div>
@@ -221,7 +181,6 @@ export function FoundationResultsView({ result, error, onReanalyze, shareableUrl
     return (
       <div className="space-y-4">
         <div className="flex justify-end gap-2">
-          {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
           <ExportMarkdownButton result={result} />
           {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
         </div>
@@ -268,7 +227,6 @@ export function FoundationResultsView({ result, error, onReanalyze, shareableUrl
             ) : null}
           </div>
           <div className="flex shrink-0 flex-col gap-2 sm:flex-row">
-            {shareableUrl ? <CopyLinkButton url={shareableUrl} /> : null}
             <ExportMarkdownButton result={result} />
             {onReanalyze ? <ReanalyzeButton onClick={onReanalyze} /> : null}
           </div>

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -31,7 +31,7 @@ import type { AspirantReadinessResult, CNCFFieldBadge, FoundationTarget } from '
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition, ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
-import { decodeFoundationUrl, encodeFoundationUrl, isValidRepoSlug } from '@/lib/export/shareable-url'
+import { decodeFoundationUrl, isValidRepoSlug } from '@/lib/export/shareable-url'
 import { parseRepos } from '@/lib/parse-repos'
 import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
 import { fetchBoardRepos, type SkippedIssue } from '@/lib/foundation/fetch-board-repos'
@@ -1038,11 +1038,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
         <FoundationResultsView
           result={foundationResult}
           error={foundationError}
-          shareableUrl={
-            foundationResult && foundationInput
-              ? encodeFoundationUrl({ foundation: foundationTarget, input: foundationInput })
-              : undefined
-          }
           onReanalyze={
             foundationResult && !loadingFoundation
               ? foundationResult.kind === 'projects-board'

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -5,6 +5,7 @@ import { normalizeOrgInput } from '@/lib/analyzer/org-inventory'
 import { parseRepos } from '@/lib/parse-repos'
 import type { FoundationTarget } from '@/lib/cncf-sandbox/types'
 import { FoundationInputSection } from '@/components/foundation/FoundationInputSection'
+import { CopyLinkButton } from '@/components/shared/CopyLinkButton'
 
 interface RepoInputFormProps {
   onSubmitRepos: (repos: string[]) => void
@@ -104,7 +105,7 @@ export function RepoInputForm({
 
   return (
     <form onSubmit={handleSubmit} noValidate>
-      <div className="mb-3 flex flex-wrap gap-2">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
         {(['repos', 'org', 'foundation'] as const).map((m) => (
           <button
             key={m}
@@ -118,6 +119,7 @@ export function RepoInputForm({
             {m === 'repos' ? 'Repositories' : m === 'org' ? 'Organization' : 'Foundation'}
           </button>
         ))}
+        <CopyLinkButton />
       </div>
       {mode === 'foundation' ? (
         <FoundationInputSection

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -105,21 +105,25 @@ export function RepoInputForm({
 
   return (
     <form onSubmit={handleSubmit} noValidate>
-      <div className="mb-3 flex flex-wrap items-center gap-2">
-        {(['repos', 'org', 'foundation'] as const).map((m) => (
-          <button
-            key={m}
-            type="button"
-            className={`rounded-full border px-4 py-2 text-sm font-medium transition ${ mode === m ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-slate-300 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200' }`}
-            onClick={() => {
-              updateMode(m)
-              setError(null)
-            }}
-          >
-            {m === 'repos' ? 'Repositories' : m === 'org' ? 'Organization' : 'Foundation'}
-          </button>
-        ))}
-        <CopyLinkButton />
+      <div className="mb-3 flex items-center gap-2">
+        <div className="flex flex-wrap gap-2">
+          {(['repos', 'org', 'foundation'] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              className={`rounded-full border px-4 py-2 text-sm font-medium transition ${ mode === m ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-slate-300 bg-white text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200' }`}
+              onClick={() => {
+                updateMode(m)
+                setError(null)
+              }}
+            >
+              {m === 'repos' ? 'Repositories' : m === 'org' ? 'Organization' : 'Foundation'}
+            </button>
+          ))}
+        </div>
+        <div className="ml-auto">
+          <CopyLinkButton />
+        </div>
       </div>
       {mode === 'foundation' ? (
         <FoundationInputSection

--- a/components/shared/CopyLinkButton.test.tsx
+++ b/components/shared/CopyLinkButton.test.tsx
@@ -19,7 +19,7 @@ describe('CopyLinkButton', () => {
     expect(screen.getByRole('button', { name: /copy link/i })).toBeInTheDocument()
   })
 
-  it('copies window.location.href to clipboard on click', async () => {
+  it('copies the current URL (without hash) to clipboard on click', async () => {
     render(<CopyLinkButton />)
     await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
@@ -27,10 +27,22 @@ describe('CopyLinkButton', () => {
     )
   })
 
+  it('strips the URL hash before copying to avoid leaking auth tokens', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { href: 'http://localhost:3000/?mode=repos#token=secret' },
+      writable: true,
+    })
+    render(<CopyLinkButton />)
+    await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'http://localhost:3000/?mode=repos',
+    )
+  })
+
   it('shows "Copied!" after successful clipboard write', async () => {
     render(<CopyLinkButton />)
     await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
-    expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /copied/i })).toBeInTheDocument()
   })
 
   it('stays silent when clipboard API fails', async () => {

--- a/components/shared/CopyLinkButton.test.tsx
+++ b/components/shared/CopyLinkButton.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CopyLinkButton } from './CopyLinkButton'
+
+describe('CopyLinkButton', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { href: 'http://localhost:3000/?mode=repos&repos=facebook%2Freact' },
+      writable: true,
+    })
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+  })
+
+  it('renders a "Copy link" button', () => {
+    render(<CopyLinkButton />)
+    expect(screen.getByRole('button', { name: /copy link/i })).toBeInTheDocument()
+  })
+
+  it('copies window.location.href to clipboard on click', async () => {
+    render(<CopyLinkButton />)
+    await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'http://localhost:3000/?mode=repos&repos=facebook%2Freact',
+    )
+  })
+
+  it('shows "Copied!" after successful clipboard write', async () => {
+    render(<CopyLinkButton />)
+    await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
+    expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument()
+  })
+
+  it('stays silent when clipboard API fails', async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    })
+    render(<CopyLinkButton />)
+    await userEvent.click(screen.getByRole('button', { name: /copy link/i }))
+    // Button should still be present, no fallback input
+    expect(screen.getByRole('button')).toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+})

--- a/components/shared/CopyLinkButton.tsx
+++ b/components/shared/CopyLinkButton.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+
+export function CopyLinkButton() {
+  const [state, setState] = useState<'idle' | 'copied'>('idle')
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+      setState('copied')
+      setTimeout(() => setState('idle'), 1500)
+    } catch {
+      // clipboard unavailable — silently ignore
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => { void handleCopy() }}
+      className="inline-flex items-center gap-1.5 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+    >
+      {state === 'copied' ? (
+        <>
+          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5 text-emerald-500" fill="none" stroke="currentColor" strokeWidth="2.5">
+            <path d="M3 8l3.5 3.5L13 4.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Copied!
+        </>
+      ) : (
+        <>
+          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <rect x="5.5" y="5.5" width="8" height="8" rx="1" />
+            <path d="M10.5 5.5V3.5a1 1 0 0 0-1-1h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2" strokeLinecap="round" />
+          </svg>
+          Copy link
+        </>
+      )}
+    </button>
+  )
+}

--- a/components/shared/CopyLinkButton.tsx
+++ b/components/shared/CopyLinkButton.tsx
@@ -1,15 +1,34 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export function CopyLinkButton() {
   const [state, setState] = useState<'idle' | 'copied'>('idle')
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current !== null) {
+        clearTimeout(resetTimeoutRef.current)
+        resetTimeoutRef.current = null
+      }
+    }
+  }, [])
 
   async function handleCopy() {
     try {
-      await navigator.clipboard.writeText(window.location.href)
+      const url = new URL(window.location.href)
+      url.hash = ''
+      await navigator.clipboard.writeText(url.toString())
       setState('copied')
-      setTimeout(() => setState('idle'), 1500)
+
+      if (resetTimeoutRef.current !== null) {
+        clearTimeout(resetTimeoutRef.current)
+      }
+      resetTimeoutRef.current = setTimeout(() => {
+        setState('idle')
+        resetTimeoutRef.current = null
+      }, 1500)
     } catch {
       // clipboard unavailable — silently ignore
     }

--- a/components/shared/CopyLinkButton.tsx
+++ b/components/shared/CopyLinkButton.tsx
@@ -38,23 +38,19 @@ export function CopyLinkButton() {
     <button
       type="button"
       onClick={() => { void handleCopy() }}
-      className="inline-flex items-center gap-1.5 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+      aria-label={state === 'copied' ? 'Copied!' : 'Copy link'}
+      title={state === 'copied' ? 'Copied!' : 'Copy link'}
+      className="inline-flex items-center justify-center rounded p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:text-slate-500 dark:hover:bg-slate-700 dark:hover:text-slate-300"
     >
       {state === 'copied' ? (
-        <>
-          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5 text-emerald-500" fill="none" stroke="currentColor" strokeWidth="2.5">
-            <path d="M3 8l3.5 3.5L13 4.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-          Copied!
-        </>
+        <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4 text-emerald-500" fill="none" stroke="currentColor" strokeWidth="2.5">
+          <path d="M3 8l3.5 3.5L13 4.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
       ) : (
-        <>
-          <svg aria-hidden="true" viewBox="0 0 16 16" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="1.5">
-            <rect x="5.5" y="5.5" width="8" height="8" rx="1" />
-            <path d="M10.5 5.5V3.5a1 1 0 0 0-1-1h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2" strokeLinecap="round" />
-          </svg>
-          Copy link
-        </>
+        <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <rect x="5.5" y="5.5" width="8" height="8" rx="1" />
+          <path d="M10.5 5.5V3.5a1 1 0 0 0-1-1h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2" strokeLinecap="round" />
+        </svg>
       )}
     </button>
   )

--- a/components/shared/CopyLinkButton.tsx
+++ b/components/shared/CopyLinkButton.tsx
@@ -48,8 +48,8 @@ export function CopyLinkButton() {
         </svg>
       ) : (
         <svg aria-hidden="true" viewBox="0 0 16 16" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.5">
-          <rect x="5.5" y="5.5" width="8" height="8" rx="1" />
-          <path d="M10.5 5.5V3.5a1 1 0 0 0-1-1h-6a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2" strokeLinecap="round" />
+          <path d="M6.5 9.5a3.535 3.535 0 0 0 5 0l2-2a3.535 3.535 0 0 0-5-5L7 4" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M9.5 6.5a3.535 3.535 0 0 0-5 0l-2 2a3.535 3.535 0 0 0 5 5L9 12" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       )}
     </button>


### PR DESCRIPTION
## Summary

Closes #503.

- Created `components/shared/CopyLinkButton.tsx` — copies `window.location.href` to clipboard (no props needed); shows clipboard icon → checkmark + "Copied!" for 1.5 s
- Rendered `CopyLinkButton` in `RepoInputForm.tsx` alongside the Repositories / Organization / Foundation tab buttons, so it's always visible regardless of mode
- Removed the private `CopyLinkButton` component and its 3 render sites from `FoundationResultsView.tsx` (repos, org, projects-board paths); removed `shareableUrl` prop entirely
- Removed `handleCopyLink` and the "Copy link" button from `ExportControls.tsx`; removed `encodeRepos` import (no longer used for copy)
- Removed `encodeFoundationUrl` import from `RepoInputClient.tsx` and the `shareableUrl` prop computation (lines 1041–1045)
- `encodeFoundationUrl` itself stays in `shareable-url.ts` (still used by `CNCFCandidacyPanel.tsx` for an `href`)

## Test plan

- [ ] `npm test` — 1883 tests pass, 0 failures
- [ ] TypeScript: `tsc --noEmit` clean
- [ ] Manual: load the app, click "Copy link" in the tab header row — URL copies successfully in all three modes (Repositories, Organization, Foundation)
- [ ] Manual: navigate to a repos URL (e.g. `?mode=repos&repos=facebook/react`) — clicking Copy link copies the full current URL
- [ ] Manual: navigate to a foundation URL — clicking Copy link copies the current URL
- [ ] Manual: verify no "Copy link" button remains in the export toolbar or foundation results panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)