### PR TITLE
docs: add AI Chat documentation (README, DEPLOYMENT, ai-chat.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Every view is shareable — the selected tab, org, foundation track, and input a
 | :office: | **Org Inventory** | Org-level health summary across all scored dimensions plus Governance; repo table supports structured search prefixes (`lang:go`, `stars:>500`, `archived:false`, `topic:kubernetes`) |
 | :seedling: | **Foundation Track** | CNCF Sandbox readiness scan (0–100 score, TAG recommendation, landscape detection); org-wide candidacy scan ranks every repo by readiness |
 | :bulb: | **Recommendations** | Actionable improvement suggestions across all scoring dimensions |
+| :speech_balloon: | **AI Chat** | Ask natural-language questions about any analysis; 5 free chats/day per GitHub login, or bring your own API key |
 | :outbox_tray: | **Export** | JSON, Markdown, and Copy Link from any view |
 | :book: | **Scoring Methodology** | Full transparency into calibration data and thresholds at [`/baseline`](https://repopulse-arun-gupta.vercel.app/baseline) |
 
@@ -95,6 +96,10 @@ npm install
 echo "GITHUB_CLIENT_ID=your_id" >> .env.local
 echo "GITHUB_CLIENT_SECRET=your_secret" >> .env.local
 
+# Optional: enable server-side AI Chat (any one key enables 5 free chats/day per GitHub login)
+# echo "ANTHROPIC_API_KEY=sk-ant-..." >> .env.local
+# echo "OPENAI_API_KEY=sk-..."       >> .env.local
+
 # 3. Run
 npm run dev
 ```
@@ -124,6 +129,7 @@ We welcome contributions! See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup ins
 - [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) — Development workflow, implementation order, verification commands
 - [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) — Vercel deployment guide
 - [`docs/scoring-and-calibration.md`](docs/scoring-and-calibration.md) — Scoring methodology, calibration pipeline, statistical approach
+- [`docs/ai-chat.md`](docs/ai-chat.md) — AI Chat feature: providers, free tier, bring-your-own-key setup
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -71,6 +71,23 @@ The workflow only refreshes **data**. Frontend and analyzer changes deploy conti
 
 **Operational tip** — merge the refresh PR promptly. If it sits open while frontend/analyzer PRs continue to land, the deployed `/demo` data can drift out of sync with the deployed UI/logic.
 
+## AI Chat (Optional)
+
+The chat panel appears on every analysis view once a user is signed in. Without a server key it operates in "bring your own key" mode only.
+
+To enable **5 free chats per GitHub login per day**, add exactly one of the following to your Vercel environment variables (the first key found wins):
+
+| Variable | Provider |
+|----------|----------|
+| `ANTHROPIC_API_KEY` | Anthropic Claude (default preference) |
+| `OPENAI_API_KEY` | OpenAI GPT |
+| `GOOGLE_API_KEY` | Google Gemini |
+| `GROQ_API_KEY` | Groq |
+
+Users who exceed the daily free limit — or who want to choose a different provider/model — can enter their own API key directly in the chat panel. That key is transmitted to the API route and forwarded to the provider; it is never logged or persisted.
+
+See [`docs/ai-chat.md`](ai-chat.md) for full feature details.
+
 ## Notes
 
 - No `GITHUB_TOKEN` server-side environment variable is used — each user authenticates via their own GitHub OAuth session

--- a/docs/ai-chat.md
+++ b/docs/ai-chat.md
@@ -1,0 +1,74 @@
+# AI Chat
+
+RepoPulse includes a conversational AI panel that lets users ask natural-language questions about any analysis result — a single repo, a multi-repo comparison, an org inventory, or a full org health run.
+
+## How it works
+
+The chat panel appears as a slide-up tray at the bottom of every analysis view. It is scoped to the currently displayed data: the model only sees the serialized analysis context (metrics, scores, recommendations) for whatever is on screen, never raw GitHub tokens or unrelated data.
+
+Each message exchange follows this flow:
+
+1. The frontend serializes the visible analysis into a JSON context block.
+2. It sends that context + the conversation history to `POST /api/chat`.
+3. The API route authenticates the user, enforces quotas, resolves a provider + model, and streams a response via the Vercel AI SDK.
+4. The streamed response is displayed incrementally in the chat bubble.
+
+The user can stop a response mid-stream using the square stop button that appears while the model is typing.
+
+## Providers
+
+The chat supports five providers. The user selects a provider and model in the chat settings panel; the choice is persisted in `localStorage`.
+
+| Provider | Models available |
+|----------|-----------------|
+| Anthropic | claude-haiku-3-5 (fast), claude-sonnet-4-5 (quality) |
+| OpenAI | gpt-4o-mini (fast), gpt-4o (quality) |
+| Google | gemini-2.0-flash (fast), gemini-2.5-pro (quality) |
+| Groq | llama-3.1-8b-instant (fast), llama-3.3-70b-versatile (quality) |
+| OpenRouter | meta-llama/llama-3.1-8b-instruct (fast), anthropic/claude-3.5-sonnet (quality) |
+
+## Free tier
+
+If the server has at least one AI provider key configured (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, or `GROQ_API_KEY`), signed-in users get **5 free chats per GitHub login per calendar day (UTC midnight reset)**. The first key found in that priority order is used for free-tier requests.
+
+- The remaining count is shown as colored dots in the chat panel.
+- Once exhausted, the panel prompts the user to enter their own API key.
+- Failed requests (provider errors, network timeouts) do not consume quota — the counter is decremented on error.
+
+If no server key is configured, the free tier is unavailable and users must always supply their own key.
+
+## Bring your own key
+
+Any user can enter their own API key in the chat settings panel. With an own key:
+
+- Provider and model selection are fully unlocked.
+- Daily quota does not apply.
+- The key is sent to `POST /api/chat` in the request body and forwarded to the selected provider. It is never logged, stored, or persisted server-side.
+
+## Context scoping
+
+The context sent to the model is trimmed to the most relevant fields:
+
+- **Repos mode**: per-repo metrics snapshot (stars, commits, PRs, issues, contributors, security/doc/license results).
+- **Org mode (inventory phase)**: repo list with stars, language, topics, push date, license.
+- **Org mode (analysis done)**: org-level panel rollups (security, bus-factor, documentation coverage, etc.) plus a per-repo status table.
+
+Context is serialized as a JSON block inside the system prompt. The model is instructed to answer strictly from the provided data and not to invent metrics.
+
+## Conversation history
+
+Up to 10 turns (20 messages) of history are sent with each request. Older messages are trimmed from the front. A visual divider is inserted in the UI whenever the underlying analysis context changes (e.g., user filters to different repos) so it's clear which data a prior answer was based on.
+
+## Starter chips
+
+The panel surfaces suggested questions as clickable chips:
+
+- **Repos**: "What are the biggest health risks?", "Which repo is most active?", "How does security compare across these repos?", etc.
+- **Org (inventory)**: "Which repos have the most stars?", "How many repos use each language?", etc.
+- **Org (analysis)**: "Which repos need the most attention?", "What are the top recommendations?", etc.
+
+Chips disappear once the first message is sent.
+
+## Server setup
+
+See [`docs/DEPLOYMENT.md`](DEPLOYMENT.md#ai-chat-optional) for the environment variables required to enable the free tier.


### PR DESCRIPTION
## Summary

- **README.md**: Added AI Chat entry to Key Features table, optional env-var hint in Quick Start, and a link to `docs/ai-chat.md`
- **docs/DEPLOYMENT.md**: New "AI Chat (Optional)" section with provider env-var table (priority order: Anthropic → OpenAI → Google → Groq) and a pointer to the full doc
- **docs/ai-chat.md** (new): Full reference covering providers, free tier (5 chats/day per GitHub login, UTC midnight reset, counter-revert on error), bring-your-own-key, context scoping, conversation history, starter chips, and server setup

Follows up on PR #514 which shipped the feature.

## Test plan

- [ ] README renders correctly on GitHub (Key Features table, Quick Start snippet, Docs links)
- [ ] `docs/DEPLOYMENT.md` AI Chat section is accurate and links resolve
- [ ] `docs/ai-chat.md` content matches the implemented behavior (providers, free tier limit, daily reset, BYOK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)