### PR TITLE
refactor: fix 2 more DRY findings from 2026-04-28 tech-debt audit (#485)

### DIFF
--- a/lib/analyzer/analyze.ts
+++ b/lib/analyzer/analyze.ts
@@ -419,6 +419,12 @@ const UNAVAILABLE_FIELDS: Array<keyof AnalysisResult> = [
   'newContributorPRAcceptanceRate',
 ]
 
+function daysAgo(from: Date, n: number): Date {
+  const d = new Date(from)
+  d.setDate(from.getDate() - n)
+  return d
+}
+
 export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
   const results: AnalysisResult[] = []
   const failures: RepositoryFetchFailure[] = []
@@ -448,26 +454,11 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
       }
 
       const now = new Date()
-      const since30 = new Date(now)
-      since30.setDate(now.getDate() - 30)
-      const since90 = new Date(now)
-      since90.setDate(now.getDate() - 90)
-      const since60 = new Date(now)
-      since60.setDate(now.getDate() - 60)
-      const since180 = new Date(now)
-      since180.setDate(now.getDate() - 180)
-      const since365 = new Date(now)
-      since365.setDate(now.getDate() - 365)
-      const staleBefore30 = new Date(now)
-      staleBefore30.setDate(now.getDate() - 30)
-      const staleBefore60 = new Date(now)
-      staleBefore60.setDate(now.getDate() - 60)
-      const staleBefore90 = new Date(now)
-      staleBefore90.setDate(now.getDate() - 90)
-      const staleBefore180 = new Date(now)
-      staleBefore180.setDate(now.getDate() - 180)
-      const staleBefore365 = new Date(now)
-      staleBefore365.setDate(now.getDate() - 365)
+      const since30 = daysAgo(now, 30)
+      const since60 = daysAgo(now, 60)
+      const since90 = daysAgo(now, 90)
+      const since180 = daysAgo(now, 180)
+      const since365 = daysAgo(now, 365)
       const repoSearch = `${owner}/${name}`
 
       // Fetch OpenSSF Scorecard data and branch protection in parallel
@@ -512,11 +503,11 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
         issuesClosed90Query: buildSearchQuery(repoSearch, 'is:issue', 'closed', since90),
         issuesClosed180Query: buildSearchQuery(repoSearch, 'is:issue', 'closed', since180),
         issuesClosed365Query: buildSearchQuery(repoSearch, 'is:issue', 'closed', since365),
-        staleIssues30Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore30),
-        staleIssues60Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore60),
-        staleIssues90Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore90),
-        staleIssues180Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore180),
-        staleIssues365Query: buildOpenIssuesOlderThanQuery(repoSearch, staleBefore365),
+        staleIssues30Query: buildOpenIssuesOlderThanQuery(repoSearch, since30),
+        staleIssues60Query: buildOpenIssuesOlderThanQuery(repoSearch, since60),
+        staleIssues90Query: buildOpenIssuesOlderThanQuery(repoSearch, since90),
+        staleIssues180Query: buildOpenIssuesOlderThanQuery(repoSearch, since180),
+        staleIssues365Query: buildOpenIssuesOlderThanQuery(repoSearch, since365),
         ...buildGoodFirstIssueQueries(repoSearch),
       }
 
@@ -545,11 +536,11 @@ export async function analyze(input: AnalyzeInput): Promise<AnalyzeResponse> {
           issuesClosed365Query: buildSearchQuery(repoSearch, 'is:issue', 'closed', since365),
           prsCreated365Query: buildSearchQuery(repoSearch, 'is:pr', 'created', since365),
           prsMerged365Query: buildSearchQuery(repoSearch, 'is:pr is:merged', 'merged', since365),
-          stalePrs30Query: buildOpenPullRequestsOlderThanQuery(repoSearch, staleBefore30),
-          stalePrs60Query: buildOpenPullRequestsOlderThanQuery(repoSearch, staleBefore60),
-          stalePrs90Query: buildOpenPullRequestsOlderThanQuery(repoSearch, staleBefore90),
-          stalePrs180Query: buildOpenPullRequestsOlderThanQuery(repoSearch, staleBefore180),
-          stalePrs365Query: buildOpenPullRequestsOlderThanQuery(repoSearch, staleBefore365),
+          stalePrs30Query: buildOpenPullRequestsOlderThanQuery(repoSearch, since30),
+          stalePrs60Query: buildOpenPullRequestsOlderThanQuery(repoSearch, since60),
+          stalePrs90Query: buildOpenPullRequestsOlderThanQuery(repoSearch, since90),
+          stalePrs180Query: buildOpenPullRequestsOlderThanQuery(repoSearch, since180),
+          stalePrs365Query: buildOpenPullRequestsOlderThanQuery(repoSearch, since365),
         },
         diagnostics,
         repo,

--- a/lib/analyzer/github-rest.ts
+++ b/lib/analyzer/github-rest.ts
@@ -143,40 +143,6 @@ export type OrgAdminListResult =
   | { kind: 'network' }
   | { kind: 'unknown' }
 
