### PR TITLE
refactor: fix 2 DRY findings from 2026-04-28 tech-debt audit (issue #485)

### DIFF
--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -5,6 +5,16 @@ export interface GitHubRestSuccess<T> {
   rateLimit: RateLimitState | null
 }
 
+type GitHubRestError = Error & { status?: number; retryAfter?: number | 'unavailable' }
+
+function throwHttpError(response: Response): never {
+  const retryAfterHeader = response.headers.get('Retry-After')
+  const error = new Error(`GitHub REST request failed with status ${response.status}`) as GitHubRestError
+  error.status = response.status
+  error.retryAfter = retryAfterHeader ? Number(retryAfterHeader) : 'unavailable'
+  throw error
+}
+
 export async function fetchContributorCount(
   token: string,
   owner: string,
@@ -19,15 +29,7 @@ export async function fetchContributorCount(
     },
   })
 
-  if (!response.ok) {
-    const retryAfterHeader = response.headers.get('Retry-After')
-    const error = new Error(`GitHub REST request failed with status ${response.status}`)
-    ;(error as Error & { status?: number; retryAfter?: number | 'unavailable' }).status = response.status
-    ;(error as Error & { status?: number; retryAfter?: number | 'unavailable' }).retryAfter = retryAfterHeader
-      ? Number(retryAfterHeader)
-      : 'unavailable'
-    throw error
-  }
+  if (!response.ok) throwHttpError(response)
 
   const contributors = (await response.json()) as unknown[]
   const linkHeader = response.headers.get('Link')
@@ -83,15 +85,7 @@ export async function fetchMaintainerCount(
       continue
     }
 
-    if (!response.ok) {
-      const retryAfterHeader = response.headers.get('Retry-After')
-      const error = new Error(`GitHub REST request failed with status ${response.status}`)
-      ;(error as Error & { status?: number; retryAfter?: number | 'unavailable' }).status = response.status
-      ;(error as Error & { status?: number; retryAfter?: number | 'unavailable' }).retryAfter = retryAfterHeader
-        ? Number(retryAfterHeader)
-        : 'unavailable'
-      throw error
-    }
+    if (!response.ok) throwHttpError(response)
 
     const payload = (await response.json()) as { content?: string; encoding?: string }
     rateLimit = extractRateLimit(response) ?? rateLimit
@@ -126,15 +120,7 @@ export async function fetchPublicUserOrganizations(
     },
   })
 
-  if (!response.ok) {
-    const retryAfterHeader = response.headers.get('Retry-After')
-    const error = new Error(`GitHub REST request failed with status ${response.status}`)
-    ;(error as Error & { status?: number; retryAfter?: number | 'unavailable' }).status = response.status
-    ;(error as Error & { status?: number; retryAfter?: number | 'unavailable' }).retryAfter = retryAfterHeader
-      ? Number(retryAfterHeader)
-      : 'unavailable'
-    throw error
-  }
+  if (!response.ok) throwHttpError(response)
 
   const payload = (await response.json()) as Array<{ login?: string }>
   const rateLimit = extractRateLimit(response)
@@ -631,7 +617,7 @@ function parseMaintainerTokens(
     return parseOwnersMaintainers(decoded)
   }
 
-  return parseGenericMaintainers(decoded)
+  return parseOwnersMaintainers(decoded)
 }
 
 function collectAtHandles(line: string, into: Map<string, MaintainerToken>) {
@@ -675,22 +661,6 @@ function parseOwnersMaintainers(decoded: string): MaintainerToken[] {
   return Array.from(out.values())
 }
 
-function parseGenericMaintainers(decoded: string): MaintainerToken[] {
-  const out = new Map<string, MaintainerToken>()
-  for (const rawLine of decoded.split('\n')) {
-    const line = rawLine.trim()
-    if (!line || line.startsWith('#') || /^---+$/.test(line)) continue
-    collectAtHandles(line, out)
-
-    const candidate = line.replace(/\[[^\]]+\]/g, ' ').replace(/[:,]/g, ' ').trim()
-    for (const token of candidate.split(/\s+/)) {
-      const normalized = token.replace(/^@/, '').trim().toLowerCase()
-      if (!isLikelyMaintainerToken(normalized)) continue
-      if (!out.has(normalized)) out.set(normalized, { token: normalized, kind: 'user' })
-    }
-  }
-  return Array.from(out.values())
-}
 
 function isLikelyMaintainerToken(token: string) {
   if (!token || token.length < 2) {


### PR DESCRIPTION
Addresses the valid fix-soon DRY findings from the 2026-04-28 tech-debt audit (#485).

**Changes to lib/analyzer/github-rest.ts:**
- Extract shared throwHttpError(response) helper to replace a 8-line error-annotation block duplicated 3×
- Remove parseGenericMaintainers (byte-for-byte identical to parseOwnersMaintainers); route generic files through the shared function

Net: -44 lines +14 lines. All 52 tests pass, typecheck clean.

The remaining 25 findings were assessed and skipped (documented in issue #485).

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/arun-gupta/repo-pulse/actions/runs/25289279784) • [`claude/issue-485-20260503-1958`](https://github.com/arun-gupta/repo-pulse/tree/claude/issue-485-20260503-1958