### PR TITLE
feat(chat): multi-provider AI, free tier UX, scoped context & flow guide

### DIFF
--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -37,6 +37,13 @@ function makeDataStreamResponseMock(captureWriter?: (w: { writeData: ReturnType<
   }
 }
 
+/** Sets up a one-shot writer-capturing mock and returns a getter for the captured writer */
+function setupWriterCapture(): { getWriter: () => { writeData: ReturnType<typeof vi.fn> } } {
+  let capturedWriter: { writeData: ReturnType<typeof vi.fn> } | null = null
+  mockCreateDataStreamResponse.mockImplementationOnce(makeDataStreamResponseMock((w) => { capturedWriter = w }))
+  return { getWriter: () => capturedWriter! }
+}
+
 mockCreateDataStreamResponse.mockImplementation(makeDataStreamResponseMock())
 
 // ---------------------------------------------------------------------------
@@ -260,28 +267,24 @@ describe('POST /api/chat', () => {
     vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
     stubFetchGitHubOk('remaining-count-user-unique')
 
-    let capturedWriter: { writeData: ReturnType<typeof vi.fn> } | null = null
-    mockCreateDataStreamResponse.mockImplementationOnce(makeDataStreamResponseMock((w) => { capturedWriter = w }))
-
+    const { getWriter } = setupWriterCapture()
     await POST(makeRequest(validBody))
 
-    expect(capturedWriter).not.toBeNull()
-    expect(capturedWriter!.writeData).toHaveBeenCalledWith(expect.objectContaining({ remaining: expect.any(Number), limit: 5 }))
+    expect(getWriter()).not.toBeNull()
+    expect(getWriter().writeData).toHaveBeenCalledWith(expect.objectContaining({ remaining: expect.any(Number), limit: 5 }))
   })
 
   it('uses BYOK without passing quota data to the stream writer', async () => {
     delete process.env.ANTHROPIC_API_KEY
     stubFetchGitHubOk('byok-user-unique')
 
-    let capturedWriter: { writeData: ReturnType<typeof vi.fn> } | null = null
-    mockCreateDataStreamResponse.mockImplementationOnce(makeDataStreamResponseMock((w) => { capturedWriter = w }))
-
+    const { getWriter } = setupWriterCapture()
     const byokBody = { ...validBody, provider: 'anthropic', apiKey: 'sk-ant-user-key' }
     const res = await POST(makeRequest(byokBody))
 
     expect(res.status).toBe(200)
-    expect(capturedWriter).not.toBeNull()
+    expect(getWriter()).not.toBeNull()
     // With BYOK the writer should NOT receive remaining/limit data
-    expect(capturedWriter!.writeData).not.toHaveBeenCalled()
+    expect(getWriter().writeData).not.toHaveBeenCalled()
   })
 })

--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -1,20 +1,43 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ---------------------------------------------------------------------------
-// Mock @anthropic-ai/sdk before importing the route
+// Mock Vercel AI SDK before importing the route
 // ---------------------------------------------------------------------------
 
-const mockStream = vi.hoisted(() => vi.fn())
+const mockStreamText = vi.hoisted(() => vi.fn())
+const mockCreateDataStreamResponse = vi.hoisted(() => vi.fn())
 
-vi.mock('@anthropic-ai/sdk', () => {
-  // Must use a regular function (not arrow) so it can be used with `new`
-  const AnthropicMock = vi.fn(function (this: { messages: { stream: typeof mockStream } }) {
-    this.messages = { stream: mockStream }
-  })
-  return { default: AnthropicMock }
-})
+vi.mock('ai', () => ({
+  streamText: mockStreamText,
+  createDataStreamResponse: mockCreateDataStreamResponse,
+}))
 
-const { POST } = await import('./route')
+// Mock @ai-sdk/* provider factories — they just need to return something callable
+vi.mock('@ai-sdk/anthropic', () => ({ createAnthropic: vi.fn(() => vi.fn(() => 'anthropic-model')) }))
+vi.mock('@ai-sdk/openai',    () => ({ createOpenAI:    vi.fn(() => vi.fn(() => 'openai-model'))    }))
+vi.mock('@ai-sdk/google',    () => ({ createGoogleGenerativeAI: vi.fn(() => vi.fn(() => 'google-model')) }))
+vi.mock('@ai-sdk/groq',      () => ({ createGroq:      vi.fn(() => vi.fn(() => 'groq-model'))      }))
+
+const { GET, POST } = await import('./route')
+
+// ---------------------------------------------------------------------------
+// Default mocks for streamText and createDataStreamResponse
+// ---------------------------------------------------------------------------
+
+/** streamText returns an object with a no-op mergeIntoDataStream to prevent unhandled errors */
+mockStreamText.mockReturnValue({ mergeIntoDataStream: vi.fn() })
+
+/** Helper to build the default createDataStreamResponse mock impl */
+function makeDataStreamResponseMock(captureWriter?: (w: { writeData: ReturnType<typeof vi.fn> }) => void) {
+  return ({ execute }: { execute: (w: unknown) => Promise<void> }) => {
+    const writer = { writeData: vi.fn() }
+    captureWriter?.(writer)
+    void execute(writer)
+    return new Response('stream', { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+  }
+}
+
+mockCreateDataStreamResponse.mockImplementation(makeDataStreamResponseMock())
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -28,7 +51,7 @@ function makeRequest(body: unknown): Request {
   })
 }
 
-/** Build a minimal valid request body */
+/** Minimal valid request body */
 const validBody = {
   messages: [{ role: 'user', content: 'What is the health score?' }],
   context: '# Repo context',
@@ -36,23 +59,59 @@ const validBody = {
   githubToken: 'ghp_valid',
 }
 
-/** Make fetch return a successful 200 response (GitHub token validation).
- * Cleanup is handled by vi.unstubAllGlobals() in afterEach. */
-function stubFetchOk() {
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })))
+/** Stub global fetch to return a fresh GitHub GraphQL response on every call.
+ * Uses mockImplementation (not mockResolvedValue) so each call gets a NEW Response
+ * object — a Response body can only be read once. */
+function stubFetchGitHubOk(login = 'testuser') {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ data: { viewer: { login } } }), { status: 200 })),
+    ),
+  )
 }
 
-/** Make fetch return a 401 response (invalid GitHub token).
- * Cleanup is handled by vi.unstubAllGlobals() in afterEach. */
-function stubFetchUnauth() {
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 401 })))
+/** Stub global fetch to return a non-ok response (invalid token) */
+function stubFetchGitHubUnauth() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(() => Promise.resolve(new Response('{}', { status: 401 }))),
+  )
 }
