### PR TITLE
feat(chat): multi-provider AI chat with free tier, scoped context, and flow guide

### DIFF
--- a/app/api/chat/route.test.ts
+++ b/app/api/chat/route.test.ts
@@ -248,6 +248,69 @@ describe('POST /api/chat', () => {
     expect(body.error.remaining).toBe(0)
   })
 
+  it('resets the free-tier counter after UTC midnight (daily reset)', async () => {
+    vi.useFakeTimers()
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchGitHubOk('daily-reset-user-unique')
+
+    // Exhaust all 5 free chats
+    for (let i = 0; i < 5; i++) {
+      await POST(makeRequest(validBody))
+    }
+
+    // Confirm quota is exhausted
+    const beforeReset = await POST(makeRequest(validBody))
+    expect(beforeReset.status).toBe(402)
+
+    // Simulate UTC midnight passing: advance to 00:01 UTC tomorrow
+    const tomorrow = new Date()
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+    tomorrow.setUTCHours(0, 1, 0, 0)
+    vi.setSystemTime(tomorrow)
+
+    // The counter should have reset — request should succeed
+    const afterReset = await POST(makeRequest(validBody))
+    expect(afterReset.status).toBe(200)
+
+    vi.useRealTimers()
+  })
+
+  it('cleans up expired usage records from the map on access', async () => {
+    vi.useFakeTimers()
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchGitHubOk('cleanup-user-unique')
+
+    // Use 1 free chat to create a map entry
+    await POST(makeRequest(validBody))
+
+    // Advance past midnight so the entry is expired
+    const tomorrow = new Date()
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+    tomorrow.setUTCHours(0, 1, 0, 0)
+    vi.setSystemTime(tomorrow)
+
+    // A new request must succeed (counter reset to 0 and old entry cleaned up)
+    const res = await POST(makeRequest(validBody))
+    expect(res.status).toBe(200)
+
+    vi.useRealTimers()
+  })
+
+  it('decrements remaining count by 1 per free chat', async () => {
+    vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-test')
+    stubFetchGitHubOk('decrement-user-unique')
+
+    // First chat: remaining should be 4 (5 - 1)
+    const { getWriter: getWriter1 } = setupWriterCapture()
+    await POST(makeRequest(validBody))
+    expect(getWriter1().writeData).toHaveBeenCalledWith(expect.objectContaining({ remaining: 4, limit: 5 }))
+
+    // Second chat: remaining should be 3
+    const { getWriter: getWriter2 } = setupWriterCapture()
+    await POST(makeRequest(validBody))
+    expect(getWriter2().writeData).toHaveBeenCalledWith(expect.objectContaining({ remaining: 3, limit: 5 }))
+  })
+
   // -------------------------------------------------------------------------
   // Successful streaming
   // -------------------------------------------------------------------------

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -32,6 +32,11 @@ function incrementUsage(username: string): void {
   freeUsage.set(username, { count: getUsageCount(username) + 1, resetAt: getNextMidnightUTC() })
 }
 
+function decrementUsage(username: string): void {
+  const r = freeUsage.get(username)
+  if (r && r.count > 0) freeUsage.set(username, { ...r, count: r.count - 1 })
+}
+
 const VALID_CONTEXT_TYPES = ['repos', 'org'] as const
 const VALID_ROLES = ['user', 'assistant'] as const
 const MAX_HISTORY_TURNS = 10
