### PR TITLE
feat: add Universities as a top-level navigation tab

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -35,7 +35,7 @@ export default function DemoLanding() {
             </p>
           </header>
 
-          <div className="grid gap-4 sm:grid-cols-3">
+          <div className="grid gap-4 sm:grid-cols-2">
             <Link
               href="/demo/repositories"
               className="group block rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md dark:border-slate-700 dark:bg-slate-900 dark:hover:border-sky-500"
@@ -88,31 +88,6 @@ export default function DemoLanding() {
               </p>
             </Link>
           </div>
-
-          <Link
-            href="/university"
-            className="group block rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md dark:border-slate-700 dark:bg-slate-900 dark:hover:border-sky-500"
-          >
-            <div className="flex items-center gap-3">
-              <span
-                aria-hidden="true"
-                className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-sky-100 text-lg text-sky-700 dark:bg-sky-900/40 dark:text-sky-200"
-              >
-                🎓
-              </span>
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100 group-hover:text-sky-700 dark:group-hover:text-sky-300">
-                Universities
-              </h2>
-            </div>
-            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
-              Browse OSS health scores for GitHub repositories affiliated with universities,
-              discovered and classified by repofinder. Filter by health tier, stars, and
-              activity to surface the most impactful projects.
-            </p>
-            <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
-              University of California, Santa Cruz — 249 repositories scored
-            </p>
-          </Link>
 
           <p className="text-center text-xs text-slate-500 dark:text-slate-400">
             Data refreshes weekly. When you&apos;re ready to analyze your own projects,{' '}

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { getCalibrationMeta } from '@/lib/scoring/config-loader'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import type { ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
@@ -129,6 +130,12 @@ export function ResultsShell({
 
           {/* Desktop nav */}
           <div className="hidden items-center gap-3 sm:flex">
+            <Link
+              href="/university"
+              className="rounded-full border border-sky-700 bg-sky-950/25 px-3 py-2 text-xs font-medium text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
+            >
+              Universities
+            </Link>
             <a
               href="/baseline"
               target="_blank"
@@ -177,6 +184,12 @@ export function ResultsShell({
             {mobileMenuOpen ? (
               <div className="absolute right-0 top-full z-50 mt-2 w-48 rounded-lg border border-sky-700 bg-sky-900 p-3 shadow-lg dark:border-slate-700 dark:bg-slate-900 sm:w-56">
                 <nav className="flex flex-col gap-2">
+                  <Link
+                    href="/university"
+                    className="rounded-md px-3 py-2 text-sm font-medium text-sky-50 transition hover:bg-sky-800"
+                  >
+                    Universities
+                  </Link>
                   <a
                     href="/baseline"
                     target="_blank"

--- a/components/auth/AuthGate.tsx
+++ b/components/auth/AuthGate.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth, type AuthSession } from './AuthContext'
 import { SignInButton } from './SignInButton'
@@ -102,13 +103,22 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
         <SignInButton />
 
-        <a
-          href="/demo"
-          data-testid="demo-link"
-          className="text-sm font-medium text-sky-700 underline-offset-2 hover:text-sky-800 hover:underline dark:text-sky-300 dark:hover:text-sky-200"
-        >
-          See an example without signing in →
-        </a>
+        <div className="flex flex-wrap justify-center gap-x-6 gap-y-1">
+          <a
+            href="/demo"
+            data-testid="demo-link"
+            className="text-sm font-medium text-sky-700 underline-offset-2 hover:text-sky-800 hover:underline dark:text-sky-300 dark:hover:text-sky-200"
+          >
+            See an example without signing in →
+          </a>
+          <Link
+            href="/university"
+            data-testid="university-link"
+            className="text-sm font-medium text-sky-700 underline-offset-2 hover:text-sky-800 hover:underline dark:text-sky-300 dark:hover:text-sky-200"
+          >
+            Browse university repos →
+          </Link>
+        </div>
 
         <PATForm onSuccess={signIn} />
 


### PR DESCRIPTION
Closes #527

## Summary

- **Sign-in screen** (`AuthGate.tsx`): adds a "Browse university repos →" link alongside the existing "See an example without signing in →" link, so `/university` is discoverable to unauthenticated users without going through `/demo`.
- **Authenticated app shell** (`ResultsShell.tsx`): adds a "Universities" nav link in both the desktop header (pill button, consistent with "Scoring Methodology") and the mobile dropdown menu.
- **Demo page** (`app/demo/page.tsx`): removes the Universities card and reverts the grid from 3-column back to 2-column, keeping `/demo` focused on Repositories and Organization showcases.

## Test plan

### Automated

```
npm test       → 1975/1981 tests passed (1 file crash pre-existing; see below)
npm run lint   → 0 errors, 3 pre-existing warnings (none in changed files)
npm run typecheck → clean
```

**Pre-existing failure:** `AuthGate.test.tsx` crashes the vitest worker process (worker exits unexpectedly / GNUPG-related OS crash on the test runner). Confirmed pre-existing by running the test against the unmodified branch — same crash. Not caused by this PR.

### Manual

- [ ] **Sign-in screen pre-auth** — visit the root `/` without being signed in; verify "Browse university repos →" link appears next to the demo link and navigates to `/university`. Requires manual verification because AuthGate renders client-side with auth state.
- [ ] **Authenticated app — desktop** — sign in and verify "Universities" pill button appears in the top-right header, navigates to `/university`, and is visible at all times (before and after running an analysis). Automated tests don't exercise the full rendered shell with auth.
- [ ] **Authenticated app — mobile** — resize to mobile viewport; verify "Universities" appears in the hamburger dropdown. Mobile layout cannot be reliably tested in the current unit test setup.
- [ ] **Demo page** — visit `/demo` and verify the Universities card is gone, only Repositories and Organization cards remain in a 2-column grid.
- [ ] **University route** — verify `/university` and `/university/[slug]` routes are unchanged and load correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)