### PR TITLE
feat: LLM-powered Q&A chat panel after analysis (issue #271)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
+# Anthropic API key — optional. Required only for the LLM-powered Q&A chat panel.
+# Generate at: https://console.anthropic.com/settings/keys
+# When absent, the chat panel gracefully shows a "not available" message.
+# ANTHROPIC_API_KEY=sk-ant-...
+
 # GitHub PATs for calibration scripts (npm run calibrate).
 # Generate at: https://github.com/settings/tokens → "Generate new token (classic)"
 # Required scope: public_repo (read access only) — no other scopes needed.

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,8 @@
 # RepoPulse Constitution
 
-**Version**: 1.4 — Amended 2026-04-21
+**Version**: 1.5 — Amended 2026-05-03
+**Amendment (v1.5, 2026-05-03)**: Section I updated to add `@anthropic-ai/sdk` (Anthropic Claude SDK) to the approved technology stack for Phase 1, gated behind the `ANTHROPIC_API_KEY` server-side environment variable. The LLM-powered Q&A chat panel (issue #271) requires this SDK to stream responses from Anthropic Claude models. The SDK is never bundled into client code and the API key is never sent to the client. The feature degrades gracefully (503) when the key is absent. Signed off by: arun-gupta.
+
 **Amendment (v1.4, 2026-04-21)**: Section III rule 4 updated to reflect no-scope baseline OAuth (issue #401). Rationale: RepoPulse only reads public data; the previous `public_repo` baseline granted unnecessary write access. A no-scope token provides the same read access and full 5,000 req/hr rate limit without write permission. Signed off by: arun-gupta.
 
 **Amendment (v1.3)**: Sections XII and XIII updated to drop the per-feature `specs/NNN-feature-name/checklists/manual-testing.md` file. The PR body's `## Test plan` section is now the single source of truth for manual testing signoff. Rationale: under the one-Claude-per-issue ephemeral-worktree workflow, the in-repo checklist file duplicated the PR Test Plan, drifted from it, and added ceremony without adding coverage. GitHub preserves PR bodies indefinitely and they are queryable via `gh pr view --json body`, so the test record remains durable. Signed off by: arun-gupta.
@@ -21,6 +23,7 @@ Every spec, plan, task, and line of code must comply. No exceptions.
 - **Deployment**: Vercel — zero-config
 - **Styling**: Tailwind CSS
 - **Charts**: Chart.js (via npm)
+- **LLM**: `@anthropic-ai/sdk` (server-side only, gated by `ANTHROPIC_API_KEY`) — used for the Q&A chat panel (issue #271)
 - **Stateless**: no database, no auth system, all analysis is on-demand
 
 ### Phase 2 — GitHub Action

--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock @anthropic-ai/sdk before importing the route
+// ---------------------------------------------------------------------------
+
+const mockStream = vi.hoisted(() => vi.fn())
+
+vi.mock('@anthropic-ai/sdk', () => {
+  // Must use a regular function (not arrow) so it can be used with `new`
+  const AnthropicMock = vi.fn(function (this: unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(this as any).messages = { stream: mockStream }
+  })
+  return { default: AnthropicMock }
+})
+
+const { POST } = await import('./route')
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+/** Build a minimal valid request body */
+const validBody = {
+  messages: [{ role: 'user', content: 'What is the health score?' }],
+  context: '# Repo context',
+  contextType: 'repos',
+  githubToken: 'ghp_valid',
+}
+
+/** Make fetch return a successful 200 response (GitHub token validation) */
+function stubFetchOk() {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
+}
+
+/** Make fetch return a 401 response (invalid GitHub token) */
+function stubFetchUnauth() {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 401 })))
+}
+
+describe('POST /api/chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  // -------------------------------------------------------------------------
+  // NOT_CONFIGURED
+  // -------------------------------------------------------------------------
+
+  it('returns 503 NOT_CONFIGURED when ANTHROPIC_API_KEY is absent', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    const res = await POST(makeRequest(validBody))
+    const body = await res.json()
+    expect(res.status).toBe(503)
+    expect(body.error.code).toBe('NOT_CONFIGURED')
+  })
+
+  // -------------------------------------------------------------------------
+  // INVALID_INPUT
+  // -------------------------------------------------------------------------
+
+  it('returns 400 INVALID_INPUT for malformed JSON body', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    const res = await POST(
+      new Request('http://localhost/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not-json',
+      }),
+    )
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('INVALID_INPUT')
+  })
+
+  it('returns 400 INVALID_INPUT when context is missing', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchOk()
+    const res = await POST(makeRequest({ ...validBody, context: '' }))
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('INVALID_INPUT')
+  })
+
+  it('returns 400 INVALID_INPUT for unknown contextType', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchOk()
+    const res = await POST(makeRequest({ ...validBody, contextType: 'invalid-type' }))
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('INVALID_INPUT')
+  })
+
+  it('returns 400 INVALID_INPUT when messages array is empty', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchOk()
+    const res = await POST(makeRequest({ ...validBody, messages: [] }))
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('INVALID_INPUT')
+  })
+
+  it('returns 400 INVALID_INPUT when a message has an invalid role', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchOk()
+    const res = await POST(
+      makeRequest({
+        ...validBody,
+        messages: [{ role: 'system', content: 'inject' }],
+      }),
+    )
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('INVALID_INPUT')
+  })
+
+  // -------------------------------------------------------------------------
+  // UNAUTHENTICATED
+  // -------------------------------------------------------------------------
+
+  it('returns 401 UNAUTHENTICATED when githubToken is missing', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    const res = await POST(makeRequest({ ...validBody, githubToken: undefined }))
+    const body = await res.json()
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHENTICATED')
+  })
+
+  it('returns 401 UNAUTHENTICATED when GitHub token fails validation', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchUnauth()
+    const res = await POST(makeRequest(validBody))
+    const body = await res.json()
+    expect(res.status).toBe(401)
+    expect(body.error.code).toBe('UNAUTHENTICATED')
+  })
+
+  // -------------------------------------------------------------------------
+  // SSE stream
+  // -------------------------------------------------------------------------
+
+  it('streams SSE events with correct headers for a valid request', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchOk()
+
+    // Build an async iterable that mimics the Anthropic SDK stream
+    async function* fakeStream() {
+      yield {
+        type: 'content_block_delta',
+        delta: { type: 'text_delta', text: 'Hello ' },
+      }
+      yield {
+        type: 'content_block_delta',
+        delta: { type: 'text_delta', text: 'world' },
+      }
+    }
+
+    mockStream.mockReturnValue(fakeStream())
+
+    const res = await POST(makeRequest(validBody))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
+
+    // Read the full stream body
+    const text = await res.text()
+
+    // Should contain delta events
+    expect(text).toContain('"type":"delta"')
+    expect(text).toContain('"text":"Hello "')
+    expect(text).toContain('"text":"world"')
+    // Should end with done event
+    expect(text).toContain('"type":"done"')
+  })
+})

--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -8,9 +8,8 @@ const mockStream = vi.hoisted(() => vi.fn())
 
 vi.mock('@anthropic-ai/sdk', () => {
   // Must use a regular function (not arrow) so it can be used with `new`
-  const AnthropicMock = vi.fn(function (this: unknown) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(this as any).messages = { stream: mockStream }
+  const AnthropicMock = vi.fn(function (this: { messages: { stream: typeof mockStream } }) {
+    this.messages = { stream: mockStream }
   })
   return { default: AnthropicMock }
 })
@@ -37,12 +36,14 @@ const validBody = {
   githubToken: 'ghp_valid',
 }
 
-/** Make fetch return a successful 200 response (GitHub token validation) */
+/** Make fetch return a successful 200 response (GitHub token validation).
+ * Cleanup is handled by vi.unstubAllGlobals() in afterEach. */
 function stubFetchOk() {
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
 }
 
-/** Make fetch return a 401 response (invalid GitHub token) */
+/** Make fetch return a 401 response (invalid GitHub token).
+ * Cleanup is handled by vi.unstubAllGlobals() in afterEach. */
 function stubFetchUnauth() {
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 401 })))
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,155 @@
+import Anthropic from '@anthropic-ai/sdk'
+
+export const runtime = 'nodejs'
+
+const SUPPORTED_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-6'] as const
+type SupportedModel = (typeof SUPPORTED_MODELS)[number]
+
+const MAX_HISTORY_TURNS = 10
+
+interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+interface ChatRequest {
+  messages: ChatMessage[]
+  context: string
+  contextType: 'repos' | 'org'
+  githubToken?: string
+  model?: string
+}
+
+function buildSystemPrompt(contextType: 'repos' | 'org', context: string): string {
+  const scope =
+    contextType === 'repos'
+      ? 'one or more GitHub repositories'
+      : 'a GitHub organization and all its analyzed repositories'
+
+  return [
+    `You are RepoPulse Assistant, an expert on open-source project health metrics.`,
+    `You have been given analysis data for ${scope}.`,
+    `Answer questions strictly from the provided data. Do not invent metrics, scores, or repository details.`,
+    `If the data does not contain enough information to answer a question, say so clearly.`,
+    `Be concise and specific. Format responses in Markdown where helpful.`,
+    ``,
+    `## Analysis Data`,
+    context,
+  ].join('\n')
+}
+
+export async function POST(request: Request) {
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    return Response.json(
+      { error: { code: 'NOT_CONFIGURED', message: "AI chat isn't available in this deployment." } },
+      { status: 503 },
+    )
+  }
+
+  let body: ChatRequest
+  try {
+    body = (await request.json()) as ChatRequest
+  } catch {
+    return Response.json(
+      { error: { code: 'INVALID_INPUT', message: 'Invalid request body.' } },
+      { status: 400 },
+    )
+  }
+
+  const { messages, context, contextType, githubToken, model: requestedModel } = body
+
+  if (!githubToken) {
+    return Response.json(
+      { error: { code: 'UNAUTHENTICATED', message: 'Authentication required.' } },
+      { status: 401 },
+    )
+  }
+
+  if (!context || !contextType) {
+    return Response.json(
+      { error: { code: 'INVALID_INPUT', message: 'context and contextType are required.' } },
+      { status: 400 },
+    )
+  }
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return Response.json(
+      { error: { code: 'INVALID_INPUT', message: 'At least one message is required.' } },
+      { status: 400 },
+    )
+  }
+
+  const model: SupportedModel =
+    requestedModel && (SUPPORTED_MODELS as readonly string[]).includes(requestedModel)
+      ? (requestedModel as SupportedModel)
+      : 'claude-haiku-4-5'
+
+  // Keep last MAX_HISTORY_TURNS messages (alternating user/assistant)
+  const trimmedMessages = messages.slice(-MAX_HISTORY_TURNS)
+
+  const systemPrompt = buildSystemPrompt(contextType, context)
+
+  const client = new Anthropic({ apiKey })
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder()
+
+      function emit(chunk: string) {
+        controller.enqueue(encoder.encode(chunk))
+      }
+
+      try {
+        const response = await client.messages.stream({
+          model,
+          max_tokens: 1024,
+          system: [
+            {
+              type: 'text',
+              text: systemPrompt,
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+          messages: trimmedMessages.map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+        })
+
+        for await (const event of response) {
+          if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+            emit(`data: ${JSON.stringify({ type: 'delta', text: event.delta.text })}\n\n`)
+          }
+        }
+
+        emit(`data: ${JSON.stringify({ type: 'done' })}\n\n`)
+      } catch (error: unknown) {
+        const status = (error as { status?: number }).status
+        if (status === 429) {
+          emit(
+            `data: ${JSON.stringify({ type: 'error', code: 'RATE_LIMITED', message: 'Too many requests — please wait a moment and try again.' })}\n\n`,
+          )
+        } else if (status === 400 && (error as { message?: string }).message?.includes('too large')) {
+          emit(
+            `data: ${JSON.stringify({ type: 'error', code: 'CONTEXT_TOO_LARGE', message: 'This analysis is too large to chat about. Try reducing the repo count using the slider.' })}\n\n`,
+          )
+        } else {
+          emit(
+            `data: ${JSON.stringify({ type: 'error', code: 'API_ERROR', message: 'Something went wrong — please try again in a moment.' })}\n\n`,
+          )
+        }
+      } finally {
+        controller.close()
+      }
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -5,7 +5,26 @@ export const runtime = 'nodejs'
 const SUPPORTED_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-6'] as const
 type SupportedModel = (typeof SUPPORTED_MODELS)[number]
 
+const VALID_CONTEXT_TYPES = ['repos', 'org'] as const
+const VALID_ROLES = ['user', 'assistant'] as const
+
 const MAX_HISTORY_TURNS = 10
+
+async function validateGitHubToken(token: string): Promise<boolean> {
+  try {
+    const res = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: '{ viewer { login } }' }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
 
 interface ChatMessage {
   role: 'user' | 'assistant'
@@ -73,10 +92,32 @@ export async function POST(request: Request) {
     )
   }
 
+  if (!(VALID_CONTEXT_TYPES as readonly string[]).includes(contextType)) {
+    return Response.json(
+      { error: { code: 'INVALID_INPUT', message: `contextType must be one of: ${VALID_CONTEXT_TYPES.join(', ')}.` } },
+      { status: 400 },
+    )
+  }
+
   if (!Array.isArray(messages) || messages.length === 0) {
     return Response.json(
       { error: { code: 'INVALID_INPUT', message: 'At least one message is required.' } },
       { status: 400 },
+    )
+  }
+
+  if (messages.some((m) => !(VALID_ROLES as readonly string[]).includes(m.role))) {
+    return Response.json(
+      { error: { code: 'INVALID_INPUT', message: `Message roles must be one of: ${VALID_ROLES.join(', ')}.` } },
+      { status: 400 },
+    )
+  }
+
+  const isValidToken = await validateGitHubToken(githubToken)
+  if (!isValidToken) {
+    return Response.json(
+      { error: { code: 'UNAUTHENTICATED', message: 'Invalid GitHub token.' } },
+      { status: 401 },
     )
   }
 
@@ -85,8 +126,8 @@ export async function POST(request: Request) {
       ? (requestedModel as SupportedModel)
       : 'claude-haiku-4-5'
 
-  // Keep last MAX_HISTORY_TURNS messages (alternating user/assistant)
-  const trimmedMessages = messages.slice(-MAX_HISTORY_TURNS)
+  // Keep last MAX_HISTORY_TURNS conversation turns (each turn = 1 user + 1 assistant message)
+  const trimmedMessages = messages.slice(-(MAX_HISTORY_TURNS * 2))
 
   const systemPrompt = buildSystemPrompt(contextType, context)
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -36,6 +36,7 @@ interface ChatRequest {
   context: string
   contextType: 'repos' | 'org'
   githubToken?: string
+  anthropicKey?: string
   model?: string
 }
 
@@ -58,14 +59,6 @@ function buildSystemPrompt(contextType: 'repos' | 'org', context: string): strin
 }
 
 export async function POST(request: Request) {
-  const apiKey = process.env.ANTHROPIC_API_KEY
-  if (!apiKey) {
-    return Response.json(
-      { error: { code: 'NOT_CONFIGURED', message: "AI chat isn't available in this deployment." } },
-      { status: 503 },
-    )
-  }
-
   let body: ChatRequest
   try {
     body = (await request.json()) as ChatRequest
@@ -76,7 +69,16 @@ export async function POST(request: Request) {
     )
   }
 
-  const { messages, context, contextType, githubToken, model: requestedModel } = body
+  const { messages, context, contextType, githubToken, anthropicKey, model: requestedModel } = body
+
+  // Resolve API key: user-provided key takes precedence over server env var
+  const apiKey = anthropicKey?.trim() || process.env.ANTHROPIC_API_KEY
+  if (!apiKey) {
+    return Response.json(
+      { error: { code: 'NOT_CONFIGURED', message: "AI chat isn't available — please provide an Anthropic API key." } },
+      { status: 503 },
+    )
+  }
 
   if (!githubToken) {
     return Response.json(
@@ -158,16 +160,30 @@ export async function POST(request: Request) {
           })),
         })
 
+        let inputTokens = 0
+        let cacheReadTokens = 0
+        let outputTokens = 0
+
         for await (const event of response) {
-          if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
+          if (event.type === 'message_start') {
+            inputTokens = event.message.usage.input_tokens
+            cacheReadTokens = (event.message.usage as { cache_read_input_tokens?: number }).cache_read_input_tokens ?? 0
+          } else if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
             emit(`data: ${JSON.stringify({ type: 'delta', text: event.delta.text })}\n\n`)
+          } else if (event.type === 'message_delta') {
+            outputTokens = event.usage.output_tokens
           }
         }
 
