### PR TITLE
fix(auth+foundation): deep-link URL params survive OAuth redirect

### DIFF
--- a/components/auth/AuthGate.test.tsx
+++ b/components/auth/AuthGate.test.tsx
@@ -1,24 +1,27 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import { AuthProvider } from './AuthContext'
 import { AuthGate } from './AuthGate'
 
 const mockUseSearchParams = vi.fn(() => new URLSearchParams())
+const mockRouterReplace = vi.fn()
 
 // Mock useRouter/useSearchParams — Next.js navigation
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: vi.fn() }),
+  useRouter: () => ({ replace: mockRouterReplace }),
   useSearchParams: () => mockUseSearchParams(),
 }))
 
 describe('AuthGate', () => {
   beforeEach(() => {
     mockUseSearchParams.mockReturnValue(new URLSearchParams())
+    mockRouterReplace.mockReset()
     // Reset location hash before each test
     Object.defineProperty(window, 'location', {
       value: { hash: '', href: 'http://localhost/', replace: vi.fn() },
       writable: true,
     })
+    sessionStorage.clear()
   })
 
   it('shows sign-in button when unauthenticated', () => {
@@ -69,5 +72,58 @@ describe('AuthGate', () => {
     const link = screen.getByRole('link', { name: /sign in with github/i })
     expect(link.getAttribute('href')).toBe('/api/auth/login')
     expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+  })
+
+  it('performs a hard reload via window.location.replace when oauth_return_search is non-empty', async () => {
+    const locationReplace = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#token=gho_abc&username=testuser&scopes=repo',
+        href: 'http://localhost/',
+        replace: locationReplace,
+      },
+      writable: true,
+    })
+    sessionStorage.setItem('oauth_return_search', '?mode=foundation&foundation=cncf-sandbox')
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <AuthGate>
+            <p>Protected content</p>
+          </AuthGate>
+        </AuthProvider>,
+      )
+    })
+
+    expect(locationReplace).toHaveBeenCalledWith('/?mode=foundation&foundation=cncf-sandbox')
+    expect(mockRouterReplace).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('oauth_return_search')).toBeNull()
+  })
+
+  it('uses router.replace when oauth_return_search is empty', async () => {
+    const locationReplace = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: {
+        hash: '#token=gho_abc&username=testuser&scopes=repo',
+        href: 'http://localhost/',
+        replace: locationReplace,
+      },
+      writable: true,
+    })
+    // No savedSearch set in sessionStorage
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <AuthGate>
+            <p>Protected content</p>
+          </AuthGate>
+        </AuthProvider>,
+      )
+    })
+
+    expect(locationReplace).not.toHaveBeenCalled()
+    expect(mockRouterReplace).toHaveBeenCalledWith('/', { scroll: false })
   })
 })

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -37,7 +37,13 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
       // Restore any query params saved before the OAuth redirect (e.g. ?repos=...)
       const savedSearch = sessionStorage.getItem('oauth_return_search') ?? ''
       sessionStorage.removeItem('oauth_return_search')
-      router.replace(`/${savedSearch}`, { scroll: false })
+      if (savedSearch) {
+        // Hard reload so useState initialisers in RepoInputClient run with the
+        // restored params — client-side router.replace doesn't re-run them.
+        window.location.replace(`/${savedSearch}`)
+      } else {
+        router.replace('/', { scroll: false })
+      }
     }
   }, [router, signIn])
 

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -38,7 +38,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
       const savedSearch = sessionStorage.getItem('oauth_return_search') ?? ''
       sessionStorage.removeItem('oauth_return_search')
       if (savedSearch) {
-        // Hard reload so useState initialisers in RepoInputClient run with the
+        // Hard reload so useState initializers in RepoInputClient run with the
         // restored params — client-side router.replace doesn't re-run them.
         window.location.replace(`/${savedSearch}`)
       } else {


### PR DESCRIPTION
## Summary

- **Foundation input → URL sync**: As the user types in the Foundation tab input, `?input=` is written to the address bar so Copy Link always captures the current value.
- **No auto-run on load**: URLs with `?input=` pre-fill the input but do not auto-trigger analysis — the user must click Analyze.
- **OAuth redirect param fix**: After GitHub login from a deep-linked URL (e.g. `?mode=foundation&foundation=cncf-sandbox&input=…`), the app now hard-reloads via `window.location.replace()` instead of `router.replace()`. This ensures `useState` initialisers in `RepoInputClient` re-run with the restored query params, so the correct tab and pre-filled input are restored. The auth session survives because it is persisted in `localStorage`.

## Root cause (OAuth param loss)

`AuthGate` already saved/restored `window.location.search` via `sessionStorage`. The bug was using Next.js `router.replace()` (SPA navigation) to restore the URL — SPA navigation does not re-run `useState` initialisers, so `?mode=`, `?foundation=`, and `?input=` were silently ignored. Switching to `window.location.replace()` (hard reload) for the non-empty `savedSearch` case fixes it.

## Test plan

- [ ] Navigate to `/?mode=foundation&foundation=cncf-sandbox&input=https%3A%2F%2Fgithub.com%2Forgs%2Fcncf%2Fprojects%2F14` in an incognito window → redirected to GitHub login → after login, lands on Foundation tab with board URL pre-filled and analysis NOT auto-started
- [ ] Navigate to `/?mode=foundation` → Foundation tab selected
- [ ] Navigate to `/?mode=org` → Org tab selected
- [ ] Type in Foundation input → address bar `?input=` updates as you type → Copy Link copies the full URL including input
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)