@@ -211,10 +216,7 @@ export async function POST(request: Request) {
     onError: (error) => {
       console.error('[chat] streamText error:', error)
       // Revert the free-tier counter so a failed provider call doesn't burn quota
-      if (!hasOwnKey) {
-        const currentCount = freeUsage.get(username) ?? 0
-        if (currentCount > 0) freeUsage.set(username, currentCount - 1)
-      }
+      if (!hasOwnKey) decrementUsage(username)
       const msg = (error as { message?: string }).message ?? ''
       if (msg.includes('401') || msg.toLowerCase().includes('invalid api key') || msg.toLowerCase().includes('unauthorized')) {
         return 'Invalid API key — check it and try again.'

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,7 +8,10 @@ import { PROVIDERS, FREE_TIER_PROVIDER, FREE_TIER_MODEL } from '@/components/cha
 
 export const runtime = 'nodejs'
 
-// Free tier: 5 requests per GitHub login per calendar day (UTC).
+// Free tier: up to 5 requests per GitHub login per calendar day (UTC).
+// Tracking is best-effort in-memory — it resets on deploy and is not
+// enforced across serverless instances. Users can always bypass by adding
+// their own API key.
 const FREE_LIMIT = 5
 
 interface UsageRecord {
@@ -24,7 +27,11 @@ function getNextMidnightUTC(): number {
 
 function getUsageCount(username: string): number {
   const r = freeUsage.get(username)
-  if (!r || Date.now() >= r.resetAt) return 0
+  if (!r) return 0
+  if (Date.now() >= r.resetAt) {
+    freeUsage.delete(username)
+    return 0
+  }
   return r.count
 }
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,10 +8,29 @@ import { PROVIDERS, FREE_TIER_PROVIDER, FREE_TIER_MODEL } from '@/components/cha
 
 export const runtime = 'nodejs'
 
-// Free tier: 5 requests per GitHub login per server lifetime.
-// Resets on deployment — intentional for a lightweight demo gate.
+// Free tier: 5 requests per GitHub login per calendar day (UTC).
 const FREE_LIMIT = 5
-const freeUsage = new Map<string, number>()
+
+interface UsageRecord {
+  count: number
+  resetAt: number // next midnight UTC
+}
+const freeUsage = new Map<string, UsageRecord>()
+
+function getNextMidnightUTC(): number {
+  const now = new Date()
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1)
+}
+
+function getUsageCount(username: string): number {
+  const r = freeUsage.get(username)
+  if (!r || Date.now() >= r.resetAt) return 0
+  return r.count
+}
+
+function incrementUsage(username: string): void {
+  freeUsage.set(username, { count: getUsageCount(username) + 1, resetAt: getNextMidnightUTC() })
+}
 
 const VALID_CONTEXT_TYPES = ['repos', 'org'] as const
 const VALID_ROLES = ['user', 'assistant'] as const
@@ -149,13 +168,13 @@ export async function POST(request: Request) {
         { status: 503 },
       )
     }
-    const usedCount = freeUsage.get(username) ?? 0
+    const usedCount = getUsageCount(username)
     if (usedCount >= FREE_LIMIT) {
       return Response.json(
         {
           error: {
             code: 'FREE_LIMIT_REACHED',
-            message: `You've used all ${FREE_LIMIT} free chats. Add an API key to continue.`,
+            message: `You've used all ${FREE_LIMIT} free chats for today. Add an API key to continue, or try again tomorrow.`,
             remaining: 0,
             limit: FREE_LIMIT,
           },
@@ -163,7 +182,7 @@ export async function POST(request: Request) {
         { status: 402 },
       )
     }
-    freeUsage.set(username, usedCount + 1)
+    incrementUsage(username)
     provider = serverConfig.provider
     modelId = serverConfig.modelId
     resolvedKey = serverConfig.key
@@ -172,7 +191,7 @@ export async function POST(request: Request) {
   const model = resolveModel(provider, modelId, resolvedKey)
   const trimmedMessages = messages.slice(-(MAX_HISTORY_TURNS * 2))
   const systemPrompt = buildSystemPrompt(contextType, context)
-  const remaining = hasOwnKey ? undefined : FREE_LIMIT - (freeUsage.get(username) ?? 0)
+  const remaining = hasOwnKey ? undefined : FREE_LIMIT - getUsageCount(username)
 
   return createDataStreamResponse({
     execute: async (writer) => {
@@ -184,7 +203,7 @@ export async function POST(request: Request) {
         model,
         system: systemPrompt,
         messages: trimmedMessages,
-        maxTokens: 1024,
+        maxTokens: 4096,
       })
 
       result.mergeIntoDataStream(writer)

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -275,7 +275,7 @@ function KeyEntryForm({
             <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clipRule="evenodd" />
           </svg>
           {exhausted
-            ? `You've used all ${FREE_LIMIT} free chats. Add an API key for unlimited access.`
+            ? `You've used all ${FREE_LIMIT} free chats for today. Add an API key for unlimited access, or try again tomorrow.`
             : 'No server API key configured — add your own key to start chatting.'}
         </div>
       )}
@@ -612,11 +612,11 @@ export function ChatPanel({
                     <span key={i} className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${freeRemaining === null ? 'bg-slate-200 dark:bg-slate-700' : i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`} />
                   ))}
                   <span className="text-[10px] text-slate-400 dark:text-slate-500">
-                    {freeRemaining === null ? `${FREE_LIMIT} free` : freeRemaining > 0 ? `${freeRemaining} free` : 'limit reached'}
+                    {freeRemaining === null ? `${FREE_LIMIT} free/day` : freeRemaining > 0 ? `${freeRemaining} free today` : 'limit reached'}
                   </span>
                   {freeRemaining === null && (
                     <span className="pointer-events-none invisible absolute bottom-full left-0 z-50 mb-2 w-52 rounded bg-slate-800 px-2.5 py-2 opacity-0 shadow-lg transition-opacity group-hover/free:visible group-hover/free:opacity-100 dark:bg-slate-700">
-                      <span className="block text-[11px] leading-snug text-white">Free quota requires a server API key (<code className="rounded bg-slate-700 px-1 font-mono text-[10px]">ANTHROPIC_API_KEY</code>, <code className="rounded bg-slate-700 px-1 font-mono text-[10px]">OPENAI_API_KEY</code>, etc.). Add your own key below to chat without limits.</span>
+                      <span className="block text-[11px] leading-snug text-white">Free quota requires a server API key. Each GitHub login gets {FREE_LIMIT} free chats per day. Add your own key below to chat without limits.</span>
                       <span className="absolute left-3 top-full border-4 border-transparent border-t-slate-800 dark:border-t-slate-700" />
                     </span>
                   )}
@@ -681,11 +681,11 @@ export function ChatPanel({
                                   <span key={i} className={`inline-block h-1.5 w-1.5 rounded-full transition-colors ${freeRemaining === null ? 'bg-slate-200 dark:bg-slate-700' : i < freeRemaining ? 'bg-green-500' : 'bg-slate-300 dark:bg-slate-600'}`} />
                                 ))}
                                 <span className="text-[10px] text-slate-400 dark:text-slate-500">
-                                  {freeRemaining === null ? `${FREE_LIMIT} free` : freeRemaining > 0 ? `${freeRemaining} free` : 'limit reached'}
+                                  {freeRemaining === null ? `${FREE_LIMIT} free/day` : freeRemaining > 0 ? `${freeRemaining} free today` : 'limit reached'}
                                 </span>
                                 {freeRemaining === null && (
                                   <span className="pointer-events-none invisible absolute bottom-full left-0 z-50 mb-2 w-52 rounded bg-slate-800 px-2.5 py-2 opacity-0 shadow-lg transition-opacity group-hover/free:visible group-hover/free:opacity-100 dark:bg-slate-700">
-                                    <span className="block text-[11px] leading-snug text-white">Free quota requires a server API key (<code className="rounded bg-slate-700 px-1 font-mono text-[10px]">ANTHROPIC_API_KEY</code>, <code className="rounded bg-slate-700 px-1 font-mono text-[10px]">OPENAI_API_KEY</code>, etc.). Add your own key below to chat without limits.</span>
+                                    <span className="block text-[11px] leading-snug text-white">Free quota requires a server API key. Each GitHub login gets {FREE_LIMIT} free chats per day. Add your own key below to chat without limits.</span>
                                     <span className="absolute left-3 top-full border-4 border-transparent border-t-slate-800 dark:border-t-slate-700" />
                                   </span>
                                 )}


### PR DESCRIPTION
Closes #271

## Summary

- **Multi-provider AI**: Chat panel supports Anthropic, OpenAI, Google, Groq, and OpenRouter. Server-side key auto-detected from env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`) in priority order; users can add their own key at any time.
- **Free tier gate**: 5 AI chats per GitHub login per day (UTC midnight reset). Dots indicator shows remaining quota; exhausted state prompts BYOK.
- **Scoped context**: Org inventory chat is filtered by the structured search query — only the matching repos are included in the LLM context. Dividers appear in the conversation when the filter changes.
- **Two-step flow guide**: Inventory phase shows a Step 1 (filter) → Step 2 (ask AI) guide before the first message, teaching the filter-first workflow.
- **Stop button**: Square stop button replaces send arrow while the AI is streaming; click to cancel at any time.
- **Higher token limit**: `maxTokens` raised 1024 → 4096 to prevent long repo list responses from being cut off mid-sentence.
- **Provider badge**: Header shows the active provider name (not model name), since users cannot switch models themselves.
- **Persistent suggestion chips**: Starter questions stay visible below messages, not just before the first one.
- **License in org context**: Repo license field included in the serialized org inventory context.

## Test plan

- [ ] Open org inventory view, confirm two-step flow guide appears
- [ ] Apply a filter (e.g. `stars:>500`), confirm Step 1 gets a green checkmark and Step 2 becomes active
- [ ] Ask a question — confirm scoped repo count badge in header matches filter
- [ ] Change filter mid-conversation — confirm dashed divider appears with updated scope label
- [ ] Confirm stop button (square) appears while AI is streaming and cancels generation when clicked
- [ ] Use up 5 free chats — confirm limit-reached banner and "try again tomorrow" message appear
- [ ] Add BYOK — confirm key form accepts key, session resets, cost tracking appears
- [ ] Click "Back to free chat" in key form — confirm it dismisses the form
- [ ] Verify provider badge in header matches server-configured provider (e.g. "OpenAI" when `OPENAI_API_KEY` is set)
- [ ] Ask a question about repos with many results — confirm response is not cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)