### PR TITLE
feat(foundation): sync input value into URL so Copy Link captures it

### DIFF
--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -867,4 +867,31 @@ describe('RepoInputClient — tab deep-links', () => {
     await userEvent.click(screen.getByRole('button', { name: /^repositories$/i }))
     expect(replaceState).toHaveBeenCalledWith(null, '', '/')
   })
+
+  it('writes ?input= to the URL as the user types in the Foundation input', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('mode=foundation'))
+    renderWithAuth(<RepoInputClient />)
+    await userEvent.type(screen.getByRole('textbox', { name: /foundation input/i }), 'kubernetes/kubernetes')
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null, '', '/?mode=foundation&foundation=cncf-sandbox&input=kubernetes%2Fkubernetes',
+    )
+  })
+
+  it('omits ?input= from the URL when the Foundation input is cleared', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('mode=foundation&foundation=cncf-sandbox&input=kubernetes%2Fkubernetes'))
+    renderWithAuth(<RepoInputClient />)
+    const textarea = screen.getByRole('textbox', { name: /foundation input/i })
+    await userEvent.clear(textarea)
+    expect(replaceState).toHaveBeenLastCalledWith(null, '', '/?mode=foundation&foundation=cncf-sandbox')
+  })
+
+  it('includes ?input= when switching to the Foundation tab with existing input', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('mode=foundation&foundation=cncf-sandbox&input=kubernetes%2Fkubernetes'))
+    renderWithAuth(<RepoInputClient />)
+    await userEvent.click(screen.getByRole('button', { name: /^repositories$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^foundation$/i }))
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null, '', '/?mode=foundation&foundation=cncf-sandbox&input=kubernetes%2Fkubernetes',
+    )
+  })
 })

--- a/components/repo-input/RepoInputClient.test.tsx
+++ b/components/repo-input/RepoInputClient.test.tsx
@@ -894,4 +894,14 @@ describe('RepoInputClient — tab deep-links', () => {
       null, '', '/?mode=foundation&foundation=cncf-sandbox&input=kubernetes%2Fkubernetes',
     )
   })
+
+  it('preserves ?input= in the URL when switching Foundation sub-tabs while input is non-empty', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('mode=foundation&foundation=cncf-sandbox'))
+    renderWithAuth(<RepoInputClient />)
+    await userEvent.type(screen.getByRole('textbox', { name: /foundation input/i }), 'kubernetes/kubernetes')
+    await userEvent.click(screen.getByRole('button', { name: /^cncf sandbox$/i }))
+    expect(replaceState).toHaveBeenLastCalledWith(
+      null, '', '/?mode=foundation&foundation=cncf-sandbox&input=kubernetes%2Fkubernetes',
+    )
+  })
 })

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -315,6 +315,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       const target = foundationTarget === 'none' ? 'cncf-sandbox' : foundationTarget
       setFoundationTarget(target)
       params.set('foundation', target)
+      if (foundationInput) params.set('input', foundationInput)
     }
     // repos is the default — no mode param needed
     const qs = params.toString()
@@ -326,6 +327,17 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     const params = new URLSearchParams()
     params.set('mode', 'foundation')
     params.set('foundation', target)
+    if (foundationInput) params.set('input', foundationInput)
+    window.history.replaceState(null, '', `/?${params.toString()}`)
+  }
+
+  function handleFoundationInputChange(value: string) {
+    setFoundationInput(value)
+    const params = new URLSearchParams()
+    params.set('mode', 'foundation')
+    const target = foundationTarget === 'none' ? 'cncf-sandbox' : foundationTarget
+    params.set('foundation', target)
+    if (value) params.set('input', value)
     window.history.replaceState(null, '', `/?${params.toString()}`)
   }
 
@@ -662,7 +674,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       foundationTarget={foundationTarget}
       onFoundationTargetChange={handleFoundationTargetChange}
       foundationInputValue={foundationInput}