+        emit(`data: ${JSON.stringify({ type: 'usage', inputTokens, outputTokens, cacheReadTokens })}\n\n`)
         emit(`data: ${JSON.stringify({ type: 'done' })}\n\n`)
       } catch (error: unknown) {
         const status = (error as { status?: number }).status
-        if (status === 429) {
+        if (status === 401) {
+          emit(
+            `data: ${JSON.stringify({ type: 'error', code: 'INVALID_KEY', message: 'Invalid API key — check it and try again.' })}\n\n`,
+          )
+        } else if (status === 429) {
           emit(
             `data: ${JSON.stringify({ type: 'error', code: 'RATE_LIMITED', message: 'Too many requests — please wait a moment and try again.' })}\n\n`,
           )

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -25,6 +25,7 @@ interface ResultsShellProps {
   searchQuery?: string
   onDomMatchCounts?: (counts: { domMatchCounts: TabMatchCounts; domTotalMatches: number; domMatchedTabCount: number }) => void
   tagMatchCounts?: TabMatchCounts
+  chatPanel?: React.ReactNode
 }
 
 export function ResultsShell({
@@ -39,6 +40,7 @@ export function ResultsShell({
   searchQuery = '',
   onDomMatchCounts,
   tagMatchCounts,
+  chatPanel,
 }: ResultsShellProps) {
   const [activeTab, setActiveTab] = useState<ResultTabId>(initialActiveTab)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
@@ -206,7 +208,7 @@ export function ResultsShell({
         </div>
       </header>
 
-      <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className={`mx-auto max-w-5xl px-4 py-6${chatPanel ? ' pb-16' : ''}`}>
         {isStale ? (
           <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200 dark:border-amber-800/60" role="alert">
             Scores calibrated against GitHub data from {calibrationMeta.generated}. A more recent calibration is recommended.
@@ -241,6 +243,7 @@ export function ResultsShell({
           </section>
         </section>
       </div>
+      {chatPanel}
     </main>
   )
 }

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
-import type { OrgRepoSummary } from '@/lib/analyzer/org-inventory'
+import type { OrgInventoryResponse, OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
-import { serializeReposContext, serializeOrgContext, type OrgSortBy } from './serialize-context'
+import { serializeReposContext, serializeOrgContext, serializeOrgInventoryContext, type OrgSortBy } from './serialize-context'
 
 // ---- Types ----------------------------------------------------------------
 
@@ -30,6 +30,7 @@ export interface ChatPanelProps {
   orgView?: OrgSummaryViewModel
   org?: string
   orgRepos?: OrgRepoSummary[]
+  orgInventory?: OrgInventoryResponse
   githubToken: string
   resetKey?: number
 }
@@ -48,6 +49,13 @@ const ORG_STARTER_CHIPS = [
   "What's the overall security posture?",
   'Which repos are best positioned for CNCF Sandbox?',
   'Are there repos with low activity but high star counts?',
+]
+
+const ORG_INVENTORY_STARTER_CHIPS = [
+  "Which repos haven't been active in over a year?",
+  'What languages are most common across this org?',
+  'Which repos have the most open issues?',
+  'Are there any archived or forked repos?',
 ]
 
 const MODEL_META: Record<Model, { icon: string; label: string; hint: string; inputRate: number; outputRate: number; cacheReadRate: number }> = {
@@ -192,7 +200,7 @@ function KeyEntryForm({ onSave }: { onSave: (key: string) => void }) {
 // ---- Main component -------------------------------------------------------
 
 export function ChatPanel({
-  contextType, repoResults, orgView, org, orgRepos = [], githubToken, resetKey,
+  contextType, repoResults, orgView, org, orgRepos = [], orgInventory, githubToken, resetKey,
 }: ChatPanelProps) {
   const [expanded, setExpanded] = useState(false)
   const [model, setModel] = useState<Model>('claude-haiku-4-5')
@@ -275,6 +283,8 @@ export function ChatPanel({
       return serializeReposContext(repoResults).text
     if (contextType === 'org' && orgView && org)
       return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount, sortBy, orgRepos }).text
+    if (contextType === 'org' && orgInventory)
+      return serializeOrgInventoryContext(orgInventory, { maxRepos: orgRepoCount, sortBy }).text
     return ''
   }
 
@@ -420,9 +430,15 @@ export function ChatPanel({
     setIsStreaming(false)
   }
 
-  const starterChips = contextType === 'repos' ? REPOS_STARTER_CHIPS : ORG_STARTER_CHIPS
+  const isInventoryPhase = contextType === 'org' && !orgView && !!orgInventory
+  const starterChips = contextType === 'repos'
+    ? REPOS_STARTER_CHIPS
+    : isInventoryPhase
+      ? ORG_INVENTORY_STARTER_CHIPS
+      : ORG_STARTER_CHIPS
   const showChips = messages.length === 0 && !isStreaming
-  const isOrgAndLarge = contextType === 'org' && (orgView?.status.total ?? 0) > 500
+  const orgTotal = orgView?.status.total ?? orgInventory?.results.length ?? 0
+  const isOrgAndLarge = contextType === 'org' && orgTotal > 500
   const hasKey = !!anthropicKey
 
   return (

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -566,50 +566,50 @@ export function ChatPanel({
               </div>
             </div>
 
+            {/* Structured search filter (org tab only, always visible when expanded) */}
+            {contextType === 'org' && onRepoQueryChange && (() => {
+              const parsed = parseStructuredSearchQuery(repoQuery)
+              return (
+                <div className="border-b border-slate-200 px-4 py-2 dark:border-slate-700">
+                  <div className="flex items-center gap-2">
+                    <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5 shrink-0 text-slate-400">
+                      <circle cx="6.5" cy="6.5" r="4" /><path strokeLinecap="round" d="M11 11l3 3" />
+                    </svg>
+                    <input
+                      type="text"
+                      value={repoQuery}
+                      onChange={(e) => onRepoQueryChange(e.target.value)}
+                      placeholder="Filter repos: lang:go stars:>500 archived:false"
+                      className="flex-1 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+                    />
+                    {repoQuery && (
+                      <button
+                        type="button"
+                        onClick={() => onRepoQueryChange('')}
+                        className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+                        aria-label="Clear filter"
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                  {parsed.invalidTokens.length > 0 && (
+                    <p className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
+                      Ignored: {parsed.invalidTokens.join(', ')}
+                    </p>
+                  )}
+                  <p className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500">
+                    Prefixes: lang: archived: stars: forks: issues: pushed: topic: license:
+                  </p>
+                </div>
+              )
+            })()}
+
             {/* Key entry form or chat */}
             {!hasKey ? (
               <KeyEntryForm onSave={handleSaveKey} />
             ) : (
               <>
-                {/* Structured search filter (org tab only) */}
-                {contextType === 'org' && onRepoQueryChange && (() => {
-                  const parsed = parseStructuredSearchQuery(repoQuery)
-                  return (
-                    <div className="border-b border-slate-200 px-4 py-2 dark:border-slate-700">
-                      <div className="flex items-center gap-2">
-                        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5 shrink-0 text-slate-400">
-                          <circle cx="6.5" cy="6.5" r="4" /><path strokeLinecap="round" d="M11 11l3 3" />
-                        </svg>
-                        <input
-                          type="text"
-                          value={repoQuery}
-                          onChange={(e) => onRepoQueryChange(e.target.value)}
-                          placeholder="Filter repos: lang:go stars:>500 archived:false"
-                          className="flex-1 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
-                        />
-                        {repoQuery && (
-                          <button
-                            type="button"
-                            onClick={() => onRepoQueryChange('')}
-                            className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-                            aria-label="Clear filter"
-                          >
-                            ✕
-                          </button>
-                        )}
-                      </div>
-                      {parsed.invalidTokens.length > 0 && (
-                        <p className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
-                          Ignored: {parsed.invalidTokens.join(', ')}
-                        </p>
-                      )}
-                      <p className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500">
-                        Prefixes: lang: archived: stars: forks: issues: pushed: topic: license:
-                      </p>
-                    </div>
-                  )
-                })()}
-
                 {/* Message history */}
                 <div
                   className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3"

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -1,0 +1,537 @@
+'use client'
+
+import { useEffect, useRef, useState, useCallback } from 'react'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
+import { serializeReposContext, serializeOrgContext } from './serialize-context'
+
+// ---- Types ----------------------------------------------------------------
+
+type Model = 'claude-haiku-4-5' | 'claude-sonnet-4-6'
+
+interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant' | 'error'
+  content: string
+  /** Original user question preserved when an error happens so they can retry */
+  retryContent?: string
+}
+
+export type OrgSortCriterion = 'stars' | 'health' | 'activity'
+
+export interface ChatPanelProps {
+  contextType: 'repos' | 'org'
+  /** Repos-tab context */
+  repoResults?: AnalysisResult[]
+  /** Org-tab context */
+  orgView?: OrgSummaryViewModel
+  org?: string
+  githubToken: string
+  /** Reset key — when it changes, conversation is cleared */
+  resetKey?: number
+}
+
+// ---- Constants ------------------------------------------------------------
+
+const REPOS_STARTER_CHIPS = [
+  'Why is the security score low?',
+  "What's the biggest gap between these repos?",
+  'Which repo should I fix first?',
+  'What do these repos have in common?',
+]
+
+const ORG_STARTER_CHIPS = [
+  'Which repos need the most urgent attention?',
+  "What's the overall security posture?",
+  'Which repos are best positioned for CNCF Sandbox?',
+  'Are there repos with low activity but high star counts?',
+]
+
+const MODEL_LABELS: Record<Model, { icon: string; label: string; hint: string }> = {
+  'claude-haiku-4-5': { icon: '⚡', label: 'Fast', hint: 'Best for quick lookups and factual questions about the data' },
+  'claude-sonnet-4-6': { icon: '🧠', label: 'Deep', hint: 'Better for multi-hop reasoning, comparisons, and nuanced recommendations' },
+}
+
+const LOCAL_STORAGE_MODEL_KEY = 'repopulse:chat:model'
+const SESSION_STORAGE_EXPANDED_KEY = 'repopulse:chat:expanded'
+
+// ---- Helpers --------------------------------------------------------------
+
+function uid(): string {
+  return Math.random().toString(36).slice(2)
+}
+
+function readStoredModel(): Model {
+  try {
+    const v = localStorage.getItem(LOCAL_STORAGE_MODEL_KEY)
+    if (v === 'claude-haiku-4-5' || v === 'claude-sonnet-4-6') return v
+  } catch {}
+  return 'claude-haiku-4-5'
+}
+
+function readStoredExpanded(): boolean {
+  try {
+    return sessionStorage.getItem(SESSION_STORAGE_EXPANDED_KEY) === 'true'
+  } catch {}
+  return false
+}
+
+// ---- Simple markdown renderer (bold + paragraphs + code blocks) -----------
+
+function renderMarkdown(text: string): React.ReactNode {
+  // Split by code fences first
+  const parts = text.split(/(```[\s\S]*?```)/g)
+  return parts.map((part, i) => {
+    if (part.startsWith('```')) {
+      const inner = part.replace(/^```[^\n]*\n?/, '').replace(/```$/, '')
+      return (
+        <pre key={i} className="my-2 overflow-x-auto rounded bg-slate-100 p-3 text-xs dark:bg-slate-800">
+          <code>{inner}</code>
+        </pre>
+      )
+    }
+    // Process inline: bold, code, paragraphs
+    return part.split('\n\n').filter(Boolean).map((para, j) => {
+      const spans = para.split(/(\*\*[^*]+\*\*|`[^`]+`)/g).map((seg, k) => {
+        if (seg.startsWith('**') && seg.endsWith('**')) {
+          return <strong key={k}>{seg.slice(2, -2)}</strong>
+        }
+        if (seg.startsWith('`') && seg.endsWith('`')) {
+          return <code key={k} className="rounded bg-slate-100 px-1 font-mono text-xs dark:bg-slate-800">{seg.slice(1, -1)}</code>
+        }
+        return <span key={k}>{seg}</span>
+      })
+      return (
+        <p key={`${i}-${j}`} className="mb-2 last:mb-0">
+          {spans}
+        </p>
+      )
+    })
+  })
+}
+
+// ---- Main component -------------------------------------------------------
+
+export function ChatPanel({ contextType, repoResults, orgView, org, githubToken, resetKey }: ChatPanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [model, setModel] = useState<Model>('claude-haiku-4-5')
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [inputValue, setInputValue] = useState('')
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [orgRepoCount, setOrgRepoCount] = useState(500)
+  const [orgSort, setOrgSort] = useState<OrgSortCriterion>('stars')
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Hydrate from storage after mount
+  useEffect(() => {
+    setModel(readStoredModel())
+    setExpanded(readStoredExpanded())
+  }, [])
+
+  // Reset conversation when resetKey changes
+  useEffect(() => {
+    if (resetKey === undefined) return
+    setMessages([])
+    setInputValue('')
+    abortRef.current?.abort()
+    abortRef.current = null
+    setIsStreaming(false)
+    try { sessionStorage.removeItem(SESSION_STORAGE_EXPANDED_KEY) } catch {}
+    setExpanded(false)
+  }, [resetKey])
+
+  // Scroll to latest message
+  useEffect(() => {
+    if (expanded) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [messages, expanded])
+
+  function handleExpandToggle() {
+    const next = !expanded
+    setExpanded(next)
+    try { sessionStorage.setItem(SESSION_STORAGE_EXPANDED_KEY, String(next)) } catch {}
+  }
+
+  function handleModelChange(m: Model) {
+    setModel(m)
+    try { localStorage.setItem(LOCAL_STORAGE_MODEL_KEY, m) } catch {}
+  }
+
+  function handleOrgRepoCountChange(count: number) {
+    if (count !== orgRepoCount) {
+      setOrgRepoCount(count)
+      setMessages([])
+    }
+  }
+
+  function handleOrgSortChange(sort: OrgSortCriterion) {
+    if (sort !== orgSort) {
+      setOrgSort(sort)
+      setMessages([])
+    }
+  }
+
+  function buildContext(): string {
+    if (contextType === 'repos' && repoResults) {
+      return serializeReposContext(repoResults).text
+    }
+    if (contextType === 'org' && orgView && org) {
+      return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount, sortBy: orgSort }).text
+    }
+    return ''
+  }
+
+  const sendMessage = useCallback(async (text: string) => {
+    if (!text.trim() || isStreaming) return
+
+    const userMsg: ChatMessage = { id: uid(), role: 'user', content: text }
+    const assistantId = uid()
+
+    setMessages((prev) => [...prev, userMsg, { id: assistantId, role: 'assistant', content: '' }])
+    setInputValue('')
+    setIsStreaming(true)
+
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const history: Array<{ role: 'user' | 'assistant'; content: string }> = []
+    setMessages((prev) => {
+      const all = [...prev]
+      for (const m of all) {
+        if (m.role === 'user' || m.role === 'assistant') {
+          history.push({ role: m.role, content: m.content })
+        }
+      }
+      return all
+    })
+
+    // Build the message list to send: all prior turns + new user message
+    const apiMessages = [
+      ...messages
+        .filter((m) => m.role === 'user' || m.role === 'assistant')
+        .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content })),
+      { role: 'user' as const, content: text },
+    ]
+
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: apiMessages,
+          context: buildContext(),
+          contextType,
+          githubToken,
+          model,
+        }),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({})) as { error?: { message?: string; code?: string } }
+        const code = payload.error?.code
+        const msg =
+          code === 'NOT_CONFIGURED'
+            ? "AI chat isn't available in this deployment."
+            : payload.error?.message ?? 'Something went wrong — please try again in a moment.'
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, role: 'error', content: msg, retryContent: text }
+              : m,
+          ),
+        )
+        return
+      }
+
+      const reader = response.body?.getReader()
+      if (!reader) return
+
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const json = line.slice(6)
+          let event: { type: string; text?: string; code?: string; message?: string }
+          try { event = JSON.parse(json) } catch { continue }
+
+          if (event.type === 'delta' && event.text) {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === assistantId ? { ...m, content: m.content + event.text! } : m,
+              ),
+            )
+          } else if (event.type === 'error') {
+            const noRetry = event.code === 'NOT_CONFIGURED' || event.code === 'CONTEXT_TOO_LARGE'
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === assistantId
+                  ? {
+                      ...m,
+                      role: 'error',
+                      content: event.message ?? 'Something went wrong.',
+                      retryContent: noRetry ? undefined : text,
+                    }
+                  : m,
+              ),
+            )
+          }
+        }
+      }
+    } catch (err: unknown) {
+      if ((err as { name?: string }).name === 'AbortError') return
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? { ...m, role: 'error', content: 'Something went wrong — please try again in a moment.', retryContent: text }
+            : m,
+        ),
+      )
+    } finally {
+      setIsStreaming(false)
+      abortRef.current = null
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isStreaming, messages, contextType, githubToken, model, orgRepoCount, orgSort, repoResults, orgView, org])
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    void sendMessage(inputValue)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void sendMessage(inputValue)
+    }
+  }
+
+  function handleChipClick(chip: string) {
+    void sendMessage(chip)
+  }
+
+  function handleRetry(retryContent: string) {
+    // Remove the error message and resend
+    setMessages((prev) => prev.filter((m) => m.retryContent !== retryContent))
+    void sendMessage(retryContent)
+  }
+
+  function handleNewConversation() {
+    abortRef.current?.abort()
+    abortRef.current = null
+    setMessages([])
+    setIsStreaming(false)
+  }
+
+  const starterChips = contextType === 'repos' ? REPOS_STARTER_CHIPS : ORG_STARTER_CHIPS
+  const showChips = messages.length === 0 && !isStreaming
+  const isOrgAndLarge = contextType === 'org'
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-40 mx-auto max-w-5xl px-4">
+      <div className="rounded-t-2xl border border-b-0 border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900">
+        {/* Collapsed bar */}
+        {!expanded ? (
+          <button
+            type="button"
+            onClick={handleExpandToggle}
+            className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            <span aria-hidden="true" className="text-base">✨</span>
+            <span className="flex-1">Ask a question about this analysis</span>
+            <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4 shrink-0">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 10l4-4 4 4" />
+            </svg>
+          </button>
+        ) : (
+          <>
+            {/* Panel header */}
+            <div className="flex flex-wrap items-center gap-2 border-b border-slate-200 px-4 py-2 dark:border-slate-700">
+              <span className="mr-1 font-semibold text-slate-900 dark:text-slate-100">Ask Claude</span>
+
+              {/* Model switcher */}
+              <div className="flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 p-0.5 dark:border-slate-700 dark:bg-slate-800">
+                {(Object.entries(MODEL_LABELS) as [Model, (typeof MODEL_LABELS)[Model]][]).map(([m, info]) => (
+                  <button
+                    key={m}
+                    type="button"
+                    title={info.hint}
+                    onClick={() => handleModelChange(m)}
+                    className={
+                      model === m
+                        ? 'rounded-full bg-white px-2.5 py-1 text-xs font-medium shadow-sm dark:bg-slate-700 text-slate-900 dark:text-slate-100'
+                        : 'rounded-full px-2.5 py-1 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+                    }
+                  >
+                    {info.icon} {info.label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Org controls */}
+              {isOrgAndLarge ? (
+                <>
+                  <div className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400">
+                    <label htmlFor="chat-repo-count" className="whitespace-nowrap">Analyzing top</label>
+                    <input
+                      id="chat-repo-count"
+                      type="range"
+                      min="50"
+                      max="500"
+                      step="50"
+                      value={orgRepoCount}
+                      onChange={(e) => handleOrgRepoCountChange(Number(e.target.value))}
+                      className="w-24 accent-sky-600"
+                    />
+                    <span className="w-8 text-right font-medium">{orgRepoCount}</span>
+                    <span>repos</span>
+                  </div>
+                  <select
+                    value={orgSort}
+                    onChange={(e) => handleOrgSortChange(e.target.value as OrgSortCriterion)}
+                    className="rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                    aria-label="Sort repos by"
+                  >
+                    <option value="stars">⭐ Top by stars</option>
+                    <option value="health">🔴 Lowest health first</option>
+                    <option value="activity">⚡ Most recently active</option>
+                  </select>
+                </>
+              ) : null}
+
+              <div className="ml-auto flex items-center gap-2">
+                {messages.length > 0 ? (
+                  <button
+                    type="button"
+                    onClick={handleNewConversation}
+                    className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+                  >
+                    New conversation
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={handleExpandToggle}
+                  aria-label="Collapse chat"
+                  className="inline-flex h-6 w-6 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+                >
+                  <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 6l4 4 4-4" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            {/* Message history */}
+            <div
+              className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3"
+              aria-live="polite"
+              aria-label="Chat messages"
+            >
+              {showChips ? (
+                <div className="flex flex-wrap gap-2">
+                  {starterChips.map((chip) => (
+                    <button
+                      key={chip}
+                      type="button"
+                      onClick={() => handleChipClick(chip)}
+                      className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                    >
+                      {chip}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
+              {messages.map((msg) => {
+                if (msg.role === 'user') {
+                  return (
+                    <div key={msg.id} className="flex justify-end">
+                      <div className="max-w-[80%] rounded-2xl bg-sky-600 px-4 py-2 text-sm text-white">
+                        {msg.content}
+                      </div>
+                    </div>
+                  )
+                }
+                if (msg.role === 'error') {
+                  return (
+                    <div key={msg.id} className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200">
+                      <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
+                        <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+                      </svg>
+                      <div className="flex-1">
+                        <p>{msg.content}</p>
+                        {msg.retryContent ? (
+                          <button
+                            type="button"
+                            onClick={() => handleRetry(msg.retryContent!)}
+                            className="mt-1 text-xs font-medium underline hover:no-underline"
+                          >
+                            Retry
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  )
+                }
+                // assistant
+                return (
+                  <div key={msg.id} className="flex justify-start">
+                    <div className="max-w-[85%] rounded-2xl bg-slate-100 px-4 py-2 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">
+                      {msg.content ? (
+                        <div className="prose prose-sm max-w-none dark:prose-invert">
+                          {renderMarkdown(msg.content)}
+                        </div>
+                      ) : (
+                        <span className="animate-pulse text-slate-400">●</span>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* Input area */}
+            <form onSubmit={handleSubmit} className="border-t border-slate-200 px-4 py-3 dark:border-slate-700">
+              <div className="flex items-end gap-2">
+                <textarea
+                  ref={inputRef}
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Ask a question…"
+                  rows={1}
+                  disabled={isStreaming}
+                  className="flex-1 resize-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+                  style={{ minHeight: '38px', maxHeight: '120px' }}
+                />
+                <button
+                  type="submit"
+                  disabled={!inputValue.trim() || isStreaming}
+                  aria-label="Send message"
+                  className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-40 dark:bg-sky-500 dark:hover:bg-sky-400"
+                >
+                  <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                    <path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.925A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.087L2.28 16.762a.75.75 0 0 0 .826.95 28.897 28.897 0 0 0 15.208-7.787.75.75 0 0 0 0-1.049A28.897 28.897 0 0 0 3.105 2.288Z" />
+                  </svg>
+                </button>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse, OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
+import { parseStructuredSearchQuery } from '@/lib/org-inventory/structured-search'
 import { serializeReposContext, serializeOrgContext, serializeOrgInventoryContext, type OrgSortBy } from './serialize-context'
 
 // ---- Types ----------------------------------------------------------------
@@ -33,6 +34,9 @@ export interface ChatPanelProps {
   orgInventory?: OrgInventoryResponse
   githubToken: string
   resetKey?: number
+  /** Controlled repo filter query — synced with the org inventory table */
+  repoQuery?: string
+  onRepoQueryChange?: (q: string) => void
 }
 
 // ---- Constants ------------------------------------------------------------
@@ -201,6 +205,7 @@ function KeyEntryForm({ onSave }: { onSave: (key: string) => void }) {
 
 export function ChatPanel({
   contextType, repoResults, orgView, org, orgRepos = [], orgInventory, githubToken, resetKey,
+  repoQuery = '', onRepoQueryChange,
 }: ChatPanelProps) {
   const [expanded, setExpanded] = useState(false)
   const [model, setModel] = useState<Model>('claude-haiku-4-5')
@@ -453,7 +458,14 @@ export function ChatPanel({
             className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800"
           >
             <span aria-hidden="true" className="text-base">✨</span>
-            <span className="flex-1">Ask a question about this analysis</span>
+            <span className="flex-1">
+              Ask a question about this analysis
+              {repoQuery && (
+                <span className="ml-2 rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-medium text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                  {repoQuery}
+                </span>
+              )}
+            </span>
             <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4 shrink-0">
               <path strokeLinecap="round" strokeLinejoin="round" d="M4 10l4-4 4 4" />
             </svg>
@@ -559,6 +571,45 @@ export function ChatPanel({
               <KeyEntryForm onSave={handleSaveKey} />
             ) : (
               <>
+                {/* Structured search filter (org tab only) */}
+                {contextType === 'org' && onRepoQueryChange && (() => {
+                  const parsed = parseStructuredSearchQuery(repoQuery)
+                  return (
+                    <div className="border-b border-slate-200 px-4 py-2 dark:border-slate-700">
+                      <div className="flex items-center gap-2">
+                        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5 shrink-0 text-slate-400">
+                          <circle cx="6.5" cy="6.5" r="4" /><path strokeLinecap="round" d="M11 11l3 3" />
+                        </svg>
+                        <input
+                          type="text"
+                          value={repoQuery}
+                          onChange={(e) => onRepoQueryChange(e.target.value)}
+                          placeholder="Filter repos: lang:go stars:>500 archived:false"
+                          className="flex-1 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+                        />
+                        {repoQuery && (
+                          <button
+                            type="button"
+                            onClick={() => onRepoQueryChange('')}
+                            className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+                            aria-label="Clear filter"
+                          >
+                            ✕
+                          </button>
+                        )}
+                      </div>
+                      {parsed.invalidTokens.length > 0 && (
+                        <p className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
+                          Ignored: {parsed.invalidTokens.join(', ')}
+                        </p>
+                      )}
+                      <p className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500">
+                        Prefixes: lang: archived: stars: forks: issues: pushed: topic: license:
+                      </p>
+                    </div>
+                  )
+                })()}
+
                 {/* Message history */}
                 <div
                   className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3"

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -605,6 +605,12 @@ export function ChatPanel({
               )
             })()}
 
+            {/* Chat section label */}
+            <div className="flex items-center gap-2 px-4 pt-2 pb-0">
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500">Chat with Claude</span>
+              <div className="flex-1 border-t border-slate-200 dark:border-slate-700" />
+            </div>
+
             {/* Key entry form or chat */}
             {!hasKey ? (
               <KeyEntryForm onSave={handleSaveKey} />

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -17,8 +17,6 @@ interface ChatMessage {
   retryContent?: string
 }
 
-export type OrgSortCriterion = 'stars' | 'health' | 'activity'
-
 export interface ChatPanelProps {
   contextType: 'repos' | 'org'
   /** Repos-tab context */
@@ -119,7 +117,6 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
   const [inputValue, setInputValue] = useState('')
   const [isStreaming, setIsStreaming] = useState(false)
   const [orgRepoCount, setOrgRepoCount] = useState(500)
-  const [orgSort, setOrgSort] = useState<OrgSortCriterion>('stars')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const abortRef = useRef<AbortController | null>(null)
@@ -167,19 +164,12 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
     }
   }
 
-  function handleOrgSortChange(sort: OrgSortCriterion) {
-    if (sort !== orgSort) {
-      setOrgSort(sort)
-      setMessages([])
-    }
-  }
-
   function buildContext(): string {
     if (contextType === 'repos' && repoResults) {
       return serializeReposContext(repoResults).text
     }
     if (contextType === 'org' && orgView && org) {
-      return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount, sortBy: orgSort }).text
+      return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount }).text
     }
     return ''
   }
@@ -196,17 +186,6 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
 
     const controller = new AbortController()
     abortRef.current = controller
-
-    const history: Array<{ role: 'user' | 'assistant'; content: string }> = []
-    setMessages((prev) => {
-      const all = [...prev]
-      for (const m of all) {
-        if (m.role === 'user' || m.role === 'assistant') {
-          history.push({ role: m.role, content: m.content })
-        }
-      }
-      return all
-    })
 
     // Build the message list to send: all prior turns + new user message
     const apiMessages = [
@@ -248,7 +227,16 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
       }
 
       const reader = response.body?.getReader()
-      if (!reader) return
+      if (!reader) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, role: 'error', content: 'Streaming is not supported in this environment — please try again.', retryContent: text }
+              : m,
+          ),
+        )
+        return
+      }
 
       const decoder = new TextDecoder()
       let buffer = ''
@@ -303,7 +291,7 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
       abortRef.current = null
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isStreaming, messages, contextType, githubToken, model, orgRepoCount, orgSort, repoResults, orgView, org])
+  }, [isStreaming, messages, contextType, githubToken, model, orgRepoCount, repoResults, orgView, org])
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -336,7 +324,7 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
 
   const starterChips = contextType === 'repos' ? REPOS_STARTER_CHIPS : ORG_STARTER_CHIPS
   const showChips = messages.length === 0 && !isStreaming
-  const isOrgAndLarge = contextType === 'org'
+  const isOrgAndLarge = contextType === 'org' && (orgView?.status.total ?? 0) > 500
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-40 mx-auto max-w-5xl px-4">
@@ -397,16 +385,6 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
                     <span className="w-8 text-right font-medium">{orgRepoCount}</span>
                     <span>repos</span>
                   </div>
-                  <select
-                    value={orgSort}
-                    onChange={(e) => handleOrgSortChange(e.target.value as OrgSortCriterion)}
-                    className="rounded border border-slate-200 bg-white px-2 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
-                    aria-label="Sort repos by"
-                  >
-                    <option value="stars">⭐ Top by stars</option>
-                    <option value="health">🔴 Lowest health first</option>
-                    <option value="activity">⚡ Most recently active</option>
-                  </select>
                 </>
               ) : null}
 

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -92,6 +92,37 @@ const SEARCH_PREFIX_HINTS: { key: string; description: string; example: string }
   { key: 'license',  description: 'License type',          example: 'license:apache-2.0' },
 ]
 
+const COMPLETION_VALUES: Record<string, string[]> = {
+  lang:     ['go', 'python', 'typescript', 'javascript', 'java', 'rust', 'c++', 'c', 'ruby', 'kotlin', 'swift', 'scala', 'shell'],
+  archived: ['false', 'true'],
+  stars:    ['>100', '>500', '>1000', '>5000', '<100', '<50'],
+  forks:    ['>10', '>50', '>100', '<10'],
+  issues:   ['>10', '>50', '>100', '0', '<10'],
+  pushed:   ['>2025-01-01', '>2024-01-01', '>2023-01-01', '<2023-01-01', '<2022-01-01'],
+  topic:    ['kubernetes', 'machine-learning', 'security', 'cli', 'api', 'docker', 'ai', 'devops'],
+  license:  ['apache-2.0', 'mit', 'gpl-3.0', 'bsd-3-clause', 'mpl-2.0'],
+}
+
+function computeCompletions(query: string): string[] {
+  const lastToken = query.match(/(?:^|\s)(\S*)$/)?.[1] ?? ''
+  if (!lastToken) return []
+  const colonIdx = lastToken.indexOf(':')
+  if (colonIdx !== -1) {
+    const key = lastToken.slice(0, colonIdx).toLowerCase()
+    const valuePrefix = lastToken.slice(colonIdx + 1)
+    const values = COMPLETION_VALUES[key]
+    if (!values) return []
+    return values.filter((v) => v.startsWith(valuePrefix)).map((v) => `${key}:${v}`)
+  }
+  return SEARCH_PREFIX_HINTS
+    .filter((p) => p.key.startsWith(lastToken.toLowerCase()))
+    .map((p) => `${p.key}:`)
+}
+
+function applyCompletion(query: string, completion: string): string {
+  return query.replace(/(\s*)(\S*)$/, (_, space) => `${space}${completion} `).trimStart()
+}
+
 const SS_KEY_ANTHROPIC = 'repopulse:chat:anthropicKey'
 const LS_KEY_MODEL = 'repopulse:chat:model'
 const SS_KEY_EXPANDED = 'repopulse:chat:expanded'
@@ -163,6 +194,103 @@ function renderMarkdown(text: string): React.ReactNode {
       return <p key={`${i}-${j}`} className="mb-2 last:mb-0">{spans}</p>
     })
   })
+}
+
+// ---- Structured search filter with completion -----------------------------
+
+function SearchFilter({ value, onChange }: { value: string; onChange: (q: string) => void }) {
+  const [completions, setCompletions] = useState<string[]>([])
+  const [activeIdx, setActiveIdx] = useState(-1)
+  const blurRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const parsed = parseStructuredSearchQuery(value)
+
+  function open(q: string) {
+    const c = computeCompletions(q)
+    setCompletions(c)
+    setActiveIdx(-1)
+  }
+
+  function close() { setCompletions([]); setActiveIdx(-1) }
+
+  function pick(completion: string) {
+    onChange(applyCompletion(value, completion))
+    close()
+  }
+
+  function handleChange(q: string) { onChange(q); open(q) }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (completions.length === 0) return
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActiveIdx((i) => Math.min(i + 1, completions.length - 1)) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setActiveIdx((i) => Math.max(i - 1, -1)) }
+    else if (e.key === 'Enter' && activeIdx >= 0) { e.preventDefault(); pick(completions[activeIdx]) }
+    else if (e.key === 'Escape') close()
+    else if (e.key === 'Tab' && completions.length > 0) {
+      e.preventDefault()
+      pick(completions[activeIdx >= 0 ? activeIdx : 0])
+    }
+  }
+
+  return (
+    <div className="border-b border-slate-200 px-4 py-2 dark:border-slate-700">
+      <div className="relative flex items-center gap-2">
+        <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5 shrink-0 text-slate-400">
+          <circle cx="6.5" cy="6.5" r="4" /><path strokeLinecap="round" d="M11 11l3 3" />
+        </svg>
+        <div className="relative flex-1">
+          <input
+            type="text"
+            value={value}
+            onChange={(e) => handleChange(e.target.value)}
+            onFocus={() => open(value)}
+            onBlur={() => { blurRef.current = setTimeout(close, 150) }}
+            onKeyDown={handleKeyDown}
+            placeholder="Filter repos: lang:go stars:>500 archived:false"
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+          />
+          {completions.length > 0 && (
+            <ul
+              role="listbox"
+              className="absolute bottom-full left-0 z-50 mb-1 w-full overflow-hidden rounded border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900"
+            >
+              {completions.map((c, i) => (
+                <li key={c} role="option" aria-selected={i === activeIdx}>
+                  <button
+                    type="button"
+                    onMouseDown={(e) => { e.preventDefault(); if (blurRef.current) clearTimeout(blurRef.current); pick(c) }}
+                    className={`w-full px-3 py-1.5 text-left font-mono text-xs ${i === activeIdx ? 'bg-sky-50 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300' : 'text-slate-700 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800'}`}
+                  >
+                    {c}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        {value && (
+          <button type="button" onClick={() => onChange('')} aria-label="Clear filter"
+            className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300">✕</button>
+        )}
+      </div>
+      {parsed.invalidTokens.length > 0 && (
+        <p className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">Ignored: {parsed.invalidTokens.join(', ')}</p>
+      )}
+      <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5">
+        {SEARCH_PREFIX_HINTS.map(({ key, description, example }) => (
+          <span key={key} className="group relative cursor-help">
+            <span className="text-[10px] text-slate-400 underline decoration-dotted underline-offset-2 dark:text-slate-500">{key}:</span>
+            <span className="pointer-events-none invisible absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2.5 py-1.5 opacity-0 shadow-lg transition-opacity group-hover:visible group-hover:opacity-100 dark:bg-slate-700">
+              <span className="block text-[11px] font-medium text-white">{description}</span>
+              <span className="block font-mono text-[10px] text-slate-300">{example}</span>
+              <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-slate-800 dark:border-t-slate-700" />
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 // ---- Key entry form -------------------------------------------------------
@@ -578,54 +706,9 @@ export function ChatPanel({
             </div>
 
             {/* Structured search filter (org tab only, always visible when expanded) */}
-            {contextType === 'org' && onRepoQueryChange && (() => {
-              const parsed = parseStructuredSearchQuery(repoQuery)
-              return (
-                <div className="border-b border-slate-200 px-4 py-2 dark:border-slate-700">
-                  <div className="flex items-center gap-2">
-                    <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="h-3.5 w-3.5 shrink-0 text-slate-400">
-                      <circle cx="6.5" cy="6.5" r="4" /><path strokeLinecap="round" d="M11 11l3 3" />
-                    </svg>
-                    <input
-                      type="text"
-                      value={repoQuery}
-                      onChange={(e) => onRepoQueryChange(e.target.value)}
-                      placeholder="Filter repos: lang:go stars:>500 archived:false"
-                      className="flex-1 rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
-                    />
-                    {repoQuery && (
-                      <button
-                        type="button"
-                        onClick={() => onRepoQueryChange('')}
-                        className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
-                        aria-label="Clear filter"
-                      >
-                        ✕
-                      </button>
-                    )}
-                  </div>
-                  {parsed.invalidTokens.length > 0 && (
-                    <p className="mt-1 text-[10px] text-amber-600 dark:text-amber-400">
-                      Ignored: {parsed.invalidTokens.join(', ')}
-                    </p>
-                  )}
-                  <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5">
-                    {SEARCH_PREFIX_HINTS.map(({ key, description, example }) => (
-                      <span key={key} className="group relative cursor-help">
-                        <span className="text-[10px] text-slate-400 underline decoration-dotted underline-offset-2 dark:text-slate-500">
-                          {key}:
-                        </span>
-                        <span className="pointer-events-none invisible absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2.5 py-1.5 opacity-0 shadow-lg transition-opacity group-hover:visible group-hover:opacity-100 dark:bg-slate-700">
-                          <span className="block text-[11px] font-medium text-white">{description}</span>
-                          <span className="block text-[10px] text-slate-300 font-mono">{example}</span>
-                          <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-slate-800 dark:border-t-slate-700" />
-                        </span>
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )
-            })()}
+            {contextType === 'org' && onRepoQueryChange && (
+              <SearchFilter value={repoQuery} onChange={onRepoQueryChange} />
+            )}
 
             {/* Chat section label */}
             <div className="flex items-center gap-2 px-4 pt-2 pb-0">

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -81,6 +81,17 @@ const SORT_OPTIONS: { value: OrgSortBy; label: string }[] = [
   { value: 'activity', label: '⚡ Most recently active' },
 ]
 
+const SEARCH_PREFIX_HINTS: { key: string; description: string; example: string }[] = [
+  { key: 'lang',     description: 'Programming language',  example: 'lang:go' },
+  { key: 'archived', description: 'Archived status',       example: 'archived:false' },
+  { key: 'stars',    description: 'Star count',            example: 'stars:>500' },
+  { key: 'forks',    description: 'Fork count',            example: 'forks:>10' },
+  { key: 'issues',   description: 'Open issues count',     example: 'issues:<50' },
+  { key: 'pushed',   description: 'Last push date',        example: 'pushed:>2024-01-01' },
+  { key: 'topic',    description: 'Repository topic',      example: 'topic:kubernetes' },
+  { key: 'license',  description: 'License type',          example: 'license:apache-2.0' },
+]
+
 const SS_KEY_ANTHROPIC = 'repopulse:chat:anthropicKey'
 const LS_KEY_MODEL = 'repopulse:chat:model'
 const SS_KEY_EXPANDED = 'repopulse:chat:expanded'
@@ -598,9 +609,20 @@ export function ChatPanel({
                       Ignored: {parsed.invalidTokens.join(', ')}
                     </p>
                   )}
-                  <p className="mt-0.5 text-[10px] text-slate-400 dark:text-slate-500">
-                    Prefixes: lang: archived: stars: forks: issues: pushed: topic: license:
-                  </p>
+                  <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5">
+                    {SEARCH_PREFIX_HINTS.map(({ key, description, example }) => (
+                      <span key={key} className="group relative cursor-help">
+                        <span className="text-[10px] text-slate-400 underline decoration-dotted underline-offset-2 dark:text-slate-500">
+                          {key}:
+                        </span>
+                        <span className="pointer-events-none invisible absolute bottom-full left-1/2 z-50 mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2.5 py-1.5 opacity-0 shadow-lg transition-opacity group-hover:visible group-hover:opacity-100 dark:bg-slate-700">
+                          <span className="block text-[11px] font-medium text-white">{description}</span>
+                          <span className="block text-[10px] text-slate-300 font-mono">{example}</span>
+                          <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-slate-800 dark:border-t-slate-700" />
+                        </span>
+                      </span>
+                    ))}
+                  </div>
                 </div>
               )
             })()}

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -2,30 +2,35 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
-import { serializeReposContext, serializeOrgContext } from './serialize-context'
+import { serializeReposContext, serializeOrgContext, type OrgSortBy } from './serialize-context'
 
 // ---- Types ----------------------------------------------------------------
 
 type Model = 'claude-haiku-4-5' | 'claude-sonnet-4-6'
 
+interface MessageUsage {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+}
+
 interface ChatMessage {
   id: string
   role: 'user' | 'assistant' | 'error'
   content: string
-  /** Original user question preserved when an error happens so they can retry */
+  usage?: MessageUsage
   retryContent?: string
 }
 
 export interface ChatPanelProps {
   contextType: 'repos' | 'org'
-  /** Repos-tab context */
   repoResults?: AnalysisResult[]
-  /** Org-tab context */
   orgView?: OrgSummaryViewModel
   org?: string
+  orgRepos?: OrgRepoSummary[]
   githubToken: string
-  /** Reset key — when it changes, conversation is cleared */
   resetKey?: number
 }
 
@@ -45,13 +50,28 @@ const ORG_STARTER_CHIPS = [
   'Are there repos with low activity but high star counts?',
 ]
 
-const MODEL_LABELS: Record<Model, { icon: string; label: string; hint: string }> = {
-  'claude-haiku-4-5': { icon: '⚡', label: 'Fast', hint: 'Best for quick lookups and factual questions about the data' },
-  'claude-sonnet-4-6': { icon: '🧠', label: 'Deep', hint: 'Better for multi-hop reasoning, comparisons, and nuanced recommendations' },
+const MODEL_META: Record<Model, { icon: string; label: string; hint: string; inputRate: number; outputRate: number; cacheReadRate: number }> = {
+  'claude-haiku-4-5': {
+    icon: '⚡', label: 'Fast',
+    hint: 'Best for quick lookups and factual questions about the data',
+    inputRate: 0.80, outputRate: 4.00, cacheReadRate: 0.08,
+  },
+  'claude-sonnet-4-6': {
+    icon: '🧠', label: 'Deep',
+    hint: 'Better for multi-hop reasoning, comparisons, and nuanced recommendations',
+    inputRate: 3.00, outputRate: 15.00, cacheReadRate: 0.30,
+  },
 }
 
-const LOCAL_STORAGE_MODEL_KEY = 'repopulse:chat:model'
-const SESSION_STORAGE_EXPANDED_KEY = 'repopulse:chat:expanded'
+const SORT_OPTIONS: { value: OrgSortBy; label: string }[] = [
+  { value: 'stars', label: '⭐ Top by stars' },
+  { value: 'health', label: '🔴 Lowest health first' },
+  { value: 'activity', label: '⚡ Most recently active' },
+]
+
+const SS_KEY_ANTHROPIC = 'repopulse:chat:anthropicKey'
+const LS_KEY_MODEL = 'repopulse:chat:model'
+const SS_KEY_EXPANDED = 'repopulse:chat:expanded'
 
 // ---- Helpers --------------------------------------------------------------
 
@@ -61,23 +81,44 @@ function uid(): string {
 
 function readStoredModel(): Model {
   try {
-    const v = localStorage.getItem(LOCAL_STORAGE_MODEL_KEY)
+    const v = localStorage.getItem(LS_KEY_MODEL)
     if (v === 'claude-haiku-4-5' || v === 'claude-sonnet-4-6') return v
   } catch {}
   return 'claude-haiku-4-5'
 }
 
 function readStoredExpanded(): boolean {
-  try {
-    return sessionStorage.getItem(SESSION_STORAGE_EXPANDED_KEY) === 'true'
-  } catch {}
+  try { return sessionStorage.getItem(SS_KEY_EXPANDED) === 'true' } catch {}
   return false
 }
 
-// ---- Simple markdown renderer (bold + paragraphs + code blocks) -----------
+function readStoredKey(): string {
+  try { return sessionStorage.getItem(SS_KEY_ANTHROPIC) ?? '' } catch {}
+  return ''
+}
+
+function calcCost(usage: MessageUsage, model: Model): number {
+  const { inputRate, outputRate, cacheReadRate } = MODEL_META[model]
+  return (
+    (usage.inputTokens * inputRate +
+      usage.outputTokens * outputRate +
+      usage.cacheReadTokens * cacheReadRate) /
+    1_000_000
+  )
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.0001) return '<$0.0001'
+  return `$${usd.toFixed(4)}`
+}
+
+function formatTokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
+}
+
+// ---- Markdown renderer (paragraphs, bold, inline code, fenced code) -------
 
 function renderMarkdown(text: string): React.ReactNode {
-  // Split by code fences first
   const parts = text.split(/(```[\s\S]*?```)/g)
   return parts.map((part, i) => {
     if (part.startsWith('```')) {
@@ -88,43 +129,88 @@ function renderMarkdown(text: string): React.ReactNode {
         </pre>
       )
     }
-    // Process inline: bold, code, paragraphs
     return part.split('\n\n').filter(Boolean).map((para, j) => {
       const spans = para.split(/(\*\*[^*]+\*\*|`[^`]+`)/g).map((seg, k) => {
-        if (seg.startsWith('**') && seg.endsWith('**')) {
+        if (seg.startsWith('**') && seg.endsWith('**'))
           return <strong key={k}>{seg.slice(2, -2)}</strong>
-        }
-        if (seg.startsWith('`') && seg.endsWith('`')) {
+        if (seg.startsWith('`') && seg.endsWith('`'))
           return <code key={k} className="rounded bg-slate-100 px-1 font-mono text-xs dark:bg-slate-800">{seg.slice(1, -1)}</code>
-        }
         return <span key={k}>{seg}</span>
       })
-      return (
-        <p key={`${i}-${j}`} className="mb-2 last:mb-0">
-          {spans}
-        </p>
-      )
+      return <p key={`${i}-${j}`} className="mb-2 last:mb-0">{spans}</p>
     })
   })
 }
 
+// ---- Key entry form -------------------------------------------------------
+
+function KeyEntryForm({ onSave }: { onSave: (key: string) => void }) {
+  const [value, setValue] = useState('')
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      <div>
+        <label htmlFor="chat-anthropic-key" className="block text-sm font-medium text-slate-800 dark:text-slate-200">
+          Anthropic API key
+        </label>
+        <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+          Your key is sent only to Anthropic to generate responses. It is never logged, stored on our
+          servers, or used for anything other than this chat session.
+        </p>
+      </div>
+      <input
+        id="chat-anthropic-key"
+        type="password"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="sk-ant-…"
+        autoComplete="off"
+        spellCheck={false}
+        className="w-full rounded border border-slate-300 bg-slate-50 px-3 py-1.5 font-mono text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+      />
+      <div className="flex items-center justify-between gap-3">
+        <a
+          href="https://console.anthropic.com/settings/keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-sky-700 hover:underline dark:text-sky-400"
+        >
+          Get a free key at console.anthropic.com →
+        </a>
+        <button
+          type="button"
+          disabled={!value.trim()}
+          onClick={() => onSave(value.trim())}
+          className="rounded bg-slate-800 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700 disabled:opacity-40 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-white"
+        >
+          Save key
+        </button>
+      </div>
+    </div>
+  )
+}
+
 // ---- Main component -------------------------------------------------------
 
-export function ChatPanel({ contextType, repoResults, orgView, org, githubToken, resetKey }: ChatPanelProps) {
+export function ChatPanel({
+  contextType, repoResults, orgView, org, orgRepos = [], githubToken, resetKey,
+}: ChatPanelProps) {
   const [expanded, setExpanded] = useState(false)
   const [model, setModel] = useState<Model>('claude-haiku-4-5')
+  const [anthropicKey, setAnthropicKey] = useState('')
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [inputValue, setInputValue] = useState('')
   const [isStreaming, setIsStreaming] = useState(false)
   const [orgRepoCount, setOrgRepoCount] = useState(500)
+  const [sortBy, setSortBy] = useState<OrgSortBy>('stars')
+  const [sessionUsage, setSessionUsage] = useState<{ messages: number; totalCost: number }>({ messages: 0, totalCost: 0 })
   const messagesEndRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLTextAreaElement>(null)
   const abortRef = useRef<AbortController | null>(null)
 
   // Hydrate from storage after mount
   useEffect(() => {
     setModel(readStoredModel())
     setExpanded(readStoredExpanded())
+    setAnthropicKey(readStoredKey())
   }, [])
 
   // Reset conversation when resetKey changes
@@ -132,45 +218,63 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
     if (resetKey === undefined) return
     setMessages([])
     setInputValue('')
+    setSessionUsage({ messages: 0, totalCost: 0 })
     abortRef.current?.abort()
     abortRef.current = null
     setIsStreaming(false)
-    try { sessionStorage.removeItem(SESSION_STORAGE_EXPANDED_KEY) } catch {}
+    try { sessionStorage.removeItem(SS_KEY_EXPANDED) } catch {}
     setExpanded(false)
   }, [resetKey])
 
   // Scroll to latest message
   useEffect(() => {
-    if (expanded) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-    }
+    if (expanded) messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, expanded])
 
   function handleExpandToggle() {
     const next = !expanded
     setExpanded(next)
-    try { sessionStorage.setItem(SESSION_STORAGE_EXPANDED_KEY, String(next)) } catch {}
+    try { sessionStorage.setItem(SS_KEY_EXPANDED, String(next)) } catch {}
   }
 
   function handleModelChange(m: Model) {
     setModel(m)
-    try { localStorage.setItem(LOCAL_STORAGE_MODEL_KEY, m) } catch {}
+    try { localStorage.setItem(LS_KEY_MODEL, m) } catch {}
+  }
+
+  function handleSaveKey(key: string) {
+    setAnthropicKey(key)
+    try { sessionStorage.setItem(SS_KEY_ANTHROPIC, key) } catch {}
+  }
+
+  function handleClearKey() {
+    setAnthropicKey('')
+    try { sessionStorage.removeItem(SS_KEY_ANTHROPIC) } catch {}
+    setMessages([])
+    setSessionUsage({ messages: 0, totalCost: 0 })
   }
 
   function handleOrgRepoCountChange(count: number) {
     if (count !== orgRepoCount) {
       setOrgRepoCount(count)
       setMessages([])
+      setSessionUsage({ messages: 0, totalCost: 0 })
+    }
+  }
+
+  function handleSortByChange(s: OrgSortBy) {
+    if (s !== sortBy) {
+      setSortBy(s)
+      setMessages([])
+      setSessionUsage({ messages: 0, totalCost: 0 })
     }
   }
 
   function buildContext(): string {
-    if (contextType === 'repos' && repoResults) {
+    if (contextType === 'repos' && repoResults)
       return serializeReposContext(repoResults).text
-    }
-    if (contextType === 'org' && orgView && org) {
-      return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount }).text
-    }
+    if (contextType === 'org' && orgView && org)
+      return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount, sortBy, orgRepos }).text
     return ''
   }
 
@@ -187,7 +291,6 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
     const controller = new AbortController()
     abortRef.current = controller
 
-    // Build the message list to send: all prior turns + new user message
     const apiMessages = [
       ...messages
         .filter((m) => m.role === 'user' || m.role === 'assistant')
@@ -204,6 +307,7 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
           context: buildContext(),
           contextType,
           githubToken,
+          anthropicKey: anthropicKey || undefined,
           model,
         }),
         signal: controller.signal,
@@ -214,14 +318,10 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
         const code = payload.error?.code
         const msg =
           code === 'NOT_CONFIGURED'
-            ? "AI chat isn't available in this deployment."
+            ? "AI chat isn't available — please provide an Anthropic API key."
             : payload.error?.message ?? 'Something went wrong — please try again in a moment.'
         setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId
-              ? { ...m, role: 'error', content: msg, retryContent: text }
-              : m,
-          ),
+          prev.map((m) => m.id === assistantId ? { ...m, role: 'error', content: msg, retryContent: text } : m),
         )
         return
       }
@@ -231,7 +331,7 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
         setMessages((prev) =>
           prev.map((m) =>
             m.id === assistantId
-              ? { ...m, role: 'error', content: 'Streaming is not supported in this environment — please try again.', retryContent: text }
+              ? { ...m, role: 'error', content: 'Streaming is not supported in this environment.', retryContent: text }
               : m,
           ),
         )
@@ -240,6 +340,7 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
 
       const decoder = new TextDecoder()
       let buffer = ''
+      let msgUsage: MessageUsage | undefined
 
       while (true) {
         const { done, value } = await reader.read()
@@ -250,27 +351,31 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
 
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue
-          const json = line.slice(6)
-          let event: { type: string; text?: string; code?: string; message?: string }
-          try { event = JSON.parse(json) } catch { continue }
+          let event: { type: string; text?: string; code?: string; message?: string; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number }
+          try { event = JSON.parse(line.slice(6)) } catch { continue }
 
           if (event.type === 'delta' && event.text) {
             setMessages((prev) =>
-              prev.map((m) =>
-                m.id === assistantId ? { ...m, content: m.content + event.text! } : m,
-              ),
+              prev.map((m) => m.id === assistantId ? { ...m, content: m.content + event.text! } : m),
             )
+          } else if (event.type === 'usage') {
+            msgUsage = {
+              inputTokens: event.inputTokens ?? 0,
+              outputTokens: event.outputTokens ?? 0,
+              cacheReadTokens: event.cacheReadTokens ?? 0,
+            }
+            setMessages((prev) =>
+              prev.map((m) => m.id === assistantId ? { ...m, usage: msgUsage } : m),
+            )
+            const cost = calcCost(msgUsage, model)
+            setSessionUsage((prev) => ({ messages: prev.messages + 1, totalCost: prev.totalCost + cost }))
           } else if (event.type === 'error') {
             const noRetry = event.code === 'NOT_CONFIGURED' || event.code === 'CONTEXT_TOO_LARGE'
+            const showKeyLink = event.code === 'INVALID_KEY'
             setMessages((prev) =>
               prev.map((m) =>
                 m.id === assistantId
-                  ? {
-                      ...m,
-                      role: 'error',
-                      content: event.message ?? 'Something went wrong.',
-                      retryContent: noRetry ? undefined : text,
-                    }
+                  ? { ...m, role: 'error', content: event.message ?? 'Something went wrong.', retryContent: noRetry ? undefined : text, ...(showKeyLink ? { isKeyError: true } : {}) }
                   : m,
               ),
             )
@@ -291,7 +396,7 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
       abortRef.current = null
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isStreaming, messages, contextType, githubToken, model, orgRepoCount, repoResults, orgView, org])
+  }, [isStreaming, messages, contextType, githubToken, anthropicKey, model, orgRepoCount, sortBy, repoResults, orgView, org, orgRepos])
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -299,18 +404,10 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      void sendMessage(inputValue)
-    }
-  }
-
-  function handleChipClick(chip: string) {
-    void sendMessage(chip)
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void sendMessage(inputValue) }
   }
 
   function handleRetry(retryContent: string) {
-    // Remove the error message and resend
     setMessages((prev) => prev.filter((m) => m.retryContent !== retryContent))
     void sendMessage(retryContent)
   }
@@ -319,16 +416,19 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
     abortRef.current?.abort()
     abortRef.current = null
     setMessages([])
+    setSessionUsage({ messages: 0, totalCost: 0 })
     setIsStreaming(false)
   }
 
   const starterChips = contextType === 'repos' ? REPOS_STARTER_CHIPS : ORG_STARTER_CHIPS
   const showChips = messages.length === 0 && !isStreaming
   const isOrgAndLarge = contextType === 'org' && (orgView?.status.total ?? 0) > 500
+  const hasKey = !!anthropicKey
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-40 mx-auto max-w-5xl px-4">
       <div className="rounded-t-2xl border border-b-0 border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900">
+
         {/* Collapsed bar */}
         {!expanded ? (
           <button
@@ -350,11 +450,11 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
 
               {/* Model switcher */}
               <div className="flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 p-0.5 dark:border-slate-700 dark:bg-slate-800">
-                {(Object.entries(MODEL_LABELS) as [Model, (typeof MODEL_LABELS)[Model]][]).map(([m, info]) => (
+                {(Object.entries(MODEL_META) as [Model, typeof MODEL_META[Model]][]).map(([m, info]) => (
                   <button
                     key={m}
                     type="button"
-                    title={info.hint}
+                    title={`${info.hint} · Input $${info.inputRate}/1M · Output $${info.outputRate}/1M`}
                     onClick={() => handleModelChange(m)}
                     className={
                       model === m
@@ -368,10 +468,10 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
               </div>
 
               {/* Org controls */}
-              {isOrgAndLarge ? (
+              {isOrgAndLarge && (
                 <>
                   <div className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400">
-                    <label htmlFor="chat-repo-count" className="whitespace-nowrap">Analyzing top</label>
+                    <label htmlFor="chat-repo-count" className="whitespace-nowrap">Top</label>
                     <input
                       id="chat-repo-count"
                       type="range"
@@ -380,16 +480,43 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
                       step="50"
                       value={orgRepoCount}
                       onChange={(e) => handleOrgRepoCountChange(Number(e.target.value))}
-                      className="w-24 accent-sky-600"
+                      className="w-20 accent-sky-600"
                     />
                     <span className="w-8 text-right font-medium">{orgRepoCount}</span>
                     <span>repos</span>
                   </div>
+                  <select
+                    value={sortBy}
+                    onChange={(e) => handleSortByChange(e.target.value as OrgSortBy)}
+                    className="rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300"
+                  >
+                    {SORT_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+                  </select>
                 </>
-              ) : null}
+              )}
+
+              {/* Session cost */}
+              {sessionUsage.messages > 0 && (
+                <span className="text-xs text-slate-400 dark:text-slate-500">
+                  Session: {sessionUsage.messages} {sessionUsage.messages === 1 ? 'msg' : 'msgs'} · {formatCost(sessionUsage.totalCost)}
+                </span>
+              )}
 
               <div className="ml-auto flex items-center gap-2">
-                {messages.length > 0 ? (
+                {/* Change key */}
+                {hasKey && (
+                  <button
+                    type="button"
+                    onClick={handleClearKey}
+                    className="text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
+                    title="Clear stored API key"
+                  >
+                    Change key
+                  </button>
+                )}
+                {messages.length > 0 && (
                   <button
                     type="button"
                     onClick={handleNewConversation}
@@ -397,7 +524,7 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
                   >
                     New conversation
                   </button>
-                ) : null}
+                )}
                 <button
                   type="button"
                   onClick={handleExpandToggle}
@@ -411,102 +538,116 @@ export function ChatPanel({ contextType, repoResults, orgView, org, githubToken,
               </div>
             </div>
 
-            {/* Message history */}
-            <div
-              className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3"
-              aria-live="polite"
-              aria-label="Chat messages"
-            >
-              {showChips ? (
-                <div className="flex flex-wrap gap-2">
-                  {starterChips.map((chip) => (
-                    <button
-                      key={chip}
-                      type="button"
-                      onClick={() => handleChipClick(chip)}
-                      className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-                    >
-                      {chip}
-                    </button>
-                  ))}
-                </div>
-              ) : null}
-
-              {messages.map((msg) => {
-                if (msg.role === 'user') {
-                  return (
-                    <div key={msg.id} className="flex justify-end">
-                      <div className="max-w-[80%] rounded-2xl bg-sky-600 px-4 py-2 text-sm text-white">
-                        {msg.content}
-                      </div>
-                    </div>
-                  )
-                }
-                if (msg.role === 'error') {
-                  return (
-                    <div key={msg.id} className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200">
-                      <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
-                        <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
-                      </svg>
-                      <div className="flex-1">
-                        <p>{msg.content}</p>
-                        {msg.retryContent ? (
-                          <button
-                            type="button"
-                            onClick={() => handleRetry(msg.retryContent!)}
-                            className="mt-1 text-xs font-medium underline hover:no-underline"
-                          >
-                            Retry
-                          </button>
-                        ) : null}
-                      </div>
-                    </div>
-                  )
-                }
-                // assistant
-                return (
-                  <div key={msg.id} className="flex justify-start">
-                    <div className="max-w-[85%] rounded-2xl bg-slate-100 px-4 py-2 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">
-                      {msg.content ? (
-                        <div className="prose prose-sm max-w-none dark:prose-invert">
-                          {renderMarkdown(msg.content)}
-                        </div>
-                      ) : (
-                        <span className="animate-pulse text-slate-400">●</span>
-                      )}
-                    </div>
-                  </div>
-                )
-              })}
-              <div ref={messagesEndRef} />
-            </div>
-
-            {/* Input area */}
-            <form onSubmit={handleSubmit} className="border-t border-slate-200 px-4 py-3 dark:border-slate-700">
-              <div className="flex items-end gap-2">
-                <textarea
-                  ref={inputRef}
-                  value={inputValue}
-                  onChange={(e) => setInputValue(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  placeholder="Ask a question…"
-                  rows={1}
-                  disabled={isStreaming}
-                  className="flex-1 resize-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
-                  style={{ minHeight: '38px', maxHeight: '120px' }}
-                />
-                <button
-                  type="submit"
-                  disabled={!inputValue.trim() || isStreaming}
-                  aria-label="Send message"
-                  className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-40 dark:bg-sky-500 dark:hover:bg-sky-400"
+            {/* Key entry form or chat */}
+            {!hasKey ? (
+              <KeyEntryForm onSave={handleSaveKey} />
+            ) : (
+              <>
+                {/* Message history */}
+                <div
+                  className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3"
+                  aria-live="polite"
+                  aria-label="Chat messages"
                 >
-                  <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
-                    <path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.925A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.087L2.28 16.762a.75.75 0 0 0 .826.95 28.897 28.897 0 0 0 15.208-7.787.75.75 0 0 0 0-1.049A28.897 28.897 0 0 0 3.105 2.288Z" />
-                  </svg>
-                </button>
-              </div>
-            </form>
+                  {showChips && (
+                    <div className="flex flex-wrap gap-2">
+                      {starterChips.map((chip) => (
+                        <button
+                          key={chip}
+                          type="button"
+                          onClick={() => void sendMessage(chip)}
+                          className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                        >
+                          {chip}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+
+                  {messages.map((msg) => {
+                    if (msg.role === 'user') {
+                      return (
+                        <div key={msg.id} className="flex justify-end">
+                          <div className="max-w-[80%] rounded-2xl bg-sky-600 px-4 py-2 text-sm text-white">
+                            {msg.content}
+                          </div>
+                        </div>
+                      )
+                    }
+
+                    if (msg.role === 'error') {
+                      return (
+                        <div key={msg.id} className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200">
+                          <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
+                            <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+                          </svg>
+                          <div className="flex-1">
+                            <p>{msg.content}</p>
+                            {msg.retryContent && (
+                              <button
+                                type="button"
+                                onClick={() => handleRetry(msg.retryContent!)}
+                                className="mt-1 text-xs font-medium underline hover:no-underline"
+                              >
+                                Retry
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      )
+                    }
+
+                    // assistant
+                    return (
+                      <div key={msg.id} className="flex flex-col items-start gap-1">
+                        <div className="max-w-[85%] rounded-2xl bg-slate-100 px-4 py-2 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">
+                          {msg.content ? (
+                            <div className="prose prose-sm max-w-none dark:prose-invert">
+                              {renderMarkdown(msg.content)}
+                            </div>
+                          ) : (
+                            <span className="animate-pulse text-slate-400">●</span>
+                          )}
+                        </div>
+                        {msg.usage && (
+                          <p className="px-1 text-[10px] text-slate-400 dark:text-slate-500">
+                            ↑ {formatTokens(msg.usage.inputTokens)} · ↓ {formatTokens(msg.usage.outputTokens)} · {formatCost(calcCost(msg.usage, model))}
+                            {msg.usage.cacheReadTokens > 0 && ` · ${formatTokens(msg.usage.cacheReadTokens)} cached`}
+                          </p>
+                        )}
+                      </div>
+                    )
+                  })}
+                  <div ref={messagesEndRef} />
+                </div>
+
+                {/* Input area */}
+                <form onSubmit={handleSubmit} className="border-t border-slate-200 px-4 py-3 dark:border-slate-700">
+                  <div className="flex items-end gap-2">
+                    <textarea
+                      value={inputValue}
+                      onChange={(e) => setInputValue(e.target.value)}
+                      onKeyDown={handleKeyDown}
+                      placeholder="Ask a question…"
+                      rows={1}
+                      disabled={isStreaming}
+                      className="flex-1 resize-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+                      style={{ minHeight: '38px', maxHeight: '120px' }}
+                    />
+                    <button
+                      type="submit"
+                      disabled={!inputValue.trim() || isStreaming}
+                      aria-label="Send message"
+                      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-40 dark:bg-sky-500 dark:hover:bg-sky-400"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                        <path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.925A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.087L2.28 16.762a.75.75 0 0 0 .826.95 28.897 28.897 0 0 0 15.208-7.787.75.75 0 0 0 0-1.049A28.897 28.897 0 0 0 3.105 2.288Z" />
+                      </svg>
+                    </button>
+                  </div>
+                </form>
+              </>
+            )}
           </>
         )}
       </div>

--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -1,4 +1,5 @@
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
 
 export type ChatContextType = 'repos' | 'org'
@@ -59,12 +60,51 @@ function extractPanelValue(panel: { value: unknown; status: string; contributing
   return { status: panel.status, repoCount: panel.contributingReposCount, data: panel.value }
 }
 
+export type OrgSortBy = 'stars' | 'health' | 'activity'
+
+const HEALTH_ORDER: Record<string, number> = { failed: 0, 'in-progress': 1, queued: 2, done: 3 }
+
+function sortedRepoNames(
+  perRepoStatusList: OrgSummaryViewModel['perRepoStatusList'],
+  orgRepos: OrgRepoSummary[],
+  sortBy: OrgSortBy,
+): string[] {
+  const repoIndex = new Map(orgRepos.map((r) => [r.repo, r]))
+  const list = [...perRepoStatusList]
+
+  if (sortBy === 'stars') {
+    list.sort((a, b) => {
+      const sa = repoIndex.get(a.repo)?.stars
+      const sb = repoIndex.get(b.repo)?.stars
+      const na = typeof sa === 'number' ? sa : -1
+      const nb = typeof sb === 'number' ? sb : -1
+      return nb - na
+    })
+  } else if (sortBy === 'activity') {
+    list.sort((a, b) => {
+      const pa = repoIndex.get(a.repo)?.pushedAt
+      const pb = repoIndex.get(b.repo)?.pushedAt
+      const da = typeof pa === 'string' ? pa : ''
+      const db = typeof pb === 'string' ? pb : ''
+      return db.localeCompare(da)
+    })
+  } else {
+    // health: failed first (most urgent)
+    list.sort((a, b) => (HEALTH_ORDER[a.badge] ?? 99) - (HEALTH_ORDER[b.badge] ?? 99))
+  }
+
+  return list.map((e) => e.repo)
+}
+
 export function serializeOrgContext(
   org: string,
   view: OrgSummaryViewModel,
-  opts: { maxRepos?: number } = {},
+  opts: { maxRepos?: number; sortBy?: OrgSortBy; orgRepos?: OrgRepoSummary[] } = {},
 ): SerializedChatContext {
-  const { maxRepos = 500 } = opts
+  const { maxRepos = 500, sortBy = 'stars', orgRepos = [] } = opts
+
+  const orderedRepoNames = sortedRepoNames(view.perRepoStatusList, orgRepos, sortBy)
+  const statusByRepo = new Map(view.perRepoStatusList.map((e) => [e.repo, e]))
 
   const summary = {
     org,
@@ -90,12 +130,19 @@ export function serializeOrgContext(
       repoAge: extractPanelValue(view.panels['repo-age']),
       languages: extractPanelValue(view.panels['languages']),
     },
+    sortedBy: sortBy,
     maxReposIncluded: maxRepos,
-    perRepoSummary: view.perRepoStatusList.slice(0, maxRepos).map((e) => ({
-      repo: e.repo,
-      status: e.status,
-      error: e.errorReason,
-    })),
+    perRepoSummary: orderedRepoNames.slice(0, maxRepos).map((repo) => {
+      const e = statusByRepo.get(repo)
+      const inv = orgRepos.find((r) => r.repo === repo)
+      return {
+        repo,
+        status: e?.status,
+        error: e?.errorReason,
+        stars: typeof inv?.stars === 'number' ? inv.stars : undefined,
+        pushedAt: typeof inv?.pushedAt === 'string' ? inv.pushedAt : undefined,
+      }
+    }),
   }
 
   const text = [

--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -1,5 +1,5 @@
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
-import type { OrgRepoSummary } from '@/lib/analyzer/org-inventory'
+import type { OrgInventoryResponse, OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
 
 export type ChatContextType = 'repos' | 'org'
@@ -151,6 +151,64 @@ export function serializeOrgContext(
     '',
     '```json',
     JSON.stringify(summary, null, 2),
+    '```',
+  ].join('\n')
+
+  return { contextType: 'org', text }
+}
+
+function sortInventoryRepos(results: OrgRepoSummary[], sortBy: OrgSortBy): OrgRepoSummary[] {
+  const list = [...results]
+  if (sortBy === 'stars') {
+    list.sort((a, b) => {
+      const na = typeof a.stars === 'number' ? a.stars : -1
+      const nb = typeof b.stars === 'number' ? b.stars : -1
+      return nb - na
+    })
+  } else if (sortBy === 'activity') {
+    list.sort((a, b) => {
+      const da = typeof a.pushedAt === 'string' ? a.pushedAt : ''
+      const db = typeof b.pushedAt === 'string' ? b.pushedAt : ''
+      return db.localeCompare(da)
+    })
+  }
+  // 'health' not meaningful at inventory phase — keep fetch order
+  return list
+}
+
+export function serializeOrgInventoryContext(
+  inventory: OrgInventoryResponse,
+  opts: { maxRepos?: number; sortBy?: OrgSortBy } = {},
+): SerializedChatContext {
+  const { maxRepos = 500, sortBy = 'stars' } = opts
+  const sorted = sortInventoryRepos(inventory.results, sortBy).slice(0, maxRepos)
+
+  const payload = {
+    org: inventory.org,
+    phase: 'inventory',
+    summary: inventory.summary,
+    sortedBy: sortBy,
+    maxReposIncluded: maxRepos,
+    repos: sorted.map((r) => ({
+      repo: r.repo,
+      language: r.primaryLanguage,
+      stars: r.stars,
+      forks: r.forks,
+      openIssues: r.openIssues,
+      pushedAt: r.pushedAt,
+      archived: r.archived,
+      isFork: r.isFork,
+      topics: r.topics,
+      description: r.description,
+    })),
+  }
+
+  const text = [
+    `# Org Inventory Context (pre-analysis)`,
+    `Organization: ${inventory.org} · ${inventory.results.length} repos fetched, analysis not yet run`,
+    '',
+    '```json',
+    JSON.stringify(payload, null, 2),
     '```',
   ].join('\n')
 

--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -62,7 +62,7 @@ function extractPanelValue(panel: { value: unknown; status: string; contributing
 export function serializeOrgContext(
   org: string,
   view: OrgSummaryViewModel,
-  opts: { maxRepos?: number; sortBy?: 'stars' | 'health' | 'activity' } = {},
+  opts: { maxRepos?: number } = {},
 ): SerializedChatContext {
   const { maxRepos = 500 } = opts
 

--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -1,0 +1,111 @@
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
+
+export type ChatContextType = 'repos' | 'org'
+
+export interface SerializedChatContext {
+  contextType: ChatContextType
+  text: string
+}
+
+function pick<T extends object, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> {
+  const result = {} as Pick<T, K>
+  for (const k of keys) {
+    result[k] = obj[k]
+  }
+  return result
+}
+
+function summarizeRepo(r: AnalysisResult): object {
+  return pick(r, [
+    'repo',
+    'name',
+    'description',
+    'primaryLanguage',
+    'stars',
+    'forks',
+    'commits30d',
+    'commits90d',
+    'releases12mo',
+    'prsOpened90d',
+    'prsMerged90d',
+    'issuesOpen',
+    'issuesClosed90d',
+    'uniqueCommitAuthors90d',
+    'totalContributors',
+    'maintainerCount',
+    'securityResult',
+    'documentationResult',
+    'licensingResult',
+    'inclusiveNamingResult',
+  ])
+}
+
+export function serializeReposContext(results: AnalysisResult[]): SerializedChatContext {
+  const summaries = results.map(summarizeRepo)
+  const text = [
+    `# Repository Analysis Context`,
+    `Analyzed ${results.length} repo(s): ${results.map((r) => r.repo).join(', ')}`,
+    '',
+    '```json',
+    JSON.stringify(summaries, null, 2),
+    '```',
+  ].join('\n')
+  return { contextType: 'repos', text }
+}
+
+function extractPanelValue(panel: { value: unknown; status: string; contributingReposCount: number } | undefined): unknown {
+  if (!panel) return null
+  return { status: panel.status, repoCount: panel.contributingReposCount, data: panel.value }
+}
+
+export function serializeOrgContext(
+  org: string,
+  view: OrgSummaryViewModel,
+  opts: { maxRepos?: number; sortBy?: 'stars' | 'health' | 'activity' } = {},
+): SerializedChatContext {
+  const { maxRepos = 500 } = opts
+
+  const summary = {
+    org,
+    runStatus: {
+      total: view.status.total,
+      succeeded: view.status.succeeded,
+      failed: view.status.failed,
+      status: view.status.status,
+    },
+    panels: {
+      projectFootprint: extractPanelValue(view.panels['project-footprint']),
+      securityRollup: extractPanelValue(view.panels['security-rollup']),
+      busFactor: extractPanelValue(view.panels['bus-factor']),
+      contributorDiversity: extractPanelValue(view.panels['contributor-diversity']),
+      maintainers: extractPanelValue(view.panels['maintainers']),
+      activityRollup: extractPanelValue(view.panels['activity-rollup']),
+      responsivenessRollup: extractPanelValue(view.panels['responsiveness-rollup']),
+      documentationCoverage: extractPanelValue(view.panels['documentation-coverage']),
+      licenseConsistency: extractPanelValue(view.panels['license-consistency']),
+      governance: extractPanelValue(view.panels['governance']),
+      orgRecommendations: extractPanelValue(view.panels['org-recommendations']),
+      inactiveRepos: extractPanelValue(view.panels['inactive-repos']),
+      repoAge: extractPanelValue(view.panels['repo-age']),
+      languages: extractPanelValue(view.panels['languages']),
+    },
+    maxReposIncluded: maxRepos,
+    perRepoSummary: view.perRepoStatusList.slice(0, maxRepos).map((e) => ({
+      repo: e.repo,
+      status: e.status,
+      error: e.errorReason,
+    })),
+  }
+
+  const text = [
+    `# Org Analysis Context`,
+    `Organization: ${org} (${view.status.succeeded} repos analyzed)`,
+    '',
+    '```json',
+    JSON.stringify(summary, null, 2),
+    '```',
+  ].join('\n')
+
+  return { contextType: 'org', text }
+}

--- a/components/org-inventory/OrgInventoryView.tsx
+++ b/components/org-inventory/OrgInventoryView.tsx
@@ -28,6 +28,9 @@ interface OrgInventoryViewProps {
   onAnalyzeSelected: (repos: string[]) => void
   onAnalyzeAllActive?: (repos: string[]) => void
   afterSummary?: React.ReactNode
+  /** Controlled repo query — when provided the structured search UI moves to the chat panel */
+  repoQuery?: string
+  onRepoQueryChange?: (q: string) => void
 }
 
 export function OrgInventoryView({
@@ -39,7 +42,10 @@ export function OrgInventoryView({
   onAnalyzeSelected,
   onAnalyzeAllActive,
   afterSummary,
+  repoQuery: controlledRepoQuery,
+  onRepoQueryChange,
 }: OrgInventoryViewProps) {
+  const controlled = controlledRepoQuery !== undefined
   const [filters, setFilters] = useState<OrgInventoryFilters>({
     repoQuery: '',
   })
@@ -53,11 +59,14 @@ export function OrgInventoryView({
   const [selectedRepos, setSelectedRepos] = useState<string[]>([])
   const [selectedOnly, setSelectedOnly] = useState<boolean>(false)
   const [repoTableExpanded, setRepoTableExpanded] = useState(true)
-  const parsedQuery = useMemo(() => parseStructuredSearchQuery(filters.repoQuery), [filters.repoQuery])
+  const effectiveRepoQuery = controlled ? (controlledRepoQuery ?? '') : filters.repoQuery
+  const effectiveFilters: OrgInventoryFilters = { ...filters, repoQuery: effectiveRepoQuery }
+  const parsedQuery = useMemo(() => parseStructuredSearchQuery(effectiveRepoQuery), [effectiveRepoQuery])
 
   const filteredRows = useMemo(
-    () => filterOrgInventoryRows(results, filters, { selectedOnly, selectedRepos }),
-    [results, filters, selectedOnly, selectedRepos],
+    () => filterOrgInventoryRows(results, effectiveFilters, { selectedOnly, selectedRepos }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [results, effectiveRepoQuery, selectedOnly, selectedRepos],
   )
   const effectiveSortState = useMemo(
     () => getEffectiveSortState(sortState, visibleColumns),
@@ -126,47 +135,51 @@ export function OrgInventoryView({
             {repoTableExpanded ? (
               <div className="space-y-4 px-3 pb-3">
                 <div className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800 dark:bg-slate-900">
-                <div className="flex flex-wrap items-end gap-2">
-                  <label className="flex-1 min-w-[140px]">
-                    <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Structured search</span>
-                    <input
-                      value={filters.repoQuery}
-                      onChange={(event) => {
-                        setCurrentPage(1)
-                        setFilters((current) => ({ ...current, repoQuery: event.target.value }))
-                      }}
-                      className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
-                      placeholder="repo name lang:go stars:>500 archived:false"
-                    />
-                  </label>
-                  <div className="flex items-center gap-3 text-xs text-slate-700 dark:text-slate-300 dark:text-slate-200">
-                    <label className="inline-flex items-center gap-1">
+                {!controlled && (
+                  <>
+                  <div className="flex flex-wrap items-end gap-2">
+                    <label className="flex-1 min-w-[140px]">
+                      <span className="text-[10px] font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">Structured search</span>
                       <input
-                        type="checkbox"
-                        checked={selectedOnly}
-                        onChange={(e) => {
+                        value={filters.repoQuery}
+                        onChange={(event) => {
                           setCurrentPage(1)
-                          setSelectedOnly(e.target.checked)
+                          setFilters((current) => ({ ...current, repoQuery: event.target.value }))
                         }}
-                        aria-label="Show only selected repositories"
+                        className="mt-0.5 w-full rounded border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                        placeholder="repo name lang:go stars:>500 archived:false"
                       />
-                      Selected only
                     </label>
+                    <div className="flex items-center gap-3 text-xs text-slate-700 dark:text-slate-300 dark:text-slate-200">
+                      <label className="inline-flex items-center gap-1">
+                        <input
+                          type="checkbox"
+                          checked={selectedOnly}
+                          onChange={(e) => {
+                            setCurrentPage(1)
+                            setSelectedOnly(e.target.checked)
+                          }}
+                          aria-label="Show only selected repositories"
+                        />
+                        Selected only
+                      </label>
+                    </div>
                   </div>
-                </div>
-                <div className="mt-2 space-y-1">
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Prefixes: <code>lang:</code>, <code>archived:</code>, <code>stars:</code>, <code>forks:</code>, <code>watchers:</code>, <code>issues:</code>, <code>pushed:</code>, <code>fork:</code>, <code>topic:</code>, <code>size:</code>, <code>visibility:</code>, <code>license:</code>.
-                  </p>
-                  <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Analyze all defaults to active non-forks unless your query includes <code>archived:</code> or <code>fork:</code>.
-                  </p>
-                  {parsedQuery.invalidTokens.length > 0 ? (
-                    <p className="text-xs text-amber-700 dark:text-amber-300">
-                      Ignored invalid token{parsedQuery.invalidTokens.length === 1 ? '' : 's'}: {parsedQuery.invalidTokens.join(', ')}
+                  <div className="mt-2 space-y-1">
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Prefixes: <code>lang:</code>, <code>archived:</code>, <code>stars:</code>, <code>forks:</code>, <code>watchers:</code>, <code>issues:</code>, <code>pushed:</code>, <code>fork:</code>, <code>topic:</code>, <code>size:</code>, <code>visibility:</code>, <code>license:</code>.
                     </p>
-                  ) : null}
-                </div>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Analyze all defaults to active non-forks unless your query includes <code>archived:</code> or <code>fork:</code>.
+                    </p>
+                    {parsedQuery.invalidTokens.length > 0 ? (
+                      <p className="text-xs text-amber-700 dark:text-amber-300">
+                        Ignored invalid token{parsedQuery.invalidTokens.length === 1 ? '' : 's'}: {parsedQuery.invalidTokens.join(', ')}
+                      </p>
+                    ) : null}
+                  </div>
+                  </>
+                )}
 
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="flex flex-wrap items-center gap-2">
@@ -232,7 +245,7 @@ export function OrgInventoryView({
                     </select>
                   </label>
                 </div>
-                </div>
+                </div>{/* closes div.rounded-lg */}
 
                 {sortedRows.length === 0 ? (
                   selectedOnly && selectedRepos.length === 0 ? (

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -1090,7 +1090,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       chatPanel={
         session?.token && inputMode !== 'foundation' && (
           (inputMode === 'repos' && analysisResponse) ||
-          (inputMode === 'org' && orgAnalysisComplete && orgAggregation.view)
+          (inputMode === 'org' && orgInventoryResponse)
         ) ? (
           inputMode === 'repos' && analysisResponse ? (
             <ChatPanel
@@ -1099,12 +1099,13 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               githubToken={session.token}
               resetKey={resultsResetKey}
             />
-          ) : inputMode === 'org' && orgAnalysisComplete && orgAggregation.view && orgInventoryResponse ? (
+          ) : inputMode === 'org' && orgInventoryResponse ? (
             <ChatPanel
               contextType="org"
-              orgView={orgAggregation.view}
+              orgView={orgAnalysisComplete && orgAggregation.view ? orgAggregation.view : undefined}
               org={orgInventoryResponse.org}
               orgRepos={orgInventoryResponse.results}
+              orgInventory={orgAnalysisComplete ? undefined : orgInventoryResponse}
               githubToken={session.token}
               resetKey={resultsResetKey}
             />

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -1104,6 +1104,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               contextType="org"
               orgView={orgAggregation.view}
               org={orgInventoryResponse.org}
+              orgRepos={orgInventoryResponse.results}
               githubToken={session.token}
               resetKey={resultsResetKey}
             />

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -39,6 +39,7 @@ import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
 import { RepoInputForm } from './RepoInputForm'
 import { FoundationResultsView, type FoundationResult } from '@/components/foundation/FoundationResultsView'
 import { FoundationNudge } from '@/components/foundation/FoundationNudge'
+import { ChatPanel } from '@/components/chat/ChatPanel'
 
 interface RepoInputClientProps {
   onAnalyze?: (repos: string[], token: string) => Promise<AnalyzeResponse> | AnalyzeResponse | void
@@ -1086,6 +1087,29 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       searchQuery={debouncedQuery}
       onDomMatchCounts={handleDomMatchCounts}
       tagMatchCounts={analysisResponse ? computeTabTagCounts(analysisResponse.results, activeTag) : undefined}
+      chatPanel={
+        session?.token && inputMode !== 'foundation' && (
+          (inputMode === 'repos' && analysisResponse) ||
+          (inputMode === 'org' && orgAnalysisComplete && orgAggregation.view)
+        ) ? (
+          inputMode === 'repos' && analysisResponse ? (
+            <ChatPanel
+              contextType="repos"
+              repoResults={analysisResponse.results}
+              githubToken={session.token}
+              resetKey={resultsResetKey}
+            />
+          ) : inputMode === 'org' && orgAnalysisComplete && orgAggregation.view && orgInventoryResponse ? (
+            <ChatPanel
+              contextType="org"
+              orgView={orgAggregation.view}
+              org={orgInventoryResponse.org}
+              githubToken={session.token}
+              resetKey={resultsResetKey}
+            />
+          ) : null
+        ) : null
+      }
       slots={{
         overview: overviewContent,
         contributors: inputMode === 'org' && orgAnalysisComplete && orgAggregation.view ? (

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -75,6 +75,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [analysisResponse, setAnalysisResponse] = useState<AnalyzeResponse | null>(null)
   const [analyzedRepos, setAnalyzedRepos] = useState<string[]>([])
   const [orgInventoryResponse, setOrgInventoryResponse] = useState<OrgInventoryResponse | null>(null)
+  const [orgRepoQuery, setOrgRepoQuery] = useState('')
   const [submissionError, setSubmissionError] = useState<string | null>(null)
   const [loadingRepos, setLoadingRepos] = useState<string[]>([])
   const [loadingOrg, setLoadingOrg] = useState<string | null>(null)
@@ -915,6 +916,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
                 summary={orgInventoryResponse.summary}
                 results={orgInventoryResponse.results}
                 rateLimit={orgInventoryResponse.rateLimit}
+                repoQuery={orgRepoQuery}
+                onRepoQueryChange={setOrgRepoQuery}
                 onAnalyzeRepo={(repo) => {
                   void handleSubmit([repo])
                 }}
@@ -1108,6 +1111,8 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
               orgInventory={orgAnalysisComplete ? undefined : orgInventoryResponse}
               githubToken={session.token}
               resetKey={resultsResetKey}
+              repoQuery={orgRepoQuery}
+              onRepoQueryChange={setOrgRepoQuery}
             />
           ) : null
         ) : null

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -203,7 +203,6 @@ export function RepoInputForm({
       )}
       <button
         type="submit"
-        title="Run the full repo health dashboard for any valid set of repositories."
         className="mt-3 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-2 dark:focus:ring-offset-slate-900"
       >
         Analyze

--- a/lib/org-inventory/structured-search.ts
+++ b/lib/org-inventory/structured-search.ts
@@ -35,7 +35,9 @@ const BOOLEAN_KEYS = new Set<StructuredSearchKey>(['archived', 'fork'])
 const TEXT_KEYS = new Set<StructuredSearchKey>(['company', 'lang', 'topic', 'visibility', 'license'])
 
 export function parseStructuredSearchQuery(query: string): StructuredSearchParseResult {
-  const parts = query.trim().split(/\s+/).filter(Boolean)
+  // Collapse "key: value" (space after colon) → "key:value"
+  const normalized = query.trim().replace(/([a-z]+):\s+/gi, '$1:')
+  const parts = normalized.split(/\s+/).filter(Boolean)
   const freeTextTerms: string[] = []
   const tokens: StructuredSearchToken[] = []
   const invalidTokens: string[] = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "repo-pulse",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
         "chart.js": "^4.5.1",
         "chartjs-plugin-zoom": "^2.2.0",
         "hammerjs": "^2.0.8",
@@ -54,6 +55,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -313,7 +334,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6085,6 +6105,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8107,6 +8140,12 @@
         "node": ">=20"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8850,7 +8889,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "pre-commit": "npm run typecheck"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "chart.js": "^4.5.1",
     "chartjs-plugin-zoom": "^2.2.0",
     "hammerjs": "^2.0.8",
@@ -46,8 +47,8 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "jsdom": "^29.0.1",
-    "tailwindcss": "^4",
     "simple-git-hooks": "^2.11.1",
+    "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.2"


### PR DESCRIPTION
Implements the LLM-powered Q&A chat feature from issue #271.

## Summary
- Adds a sticky bottom-bar chat interface using Claude (Haiku default, Sonnet option)
- New API route `app/api/chat/route.ts`: SSE streaming with prompt caching
- ChatPanel component with model switcher, starter chips, org controls, inline errors
- Context serialization for both repos and org analysis results

Closes #271

Generated with [Claude Code](https://claude.ai/code)