+
+describe('GET /api/chat', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns configured:false when no server key is set', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.OPENAI_API_KEY
+    delete process.env.GOOGLE_API_KEY
+    delete process.env.GROQ_API_KEY
+    const res = await GET()
+    const body = await res.json()
+    expect(res.status).toBe(200)
+    expect(body.configured).toBe(false)
+  })
+
+  it('returns configured:true with provider when ANTHROPIC_API_KEY is set', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    const res = await GET()
+    const body = await res.json()
+    expect(body.configured).toBe(true)
+    expect(body.provider).toBe('anthropic')
+  })
+})
 
 describe('POST /api/chat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.unstubAllEnvs()
     vi.unstubAllGlobals()
+    // Restore default mocks after clearAllMocks
+    mockStreamText.mockReturnValue({ mergeIntoDataStream: vi.fn() })
+    mockCreateDataStreamResponse.mockImplementation(makeDataStreamResponseMock())
   })
 
   afterEach(() => {
@@ -61,23 +120,10 @@ describe('POST /api/chat', () => {
   })
 
   // -------------------------------------------------------------------------
-  // NOT_CONFIGURED
-  // -------------------------------------------------------------------------
-
-  it('returns 503 NOT_CONFIGURED when ANTHROPIC_API_KEY is absent', async () => {
-    delete process.env.ANTHROPIC_API_KEY
-    const res = await POST(makeRequest(validBody))
-    const body = await res.json()
-    expect(res.status).toBe(503)
-    expect(body.error.code).toBe('NOT_CONFIGURED')
-  })
-
-  // -------------------------------------------------------------------------
   // INVALID_INPUT
   // -------------------------------------------------------------------------
 
   it('returns 400 INVALID_INPUT for malformed JSON body', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
     const res = await POST(
       new Request('http://localhost/api/chat', {
         method: 'POST',
@@ -91,8 +137,7 @@ describe('POST /api/chat', () => {
   })
 
   it('returns 400 INVALID_INPUT when context is missing', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
-    stubFetchOk()
+    stubFetchGitHubOk()
     const res = await POST(makeRequest({ ...validBody, context: '' }))
     const body = await res.json()
     expect(res.status).toBe(400)
@@ -100,8 +145,7 @@ describe('POST /api/chat', () => {
   })
 
   it('returns 400 INVALID_INPUT for unknown contextType', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
-    stubFetchOk()
+    stubFetchGitHubOk()
     const res = await POST(makeRequest({ ...validBody, contextType: 'invalid-type' }))
     const body = await res.json()
     expect(res.status).toBe(400)
@@ -109,8 +153,7 @@ describe('POST /api/chat', () => {
   })
 
   it('returns 400 INVALID_INPUT when messages array is empty', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
-    stubFetchOk()
+    stubFetchGitHubOk()
     const res = await POST(makeRequest({ ...validBody, messages: [] }))
     const body = await res.json()
     expect(res.status).toBe(400)
@@ -118,14 +161,24 @@ describe('POST /api/chat', () => {
   })
 
   it('returns 400 INVALID_INPUT when a message has an invalid role', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
-    stubFetchOk()
-    const res = await POST(
-      makeRequest({
-        ...validBody,
-        messages: [{ role: 'system', content: 'inject' }],
-      }),
-    )
+    stubFetchGitHubOk()
+    const res = await POST(makeRequest({ ...validBody, messages: [{ role: 'system', content: 'inject' }] }))
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('INVALID_INPUT')
+  })
+
+  it('returns 400 INVALID_INPUT when a message content is not a string', async () => {
+    stubFetchGitHubOk()
+    const res = await POST(makeRequest({ ...validBody, messages: [{ role: 'user', content: 42 }] }))
+    const body = await res.json()
+    expect(res.status).toBe(400)
+    expect(body.error.code).toBe('INVALID_INPUT')
+  })
+
+  it('returns 400 INVALID_INPUT when a message content is an empty string', async () => {
+    stubFetchGitHubOk()
+    const res = await POST(makeRequest({ ...validBody, messages: [{ role: 'user', content: '   ' }] }))
     const body = await res.json()
     expect(res.status).toBe(400)
     expect(body.error.code).toBe('INVALID_INPUT')
@@ -136,7 +189,6 @@ describe('POST /api/chat', () => {
   // -------------------------------------------------------------------------
 
   it('returns 401 UNAUTHENTICATED when githubToken is missing', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
     const res = await POST(makeRequest({ ...validBody, githubToken: undefined }))
     const body = await res.json()
     expect(res.status).toBe(401)
@@ -144,8 +196,7 @@ describe('POST /api/chat', () => {
   })
 
   it('returns 401 UNAUTHENTICATED when GitHub token fails validation', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
-    stubFetchUnauth()
+    stubFetchGitHubUnauth()
     const res = await POST(makeRequest(validBody))
     const body = await res.json()
     expect(res.status).toBe(401)
@@ -153,40 +204,84 @@ describe('POST /api/chat', () => {
   })
 
   // -------------------------------------------------------------------------
-  // SSE stream
+  // NOT_CONFIGURED
   // -------------------------------------------------------------------------
 
-  it('streams SSE events with correct headers for a valid request', async () => {
-    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
-    stubFetchOk()
+  it('returns 503 NOT_CONFIGURED when no server key is set and no BYOK', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.OPENAI_API_KEY
+    delete process.env.GOOGLE_API_KEY
+    delete process.env.GROQ_API_KEY
+    stubFetchGitHubOk()
+    const res = await POST(makeRequest(validBody))
+    const body = await res.json()
+    expect(res.status).toBe(503)
+    expect(body.error.code).toBe('NOT_CONFIGURED')
+  })
 
-    // Build an async iterable that mimics the Anthropic SDK stream
-    async function* fakeStream() {
-      yield {
-        type: 'content_block_delta',
-        delta: { type: 'text_delta', text: 'Hello ' },
-      }
-      yield {
-        type: 'content_block_delta',
-        delta: { type: 'text_delta', text: 'world' },
-      }
+  // -------------------------------------------------------------------------
+  // FREE_LIMIT_REACHED
+  // -------------------------------------------------------------------------
+
+  it('returns 402 FREE_LIMIT_REACHED after exhausting free tier', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    // Use a unique login so this test has an isolated counter
+    stubFetchGitHubOk('quota-test-user-unique')
+
+    // Exhaust the 5 free chats
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest(validBody))
     }
 
-    mockStream.mockReturnValue(fakeStream())
+    // 6th request should be rejected
+    const res = await POST(makeRequest(validBody))
+    const body = await res.json()
+    expect(res.status).toBe(402)
+    expect(body.error.code).toBe('FREE_LIMIT_REACHED')
+    expect(body.error.remaining).toBe(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // Successful streaming
+  // -------------------------------------------------------------------------
+
+  it('returns a streaming response with correct headers for a valid request', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchGitHubOk('streaming-test-user')
 
     const res = await POST(makeRequest(validBody))
 
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('text/event-stream')
+    expect(mockCreateDataStreamResponse).toHaveBeenCalledOnce()
+  })
 
-    // Read the full stream body
-    const text = await res.text()
+  it('passes remaining free count to the stream writer', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchGitHubOk('remaining-count-user-unique')
 
-    // Should contain delta events
-    expect(text).toContain('"type":"delta"')
-    expect(text).toContain('"text":"Hello "')
-    expect(text).toContain('"text":"world"')
-    // Should end with done event
-    expect(text).toContain('"type":"done"')
+    let capturedWriter: { writeData: ReturnType<typeof vi.fn> } | null = null
+    mockCreateDataStreamResponse.mockImplementationOnce(makeDataStreamResponseMock((w) => { capturedWriter = w }))
+
+    await POST(makeRequest(validBody))
+
+    expect(capturedWriter).not.toBeNull()
+    expect(capturedWriter!.writeData).toHaveBeenCalledWith(expect.objectContaining({ remaining: expect.any(Number), limit: 5 }))
+  })
+
+  it('uses BYOK without passing quota data to the stream writer', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    stubFetchGitHubOk('byok-user-unique')
+
+    let capturedWriter: { writeData: ReturnType<typeof vi.fn> } | null = null
+    mockCreateDataStreamResponse.mockImplementationOnce(makeDataStreamResponseMock((w) => { capturedWriter = w }))
+
+    const byokBody = { ...validBody, provider: 'anthropic', apiKey: 'sk-ant-user-key' }
+    const res = await POST(makeRequest(byokBody))
+
+    expect(res.status).toBe(200)
+    expect(capturedWriter).not.toBeNull()
+    // With BYOK the writer should NOT receive remaining/limit data
+    expect(capturedWriter!.writeData).not.toHaveBeenCalled()
   })
 })

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -10,7 +10,13 @@ const VALID_ROLES = ['user', 'assistant'] as const
 
 const MAX_HISTORY_TURNS = 10
 
-async function validateGitHubToken(token: string): Promise<boolean> {
+// Free tier: 5 requests per GitHub login per server lifetime.
+// Resets on deployment — this is intentional for a lightweight demo gate.
+const FREE_LIMIT = 5
+const freeUsage = new Map<string, number>()
+
+// Returns the GitHub username, or null if the token is invalid.
+async function validateGitHubToken(token: string): Promise<string | null> {
   try {
     const res = await fetch('https://api.github.com/graphql', {
       method: 'POST',
@@ -20,9 +26,11 @@ async function validateGitHubToken(token: string): Promise<boolean> {
       },
       body: JSON.stringify({ query: '{ viewer { login } }' }),
     })
-    return res.ok
+    if (!res.ok) return null
+    const data = (await res.json()) as { data?: { viewer?: { login?: string } } }
+    return data.data?.viewer?.login ?? null
   } catch {
-    return false
+    return null
   }
 }
 
@@ -72,6 +80,7 @@ export async function POST(request: Request) {
   const { messages, context, contextType, githubToken, anthropicKey, model: requestedModel } = body
 
   // Resolve API key: user-provided key takes precedence over server env var
+  const hasOwnKey = !!anthropicKey?.trim()
   const apiKey = anthropicKey?.trim() || process.env.ANTHROPIC_API_KEY
   if (!apiKey) {
     return Response.json(
@@ -115,12 +124,33 @@ export async function POST(request: Request) {
     )
   }
 
-  const isValidToken = await validateGitHubToken(githubToken)
-  if (!isValidToken) {
+  const username = await validateGitHubToken(githubToken)
+  if (!username) {
     return Response.json(
       { error: { code: 'UNAUTHENTICATED', message: 'Invalid GitHub token.' } },
       { status: 401 },
     )
+  }
+
+  // Enforce free tier limit when no own key is provided
+  const usedCount = freeUsage.get(username) ?? 0
+  if (!hasOwnKey && usedCount >= FREE_LIMIT) {
+    return Response.json(
+      {
+        error: {
+          code: 'FREE_LIMIT_REACHED',
+          message: `You've used all ${FREE_LIMIT} free chats. Add your Anthropic API key to continue with unlimited access.`,
+          remaining: 0,
+          limit: FREE_LIMIT,
+        },
+      },
+      { status: 402 },
+    )
+  }
+
+  // Consume one free slot before streaming (charge on attempt, not on success)
+  if (!hasOwnKey) {
+    freeUsage.set(username, usedCount + 1)
   }
 
   const model: SupportedModel =
@@ -134,6 +164,8 @@ export async function POST(request: Request) {
   const systemPrompt = buildSystemPrompt(contextType, context)
 
   const client = new Anthropic({ apiKey })
+
+  const remaining = hasOwnKey ? undefined : FREE_LIMIT - (freeUsage.get(username) ?? 0)
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -175,7 +207,7 @@ export async function POST(request: Request) {
           }
         }
 
-        emit(`data: ${JSON.stringify({ type: 'usage', inputTokens, outputTokens, cacheReadTokens })}\n\n`)
+        emit(`data: ${JSON.stringify({ type: 'usage', inputTokens, outputTokens, cacheReadTokens, remaining })}\n\n`)
         emit(`data: ${JSON.stringify({ type: 'done' })}\n\n`)
       } catch (error: unknown) {
         const status = (error as { status?: number }).status

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -121,8 +121,8 @@ export async function POST(request: Request) {
   }
 
   if (!Array.isArray(messages) || messages.length === 0 ||
-      messages.some((m) => !(VALID_ROLES as readonly string[]).includes(m.role))) {
-    return Response.json({ error: { code: 'INVALID_INPUT', message: 'messages must be a non-empty array of {role, content}.' } }, { status: 400 })
+      messages.some((m) => !(VALID_ROLES as readonly string[]).includes(m.role) || typeof m.content !== 'string' || !m.content.trim())) {
+    return Response.json({ error: { code: 'INVALID_INPUT', message: 'messages must be a non-empty array of {role, content} where content is a non-empty string.' } }, { status: 400 })
   }
 
   const username = await getGitHubUsername(githubToken)
@@ -191,6 +191,11 @@ export async function POST(request: Request) {
     },
     onError: (error) => {
       console.error('[chat] streamText error:', error)
+      // Revert the free-tier counter so a failed provider call doesn't burn quota
+      if (!hasOwnKey) {
+        const currentCount = freeUsage.get(username) ?? 0
+        if (currentCount > 0) freeUsage.set(username, currentCount - 1)
+      }
       const msg = (error as { message?: string }).message ?? ''
       if (msg.includes('401') || msg.toLowerCase().includes('invalid api key') || msg.toLowerCase().includes('unauthorized')) {
         return 'Invalid API key — check it and try again.'

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,29 +1,27 @@
-import Anthropic from '@anthropic-ai/sdk'
+import { streamText, createDataStreamResponse } from 'ai'
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { createOpenAI } from '@ai-sdk/openai'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createGroq } from '@ai-sdk/groq'
+import type { ProviderId } from '@/components/chat/providers'
+import { PROVIDERS, FREE_TIER_PROVIDER, FREE_TIER_MODEL } from '@/components/chat/providers'
 
 export const runtime = 'nodejs'
 
-const SUPPORTED_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-6'] as const
-type SupportedModel = (typeof SUPPORTED_MODELS)[number]
-
-const VALID_CONTEXT_TYPES = ['repos', 'org'] as const
-const VALID_ROLES = ['user', 'assistant'] as const
-
-const MAX_HISTORY_TURNS = 10
-
 // Free tier: 5 requests per GitHub login per server lifetime.
-// Resets on deployment — this is intentional for a lightweight demo gate.
+// Resets on deployment — intentional for a lightweight demo gate.
 const FREE_LIMIT = 5
 const freeUsage = new Map<string, number>()
 
-// Returns the GitHub username, or null if the token is invalid.
-async function validateGitHubToken(token: string): Promise<string | null> {
+const VALID_CONTEXT_TYPES = ['repos', 'org'] as const
+const VALID_ROLES = ['user', 'assistant'] as const
+const MAX_HISTORY_TURNS = 10
+
+async function getGitHubUsername(token: string): Promise<string | null> {
   try {
     const res = await fetch('https://api.github.com/graphql', {
       method: 'POST',
-      headers: {
-        Authorization: `bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
+      headers: { Authorization: `bearer ${token}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: '{ viewer { login } }' }),
     })
     if (!res.ok) return null
@@ -31,6 +29,21 @@ async function validateGitHubToken(token: string): Promise<string | null> {
     return data.data?.viewer?.login ?? null
   } catch {
     return null
+  }
+}
+
+function resolveModel(provider: ProviderId, modelId: string, apiKey: string) {
+  switch (provider) {
+    case 'openrouter':
+      return createOpenAI({ baseURL: 'https://openrouter.ai/api/v1', apiKey })(modelId)
+    case 'anthropic':
+      return createAnthropic({ apiKey })(modelId)
+    case 'openai':
+      return createOpenAI({ apiKey })(modelId)
+    case 'google':
+      return createGoogleGenerativeAI({ apiKey })(modelId)
+    case 'groq':
+      return createGroq({ apiKey })(modelId)
   }
 }
 
@@ -44,8 +57,9 @@ interface ChatRequest {
   context: string
   contextType: 'repos' | 'org'
   githubToken?: string
-  anthropicKey?: string
+  provider?: ProviderId
   model?: string
+  apiKey?: string
 }
 
 function buildSystemPrompt(contextType: 'repos' | 'org', context: string): string {
@@ -55,13 +69,13 @@ function buildSystemPrompt(contextType: 'repos' | 'org', context: string): strin
       : 'a GitHub organization and all its analyzed repositories'
 
   return [
-    `You are RepoPulse Assistant, an expert on open-source project health metrics.`,
+    'You are RepoPulse Assistant, an expert on open-source project health metrics.',
     `You have been given analysis data for ${scope}.`,
-    `Answer questions strictly from the provided data. Do not invent metrics, scores, or repository details.`,
-    `If the data does not contain enough information to answer a question, say so clearly.`,
-    `Be concise and specific. Format responses in Markdown where helpful.`,
-    ``,
-    `## Analysis Data`,
+    'Answer questions strictly from the provided data. Do not invent metrics, scores, or repository details.',
+    'If the data does not contain enough information to answer a question, say so clearly.',
+    'Be concise and specific. Format responses in Markdown where helpful.',
+    '',
+    '## Analysis Data',
     context,
   ].join('\n')
 }
@@ -71,174 +85,98 @@ export async function POST(request: Request) {
   try {
     body = (await request.json()) as ChatRequest
   } catch {
-    return Response.json(
-      { error: { code: 'INVALID_INPUT', message: 'Invalid request body.' } },
-      { status: 400 },
-    )
+    return Response.json({ error: { code: 'INVALID_INPUT', message: 'Invalid request body.' } }, { status: 400 })
   }
 
-  const { messages, context, contextType, githubToken, anthropicKey, model: requestedModel } = body
-
-  // Resolve API key: user-provided key takes precedence over server env var
-  const hasOwnKey = !!anthropicKey?.trim()
-  const apiKey = anthropicKey?.trim() || process.env.ANTHROPIC_API_KEY
-  if (!apiKey) {
-    return Response.json(
-      { error: { code: 'NOT_CONFIGURED', message: "AI chat isn't available — please provide an Anthropic API key." } },
-      { status: 503 },
-    )
-  }
+  const { messages, context, contextType, githubToken, provider: reqProvider, model: reqModel, apiKey } = body
 
   if (!githubToken) {
-    return Response.json(
-      { error: { code: 'UNAUTHENTICATED', message: 'Authentication required.' } },
-      { status: 401 },
-    )
+    return Response.json({ error: { code: 'UNAUTHENTICATED', message: 'Authentication required.' } }, { status: 401 })
   }
 
-  if (!context || !contextType) {
-    return Response.json(
-      { error: { code: 'INVALID_INPUT', message: 'context and contextType are required.' } },
-      { status: 400 },
-    )
+  if (!context || !contextType || !(VALID_CONTEXT_TYPES as readonly string[]).includes(contextType)) {
+    return Response.json({ error: { code: 'INVALID_INPUT', message: 'context and contextType are required.' } }, { status: 400 })
   }
 
-  if (!(VALID_CONTEXT_TYPES as readonly string[]).includes(contextType)) {
-    return Response.json(
-      { error: { code: 'INVALID_INPUT', message: `contextType must be one of: ${VALID_CONTEXT_TYPES.join(', ')}.` } },
-      { status: 400 },
-    )
+  if (!Array.isArray(messages) || messages.length === 0 ||
+      messages.some((m) => !(VALID_ROLES as readonly string[]).includes(m.role))) {
+    return Response.json({ error: { code: 'INVALID_INPUT', message: 'messages must be a non-empty array of {role, content}.' } }, { status: 400 })
   }
 
-  if (!Array.isArray(messages) || messages.length === 0) {
-    return Response.json(
-      { error: { code: 'INVALID_INPUT', message: 'At least one message is required.' } },
-      { status: 400 },
-    )
-  }
-
-  if (messages.some((m) => !(VALID_ROLES as readonly string[]).includes(m.role))) {
-    return Response.json(
-      { error: { code: 'INVALID_INPUT', message: `Message roles must be one of: ${VALID_ROLES.join(', ')}.` } },
-      { status: 400 },
-    )
-  }
-
-  const username = await validateGitHubToken(githubToken)
+  const username = await getGitHubUsername(githubToken)
   if (!username) {
-    return Response.json(
-      { error: { code: 'UNAUTHENTICATED', message: 'Invalid GitHub token.' } },
-      { status: 401 },
-    )
+    return Response.json({ error: { code: 'UNAUTHENTICATED', message: 'Invalid GitHub token.' } }, { status: 401 })
   }
 
-  // Enforce free tier limit when no own key is provided
-  const usedCount = freeUsage.get(username) ?? 0
-  if (!hasOwnKey && usedCount >= FREE_LIMIT) {
-    return Response.json(
-      {
-        error: {
-          code: 'FREE_LIMIT_REACHED',
-          message: `You've used all ${FREE_LIMIT} free chats. Add your Anthropic API key to continue with unlimited access.`,
-          remaining: 0,
-          limit: FREE_LIMIT,
+  const hasOwnKey = !!apiKey?.trim()
+
+  // Resolve provider + model + key
+  let provider: ProviderId
+  let modelId: string
+  let resolvedKey: string
+
+  if (hasOwnKey) {
+    provider = reqProvider && reqProvider in PROVIDERS ? reqProvider : FREE_TIER_PROVIDER
+    modelId = reqModel ?? PROVIDERS[provider].models[FREE_TIER_MODEL].id
+    resolvedKey = apiKey!.trim()
+  } else {
+    const serverKey = process.env.ANTHROPIC_API_KEY
+    if (!serverKey) {
+      return Response.json(
+        { error: { code: 'NOT_CONFIGURED', message: "AI chat isn't available — please provide an API key." } },
+        { status: 503 },
+      )
+    }
+    const usedCount = freeUsage.get(username) ?? 0
+    if (usedCount >= FREE_LIMIT) {
+      return Response.json(
+        {
+          error: {
+            code: 'FREE_LIMIT_REACHED',
+            message: `You've used all ${FREE_LIMIT} free chats. Add an API key to continue.`,
+            remaining: 0,
+            limit: FREE_LIMIT,
+          },
         },
-      },
-      { status: 402 },
-    )
-  }
-
-  // Consume one free slot before streaming (charge on attempt, not on success)
-  if (!hasOwnKey) {
+        { status: 402 },
+      )
+    }
     freeUsage.set(username, usedCount + 1)
+    provider = FREE_TIER_PROVIDER
+    modelId = PROVIDERS[FREE_TIER_PROVIDER].models[FREE_TIER_MODEL].id
+    resolvedKey = serverKey
   }
 
-  const model: SupportedModel =
-    requestedModel && (SUPPORTED_MODELS as readonly string[]).includes(requestedModel)
-      ? (requestedModel as SupportedModel)
-      : 'claude-haiku-4-5'
-
-  // Keep last MAX_HISTORY_TURNS conversation turns (each turn = 1 user + 1 assistant message)
+  const model = resolveModel(provider, modelId, resolvedKey)
   const trimmedMessages = messages.slice(-(MAX_HISTORY_TURNS * 2))
-
   const systemPrompt = buildSystemPrompt(contextType, context)
-
-  const client = new Anthropic({ apiKey })
-
   const remaining = hasOwnKey ? undefined : FREE_LIMIT - (freeUsage.get(username) ?? 0)
 
-  const stream = new ReadableStream({
-    async start(controller) {
-      const encoder = new TextEncoder()
-
-      function emit(chunk: string) {
-        controller.enqueue(encoder.encode(chunk))
+  return createDataStreamResponse({
+    execute: async (writer) => {
+      if (remaining !== undefined) {
+        writer.writeData({ remaining, limit: FREE_LIMIT })
       }
 
-      try {
-        const response = await client.messages.stream({
-          model,
-          max_tokens: 1024,
-          system: [
-            {
-              type: 'text',
-              text: systemPrompt,
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-          messages: trimmedMessages.map((m) => ({
-            role: m.role,
-            content: m.content,
-          })),
-        })
+      const result = streamText({
+        model,
+        system: systemPrompt,
+        messages: trimmedMessages,
+        maxTokens: 1024,
+      })
 
-        let inputTokens = 0
-        let cacheReadTokens = 0
-        let outputTokens = 0
-
-        for await (const event of response) {
-          if (event.type === 'message_start') {
-            inputTokens = event.message.usage.input_tokens
-            cacheReadTokens = (event.message.usage as { cache_read_input_tokens?: number }).cache_read_input_tokens ?? 0
-          } else if (event.type === 'content_block_delta' && event.delta.type === 'text_delta') {
-            emit(`data: ${JSON.stringify({ type: 'delta', text: event.delta.text })}\n\n`)
-          } else if (event.type === 'message_delta') {
-            outputTokens = event.usage.output_tokens
-          }
-        }
-
-        emit(`data: ${JSON.stringify({ type: 'usage', inputTokens, outputTokens, cacheReadTokens, remaining })}\n\n`)
-        emit(`data: ${JSON.stringify({ type: 'done' })}\n\n`)
-      } catch (error: unknown) {
-        const status = (error as { status?: number }).status
-        if (status === 401) {
-          emit(
-            `data: ${JSON.stringify({ type: 'error', code: 'INVALID_KEY', message: 'Invalid API key — check it and try again.' })}\n\n`,
-          )
-        } else if (status === 429) {
-          emit(
-            `data: ${JSON.stringify({ type: 'error', code: 'RATE_LIMITED', message: 'Too many requests — please wait a moment and try again.' })}\n\n`,
-          )
-        } else if (status === 400 && (error as { message?: string }).message?.includes('too large')) {
-          emit(
-            `data: ${JSON.stringify({ type: 'error', code: 'CONTEXT_TOO_LARGE', message: 'This analysis is too large to chat about. Try reducing the repo count using the slider.' })}\n\n`,
-          )
-        } else {
-          emit(
-            `data: ${JSON.stringify({ type: 'error', code: 'API_ERROR', message: 'Something went wrong — please try again in a moment.' })}\n\n`,
-          )
-        }
-      } finally {
-        controller.close()
-      }
+      result.mergeIntoDataStream(writer)
     },
-  })
-
-  return new Response(stream, {
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
+    onError: (error) => {
+      const msg = (error as { message?: string }).message ?? ''
+      if (msg.includes('401') || msg.toLowerCase().includes('invalid api key') || msg.toLowerCase().includes('unauthorized')) {
+        return 'Invalid API key — check it and try again.'
+      }
+      if (msg.includes('429')) return 'Too many requests — please wait a moment and try again.'
+      if (msg.includes('too large') || msg.includes('context_length')) {
+        return 'This analysis is too large to chat about. Try reducing the repo count using the slider.'
+      }
+      return 'Something went wrong — please try again in a moment.'
     },
   })
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -168,6 +168,7 @@ export async function POST(request: Request) {
       result.mergeIntoDataStream(writer)
     },
     onError: (error) => {
+      console.error('[chat] streamText error:', error)
       const msg = (error as { message?: string }).message ?? ''
       if (msg.includes('401') || msg.toLowerCase().includes('invalid api key') || msg.toLowerCase().includes('unauthorized')) {
         return 'Invalid API key — check it and try again.'

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -47,6 +47,22 @@ function resolveModel(provider: ProviderId, modelId: string, apiKey: string) {
   }
 }
 
+// Priority order: whichever server key is configured first wins.
+const SERVER_KEY_CANDIDATES: { env: string; provider: ProviderId; modelId: string }[] = [
+  { env: 'ANTHROPIC_API_KEY', provider: 'anthropic', modelId: PROVIDERS.anthropic.models[FREE_TIER_MODEL].id },
+  { env: 'OPENAI_API_KEY',    provider: 'openai',    modelId: PROVIDERS.openai.models[FREE_TIER_MODEL].id },
+  { env: 'GOOGLE_API_KEY',    provider: 'google',    modelId: PROVIDERS.google.models[FREE_TIER_MODEL].id },
+  { env: 'GROQ_API_KEY',      provider: 'groq',      modelId: PROVIDERS.groq.models[FREE_TIER_MODEL].id },
+]
+
+function resolveServerKey(): { provider: ProviderId; modelId: string; key: string } | null {
+  for (const candidate of SERVER_KEY_CANDIDATES) {
+    const key = process.env[candidate.env]
+    if (key) return { provider: candidate.provider, modelId: candidate.modelId, key }
+  }
+  return null
+}
+
 interface ChatMessage {
   role: 'user' | 'assistant'
   content: string
@@ -78,6 +94,12 @@ function buildSystemPrompt(contextType: 'repos' | 'org', context: string): strin
     '## Analysis Data',
     context,
   ].join('\n')
+}
+
+export async function GET() {
+  const serverConfig = resolveServerKey()
+  if (!serverConfig) return Response.json({ configured: false })
+  return Response.json({ configured: true, provider: serverConfig.provider, modelId: serverConfig.modelId })
 }
 
 export async function POST(request: Request) {
@@ -120,8 +142,8 @@ export async function POST(request: Request) {
     modelId = reqModel ?? PROVIDERS[provider].models[FREE_TIER_MODEL].id
     resolvedKey = apiKey!.trim()
   } else {
-    const serverKey = process.env.ANTHROPIC_API_KEY
-    if (!serverKey) {
+    const serverConfig = resolveServerKey()
+    if (!serverConfig) {
       return Response.json(
         { error: { code: 'NOT_CONFIGURED', message: "AI chat isn't available — please provide an API key." } },
         { status: 503 },
@@ -142,9 +164,9 @@ export async function POST(request: Request) {
       )
     }
     freeUsage.set(username, usedCount + 1)
-    provider = FREE_TIER_PROVIDER
-    modelId = PROVIDERS[FREE_TIER_PROVIDER].models[FREE_TIER_MODEL].id
-    resolvedKey = serverKey
+    provider = serverConfig.provider
+    modelId = serverConfig.modelId
+    resolvedKey = serverConfig.key
   }
 
   const model = resolveModel(provider, modelId, resolvedKey)
@@ -175,7 +197,7 @@ export async function POST(request: Request) {
       }
       if (msg.includes('429')) return 'Too many requests — please wait a moment and try again.'
       if (msg.includes('too large') || msg.includes('context_length')) {
-        return 'This analysis is too large to chat about. Try reducing the repo count using the slider.'
+        return 'This analysis is too large to chat about. Try narrowing the filter to fewer repos.'
       }
       return 'Something went wrong — please try again in a moment.'
     },

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -122,10 +122,6 @@ function formatCost(usd: number): string {
   return `$${usd.toFixed(4)}`
 }
 
-function formatTokens(n: number): string {
-  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
-}
-
 function calcCost(promptTokens: number, completionTokens: number, provider: ProviderId): number {
   const spec = PROVIDERS[provider].models['fast']
   return (promptTokens * spec.inputRate + completionTokens * spec.outputRate) / 1_000_000
@@ -335,7 +331,7 @@ function KeyEntryForm({
           className="w-full rounded border border-slate-300 bg-slate-50 px-3 py-1.5 font-mono text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
         />
         <p className="mt-1 text-[10px] text-slate-400 dark:text-slate-500">
-          Your key is sent only to {config.name} to generate responses. Never logged or stored on our servers.
+          Your key is transmitted via the RepoPulse API route to {config.name} to generate responses. It is never logged or persisted on our servers.
         </p>
       </div>
 
@@ -534,7 +530,6 @@ export function ChatPanel({
   const isInventoryPhase = contextType === 'org' && !orgView && !!orgInventory
   const starterChips = contextType === 'repos' ? REPOS_STARTER_CHIPS : isInventoryPhase ? ORG_INVENTORY_STARTER_CHIPS : ORG_STARTER_CHIPS
   const showChips = messages.length === 0 && !isLoading
-  const activeModelSpec = PROVIDERS[activeProvider].models['fast']
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-40 mx-auto max-w-5xl px-4">

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -123,6 +123,8 @@ function applyCompletion(query: string, completion: string): string {
   return query.replace(/(\s*)(\S*)$/, (_, space) => `${space}${completion} `).trimStart()
 }
 
+const FREE_LIMIT = 5
+
 const SS_KEY_ANTHROPIC = 'repopulse:chat:anthropicKey'
 const LS_KEY_MODEL = 'repopulse:chat:model'
 const SS_KEY_EXPANDED = 'repopulse:chat:expanded'
@@ -295,10 +297,18 @@ function SearchFilter({ value, onChange }: { value: string; onChange: (q: string
 
 // ---- Key entry form -------------------------------------------------------
 
-function KeyEntryForm({ onSave }: { onSave: (key: string) => void }) {
+function KeyEntryForm({ onSave, exhausted = false }: { onSave: (key: string) => void; exhausted?: boolean }) {
   const [value, setValue] = useState('')
   return (
     <div className="flex flex-col gap-3 p-4">
+      {exhausted && (
+        <div className="flex items-center gap-2 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+          <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 shrink-0">
+            <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+          </svg>
+          You&apos;ve used all {FREE_LIMIT} free chats. Add your Anthropic API key for unlimited access.
+        </div>
+      )}
       <div>
         <label htmlFor="chat-anthropic-key" className="block text-sm font-medium text-slate-800 dark:text-slate-200">
           Anthropic API key
@@ -355,6 +365,7 @@ export function ChatPanel({
   const [orgRepoCount, setOrgRepoCount] = useState(500)
   const [sortBy, setSortBy] = useState<OrgSortBy>('stars')
   const [sessionUsage, setSessionUsage] = useState<{ messages: number; totalCost: number }>({ messages: 0, totalCost: 0 })
+  const [freeRemaining, setFreeRemaining] = useState<number>(FREE_LIMIT)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const abortRef = useRef<AbortController | null>(null)
 
@@ -468,8 +479,13 @@ export function ChatPanel({
       })
 
       if (!response.ok) {
-        const payload = await response.json().catch(() => ({})) as { error?: { message?: string; code?: string } }
+        const payload = await response.json().catch(() => ({})) as { error?: { message?: string; code?: string; remaining?: number } }
         const code = payload.error?.code
+        if (code === 'FREE_LIMIT_REACHED') {
+          setFreeRemaining(0)
+          setMessages((prev) => prev.filter((m) => m.id !== assistantId))
+          return
+        }
         const msg =
           code === 'NOT_CONFIGURED'
             ? "AI chat isn't available — please provide an Anthropic API key."
@@ -505,7 +521,7 @@ export function ChatPanel({
 
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue
-          let event: { type: string; text?: string; code?: string; message?: string; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number }
+          let event: { type: string; text?: string; code?: string; message?: string; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; remaining?: number }
           try { event = JSON.parse(line.slice(6)) } catch { continue }
 
           if (event.type === 'delta' && event.text) {
@@ -523,6 +539,9 @@ export function ChatPanel({
             )
             const cost = calcCost(msgUsage, model)
             setSessionUsage((prev) => ({ messages: prev.messages + 1, totalCost: prev.totalCost + cost }))
+            if (typeof event.remaining === 'number') {
+              setFreeRemaining(event.remaining)
+            }
           } else if (event.type === 'error') {
             const noRetry = event.code === 'NOT_CONFIGURED' || event.code === 'CONTEXT_TOO_LARGE'
             const showKeyLink = event.code === 'INVALID_KEY'
@@ -671,6 +690,23 @@ export function ChatPanel({
                 </span>
               )}
 
+              {/* Free chat indicator (shown when no own key) */}
+              {!hasKey && (
+                <div className="flex items-center gap-1.5">
+                  {Array.from({ length: FREE_LIMIT }, (_, i) => (
+                    <span
+                      key={i}
+                      className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`}
+                    />
+                  ))}
+                  <span className="text-[10px] text-slate-400 dark:text-slate-500">
+                    {freeRemaining > 0
+                      ? `${freeRemaining} free ${freeRemaining === 1 ? 'chat' : 'chats'} left`
+                      : 'Free limit reached'}
+                  </span>
+                </div>
+              )}
+
               <div className="ml-auto flex items-center gap-2">
                 {/* Change key */}
                 {hasKey && (
@@ -716,9 +752,9 @@ export function ChatPanel({
               <div className="flex-1 border-t border-slate-200 dark:border-slate-700" />
             </div>
 
-            {/* Key entry form or chat */}
-            {!hasKey ? (
-              <KeyEntryForm onSave={handleSaveKey} />
+            {/* Key entry form (no key, or free limit exhausted) or chat */}
+            {!hasKey || freeRemaining === 0 ? (
+              <KeyEntryForm onSave={handleSaveKey} exhausted={!hasKey && freeRemaining === 0} />
             ) : (
               <>
                 {/* Message history */}

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
+import React, { useEffect, useRef, useState, useMemo } from 'react'
 import { useChat } from 'ai/react'
 import type { Message } from 'ai'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse, OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
-import { parseStructuredSearchQuery } from '@/lib/org-inventory/structured-search'
-import { serializeReposContext, serializeOrgContext, serializeOrgInventoryContext, type OrgSortBy } from './serialize-context'
-import { PROVIDERS, type ProviderId, type ModelTier } from './providers'
+import { parseStructuredSearchQuery, matchesStructuredSearch } from '@/lib/org-inventory/structured-search'
+import { serializeReposContext, serializeOrgContext, serializeOrgInventoryContext } from './serialize-context'
+import { PROVIDERS, type ProviderId } from './providers'
 
 // ---- Types ----------------------------------------------------------------
 
@@ -33,25 +33,30 @@ const REPOS_STARTER_CHIPS = [
   'Why is the security score low?',
   "What's the biggest gap between these repos?",
   'Which repo should I fix first?',
+  'Which repos are missing a CODE_OF_CONDUCT?',
+  "What's the most common issue across these repos?",
+  'Which repos have the best documentation?',
 ]
 
 const ORG_STARTER_CHIPS = [
   'Which repos need the most urgent attention?',
   "What's the overall security posture?",
   'Which repos are best positioned for CNCF Sandbox?',
+  'What are the biggest contributors to low health scores?',
+  'Which repos need contributors the most?',
+  'Compare the top 3 repos by health score',
 ]
 
 const ORG_INVENTORY_STARTER_CHIPS = [
   "Which repos haven't been active in over a year?",
   'What languages are most common across this org?',
   'Which repos have the most open issues?',
+  'Which repos have no license?',
+  'Which repos are forks?',
+  'Show repos with high stars but no recent activity',
 ]
 
-const SORT_OPTIONS: { value: OrgSortBy; label: string }[] = [
-  { value: 'stars',    label: '⭐ Top by stars' },
-  { value: 'health',   label: '🔴 Lowest health first' },
-  { value: 'activity', label: '⚡ Most recently active' },
-]
+const MAX_CONTEXT_REPOS = 300
 
 const COMPLETION_VALUES: Record<string, string[]> = {
   lang:     ['go', 'python', 'typescript', 'javascript', 'java', 'rust', 'c++', 'c', 'ruby', 'kotlin', 'swift', 'scala', 'shell'],
@@ -76,7 +81,6 @@ const SEARCH_PREFIX_HINTS: { key: string; description: string; example: string }
 ]
 
 const LS_KEY_PROVIDER  = 'repopulse:chat:provider'
-const LS_KEY_MODEL_TIER = 'repopulse:chat:modelTier'
 const SS_KEY_EXPANDED  = 'repopulse:chat:expanded'
 const SS_KEY_PROVIDER  = 'repopulse:chat:provider:session'
 const SS_KEY_API_KEY   = 'repopulse:chat:apiKey'
@@ -103,6 +107,16 @@ function applyCompletion(query: string, completion: string): string {
   return query.replace(/(\s*)(\S*)$/, (_, space) => `${space}${completion} `).trimStart()
 }
 
+function parseApiError(message: string): { code: string; userMessage: string } | null {
+  try {
+    const parsed = JSON.parse(message) as { error?: { code?: string; message?: string } }
+    if (parsed.error?.code) {
+      return { code: parsed.error.code, userMessage: parsed.error.message ?? message }
+    }
+  } catch {}
+  return null
+}
+
 function formatCost(usd: number): string {
   if (usd < 0.0001) return '<$0.0001'
   return `$${usd.toFixed(4)}`
@@ -112,8 +126,8 @@ function formatTokens(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
 }
 
-function calcCost(promptTokens: number, completionTokens: number, provider: ProviderId, modelTier: ModelTier): number {
-  const spec = PROVIDERS[provider].models[modelTier]
+function calcCost(promptTokens: number, completionTokens: number, provider: ProviderId): number {
+  const spec = PROVIDERS[provider].models['fast']
   return (promptTokens * spec.inputRate + completionTokens * spec.outputRate) / 1_000_000
 }
 
@@ -229,10 +243,14 @@ const DIRECT_PROVIDERS: ProviderId[] = ['anthropic', 'openai', 'google', 'groq']
 
 function KeyEntryForm({
   onSave,
+  onCancel,
   exhausted = false,
+  notConfigured = false,
 }: {
   onSave: (provider: ProviderId, key: string) => void
+  onCancel?: () => void
   exhausted?: boolean
+  notConfigured?: boolean
 }) {
   const [tab, setTab] = useState<'openrouter' | 'direct'>('openrouter')
   const [directProvider, setDirectProvider] = useState<ProviderId>('anthropic')
@@ -248,12 +266,21 @@ function KeyEntryForm({
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      {exhausted && (
+      {onCancel && (
+        <button type="button" onClick={onCancel}
+          className="flex items-center gap-1 text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="h-3 w-3"><path strokeLinecap="round" strokeLinejoin="round" d="M10 4L6 8l4 4" /></svg>
+          Back to free chat
+        </button>
+      )}
+      {(exhausted || notConfigured) && (
         <div className="flex items-start gap-2 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
           <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
             <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
           </svg>
-          You&apos;ve used all {FREE_LIMIT} free chats. Add an API key for unlimited access.
+          {exhausted
+            ? `You've used all ${FREE_LIMIT} free chats. Add an API key for unlimited access.`
+            : 'No server API key configured — add your own key to start chatting.'}
         </div>
       )}
 
@@ -317,14 +344,18 @@ function KeyEntryForm({
           className="text-xs text-sky-700 hover:underline dark:text-sky-400">
           Get a key at {config.consoleLabel} →
         </a>
-        <button
-          type="button"
-          disabled={!keyValue.trim()}
-          onClick={handleSave}
-          className="rounded bg-slate-800 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700 disabled:opacity-40 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-white"
-        >
-          Save key
-        </button>
+        <div className="flex items-center gap-2">
+          {onCancel && (
+            <button type="button" onClick={onCancel}
+              className="text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300">
+              Cancel
+            </button>
+          )}
+          <button type="button" disabled={!keyValue.trim()} onClick={handleSave}
+            className="rounded bg-slate-800 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700 disabled:opacity-40 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-white">
+            Save key
+          </button>
+        </div>
       </div>
     </div>
   )
@@ -338,13 +369,14 @@ export function ChatPanel({
 }: ChatPanelProps) {
   const [expanded, setExpanded] = useState(false)
   const [provider, setProvider] = useState<ProviderId>('openrouter')
-  const [modelTier, setModelTier] = useState<ModelTier>('fast')
   const [userKey, setUserKey] = useState('')
-  const [orgRepoCount, setOrgRepoCount] = useState(500)
-  const [sortBy, setSortBy] = useState<OrgSortBy>('stars')
-  const [freeRemaining, setFreeRemaining] = useState(FREE_LIMIT)
+  const [freeRemaining, setFreeRemaining] = useState<number | null>(null)
+  const [needsKey, setNeedsKey] = useState(false)
+  const [keyFormOpen, setKeyFormOpen] = useState(false)
+  const [serverProvider, setServerProvider] = useState<ProviderId | null>(null)
   const [sessionCost, setSessionCost] = useState(0)
   const [sessionMsgCount, setSessionMsgCount] = useState(0)
+  const [contextNotices, setContextNotices] = useState<{ afterIndex: number; label: string }[]>([])
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
   // Hydrate from storage after mount
@@ -352,22 +384,53 @@ export function ChatPanel({
     try {
       const p = sessionStorage.getItem(SS_KEY_PROVIDER) ?? localStorage.getItem(LS_KEY_PROVIDER)
       if (p && p in PROVIDERS) setProvider(p as ProviderId)
-      const t = localStorage.getItem(LS_KEY_MODEL_TIER)
-      if (t === 'fast' || t === 'smart') setModelTier(t)
       const k = sessionStorage.getItem(SS_KEY_API_KEY) ?? ''
       setUserKey(k)
       setExpanded(sessionStorage.getItem(SS_KEY_EXPANDED) === 'true')
     } catch {}
   }, [])
 
+  // Check server key configuration on mount
+  useEffect(() => {
+    fetch('/api/chat')
+      .then((r) => r.json())
+      .then((data: { configured: boolean; provider?: ProviderId }) => {
+        if (data.configured) {
+          setFreeRemaining(FREE_LIMIT)
+          if (data.provider) setServerProvider(data.provider)
+        } else {
+          setNeedsKey(true)
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  // Insert context notice when filter changes during an active conversation
+  const prevRepoQuery = useRef(repoQuery)
+  useEffect(() => {
+    const prev = prevRepoQuery.current
+    prevRepoQuery.current = repoQuery
+    if (prev === repoQuery || messages.length === 0) return
+    const label = repoQuery.trim()
+      ? `Context updated: scoped to filter "${repoQuery.trim()}"`
+      : 'Context updated: filter cleared — using full org'
+    setContextNotices((n) => [...n, { afterIndex: messages.length, label }])
+  }, [repoQuery])
+
+  const filteredInventory = useMemo(() => {
+    if (!orgInventory || !repoQuery.trim()) return orgInventory
+    const parsed = parseStructuredSearchQuery(repoQuery)
+    return { ...orgInventory, results: orgInventory.results.filter((r) => matchesStructuredSearch(r, parsed)) }
+  }, [orgInventory, repoQuery])
+
   const context = useMemo(() => {
     if (contextType === 'repos' && repoResults) return serializeReposContext(repoResults).text
-    if (contextType === 'org' && orgView && org) return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount, sortBy, orgRepos }).text
-    if (contextType === 'org' && orgInventory) return serializeOrgInventoryContext(orgInventory, { maxRepos: orgRepoCount, sortBy }).text
+    if (contextType === 'org' && orgView && org) return serializeOrgContext(org, orgView, { maxRepos: MAX_CONTEXT_REPOS, sortBy: 'stars', orgRepos }).text
+    if (contextType === 'org' && filteredInventory) return serializeOrgInventoryContext(filteredInventory, { maxRepos: MAX_CONTEXT_REPOS, sortBy: 'stars' }).text
     return ''
-  }, [contextType, repoResults, orgView, org, orgRepos, orgInventory, orgRepoCount, sortBy])
+  }, [contextType, repoResults, orgView, org, orgRepos, filteredInventory])
 
-  const activeProvider = userKey ? provider : ('anthropic' as ProviderId)
+  const activeProvider = userKey ? provider : (serverProvider ?? 'anthropic')
 
   const { messages, input, setInput, handleSubmit, isLoading, stop, setMessages, data, append, error: chatError } = useChat({
     api: '/api/chat',
@@ -376,20 +439,25 @@ export function ChatPanel({
       contextType,
       githubToken,
       provider: activeProvider,
-      model: PROVIDERS[activeProvider].models[modelTier].id,
+      model: PROVIDERS[activeProvider].models['fast'].id,
       apiKey: userKey || undefined,
     },
     onFinish: (_message: Message, options: { usage?: { promptTokens: number; completionTokens: number } }) => {
       const usage = options?.usage
-      if (usage) {
-        const cost = calcCost(usage.promptTokens, usage.completionTokens, activeProvider, modelTier)
+      if (usage && Number.isFinite(usage.promptTokens) && Number.isFinite(usage.completionTokens)) {
+        const cost = calcCost(usage.promptTokens, usage.completionTokens, activeProvider)
         setSessionCost((prev) => prev + cost)
-        setSessionMsgCount((prev) => prev + 1)
       }
+      setSessionMsgCount((prev) => prev + 1)
     },
     onError: (error: Error) => {
-      if (error.message.includes('FREE_LIMIT_REACHED') || error.message.includes('free chats')) {
+      const parsed = parseApiError(error.message)
+      const code = parsed?.code ?? ''
+      if (code === 'FREE_LIMIT_REACHED' || error.message.includes('free chats')) {
         setFreeRemaining(0)
+      }
+      if (code === 'NOT_CONFIGURED') {
+        setNeedsKey(true)
       }
     },
   })
@@ -413,6 +481,7 @@ export function ChatPanel({
     setInput('')
     setSessionCost(0)
     setSessionMsgCount(0)
+    setContextNotices([])
     stop()
     try { sessionStorage.removeItem(SS_KEY_EXPANDED) } catch {}
     setExpanded(false)
@@ -428,6 +497,8 @@ export function ChatPanel({
   function handleSaveKey(p: ProviderId, key: string) {
     setProvider(p)
     setUserKey(key)
+    setNeedsKey(false)
+    setKeyFormOpen(false)
     try {
       sessionStorage.setItem(SS_KEY_PROVIDER, p)
       sessionStorage.setItem(SS_KEY_API_KEY, key)
@@ -449,31 +520,6 @@ export function ChatPanel({
     setSessionMsgCount(0)
   }
 
-  function handleModelTierChange(t: ModelTier) {
-    setModelTier(t)
-    try { localStorage.setItem(LS_KEY_MODEL_TIER, t) } catch {}
-    setMessages([])
-    setSessionCost(0)
-    setSessionMsgCount(0)
-  }
-
-  function handleOrgRepoCountChange(count: number) {
-    if (count !== orgRepoCount) {
-      setOrgRepoCount(count)
-      setMessages([])
-      setSessionCost(0)
-      setSessionMsgCount(0)
-    }
-  }
-
-  function handleSortByChange(s: OrgSortBy) {
-    if (s !== sortBy) {
-      setSortBy(s)
-      setMessages([])
-      setSessionCost(0)
-      setSessionMsgCount(0)
-    }
-  }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -483,13 +529,12 @@ export function ChatPanel({
   }
 
   const hasKey = !!userKey
-  const limitReached = !hasKey && freeRemaining === 0
+  const limitReached = !hasKey && freeRemaining !== null && freeRemaining === 0
+  const showKeyForm = limitReached || needsKey || keyFormOpen
   const isInventoryPhase = contextType === 'org' && !orgView && !!orgInventory
   const starterChips = contextType === 'repos' ? REPOS_STARTER_CHIPS : isInventoryPhase ? ORG_INVENTORY_STARTER_CHIPS : ORG_STARTER_CHIPS
   const showChips = messages.length === 0 && !isLoading
-  const orgTotal = orgView?.status.total ?? orgInventory?.results.length ?? 0
-  const isOrgAndLarge = contextType === 'org' && orgTotal > 500
-  const activeModelSpec = PROVIDERS[activeProvider].models[modelTier]
+  const activeModelSpec = PROVIDERS[activeProvider].models['fast']
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-40 mx-auto max-w-5xl px-4">
@@ -516,78 +561,29 @@ export function ChatPanel({
           <>
             {/* Panel header */}
             <div className="flex flex-wrap items-center gap-2 border-b border-slate-200 px-4 py-2 dark:border-slate-700">
-              <span className="mr-1 font-semibold text-slate-900 dark:text-slate-100">Ask Claude</span>
+              <span className="mr-1 font-semibold text-slate-900 dark:text-slate-100">Ask AI</span>
+              <span className="rounded border border-slate-200 px-2 py-0.5 text-[10px] text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                {PROVIDERS[activeProvider].name}
+              </span>
 
-              {/* Model tier switcher */}
-              <div className="flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 p-0.5 dark:border-slate-700 dark:bg-slate-800">
-                {(['fast', 'smart'] as ModelTier[]).map((t) => {
-                  const spec = PROVIDERS[activeProvider].models[t]
-                  return (
-                    <button key={t} type="button"
-                      title={`${spec.label} · $${PROVIDERS[activeProvider].models[t].inputRate}/1M in · $${PROVIDERS[activeProvider].models[t].outputRate}/1M out`}
-                      onClick={() => handleModelTierChange(t)}
-                      className={modelTier === t
-                        ? 'rounded-full bg-white px-2.5 py-1 text-xs font-medium shadow-sm text-slate-900 dark:bg-slate-700 dark:text-slate-100'
-                        : 'rounded-full px-2.5 py-1 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}>
-                      {t === 'fast' ? '⚡' : '🧠'} {t === 'fast' ? 'Fast' : 'Smart'}
-                    </button>
-                  )
-                })}
-              </div>
 
-              {/* Provider badge (when key set) */}
-              {hasKey && (
-                <span className="rounded border border-slate-200 px-2 py-0.5 text-[10px] text-slate-500 dark:border-slate-700 dark:text-slate-400">
-                  {PROVIDERS[provider].name} · {activeModelSpec.label}
-                </span>
-              )}
 
-              {/* Org controls */}
-              {isOrgAndLarge && (
-                <>
-                  <div className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400">
-                    <label htmlFor="chat-repo-count" className="whitespace-nowrap">Top</label>
-                    <input id="chat-repo-count" type="range" min="50" max="500" step="50"
-                      value={orgRepoCount} onChange={(e) => handleOrgRepoCountChange(Number(e.target.value))}
-                      className="w-20 accent-sky-600" />
-                    <span className="w-8 text-right font-medium">{orgRepoCount}</span>
-                    <span>repos</span>
-                  </div>
-                  <select value={sortBy} onChange={(e) => handleSortByChange(e.target.value as OrgSortBy)}
-                    className="rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
-                    {SORT_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-                  </select>
-                </>
-              )}
-
-              {/* Session cost */}
-              {sessionMsgCount > 0 && (
+              {/* Session cost — only shown when user has their own key */}
+              {hasKey && sessionMsgCount > 0 && (
                 <span className="text-xs text-slate-400 dark:text-slate-500">
-                  {sessionMsgCount} {sessionMsgCount === 1 ? 'msg' : 'msgs'} · {formatCost(sessionCost)}
+                  {sessionMsgCount} {sessionMsgCount === 1 ? 'msg' : 'msgs'}{sessionCost > 0 ? ` · ${formatCost(sessionCost)}` : ''}
                 </span>
               )}
 
-              {/* Free chat indicator */}
-              {!hasKey && (
-                <div className="flex items-center gap-1.5">
-                  {Array.from({ length: FREE_LIMIT }, (_, i) => (
-                    <span key={i} className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`} />
-                  ))}
-                  <span className="text-[10px] text-slate-400 dark:text-slate-500">
-                    {freeRemaining > 0 ? `${freeRemaining} free ${freeRemaining === 1 ? 'chat' : 'chats'} left` : 'Free limit reached'}
-                  </span>
-                </div>
-              )}
 
               <div className="ml-auto flex items-center gap-2">
-                {hasKey && (
-                  <button type="button" onClick={handleClearKey}
-                    className="text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300">
-                    Change key
-                  </button>
-                )}
+                <button type="button"
+                  onClick={() => { if (hasKey) handleClearKey(); else setKeyFormOpen((v) => !v) }}
+                  className="text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300">
+                  {hasKey ? 'Change key' : keyFormOpen ? 'Cancel' : 'Add key'}
+                </button>
                 {messages.length > 0 && (
-                  <button type="button" onClick={() => { setMessages([]); setSessionCost(0); setSessionMsgCount(0); stop() }}
+                  <button type="button" onClick={() => { setMessages([]); setSessionCost(0); setSessionMsgCount(0); setContextNotices([]); stop() }}
                     className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200">
                     New conversation
                   </button>
@@ -608,19 +604,152 @@ export function ChatPanel({
 
             {/* Chat section label */}
             <div className="flex items-center gap-2 px-4 pt-2 pb-0">
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500">Chat with Claude</span>
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500">Chat with AI</span>
+              {repoQuery.trim() && filteredInventory && (
+                <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-medium text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                  scoped to {filteredInventory.results.length} filtered repos
+                </span>
+              )}
+              {/* Show dots here only when the flow guide isn't visible */}
+              {!hasKey && !(isInventoryPhase && showChips) && (
+                <div className={`relative flex items-center gap-1 ${freeRemaining === null ? 'group/free cursor-help' : ''}`}>
+                  {Array.from({ length: FREE_LIMIT }, (_, i) => (
+                    <span key={i} className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${freeRemaining === null ? 'bg-slate-200 dark:bg-slate-700' : i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`} />
+                  ))}
+                  <span className="text-[10px] text-slate-400 dark:text-slate-500">
+                    {freeRemaining === null ? `${FREE_LIMIT} free` : freeRemaining > 0 ? `${freeRemaining} free` : 'limit reached'}
+                  </span>
+                  {freeRemaining === null && (
+                    <span className="pointer-events-none invisible absolute bottom-full left-0 z-50 mb-2 w-52 rounded bg-slate-800 px-2.5 py-2 opacity-0 shadow-lg transition-opacity group-hover/free:visible group-hover/free:opacity-100 dark:bg-slate-700">
+                      <span className="block text-[11px] leading-snug text-white">Free quota requires a server API key (<code className="rounded bg-slate-700 px-1 font-mono text-[10px]">ANTHROPIC_API_KEY</code>, <code className="rounded bg-slate-700 px-1 font-mono text-[10px]">OPENAI_API_KEY</code>, etc.). Add your own key below to chat without limits.</span>
+                      <span className="absolute left-3 top-full border-4 border-transparent border-t-slate-800 dark:border-t-slate-700" />
+                    </span>
+                  )}
+                </div>
+              )}
               <div className="flex-1 border-t border-slate-200 dark:border-slate-700" />
             </div>
 
             {/* Key entry or chat */}
-            {limitReached ? (
-              <KeyEntryForm onSave={handleSaveKey} exhausted />
+            {showKeyForm ? (
+              <KeyEntryForm onSave={handleSaveKey} exhausted={limitReached} notConfigured={needsKey && !limitReached}
+                onCancel={keyFormOpen && !limitReached && !needsKey ? () => setKeyFormOpen(false) : undefined} />
             ) : (
               <>
                 {/* Message history */}
                 <div className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3" aria-live="polite" aria-label="Chat messages">
-                  {showChips && (
-                    <div className="flex flex-wrap gap-2">
+                  {showChips && isInventoryPhase ? (
+                    <div className="flex flex-col gap-3 py-2">
+                      {/* Step 1 */}
+                      <div className="flex gap-3">
+                        {repoQuery.trim() ? (
+                          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-green-500 text-white">
+                            <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" className="h-3 w-3"><path strokeLinecap="round" strokeLinejoin="round" d="M2 6l3 3 5-5" /></svg>
+                          </span>
+                        ) : (
+                          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-sky-600 text-[10px] font-bold text-white">1</span>
+                        )}
+                        <div className="flex flex-col gap-1.5">
+                          <p className={`text-xs font-medium ${repoQuery.trim() ? 'text-slate-400 dark:text-slate-500' : 'text-slate-700 dark:text-slate-200'}`}>
+                            Filter repos above to narrow your scope
+                          </p>
+                          <div className="flex flex-wrap gap-1.5">
+                            {['lang:go', 'archived:false', 'stars:>500', 'pushed:>2024-01-01'].map((f) => (
+                              <button key={f} type="button"
+                                onClick={() => {
+                                  const tokens = repoQuery.trim().split(/\s+/).filter(Boolean)
+                                  const next = tokens.includes(f)
+                                    ? tokens.filter((t) => t !== f).join(' ')
+                                    : [...tokens, f].join(' ')
+                                  onRepoQueryChange?.(next)
+                                }}
+                                className={`rounded border px-2 py-0.5 font-mono text-[11px] transition-colors ${repoQuery.split(/\s+/).includes(f) ? 'border-sky-300 bg-sky-50 text-sky-700 dark:border-sky-700 dark:bg-sky-900/20 dark:text-sky-300' : 'border-slate-200 bg-slate-50 text-slate-500 hover:bg-sky-50 hover:border-sky-300 hover:text-sky-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-500 dark:hover:bg-sky-900/20 dark:hover:text-sky-300'}`}>
+                                {f}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                      {/* Connector */}
+                      <div className="ml-2.5 h-4 w-px bg-slate-200 dark:bg-slate-700" />
+                      {/* Step 2 */}
+                      <div className="flex gap-3">
+                        <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold ${repoQuery.trim() ? 'bg-sky-600 text-white' : 'border border-slate-300 text-slate-400 dark:border-slate-600 dark:text-slate-500'}`}>2</span>
+                        <div className="flex flex-col gap-1.5">
+                          <div className="flex items-center gap-2">
+                            <p className={`text-xs ${repoQuery.trim() ? 'font-medium text-slate-700 dark:text-slate-200' : 'text-slate-400 dark:text-slate-500'}`}>
+                              Ask AI about the filtered repos
+                            </p>
+                            {!hasKey && (
+                              <div className={`relative flex items-center gap-1 ${freeRemaining === null ? 'group/free cursor-help' : ''}`}>
+                                {Array.from({ length: FREE_LIMIT }, (_, i) => (
+                                  <span key={i} className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${freeRemaining === null ? 'bg-slate-200 dark:bg-slate-700' : i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`} />
+                                ))}
+                                <span className="text-[10px] text-slate-400 dark:text-slate-500">
+                                  {freeRemaining === null ? `${FREE_LIMIT} free` : freeRemaining > 0 ? `${freeRemaining} free` : 'limit reached'}
+                                </span>
+                                {freeRemaining === null && (
+                                  <span className="pointer-events-none invisible absolute bottom-full left-0 z-50 mb-2 w-52 rounded bg-slate-800 px-2.5 py-2 opacity-0 shadow-lg transition-opacity group-hover/free:visible group-hover/free:opacity-100 dark:bg-slate-700">
+                                    <span className="block text-[11px] leading-snug text-white">Free quota requires a server API key (<code className="rounded bg-slate-700 px-1 font-mono text-[10px]">ANTHROPIC_API_KEY</code>, <code className="rounded bg-slate-700 px-1 font-mono text-[10px]">OPENAI_API_KEY</code>, etc.). Add your own key below to chat without limits.</span>
+                                    <span className="absolute left-3 top-full border-4 border-transparent border-t-slate-800 dark:border-t-slate-700" />
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          <div className="flex flex-wrap gap-1.5">
+                            {ORG_INVENTORY_STARTER_CHIPS.map((chip) => (
+                              <button key={chip} type="button"
+                                disabled={!repoQuery.trim()}
+                                onClick={() => void append({ role: 'user', content: chip })}
+                                className={`rounded-full border px-3 py-1.5 text-xs transition-colors ${repoQuery.trim() ? 'border-slate-200 bg-slate-50 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700' : 'cursor-not-allowed border-slate-200 bg-slate-50 text-slate-300 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-600'}`}>
+                                {chip}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {messages.map((msg, idx) => (
+                    <React.Fragment key={msg.id}>
+                      {contextNotices.filter((n) => n.afterIndex === idx).map((n, ni) => (
+                        <div key={`notice-${idx}-${ni}`} className="flex items-center gap-2 py-1">
+                          <div className="flex-1 border-t border-dashed border-slate-200 dark:border-slate-700" />
+                          <span className="text-[10px] text-slate-400 dark:text-slate-500">{n.label}</span>
+                          <div className="flex-1 border-t border-dashed border-slate-200 dark:border-slate-700" />
+                        </div>
+                      ))}
+                      {msg.role === 'user' ? (
+                        <div className="flex justify-end">
+                          <div className="max-w-[80%] rounded-2xl bg-sky-600 px-4 py-2 text-sm text-white">{msg.content}</div>
+                        </div>
+                      ) : (
+                        <div className="flex flex-col items-start gap-1">
+                          <div className="max-w-[85%] rounded-2xl bg-slate-100 px-4 py-2 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">
+                            {msg.content ? (
+                              <div className="prose prose-sm max-w-none dark:prose-invert">{renderMarkdown(msg.content)}</div>
+                            ) : (
+                              <span className="animate-pulse text-slate-400">●</span>
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </React.Fragment>
+                  ))}
+                  {/* Notices added after all current messages */}
+                  {contextNotices.filter((n) => n.afterIndex >= messages.length).map((n, ni) => (
+                    <div key={`notice-end-${ni}`} className="flex items-center gap-2 py-1">
+                      <div className="flex-1 border-t border-dashed border-slate-200 dark:border-slate-700" />
+                      <span className="text-[10px] text-slate-400 dark:text-slate-500">{n.label}</span>
+                      <div className="flex-1 border-t border-dashed border-slate-200 dark:border-slate-700" />
+                    </div>
+                  ))}
+
+                  {/* Persistent suggestion chips — always visible, not just before first message */}
+                  {!isLoading && !(isInventoryPhase && showChips) && (
+                    <div className="flex flex-wrap gap-2 pt-1">
                       {starterChips.map((chip) => (
                         <button key={chip} type="button"
                           onClick={() => void append({ role: 'user', content: chip })}
@@ -630,39 +759,23 @@ export function ChatPanel({
                       ))}
                     </div>
                   )}
-
-                  {messages.map((msg) => {
-                    if (msg.role === 'user') {
-                      return (
-                        <div key={msg.id} className="flex justify-end">
-                          <div className="max-w-[80%] rounded-2xl bg-sky-600 px-4 py-2 text-sm text-white">{msg.content}</div>
-                        </div>
-                      )
-                    }
-                    return (
-                      <div key={msg.id} className="flex flex-col items-start gap-1">
-                        <div className="max-w-[85%] rounded-2xl bg-slate-100 px-4 py-2 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">
-                          {msg.content ? (
-                            <div className="prose prose-sm max-w-none dark:prose-invert">{renderMarkdown(msg.content)}</div>
-                          ) : (
-                            <span className="animate-pulse text-slate-400">●</span>
-                          )}
-                        </div>
-                      </div>
-                    )
-                  })}
                   <div ref={messagesEndRef} />
                 </div>
 
-                {/* Error banner */}
-                {chatError && (
-                  <div className="mx-4 mb-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200">
-                    <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
-                      <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
-                    </svg>
-                    <span>{chatError.message || 'Something went wrong — please try again.'}</span>
-                  </div>
-                )}
+                {/* Error banner — only for errors that aren't handled by showing the key form */}
+                {chatError && (() => {
+                  const parsed = parseApiError(chatError.message)
+                  if (parsed?.code === 'NOT_CONFIGURED' || parsed?.code === 'FREE_LIMIT_REACHED') return null
+                  const displayMsg = parsed?.userMessage ?? chatError.message ?? 'Something went wrong — please try again.'
+                  return (
+                    <div className="mx-4 mb-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200">
+                      <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
+                        <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+                      </svg>
+                      <span>{displayMsg}</span>
+                    </div>
+                  )
+                })()}
 
                 {/* Input */}
                 <form onSubmit={handleSubmit} className="border-t border-slate-200 px-4 py-3 dark:border-slate-700">

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -613,8 +613,8 @@ export function ChatPanel({
             </div>
 
             {/* Key entry or chat */}
-            {!hasKey || limitReached ? (
-              <KeyEntryForm onSave={handleSaveKey} exhausted={limitReached} />
+            {limitReached ? (
+              <KeyEntryForm onSave={handleSaveKey} exhausted />
             ) : (
               <>
                 {/* Message history */}

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -369,7 +369,7 @@ export function ChatPanel({
 
   const activeProvider = userKey ? provider : ('anthropic' as ProviderId)
 
-  const { messages, input, setInput, handleSubmit, isLoading, stop, setMessages, data, append } = useChat({
+  const { messages, input, setInput, handleSubmit, isLoading, stop, setMessages, data, append, error: chatError } = useChat({
     api: '/api/chat',
     body: {
       context,
@@ -653,6 +653,16 @@ export function ChatPanel({
                   })}
                   <div ref={messagesEndRef} />
                 </div>
+
+                {/* Error banner */}
+                {chatError && (
+                  <div className="mx-4 mb-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200">
+                    <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
+                      <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
+                    </svg>
+                    <span>{chatError.message || 'Something went wrong — please try again.'}</span>
+                  </div>
+                )}
 
                 {/* Input */}
                 <form onSubmit={handleSubmit} className="border-t border-slate-200 px-4 py-3 dark:border-slate-700">

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -1,29 +1,16 @@
 'use client'
 
-import { useEffect, useRef, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
+import { useChat } from 'ai/react'
+import type { Message } from 'ai'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse, OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
 import { parseStructuredSearchQuery } from '@/lib/org-inventory/structured-search'
 import { serializeReposContext, serializeOrgContext, serializeOrgInventoryContext, type OrgSortBy } from './serialize-context'
+import { PROVIDERS, type ProviderId, type ModelTier } from './providers'
 
 // ---- Types ----------------------------------------------------------------
-
-type Model = 'claude-haiku-4-5' | 'claude-sonnet-4-6'
-
-interface MessageUsage {
-  inputTokens: number
-  outputTokens: number
-  cacheReadTokens: number
-}
-
-interface ChatMessage {
-  id: string
-  role: 'user' | 'assistant' | 'error'
-  content: string
-  usage?: MessageUsage
-  retryContent?: string
-}
 
 export interface ChatPanelProps {
   contextType: 'repos' | 'org'
@@ -34,62 +21,36 @@ export interface ChatPanelProps {
   orgInventory?: OrgInventoryResponse
   githubToken: string
   resetKey?: number
-  /** Controlled repo filter query — synced with the org inventory table */
   repoQuery?: string
   onRepoQueryChange?: (q: string) => void
 }
 
 // ---- Constants ------------------------------------------------------------
 
+const FREE_LIMIT = 5
+
 const REPOS_STARTER_CHIPS = [
   'Why is the security score low?',
   "What's the biggest gap between these repos?",
   'Which repo should I fix first?',
-  'What do these repos have in common?',
 ]
 
 const ORG_STARTER_CHIPS = [
   'Which repos need the most urgent attention?',
   "What's the overall security posture?",
   'Which repos are best positioned for CNCF Sandbox?',
-  'Are there repos with low activity but high star counts?',
 ]
 
 const ORG_INVENTORY_STARTER_CHIPS = [
   "Which repos haven't been active in over a year?",
   'What languages are most common across this org?',
   'Which repos have the most open issues?',
-  'Are there any archived or forked repos?',
 ]
-
-const MODEL_META: Record<Model, { icon: string; label: string; hint: string; inputRate: number; outputRate: number; cacheReadRate: number }> = {
-  'claude-haiku-4-5': {
-    icon: '⚡', label: 'Fast',
-    hint: 'Best for quick lookups and factual questions about the data',
-    inputRate: 0.80, outputRate: 4.00, cacheReadRate: 0.08,
-  },
-  'claude-sonnet-4-6': {
-    icon: '🧠', label: 'Deep',
-    hint: 'Better for multi-hop reasoning, comparisons, and nuanced recommendations',
-    inputRate: 3.00, outputRate: 15.00, cacheReadRate: 0.30,
-  },
-}
 
 const SORT_OPTIONS: { value: OrgSortBy; label: string }[] = [
-  { value: 'stars', label: '⭐ Top by stars' },
-  { value: 'health', label: '🔴 Lowest health first' },
+  { value: 'stars',    label: '⭐ Top by stars' },
+  { value: 'health',   label: '🔴 Lowest health first' },
   { value: 'activity', label: '⚡ Most recently active' },
-]
-
-const SEARCH_PREFIX_HINTS: { key: string; description: string; example: string }[] = [
-  { key: 'lang',     description: 'Programming language',  example: 'lang:go' },
-  { key: 'archived', description: 'Archived status',       example: 'archived:false' },
-  { key: 'stars',    description: 'Star count',            example: 'stars:>500' },
-  { key: 'forks',    description: 'Fork count',            example: 'forks:>10' },
-  { key: 'issues',   description: 'Open issues count',     example: 'issues:<50' },
-  { key: 'pushed',   description: 'Last push date',        example: 'pushed:>2024-01-01' },
-  { key: 'topic',    description: 'Repository topic',      example: 'topic:kubernetes' },
-  { key: 'license',  description: 'License type',          example: 'license:apache-2.0' },
 ]
 
 const COMPLETION_VALUES: Record<string, string[]> = {
@@ -102,6 +63,25 @@ const COMPLETION_VALUES: Record<string, string[]> = {
   topic:    ['kubernetes', 'machine-learning', 'security', 'cli', 'api', 'docker', 'ai', 'devops'],
   license:  ['apache-2.0', 'mit', 'gpl-3.0', 'bsd-3-clause', 'mpl-2.0'],
 }
+
+const SEARCH_PREFIX_HINTS: { key: string; description: string; example: string }[] = [
+  { key: 'lang',     description: 'Programming language',  example: 'lang:go' },
+  { key: 'archived', description: 'Archived status',       example: 'archived:false' },
+  { key: 'stars',    description: 'Star count',            example: 'stars:>500' },
+  { key: 'forks',    description: 'Fork count',            example: 'forks:>10' },
+  { key: 'issues',   description: 'Open issues count',     example: 'issues:<50' },
+  { key: 'pushed',   description: 'Last push date',        example: 'pushed:>2024-01-01' },
+  { key: 'topic',    description: 'Repository topic',      example: 'topic:kubernetes' },
+  { key: 'license',  description: 'License type',          example: 'license:apache-2.0' },
+]
+
+const LS_KEY_PROVIDER  = 'repopulse:chat:provider'
+const LS_KEY_MODEL_TIER = 'repopulse:chat:modelTier'
+const SS_KEY_EXPANDED  = 'repopulse:chat:expanded'
+const SS_KEY_PROVIDER  = 'repopulse:chat:provider:session'
+const SS_KEY_API_KEY   = 'repopulse:chat:apiKey'
+
+// ---- Helpers --------------------------------------------------------------
 
 function computeCompletions(query: string): string[] {
   const lastToken = query.match(/(?:^|\s)(\S*)$/)?.[1] ?? ''
@@ -123,46 +103,6 @@ function applyCompletion(query: string, completion: string): string {
   return query.replace(/(\s*)(\S*)$/, (_, space) => `${space}${completion} `).trimStart()
 }
 
-const FREE_LIMIT = 5
-
-const SS_KEY_ANTHROPIC = 'repopulse:chat:anthropicKey'
-const LS_KEY_MODEL = 'repopulse:chat:model'
-const SS_KEY_EXPANDED = 'repopulse:chat:expanded'
-
-// ---- Helpers --------------------------------------------------------------
-
-function uid(): string {
-  return Math.random().toString(36).slice(2)
-}
-
-function readStoredModel(): Model {
-  try {
-    const v = localStorage.getItem(LS_KEY_MODEL)
-    if (v === 'claude-haiku-4-5' || v === 'claude-sonnet-4-6') return v
-  } catch {}
-  return 'claude-haiku-4-5'
-}
-
-function readStoredExpanded(): boolean {
-  try { return sessionStorage.getItem(SS_KEY_EXPANDED) === 'true' } catch {}
-  return false
-}
-
-function readStoredKey(): string {
-  try { return sessionStorage.getItem(SS_KEY_ANTHROPIC) ?? '' } catch {}
-  return ''
-}
-
-function calcCost(usage: MessageUsage, model: Model): number {
-  const { inputRate, outputRate, cacheReadRate } = MODEL_META[model]
-  return (
-    (usage.inputTokens * inputRate +
-      usage.outputTokens * outputRate +
-      usage.cacheReadTokens * cacheReadRate) /
-    1_000_000
-  )
-}
-
 function formatCost(usd: number): string {
   if (usd < 0.0001) return '<$0.0001'
   return `$${usd.toFixed(4)}`
@@ -172,7 +112,12 @@ function formatTokens(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
 }
 
-// ---- Markdown renderer (paragraphs, bold, inline code, fenced code) -------
+function calcCost(promptTokens: number, completionTokens: number, provider: ProviderId, modelTier: ModelTier): number {
+  const spec = PROVIDERS[provider].models[modelTier]
+  return (promptTokens * spec.inputRate + completionTokens * spec.outputRate) / 1_000_000
+}
+
+// ---- Markdown renderer ----------------------------------------------------
 
 function renderMarkdown(text: string): React.ReactNode {
   const parts = text.split(/(```[\s\S]*?```)/g)
@@ -206,20 +151,9 @@ function SearchFilter({ value, onChange }: { value: string; onChange: (q: string
   const blurRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const parsed = parseStructuredSearchQuery(value)
 
-  function open(q: string) {
-    const c = computeCompletions(q)
-    setCompletions(c)
-    setActiveIdx(-1)
-  }
-
+  function open(q: string) { const c = computeCompletions(q); setCompletions(c); setActiveIdx(-1) }
   function close() { setCompletions([]); setActiveIdx(-1) }
-
-  function pick(completion: string) {
-    onChange(applyCompletion(value, completion))
-    close()
-  }
-
-  function handleChange(q: string) { onChange(q); open(q) }
+  function pick(c: string) { onChange(applyCompletion(value, c)); close() }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (completions.length === 0) return
@@ -227,10 +161,7 @@ function SearchFilter({ value, onChange }: { value: string; onChange: (q: string
     else if (e.key === 'ArrowUp') { e.preventDefault(); setActiveIdx((i) => Math.max(i - 1, -1)) }
     else if (e.key === 'Enter' && activeIdx >= 0) { e.preventDefault(); pick(completions[activeIdx]) }
     else if (e.key === 'Escape') close()
-    else if (e.key === 'Tab' && completions.length > 0) {
-      e.preventDefault()
-      pick(completions[activeIdx >= 0 ? activeIdx : 0])
-    }
+    else if (e.key === 'Tab' && completions.length > 0) { e.preventDefault(); pick(completions[activeIdx >= 0 ? activeIdx : 0]) }
   }
 
   return (
@@ -243,7 +174,7 @@ function SearchFilter({ value, onChange }: { value: string; onChange: (q: string
           <input
             type="text"
             value={value}
-            onChange={(e) => handleChange(e.target.value)}
+            onChange={(e) => { onChange(e.target.value); open(e.target.value) }}
             onFocus={() => open(value)}
             onBlur={() => { blurRef.current = setTimeout(close, 150) }}
             onKeyDown={handleKeyDown}
@@ -253,10 +184,7 @@ function SearchFilter({ value, onChange }: { value: string; onChange: (q: string
             className="w-full rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
           />
           {completions.length > 0 && (
-            <ul
-              role="listbox"
-              className="absolute bottom-full left-0 z-50 mb-1 w-full overflow-hidden rounded border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900"
-            >
+            <ul role="listbox" className="absolute bottom-full left-0 z-50 mb-1 w-full overflow-hidden rounded border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900">
               {completions.map((c, i) => (
                 <li key={c} role="option" aria-selected={i === activeIdx}>
                   <button
@@ -297,50 +225,102 @@ function SearchFilter({ value, onChange }: { value: string; onChange: (q: string
 
 // ---- Key entry form -------------------------------------------------------
 
-function KeyEntryForm({ onSave, exhausted = false }: { onSave: (key: string) => void; exhausted?: boolean }) {
-  const [value, setValue] = useState('')
+const DIRECT_PROVIDERS: ProviderId[] = ['anthropic', 'openai', 'google', 'groq']
+
+function KeyEntryForm({
+  onSave,
+  exhausted = false,
+}: {
+  onSave: (provider: ProviderId, key: string) => void
+  exhausted?: boolean
+}) {
+  const [tab, setTab] = useState<'openrouter' | 'direct'>('openrouter')
+  const [directProvider, setDirectProvider] = useState<ProviderId>('anthropic')
+  const [keyValue, setKeyValue] = useState('')
+
+  const activeProvider: ProviderId = tab === 'openrouter' ? 'openrouter' : directProvider
+  const config = PROVIDERS[activeProvider]
+
+  function handleSave() {
+    if (!keyValue.trim()) return
+    onSave(activeProvider, keyValue.trim())
+  }
+
   return (
     <div className="flex flex-col gap-3 p-4">
       {exhausted && (
-        <div className="flex items-center gap-2 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
-          <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4 shrink-0">
+        <div className="flex items-start gap-2 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+          <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
             <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
           </svg>
-          You&apos;ve used all {FREE_LIMIT} free chats. Add your Anthropic API key for unlimited access.
+          You&apos;ve used all {FREE_LIMIT} free chats. Add an API key for unlimited access.
         </div>
       )}
+
+      {/* Provider tabs */}
+      <div className="flex gap-1 rounded-lg border border-slate-200 bg-slate-50 p-1 dark:border-slate-700 dark:bg-slate-800">
+        <button
+          type="button"
+          onClick={() => { setTab('openrouter'); setKeyValue('') }}
+          className={`flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'openrouter' ? 'bg-white shadow-sm text-slate-900 dark:bg-slate-700 dark:text-slate-100' : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
+        >
+          OpenRouter
+          <span className="ml-1.5 rounded-full bg-sky-100 px-1.5 py-0.5 text-[9px] font-semibold text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">recommended</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => { setTab('direct'); setKeyValue('') }}
+          className={`flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${tab === 'direct' ? 'bg-white shadow-sm text-slate-900 dark:bg-slate-700 dark:text-slate-100' : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}`}
+        >
+          Direct provider
+        </button>
+      </div>
+
+      {/* Direct provider selector */}
+      {tab === 'direct' && (
+        <div className="flex gap-1">
+          {DIRECT_PROVIDERS.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => { setDirectProvider(p); setKeyValue('') }}
+              className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${directProvider === p ? 'bg-slate-800 text-white dark:bg-slate-200 dark:text-slate-900' : 'border border-slate-200 text-slate-600 hover:border-slate-400 dark:border-slate-700 dark:text-slate-400 dark:hover:border-slate-500'}`}
+            >
+              {PROVIDERS[p].name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Tagline */}
+      <p className="text-xs text-slate-500 dark:text-slate-400">{config.tagline}</p>
+
+      {/* Key input */}
       <div>
-        <label htmlFor="chat-anthropic-key" className="block text-sm font-medium text-slate-800 dark:text-slate-200">
-          Anthropic API key
-        </label>
-        <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
-          Your key is sent only to Anthropic to generate responses. It is never logged, stored on our
-          servers, or used for anything other than this chat session.
+        <input
+          type="password"
+          value={keyValue}
+          onChange={(e) => setKeyValue(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleSave() }}
+          placeholder={config.keyPlaceholder}
+          autoComplete="off"
+          spellCheck={false}
+          className="w-full rounded border border-slate-300 bg-slate-50 px-3 py-1.5 font-mono text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
+        />
+        <p className="mt-1 text-[10px] text-slate-400 dark:text-slate-500">
+          Your key is sent only to {config.name} to generate responses. Never logged or stored on our servers.
         </p>
       </div>
-      <input
-        id="chat-anthropic-key"
-        type="password"
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        placeholder="sk-ant-…"
-        autoComplete="off"
-        spellCheck={false}
-        className="w-full rounded border border-slate-300 bg-slate-50 px-3 py-1.5 font-mono text-xs text-slate-900 placeholder-slate-400 focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
-      />
-      <div className="flex items-center justify-between gap-3">
-        <a
-          href="https://console.anthropic.com/settings/keys"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-sky-700 hover:underline dark:text-sky-400"
-        >
-          Get a free key at console.anthropic.com →
+
+      <div className="flex items-center justify-between">
+        <a href={config.consoleUrl} target="_blank" rel="noopener noreferrer"
+          className="text-xs text-sky-700 hover:underline dark:text-sky-400">
+          Get a key at {config.consoleLabel} →
         </a>
         <button
           type="button"
-          disabled={!value.trim()}
-          onClick={() => onSave(value.trim())}
+          disabled={!keyValue.trim()}
+          onClick={handleSave}
           className="rounded bg-slate-800 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700 disabled:opacity-40 dark:bg-slate-200 dark:text-slate-900 dark:hover:bg-white"
         >
           Save key
@@ -357,42 +337,87 @@ export function ChatPanel({
   repoQuery = '', onRepoQueryChange,
 }: ChatPanelProps) {
   const [expanded, setExpanded] = useState(false)
-  const [model, setModel] = useState<Model>('claude-haiku-4-5')
-  const [anthropicKey, setAnthropicKey] = useState('')
-  const [messages, setMessages] = useState<ChatMessage[]>([])
-  const [inputValue, setInputValue] = useState('')
-  const [isStreaming, setIsStreaming] = useState(false)
+  const [provider, setProvider] = useState<ProviderId>('openrouter')
+  const [modelTier, setModelTier] = useState<ModelTier>('fast')
+  const [userKey, setUserKey] = useState('')
   const [orgRepoCount, setOrgRepoCount] = useState(500)
   const [sortBy, setSortBy] = useState<OrgSortBy>('stars')
-  const [sessionUsage, setSessionUsage] = useState<{ messages: number; totalCost: number }>({ messages: 0, totalCost: 0 })
-  const [freeRemaining, setFreeRemaining] = useState<number>(FREE_LIMIT)
+  const [freeRemaining, setFreeRemaining] = useState(FREE_LIMIT)
+  const [sessionCost, setSessionCost] = useState(0)
+  const [sessionMsgCount, setSessionMsgCount] = useState(0)
   const messagesEndRef = useRef<HTMLDivElement>(null)
-  const abortRef = useRef<AbortController | null>(null)
 
   // Hydrate from storage after mount
   useEffect(() => {
-    setModel(readStoredModel())
-    setExpanded(readStoredExpanded())
-    setAnthropicKey(readStoredKey())
+    try {
+      const p = sessionStorage.getItem(SS_KEY_PROVIDER) ?? localStorage.getItem(LS_KEY_PROVIDER)
+      if (p && p in PROVIDERS) setProvider(p as ProviderId)
+      const t = localStorage.getItem(LS_KEY_MODEL_TIER)
+      if (t === 'fast' || t === 'smart') setModelTier(t)
+      const k = sessionStorage.getItem(SS_KEY_API_KEY) ?? ''
+      setUserKey(k)
+      setExpanded(sessionStorage.getItem(SS_KEY_EXPANDED) === 'true')
+    } catch {}
   }, [])
 
-  // Reset conversation when resetKey changes
+  const context = useMemo(() => {
+    if (contextType === 'repos' && repoResults) return serializeReposContext(repoResults).text
+    if (contextType === 'org' && orgView && org) return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount, sortBy, orgRepos }).text
+    if (contextType === 'org' && orgInventory) return serializeOrgInventoryContext(orgInventory, { maxRepos: orgRepoCount, sortBy }).text
+    return ''
+  }, [contextType, repoResults, orgView, org, orgRepos, orgInventory, orgRepoCount, sortBy])
+
+  const activeProvider = userKey ? provider : ('anthropic' as ProviderId)
+
+  const { messages, input, setInput, handleSubmit, isLoading, stop, setMessages, data, append } = useChat({
+    api: '/api/chat',
+    body: {
+      context,
+      contextType,
+      githubToken,
+      provider: activeProvider,
+      model: PROVIDERS[activeProvider].models[modelTier].id,
+      apiKey: userKey || undefined,
+    },
+    onFinish: (_message: Message, options: { usage?: { promptTokens: number; completionTokens: number } }) => {
+      const usage = options?.usage
+      if (usage) {
+        const cost = calcCost(usage.promptTokens, usage.completionTokens, activeProvider, modelTier)
+        setSessionCost((prev) => prev + cost)
+        setSessionMsgCount((prev) => prev + 1)
+      }
+    },
+    onError: (error: Error) => {
+      if (error.message.includes('FREE_LIMIT_REACHED') || error.message.includes('free chats')) {
+        setFreeRemaining(0)
+      }
+    },
+  })
+
+  // Sync freeRemaining from stream data
   useEffect(() => {
-    if (resetKey === undefined) return
-    setMessages([])
-    setInputValue('')
-    setSessionUsage({ messages: 0, totalCost: 0 })
-    abortRef.current?.abort()
-    abortRef.current = null
-    setIsStreaming(false)
-    try { sessionStorage.removeItem(SS_KEY_EXPANDED) } catch {}
-    setExpanded(false)
-  }, [resetKey])
+    if (!data?.length) return
+    const last = [...data].reverse().find((d) => typeof (d as { remaining?: number }).remaining === 'number')
+    if (last) setFreeRemaining((last as { remaining: number }).remaining)
+  }, [data])
 
   // Scroll to latest message
   useEffect(() => {
     if (expanded) messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, expanded])
+
+  // Reset on resetKey change
+  useEffect(() => {
+    if (resetKey === undefined) return
+    setMessages([])
+    setInput('')
+    setSessionCost(0)
+    setSessionMsgCount(0)
+    stop()
+    try { sessionStorage.removeItem(SS_KEY_EXPANDED) } catch {}
+    setExpanded(false)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey])
 
   function handleExpandToggle() {
     const next = !expanded
@@ -400,28 +425,44 @@ export function ChatPanel({
     try { sessionStorage.setItem(SS_KEY_EXPANDED, String(next)) } catch {}
   }
 
-  function handleModelChange(m: Model) {
-    setModel(m)
-    try { localStorage.setItem(LS_KEY_MODEL, m) } catch {}
-  }
-
-  function handleSaveKey(key: string) {
-    setAnthropicKey(key)
-    try { sessionStorage.setItem(SS_KEY_ANTHROPIC, key) } catch {}
+  function handleSaveKey(p: ProviderId, key: string) {
+    setProvider(p)
+    setUserKey(key)
+    try {
+      sessionStorage.setItem(SS_KEY_PROVIDER, p)
+      sessionStorage.setItem(SS_KEY_API_KEY, key)
+      localStorage.setItem(LS_KEY_PROVIDER, p)
+    } catch {}
+    setMessages([])
+    setSessionCost(0)
+    setSessionMsgCount(0)
   }
 
   function handleClearKey() {
-    setAnthropicKey('')
-    try { sessionStorage.removeItem(SS_KEY_ANTHROPIC) } catch {}
+    setUserKey('')
+    try {
+      sessionStorage.removeItem(SS_KEY_API_KEY)
+      sessionStorage.removeItem(SS_KEY_PROVIDER)
+    } catch {}
     setMessages([])
-    setSessionUsage({ messages: 0, totalCost: 0 })
+    setSessionCost(0)
+    setSessionMsgCount(0)
+  }
+
+  function handleModelTierChange(t: ModelTier) {
+    setModelTier(t)
+    try { localStorage.setItem(LS_KEY_MODEL_TIER, t) } catch {}
+    setMessages([])
+    setSessionCost(0)
+    setSessionMsgCount(0)
   }
 
   function handleOrgRepoCountChange(count: number) {
     if (count !== orgRepoCount) {
       setOrgRepoCount(count)
       setMessages([])
-      setSessionUsage({ messages: 0, totalCost: 0 })
+      setSessionCost(0)
+      setSessionMsgCount(0)
     }
   }
 
@@ -429,180 +470,26 @@ export function ChatPanel({
     if (s !== sortBy) {
       setSortBy(s)
       setMessages([])
-      setSessionUsage({ messages: 0, totalCost: 0 })
+      setSessionCost(0)
+      setSessionMsgCount(0)
     }
-  }
-
-  function buildContext(): string {
-    if (contextType === 'repos' && repoResults)
-      return serializeReposContext(repoResults).text
-    if (contextType === 'org' && orgView && org)
-      return serializeOrgContext(org, orgView, { maxRepos: orgRepoCount, sortBy, orgRepos }).text
-    if (contextType === 'org' && orgInventory)
-      return serializeOrgInventoryContext(orgInventory, { maxRepos: orgRepoCount, sortBy }).text
-    return ''
-  }
-
-  const sendMessage = useCallback(async (text: string) => {
-    if (!text.trim() || isStreaming) return
-
-    const userMsg: ChatMessage = { id: uid(), role: 'user', content: text }
-    const assistantId = uid()
-
-    setMessages((prev) => [...prev, userMsg, { id: assistantId, role: 'assistant', content: '' }])
-    setInputValue('')
-    setIsStreaming(true)
-
-    const controller = new AbortController()
-    abortRef.current = controller
-
-    const apiMessages = [
-      ...messages
-        .filter((m) => m.role === 'user' || m.role === 'assistant')
-        .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content })),
-      { role: 'user' as const, content: text },
-    ]
-
-    try {
-      const response = await fetch('/api/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          messages: apiMessages,
-          context: buildContext(),
-          contextType,
-          githubToken,
-          anthropicKey: anthropicKey || undefined,
-          model,
-        }),
-        signal: controller.signal,
-      })
-
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({})) as { error?: { message?: string; code?: string; remaining?: number } }
-        const code = payload.error?.code
-        if (code === 'FREE_LIMIT_REACHED') {
-          setFreeRemaining(0)
-          setMessages((prev) => prev.filter((m) => m.id !== assistantId))
-          return
-        }
-        const msg =
-          code === 'NOT_CONFIGURED'
-            ? "AI chat isn't available — please provide an Anthropic API key."
-            : payload.error?.message ?? 'Something went wrong — please try again in a moment.'
-        setMessages((prev) =>
-          prev.map((m) => m.id === assistantId ? { ...m, role: 'error', content: msg, retryContent: text } : m),
-        )
-        return
-      }
-
-      const reader = response.body?.getReader()
-      if (!reader) {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === assistantId
-              ? { ...m, role: 'error', content: 'Streaming is not supported in this environment.', retryContent: text }
-              : m,
-          ),
-        )
-        return
-      }
-
-      const decoder = new TextDecoder()
-      let buffer = ''
-      let msgUsage: MessageUsage | undefined
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop() ?? ''
-
-        for (const line of lines) {
-          if (!line.startsWith('data: ')) continue
-          let event: { type: string; text?: string; code?: string; message?: string; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; remaining?: number }
-          try { event = JSON.parse(line.slice(6)) } catch { continue }
-
-          if (event.type === 'delta' && event.text) {
-            setMessages((prev) =>
-              prev.map((m) => m.id === assistantId ? { ...m, content: m.content + event.text! } : m),
-            )
-          } else if (event.type === 'usage') {
-            msgUsage = {
-              inputTokens: event.inputTokens ?? 0,
-              outputTokens: event.outputTokens ?? 0,
-              cacheReadTokens: event.cacheReadTokens ?? 0,
-            }
-            setMessages((prev) =>
-              prev.map((m) => m.id === assistantId ? { ...m, usage: msgUsage } : m),
-            )
-            const cost = calcCost(msgUsage, model)
-            setSessionUsage((prev) => ({ messages: prev.messages + 1, totalCost: prev.totalCost + cost }))
-            if (typeof event.remaining === 'number') {
-              setFreeRemaining(event.remaining)
-            }
-          } else if (event.type === 'error') {
-            const noRetry = event.code === 'NOT_CONFIGURED' || event.code === 'CONTEXT_TOO_LARGE'
-            const showKeyLink = event.code === 'INVALID_KEY'
-            setMessages((prev) =>
-              prev.map((m) =>
-                m.id === assistantId
-                  ? { ...m, role: 'error', content: event.message ?? 'Something went wrong.', retryContent: noRetry ? undefined : text, ...(showKeyLink ? { isKeyError: true } : {}) }
-                  : m,
-              ),
-            )
-          }
-        }
-      }
-    } catch (err: unknown) {
-      if ((err as { name?: string }).name === 'AbortError') return
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === assistantId
-            ? { ...m, role: 'error', content: 'Something went wrong — please try again in a moment.', retryContent: text }
-            : m,
-        ),
-      )
-    } finally {
-      setIsStreaming(false)
-      abortRef.current = null
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isStreaming, messages, contextType, githubToken, anthropicKey, model, orgRepoCount, sortBy, repoResults, orgView, org, orgRepos])
-
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    void sendMessage(inputValue)
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); void sendMessage(inputValue) }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit(e as unknown as React.FormEvent)
+    }
   }
 
-  function handleRetry(retryContent: string) {
-    setMessages((prev) => prev.filter((m) => m.retryContent !== retryContent))
-    void sendMessage(retryContent)
-  }
-
-  function handleNewConversation() {
-    abortRef.current?.abort()
-    abortRef.current = null
-    setMessages([])
-    setSessionUsage({ messages: 0, totalCost: 0 })
-    setIsStreaming(false)
-  }
-
+  const hasKey = !!userKey
+  const limitReached = !hasKey && freeRemaining === 0
   const isInventoryPhase = contextType === 'org' && !orgView && !!orgInventory
-  const starterChips = contextType === 'repos'
-    ? REPOS_STARTER_CHIPS
-    : isInventoryPhase
-      ? ORG_INVENTORY_STARTER_CHIPS
-      : ORG_STARTER_CHIPS
-  const showChips = messages.length === 0 && !isStreaming
+  const starterChips = contextType === 'repos' ? REPOS_STARTER_CHIPS : isInventoryPhase ? ORG_INVENTORY_STARTER_CHIPS : ORG_STARTER_CHIPS
+  const showChips = messages.length === 0 && !isLoading
   const orgTotal = orgView?.status.total ?? orgInventory?.results.length ?? 0
   const isOrgAndLarge = contextType === 'org' && orgTotal > 500
-  const hasKey = !!anthropicKey
+  const activeModelSpec = PROVIDERS[activeProvider].models[modelTier]
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-40 mx-auto max-w-5xl px-4">
@@ -610,11 +497,8 @@ export function ChatPanel({
 
         {/* Collapsed bar */}
         {!expanded ? (
-          <button
-            type="button"
-            onClick={handleExpandToggle}
-            className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800"
-          >
+          <button type="button" onClick={handleExpandToggle}
+            className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800">
             <span aria-hidden="true" className="text-base">✨</span>
             <span className="flex-1">
               Ask a question about this analysis
@@ -634,106 +518,82 @@ export function ChatPanel({
             <div className="flex flex-wrap items-center gap-2 border-b border-slate-200 px-4 py-2 dark:border-slate-700">
               <span className="mr-1 font-semibold text-slate-900 dark:text-slate-100">Ask Claude</span>
 
-              {/* Model switcher */}
+              {/* Model tier switcher */}
               <div className="flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 p-0.5 dark:border-slate-700 dark:bg-slate-800">
-                {(Object.entries(MODEL_META) as [Model, typeof MODEL_META[Model]][]).map(([m, info]) => (
-                  <button
-                    key={m}
-                    type="button"
-                    title={`${info.hint} · Input $${info.inputRate}/1M · Output $${info.outputRate}/1M`}
-                    onClick={() => handleModelChange(m)}
-                    className={
-                      model === m
-                        ? 'rounded-full bg-white px-2.5 py-1 text-xs font-medium shadow-sm dark:bg-slate-700 text-slate-900 dark:text-slate-100'
-                        : 'rounded-full px-2.5 py-1 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
-                    }
-                  >
-                    {info.icon} {info.label}
-                  </button>
-                ))}
+                {(['fast', 'smart'] as ModelTier[]).map((t) => {
+                  const spec = PROVIDERS[activeProvider].models[t]
+                  return (
+                    <button key={t} type="button"
+                      title={`${spec.label} · $${PROVIDERS[activeProvider].models[t].inputRate}/1M in · $${PROVIDERS[activeProvider].models[t].outputRate}/1M out`}
+                      onClick={() => handleModelTierChange(t)}
+                      className={modelTier === t
+                        ? 'rounded-full bg-white px-2.5 py-1 text-xs font-medium shadow-sm text-slate-900 dark:bg-slate-700 dark:text-slate-100'
+                        : 'rounded-full px-2.5 py-1 text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'}>
+                      {t === 'fast' ? '⚡' : '🧠'} {t === 'fast' ? 'Fast' : 'Smart'}
+                    </button>
+                  )
+                })}
               </div>
+
+              {/* Provider badge (when key set) */}
+              {hasKey && (
+                <span className="rounded border border-slate-200 px-2 py-0.5 text-[10px] text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                  {PROVIDERS[provider].name} · {activeModelSpec.label}
+                </span>
+              )}
 
               {/* Org controls */}
               {isOrgAndLarge && (
                 <>
                   <div className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-slate-400">
                     <label htmlFor="chat-repo-count" className="whitespace-nowrap">Top</label>
-                    <input
-                      id="chat-repo-count"
-                      type="range"
-                      min="50"
-                      max="500"
-                      step="50"
-                      value={orgRepoCount}
-                      onChange={(e) => handleOrgRepoCountChange(Number(e.target.value))}
-                      className="w-20 accent-sky-600"
-                    />
+                    <input id="chat-repo-count" type="range" min="50" max="500" step="50"
+                      value={orgRepoCount} onChange={(e) => handleOrgRepoCountChange(Number(e.target.value))}
+                      className="w-20 accent-sky-600" />
                     <span className="w-8 text-right font-medium">{orgRepoCount}</span>
                     <span>repos</span>
                   </div>
-                  <select
-                    value={sortBy}
-                    onChange={(e) => handleSortByChange(e.target.value as OrgSortBy)}
-                    className="rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300"
-                  >
-                    {SORT_OPTIONS.map((o) => (
-                      <option key={o.value} value={o.value}>{o.label}</option>
-                    ))}
+                  <select value={sortBy} onChange={(e) => handleSortByChange(e.target.value as OrgSortBy)}
+                    className="rounded border border-slate-200 bg-slate-50 px-2 py-1 text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                    {SORT_OPTIONS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
                   </select>
                 </>
               )}
 
               {/* Session cost */}
-              {sessionUsage.messages > 0 && (
+              {sessionMsgCount > 0 && (
                 <span className="text-xs text-slate-400 dark:text-slate-500">
-                  Session: {sessionUsage.messages} {sessionUsage.messages === 1 ? 'msg' : 'msgs'} · {formatCost(sessionUsage.totalCost)}
+                  {sessionMsgCount} {sessionMsgCount === 1 ? 'msg' : 'msgs'} · {formatCost(sessionCost)}
                 </span>
               )}
 
-              {/* Free chat indicator (shown when no own key) */}
+              {/* Free chat indicator */}
               {!hasKey && (
                 <div className="flex items-center gap-1.5">
                   {Array.from({ length: FREE_LIMIT }, (_, i) => (
-                    <span
-                      key={i}
-                      className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`}
-                    />
+                    <span key={i} className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`} />
                   ))}
                   <span className="text-[10px] text-slate-400 dark:text-slate-500">
-                    {freeRemaining > 0
-                      ? `${freeRemaining} free ${freeRemaining === 1 ? 'chat' : 'chats'} left`
-                      : 'Free limit reached'}
+                    {freeRemaining > 0 ? `${freeRemaining} free ${freeRemaining === 1 ? 'chat' : 'chats'} left` : 'Free limit reached'}
                   </span>
                 </div>
               )}
 
               <div className="ml-auto flex items-center gap-2">
-                {/* Change key */}
                 {hasKey && (
-                  <button
-                    type="button"
-                    onClick={handleClearKey}
-                    className="text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300"
-                    title="Clear stored API key"
-                  >
+                  <button type="button" onClick={handleClearKey}
+                    className="text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300">
                     Change key
                   </button>
                 )}
                 {messages.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={handleNewConversation}
-                    className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
-                  >
+                  <button type="button" onClick={() => { setMessages([]); setSessionCost(0); setSessionMsgCount(0); stop() }}
+                    className="text-xs text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200">
                     New conversation
                   </button>
                 )}
-                <button
-                  type="button"
-                  onClick={handleExpandToggle}
-                  aria-label="Collapse chat"
-                  className="inline-flex h-6 w-6 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
-                >
+                <button type="button" onClick={handleExpandToggle} aria-label="Collapse chat"
+                  className="inline-flex h-6 w-6 items-center justify-center rounded text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200">
                   <svg aria-hidden="true" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" className="h-4 w-4">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M4 6l4 4 4-4" />
                   </svg>
@@ -741,7 +601,7 @@ export function ChatPanel({
               </div>
             </div>
 
-            {/* Structured search filter (org tab only, always visible when expanded) */}
+            {/* Structured search filter */}
             {contextType === 'org' && onRepoQueryChange && (
               <SearchFilter value={repoQuery} onChange={onRepoQueryChange} />
             )}
@@ -752,26 +612,19 @@ export function ChatPanel({
               <div className="flex-1 border-t border-slate-200 dark:border-slate-700" />
             </div>
 
-            {/* Key entry form (no key, or free limit exhausted) or chat */}
-            {!hasKey || freeRemaining === 0 ? (
-              <KeyEntryForm onSave={handleSaveKey} exhausted={!hasKey && freeRemaining === 0} />
+            {/* Key entry or chat */}
+            {!hasKey || limitReached ? (
+              <KeyEntryForm onSave={handleSaveKey} exhausted={limitReached} />
             ) : (
               <>
                 {/* Message history */}
-                <div
-                  className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3"
-                  aria-live="polite"
-                  aria-label="Chat messages"
-                >
+                <div className="flex h-[40vh] flex-col overflow-y-auto px-4 py-3 space-y-3" aria-live="polite" aria-label="Chat messages">
                   {showChips && (
                     <div className="flex flex-wrap gap-2">
                       {starterChips.map((chip) => (
-                        <button
-                          key={chip}
-                          type="button"
-                          onClick={() => void sendMessage(chip)}
-                          className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
-                        >
+                        <button key={chip} type="button"
+                          onClick={() => void append({ role: 'user', content: chip })}
+                          className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700">
                           {chip}
                         </button>
                       ))}
@@ -782,82 +635,53 @@ export function ChatPanel({
                     if (msg.role === 'user') {
                       return (
                         <div key={msg.id} className="flex justify-end">
-                          <div className="max-w-[80%] rounded-2xl bg-sky-600 px-4 py-2 text-sm text-white">
-                            {msg.content}
-                          </div>
+                          <div className="max-w-[80%] rounded-2xl bg-sky-600 px-4 py-2 text-sm text-white">{msg.content}</div>
                         </div>
                       )
                     }
-
-                    if (msg.role === 'error') {
-                      return (
-                        <div key={msg.id} className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-200">
-                          <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="mt-0.5 h-4 w-4 shrink-0">
-                            <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
-                          </svg>
-                          <div className="flex-1">
-                            <p>{msg.content}</p>
-                            {msg.retryContent && (
-                              <button
-                                type="button"
-                                onClick={() => handleRetry(msg.retryContent!)}
-                                className="mt-1 text-xs font-medium underline hover:no-underline"
-                              >
-                                Retry
-                              </button>
-                            )}
-                          </div>
-                        </div>
-                      )
-                    }
-
-                    // assistant
                     return (
                       <div key={msg.id} className="flex flex-col items-start gap-1">
                         <div className="max-w-[85%] rounded-2xl bg-slate-100 px-4 py-2 text-sm text-slate-800 dark:bg-slate-800 dark:text-slate-200">
                           {msg.content ? (
-                            <div className="prose prose-sm max-w-none dark:prose-invert">
-                              {renderMarkdown(msg.content)}
-                            </div>
+                            <div className="prose prose-sm max-w-none dark:prose-invert">{renderMarkdown(msg.content)}</div>
                           ) : (
                             <span className="animate-pulse text-slate-400">●</span>
                           )}
                         </div>
-                        {msg.usage && (
-                          <p className="px-1 text-[10px] text-slate-400 dark:text-slate-500">
-                            ↑ {formatTokens(msg.usage.inputTokens)} · ↓ {formatTokens(msg.usage.outputTokens)} · {formatCost(calcCost(msg.usage, model))}
-                            {msg.usage.cacheReadTokens > 0 && ` · ${formatTokens(msg.usage.cacheReadTokens)} cached`}
-                          </p>
-                        )}
                       </div>
                     )
                   })}
                   <div ref={messagesEndRef} />
                 </div>
 
-                {/* Input area */}
+                {/* Input */}
                 <form onSubmit={handleSubmit} className="border-t border-slate-200 px-4 py-3 dark:border-slate-700">
                   <div className="flex items-end gap-2">
                     <textarea
-                      value={inputValue}
-                      onChange={(e) => setInputValue(e.target.value)}
+                      value={input}
+                      onChange={(e) => setInput(e.target.value)}
                       onKeyDown={handleKeyDown}
                       placeholder="Ask a question…"
                       rows={1}
-                      disabled={isStreaming}
+                      disabled={isLoading}
                       className="flex-1 resize-none rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-sky-500 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder-slate-500"
                       style={{ minHeight: '38px', maxHeight: '120px' }}
                     />
-                    <button
-                      type="submit"
-                      disabled={!inputValue.trim() || isStreaming}
-                      aria-label="Send message"
-                      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-40 dark:bg-sky-500 dark:hover:bg-sky-400"
-                    >
-                      <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
-                        <path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.925A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.087L2.28 16.762a.75.75 0 0 0 .826.95 28.897 28.897 0 0 0 15.208-7.787.75.75 0 0 0 0-1.049A28.897 28.897 0 0 0 3.105 2.288Z" />
-                      </svg>
-                    </button>
+                    {isLoading ? (
+                      <button type="button" onClick={stop}
+                        className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-200 text-slate-600 hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-300">
+                        <svg aria-label="Stop" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                          <rect x="4" y="4" width="12" height="12" rx="1" />
+                        </svg>
+                      </button>
+                    ) : (
+                      <button type="submit" disabled={!input.trim()} aria-label="Send message"
+                        className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-40 dark:bg-sky-500 dark:hover:bg-sky-400">
+                        <svg aria-hidden="true" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                          <path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.925A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.087L2.28 16.762a.75.75 0 0 0 .826.95 28.897 28.897 0 0 0 15.208-7.787.75.75 0 0 0 0-1.049A28.897 28.897 0 0 0 3.105 2.288Z" />
+                        </svg>
+                      </button>
+                    )}
                   </div>
                 </form>
               </>

--- a/components/chat/providers.ts
+++ b/components/chat/providers.ts
@@ -1,0 +1,87 @@
+export type ProviderId = 'openrouter' | 'anthropic' | 'openai' | 'google' | 'groq'
+export type ModelTier = 'fast' | 'smart'
+
+export interface ModelSpec {
+  id: string
+  label: string
+  /** USD per 1M input tokens */
+  inputRate: number
+  /** USD per 1M output tokens */
+  outputRate: number
+}
+
+export interface ProviderConfig {
+  id: ProviderId
+  name: string
+  tagline: string
+  keyPlaceholder: string
+  consoleUrl: string
+  consoleLabel: string
+  models: Record<ModelTier, ModelSpec>
+}
+
+export const PROVIDERS: Record<ProviderId, ProviderConfig> = {
+  openrouter: {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    tagline: 'One key for Claude, GPT-4o, Gemini & more',
+    keyPlaceholder: 'sk-or-…',
+    consoleUrl: 'https://openrouter.ai/keys',
+    consoleLabel: 'openrouter.ai',
+    models: {
+      fast:  { id: 'anthropic/claude-haiku-4-5',  label: 'Claude Haiku',   inputRate: 0.88,  outputRate: 4.40  },
+      smart: { id: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet',  inputRate: 3.30,  outputRate: 16.50 },
+    },
+  },
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    tagline: 'Claude models direct from Anthropic',
+    keyPlaceholder: 'sk-ant-…',
+    consoleUrl: 'https://console.anthropic.com/settings/keys',
+    consoleLabel: 'console.anthropic.com',
+    models: {
+      fast:  { id: 'claude-haiku-4-5',  label: 'Claude Haiku',  inputRate: 0.80, outputRate: 4.00  },
+      smart: { id: 'claude-sonnet-4-6', label: 'Claude Sonnet', inputRate: 3.00, outputRate: 15.00 },
+    },
+  },
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    tagline: 'GPT models from OpenAI',
+    keyPlaceholder: 'sk-proj-…',
+    consoleUrl: 'https://platform.openai.com/api-keys',
+    consoleLabel: 'platform.openai.com',
+    models: {
+      fast:  { id: 'gpt-4o-mini', label: 'GPT-4o mini', inputRate: 0.15, outputRate: 0.60 },
+      smart: { id: 'gpt-4o',      label: 'GPT-4o',      inputRate: 2.50, outputRate: 10.00 },
+    },
+  },
+  google: {
+    id: 'google',
+    name: 'Google',
+    tagline: 'Gemini models from Google',
+    keyPlaceholder: 'AIza…',
+    consoleUrl: 'https://aistudio.google.com/app/apikey',
+    consoleLabel: 'aistudio.google.com',
+    models: {
+      fast:  { id: 'gemini-2.0-flash',              label: 'Gemini 2.0 Flash', inputRate: 0.10, outputRate: 0.40  },
+      smart: { id: 'gemini-2.5-pro-preview-05-06',  label: 'Gemini 2.5 Pro',  inputRate: 1.25, outputRate: 10.00 },
+    },
+  },
+  groq: {
+    id: 'groq',
+    name: 'Groq',
+    tagline: 'Ultra-fast open-source models via Groq',
+    keyPlaceholder: 'gsk_…',
+    consoleUrl: 'https://console.groq.com/keys',
+    consoleLabel: 'console.groq.com',
+    models: {
+      fast:  { id: 'llama-3.3-70b-versatile', label: 'Llama 3.3 70B', inputRate: 0.05, outputRate: 0.08 },
+      smart: { id: 'llama-3.3-70b-versatile', label: 'Llama 3.3 70B', inputRate: 0.05, outputRate: 0.08 },
+    },
+  },
+}
+
+export const FREE_TIER_PROVIDER: ProviderId = 'anthropic'
+export const FREE_TIER_MODEL: ModelTier = 'fast'

--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -193,7 +193,7 @@ export function serializeOrgInventoryContext(
     totalRepos: sorted.length,
     archived: sorted.filter((r) => r.archived).length,
     forks: sorted.filter((r) => r.isFork).length,
-    languages: [...new Set(sorted.map((r) => r.primaryLanguage).filter((lang) => !!lang && lang !== 'unavailable'))].sort(),
+    languages: [...new Set(sorted.map((r) => r.primaryLanguage).filter((lang) => lang && lang !== 'unavailable'))].sort(),
   }
 
   const payload = {

--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -176,6 +176,12 @@ function sortInventoryRepos(results: OrgRepoSummary[], sortBy: OrgSortBy): OrgRe
   return list
 }
 
+function resolveLicense(spdxId: string | null | undefined, name: string | null | undefined): string | null {
+  if (spdxId && spdxId !== 'unavailable') return spdxId
+  if (name && name !== 'unavailable') return name
+  return null
+}
+
 export function serializeOrgInventoryContext(
   inventory: OrgInventoryResponse,
   opts: { maxRepos?: number; sortBy?: OrgSortBy } = {},
@@ -187,7 +193,7 @@ export function serializeOrgInventoryContext(
     totalRepos: sorted.length,
     archived: sorted.filter((r) => r.archived).length,
     forks: sorted.filter((r) => r.isFork).length,
-    languages: [...new Set(sorted.map((r) => r.primaryLanguage).filter(Boolean))],
+    languages: [...new Set(sorted.map((r) => r.primaryLanguage).filter((lang) => !!lang && lang !== 'unavailable'))].sort(),
   }
 
   const payload = {
@@ -206,7 +212,7 @@ export function serializeOrgInventoryContext(
       pushedAt: r.pushedAt,
       archived: r.archived,
       isFork: r.isFork,
-      license: r.licenseSpdxId !== 'unavailable' ? r.licenseSpdxId : r.licenseName !== 'unavailable' ? r.licenseName : null,
+      license: resolveLicense(r.licenseSpdxId, r.licenseName),
       topics: r.topics,
       description: r.description,
     })),

--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -183,10 +183,18 @@ export function serializeOrgInventoryContext(
   const { maxRepos = 500, sortBy = 'stars' } = opts
   const sorted = sortInventoryRepos(inventory.results, sortBy).slice(0, maxRepos)
 
+  const sliceSummary = {
+    totalRepos: sorted.length,
+    archived: sorted.filter((r) => r.archived).length,
+    forks: sorted.filter((r) => r.isFork).length,
+    languages: [...new Set(sorted.map((r) => r.primaryLanguage).filter(Boolean))],
+  }
+
   const payload = {
     org: inventory.org,
     phase: 'inventory',
-    summary: inventory.summary,
+    summary: sliceSummary,
+    totalOrgRepos: inventory.results.length,
     sortedBy: sortBy,
     maxReposIncluded: maxRepos,
     repos: sorted.map((r) => ({
@@ -198,6 +206,7 @@ export function serializeOrgInventoryContext(
       pushedAt: r.pushedAt,
       archived: r.archived,
       isFork: r.isFork,
+      license: r.licenseSpdxId !== 'unavailable' ? r.licenseSpdxId : r.licenseName !== 'unavailable' ? r.licenseName : null,
       topics: r.topics,
       description: r.description,
     })),
@@ -205,7 +214,7 @@ export function serializeOrgInventoryContext(
 
   const text = [
     `# Org Inventory Context (pre-analysis)`,
-    `Organization: ${inventory.org} · ${inventory.results.length} repos fetched, analysis not yet run`,
+    `Organization: ${inventory.org} · showing top ${sorted.length} of ${inventory.results.length} repos by ${sortBy}, analysis not yet run`,
     '',
     '```json',
     JSON.stringify(payload, null, 2),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@ai-sdk/google": "^1.2.22",
         "@ai-sdk/groq": "^1.2.9",
         "@ai-sdk/openai": "^1.3.24",
-        "@anthropic-ai/sdk": "^0.92.0",
         "ai": "^4.3.19",
         "chart.js": "^4.5.1",
         "chartjs-plugin-zoom": "^2.2.0",
@@ -288,26 +287,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
-      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
@@ -565,6 +544,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -5479,6 +5459,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6438,19 +6419,6 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -8533,12 +8501,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,12 @@
       "name": "repo-pulse",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^1.2.12",
+        "@ai-sdk/google": "^1.2.22",
+        "@ai-sdk/groq": "^1.2.9",
+        "@ai-sdk/openai": "^1.3.24",
         "@anthropic-ai/sdk": "^0.92.0",
+        "ai": "^4.3.19",
         "chart.js": "^4.5.1",
         "chartjs-plugin-zoom": "^2.2.0",
         "hammerjs": "^2.0.8",
@@ -43,6 +48,232 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
+      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.22.tgz",
+      "integrity": "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/groq": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/groq/-/groq-1.2.9.tgz",
+      "integrity": "sha512-7MoDaxm8yWtiRbD1LipYZG0kBl+Xe0sv/EeyxnHnGPZappXdlgtdOgTZVjjXkT3nWP30jjZi9A45zoVrBMb3Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/groq/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/groq/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1956,6 +2187,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.122.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
@@ -2693,6 +2933,12 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3478,6 +3724,85 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -4211,9 +4536,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4227,6 +4550,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -5150,7 +5479,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6105,6 +6433,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -6143,6 +6477,35 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7502,6 +7865,12 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -7978,6 +8347,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8004,6 +8386,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinybench": {
@@ -8467,6 +8861,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
@@ -8886,13 +9289,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "devOptional": true,
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
     "pre-commit": "npm run typecheck"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.2.12",
+    "@ai-sdk/google": "^1.2.22",
+    "@ai-sdk/groq": "^1.2.9",
+    "@ai-sdk/openai": "^1.3.24",
     "@anthropic-ai/sdk": "^0.92.0",
+    "ai": "^4.3.19",
     "chart.js": "^4.5.1",
     "chartjs-plugin-zoom": "^2.2.0",
     "hammerjs": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@ai-sdk/google": "^1.2.22",
     "@ai-sdk/groq": "^1.2.9",
     "@ai-sdk/openai": "^1.3.24",
-    "@anthropic-ai/sdk": "^0.92.0",
     "ai": "^4.3.19",
     "chart.js": "^4.5.1",
     "chartjs-plugin-zoom": "^2.2.0",


### PR DESCRIPTION
Closes #271

## Summary

- **Multi-provider support**: server picks first configured env key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`); users can BYOK for any provider via OpenRouter or direct
- **Free tier UX**: dots appear only after server confirms quota; tooltip explains server key requirement; indicator moved into "Chat with AI" section
- **Scoped context**: search filter drives Claude's context via `matchesStructuredSearch`; "scoped to N repos" badge; context-change dividers when filter changes mid-chat
- **Two-step flow guide** for org inventory: filter first → ask AI; filter badges toggle/append without duplicates; Step 2 chips unlock when filter is active
- **UX cleanup**: removed Fast/Smart tier switcher (always fast model); removed repo count slider (silent 300-repo cap); starter chips expand to 6 per context and persist after first message; "Add key" always visible with "Back to free chat" escape; license field added to org inventory context; provider badge in header

## Test plan

- [ ] With no server key: dots show grey, tooltip explains, "Add key" opens key form, "Back to free chat" dismisses it
- [ ] With `OPENAI_API_KEY` on server: badge shows "OpenAI", dots turn green on first chat, count decrements
- [ ] After 5 free chats: key form appears with exhausted message
- [ ] BYOK: enter OpenRouter key, chat works, cost shown, "Change key" visible
- [ ] Org inventory flow guide: Step 1 active before filter, Step 2 unlocks after filter, guide disappears after first message
- [ ] Filter scoping: `lang:go` → "scoped to N repos" badge, Claude only answers from filtered subset
- [ ] Filter cleared mid-chat: context-change divider appears in conversation
- [ ] Filter badges toggle (click active filter removes it, no duplicates)
- [ ] Starter chips persist after first AI response
- [ ] License question answered correctly: "which repos have no license?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)