-      onFoundationInputChange={setFoundationInput}
+      onFoundationInputChange={handleFoundationInputChange}
       foundationError={foundationError}
       verifyRepos={verifyRepos}
       onVerifyReposChange={setVerifyRepos}

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -71,7 +71,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     initialFoundationState ? 'foundation' : urlMode ?? 'repos'
   const initialTab = (searchParams.get('tab') ?? 'overview') as ResultTabId
   const autoTriggeredRef = useRef(false)
-  const foundationAutoTriggeredRef = useRef(false)
   const [analysisResponse, setAnalysisResponse] = useState<AnalyzeResponse | null>(null)
   const [analyzedRepos, setAnalyzedRepos] = useState<string[]>([])
   const [orgInventoryResponse, setOrgInventoryResponse] = useState<OrgInventoryResponse | null>(null)
@@ -87,7 +86,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [foundationTarget, setFoundationTarget] = useState<FoundationTarget>(initialFoundationTarget)
   const [aspirantResult, setAspirantResult] = useState<AspirantReadinessResult | null>(null)
   // Foundation mode state
-  const [foundationInput, setFoundationInput] = useState('')
+  const [foundationInput, setFoundationInput] = useState(searchParams.get('input') ?? '')
   const [foundationResult, setFoundationResult] = useState<FoundationResult | null>(null)
   const [loadingFoundation, setLoadingFoundation] = useState(false)
   const [foundationLoadingItems, setFoundationLoadingItems] = useState<string[]>([])
@@ -121,8 +120,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   // without taking it as a dep (which would cause the effects to re-run on every render).
   const handleSubmitRef = useRef(handleSubmit)
   handleSubmitRef.current = handleSubmit
-  const handleFoundationSubmitRef = useRef(handleFoundationSubmit)
-  handleFoundationSubmitRef.current = handleFoundationSubmit
 
   const isLoading = loadingRepos.length > 0 || !!loadingOrg || loadingFoundation
 
@@ -472,18 +469,6 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     void handleSubmitRef.current(parsed.repos)
   }, [session?.token, initialRawRepos, initialRepoValue])
 
-  // Auto-trigger Foundation scan when URL has mode=foundation params
-  useEffect(() => {
-    if (foundationAutoTriggeredRef.current) return
-    if (!session?.token) return
-    if (!initialFoundationState) return
-
-    foundationAutoTriggeredRef.current = true
-    setInputMode('foundation')
-    setFoundationTarget(initialFoundationState.foundation)
-    setFoundationInput(initialFoundationState.input)
-    void handleFoundationSubmitRef.current(initialFoundationState.input)
-  }, [session?.token, initialFoundationState, setInputMode, setFoundationTarget, setFoundationInput])
 
   async function handleSubmit(repos: string[]) {
     if (!session?.token) return

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -333,6 +333,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     const params = new URLSearchParams()
     params.set('mode', 'foundation')
     const target = foundationTarget === 'none' ? 'cncf-sandbox' : foundationTarget
+    if (target !== foundationTarget) setFoundationTarget(target)
     params.set('foundation', target)
     if (value) params.set('input', value)
     window.history.replaceState(null, '', `/?${params.toString()}`)


### PR DESCRIPTION
## Summary

- Typing/pasting into the Foundation textarea writes `?input=` to the address bar via `history.replaceState`, so `window.location.href` (used by Copy Link) always reflects the current input
- Clearing the input drops `?input=` from the URL
- Switching tabs or Foundation sub-tabs while input is non-empty preserves `?input=` in the URL
- Opening a URL with `?input=` pre-fills the textarea but does **not** auto-run analysis — the user must click Analyze (removes the previous auto-trigger behaviour)

## Test plan
- [x] 3 new unit tests — all 37 pass
- [ ] Manual: open Foundation tab, type a board URL → verify address bar updates with `?input=`
- [ ] Manual: click Copy Link → paste in a new tab → verify input is pre-filled but analysis does **not** auto-run
- [ ] Manual: clear the input → verify `?input=` is removed from the address bar
- [ ] Manual: verify clicking Analyze after pre-fill runs the analysis correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)