-export async function fetchOrgAdmins(token: string, org: string): Promise<OrgAdminListResult> {
-  const admins: { login: string }[] = []
-  let url: string | null = `https://api.github.com/orgs/${encodeURIComponent(org)}/members?role=admin&per_page=100`
-
-  try {
-    while (url) {
-      const response: Response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      })
-
-      const status = classifyRestStatus(response)
-      if (status !== 'ok') return status
-
-      const payload = (await response.json()) as Array<{ login?: unknown }>
-      if (!Array.isArray(payload)) return { kind: 'unknown' }
-      for (const member of payload) {
-        if (typeof member.login === 'string' && member.login.length > 0) {
-          admins.push({ login: member.login })
-        }
-      }
-
-      url = parseNextLink(response.headers.get('Link'))
-    }
-  } catch {
-    return { kind: 'network' }
-  }
-
-  return { kind: 'ok', admins }
-}
-
 export type OrgMemberListResult =
   | { kind: 'ok'; members: { login: string }[] }
   | { kind: 'rate-limited' }
@@ -185,9 +151,17 @@ export type OrgMemberListResult =
   | { kind: 'network' }
   | { kind: 'unknown' }
 
-export async function fetchOrgMembers(token: string, org: string): Promise<OrgMemberListResult> {
-  const members: { login: string }[] = []
-  let url: string | null = `https://api.github.com/orgs/${encodeURIComponent(org)}/members?role=all&per_page=100`
+type OrgLoginListResult =
+  | { kind: 'ok'; logins: { login: string }[] }
+  | { kind: 'rate-limited' }
+  | { kind: 'auth-failed' }
+  | { kind: 'scope-insufficient' }
+  | { kind: 'network' }
+  | { kind: 'unknown' }
+
+async function fetchOrgLoginList(token: string, initialUrl: string): Promise<OrgLoginListResult> {
+  const logins: { login: string }[] = []
+  let url: string | null = initialUrl
 
   try {
     while (url) {
@@ -200,13 +174,13 @@ export async function fetchOrgMembers(token: string, org: string): Promise<OrgMe
       })
 
       const status = classifyRestStatus(response)
-      if (status !== 'ok') return status as OrgMemberListResult
+      if (status !== 'ok') return status as OrgLoginListResult
 
       const payload = (await response.json()) as Array<{ login?: unknown }>
       if (!Array.isArray(payload)) return { kind: 'unknown' }
       for (const member of payload) {
         if (typeof member.login === 'string' && member.login.length > 0) {
-          members.push({ login: member.login })
+          logins.push({ login: member.login })
         }
       }
 
@@ -216,7 +190,19 @@ export async function fetchOrgMembers(token: string, org: string): Promise<OrgMe
     return { kind: 'network' }
   }
 
-  return { kind: 'ok', members }
+  return { kind: 'ok', logins }
+}
+
+export async function fetchOrgAdmins(token: string, org: string): Promise<OrgAdminListResult> {
+  const result = await fetchOrgLoginList(token, `https://api.github.com/orgs/${encodeURIComponent(org)}/members?role=admin&per_page=100`)
+  if (result.kind !== 'ok') return result
+  return { kind: 'ok', admins: result.logins }
+}
+
+export async function fetchOrgMembers(token: string, org: string): Promise<OrgMemberListResult> {
+  const result = await fetchOrgLoginList(token, `https://api.github.com/orgs/${encodeURIComponent(org)}/members?role=all&per_page=100`)
+  if (result.kind !== 'ok') return result
+  return { kind: 'ok', members: result.logins }
 }
 
 export type OrgPublicMember = { login: string; avatarUrl: string }
@@ -280,37 +266,9 @@ export async function fetchOrgOutsideCollaborators(
   token: string,
   org: string,
 ): Promise<OrgCollaboratorListResult> {
-  const collaborators: { login: string }[] = []
-  let url: string | null = `https://api.github.com/orgs/${encodeURIComponent(org)}/outside_collaborators?per_page=100`
-
-  try {
-    while (url) {
-      const response: Response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-      })
-
-      const status = classifyRestStatus(response)
-      if (status !== 'ok') return status as OrgCollaboratorListResult
-
-      const payload = (await response.json()) as Array<{ login?: unknown }>
-      if (!Array.isArray(payload)) return { kind: 'unknown' }
-      for (const member of payload) {
-        if (typeof member.login === 'string' && member.login.length > 0) {
-          collaborators.push({ login: member.login })
-        }
-      }
-
-      url = parseNextLink(response.headers.get('Link'))
-    }
-  } catch {
-    return { kind: 'network' }
-  }
-
-  return { kind: 'ok', collaborators }
+  const result = await fetchOrgLoginList(token, `https://api.github.com/orgs/${encodeURIComponent(org)}/outside_collaborators?per_page=100`)
+  if (result.kind !== 'ok') return result
+  return { kind: 'ok', collaborators: result.logins }
 }
 
 export type OrgTwoFactorRequirementResult =


### PR DESCRIPTION
Fixes 2 more fix-soon DRY findings from the 2026-04-28 tech-debt audit (#485).

**lib/analyzer/github-rest.ts**
Extract shared `fetchOrgLoginList` helper to replace three identical 32-line pagination loops (fetchOrgAdmins, fetchOrgMembers, fetchOrgOutsideCollaborators). Each function is now a 3-line wrapper.

**lib/analyzer/analyze.ts**
Extract `daysAgo` helper and remove 5 `staleBefore*` variables that were computing the same values as the already-declared `since*` variables.

Net: -101 lines, +50 lines. Typecheck clean, 1971/1972 tests passing (1 pre-existing UI failure unrelated to these files).

The remaining 23 fix-soon findings were assessed and skipped (documented in issue #485).

Generated with [Claude Code](https://claude.ai/code)