### PR TITLE
fix(auth): preserve return host across GitHub OAuth redirect

### DIFF
--- a/app/api/auth/callback/route.test.ts
+++ b/app/api/auth/callback/route.test.ts
@@ -13,52 +13,55 @@ vi.mock('next/headers', () => ({
 
 global.fetch = vi.fn()
 
-// State format: "{csrf}|{returnOrigin}". Cookie stores just the csrf portion.
+// Callback host and matching return origin (same-origin path)
+const CALLBACK_ORIGIN = 'http://localhost:3000'
 const CSRF = 'valid_state'
-const RETURN_ORIGIN = 'http://localhost:3010'
-const VALID_STATE = `${CSRF}|${RETURN_ORIGIN}`
+// State where returnOrigin matches the callback host → same-origin path
+const SAME_ORIGIN_STATE = `${CSRF}|${CALLBACK_ORIGIN}`
 
 describe('GET /api/auth/callback', () => {
   beforeEach(() => {
     vi.stubEnv('GITHUB_CLIENT_ID', 'test_client_id')
     vi.stubEnv('GITHUB_CLIENT_SECRET', 'test_client_secret')
     vi.resetAllMocks()
-    // Cookie stores only the csrf token (not the full state string)
     mockCookieGet.mockReturnValue({ value: CSRF })
   })
 
-  function makeRequest(params: Record<string, string>) {
-    const url = new URL('http://localhost/api/auth/callback')
+  function makeRequest(params: Record<string, string>, callbackOrigin = CALLBACK_ORIGIN) {
+    const url = new URL(`${callbackOrigin}/api/auth/callback`)
     Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
     return new Request(url.toString())
   }
 
-  it('redirects to error page when error param is present', async () => {
-    const req = makeRequest({ error: 'access_denied', state: VALID_STATE })
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  it('redirects to error page (at return origin) when error param is present', async () => {
+    const req = makeRequest({ error: 'access_denied', state: SAME_ORIGIN_STATE })
     const response = await GET(req)
     expect(response.status).toBe(302)
     const location = response.headers.get('location') ?? ''
     expect(location).toContain('auth_error=access_denied')
-    // Should redirect to the return origin extracted from state, not the callback host
-    expect(location).toContain(RETURN_ORIGIN)
+    expect(location.startsWith(CALLBACK_ORIGIN)).toBe(true)
   })
 
-  it('redirects to error page when state is missing', async () => {
+  // ── Same-origin path (returnOrigin === callback host) ─────────────────────
+
+  it('redirects to invalid_state when CSRF cookie is missing', async () => {
     mockCookieGet.mockReturnValue(undefined)
-    const req = makeRequest({ code: 'abc123', state: VALID_STATE })
+    const req = makeRequest({ code: 'abc123', state: SAME_ORIGIN_STATE })
     const response = await GET(req)
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toContain('auth_error=invalid_state')
   })
 
-  it('redirects to error page when csrf portion of state does not match cookie', async () => {
-    const req = makeRequest({ code: 'abc123', state: `wrong_csrf|${RETURN_ORIGIN}` })
+  it('redirects to invalid_state when CSRF portion of state does not match cookie', async () => {
+    const req = makeRequest({ code: 'abc123', state: `wrong_csrf|${CALLBACK_ORIGIN}` })
     const response = await GET(req)
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toContain('auth_error=invalid_state')
   })
 
-  it('exchanges code for token and redirects with fragment to the return origin', async () => {
+  it('exchanges code for token and redirects with fragment on same-origin success', async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ access_token: 'gho_token123' }), {
@@ -71,19 +74,31 @@ describe('GET /api/auth/callback', () => {
         }),
       )
 
-    const req = makeRequest({ code: 'abc123', state: VALID_STATE })
+    const req = makeRequest({ code: 'abc123', state: SAME_ORIGIN_STATE })
     const response = await GET(req)
     expect(response.status).toBe(302)
     const location = response.headers.get('location') ?? ''
     expect(location).toContain('token=gho_token123')
     expect(location).toContain('username=arun-gupta')
     expect(location).toContain('#')
-    // Should redirect to the return origin from the state, not the callback's own host
-    expect(location.startsWith(RETURN_ORIGIN)).toBe(true)
+    expect(location.startsWith(CALLBACK_ORIGIN)).toBe(true)
+  })
+
+  it('redirects to error page when token exchange fails (same-origin)', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'bad_verification_code' }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const req = makeRequest({ code: 'bad_code', state: SAME_ORIGIN_STATE })
+    const response = await GET(req)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toContain('auth_error=token_exchange_failed')
   })
 
   it('falls back to the callback host origin when state has no return origin', async () => {
-    // Handles old-format state (no pipe separator) gracefully
+    // Old-format state (no pipe separator) — graceful fallback
     mockCookieGet.mockReturnValue({ value: 'bare_csrf' })
     vi.mocked(fetch)
       .mockResolvedValueOnce(
@@ -101,20 +116,43 @@ describe('GET /api/auth/callback', () => {
     const response = await GET(req)
     expect(response.status).toBe(302)
     const location = response.headers.get('location') ?? ''
-    // Falls back to the request origin (localhost in this test)
-    expect(location.startsWith('http://localhost')).toBe(true)
+    expect(location.startsWith(CALLBACK_ORIGIN)).toBe(true)
   })
 
-  it('redirects to error page when token exchange fails', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: 'bad_verification_code' }), {
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
+  // ── Cross-domain relay path ────────────────────────────────────────────────
 
-    const req = makeRequest({ code: 'bad_code', state: VALID_STATE })
+  it('relays to originating host when returnOrigin differs from callback host', async () => {
+    const loginOrigin = 'http://localhost:3010'
+    const crossDomainState = `${CSRF}|${loginOrigin}`
+
+    // Callback is on Vercel; login was on localhost:3010
+    const req = makeRequest(
+      { code: 'abc123', state: crossDomainState },
+      'https://repopulse-arun-gupta.vercel.app',
+    )
     const response = await GET(req)
     expect(response.status).toBe(302)
-    expect(response.headers.get('location')).toContain('auth_error=token_exchange_failed')
+    const location = response.headers.get('location') ?? ''
+    // Should relay to the originating host's relay endpoint
+    expect(location.startsWith(`${loginOrigin}/api/auth/relay`)).toBe(true)
+    expect(location).toContain('code=abc123')
+    expect(location).toContain(encodeURIComponent(crossDomainState))
+    // Should NOT exchange the token itself
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+  })
+
+  it('redirects to error page on the return origin when code is missing in cross-domain case', async () => {
+    const loginOrigin = 'http://localhost:3010'
+    const crossDomainState = `${CSRF}|${loginOrigin}`
+
+    const req = makeRequest(
+      { state: crossDomainState },
+      'https://repopulse-arun-gupta.vercel.app',
+    )
+    const response = await GET(req)
+    expect(response.status).toBe(302)
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('auth_error=missing_code')
+    expect(location.startsWith(loginOrigin)).toBe(true)
   })
 })

--- a/app/api/auth/callback/route.test.ts
+++ b/app/api/auth/callback/route.test.ts
@@ -13,12 +13,18 @@ vi.mock('next/headers', () => ({
 
 global.fetch = vi.fn()
 
+// State format: "{csrf}|{returnOrigin}". Cookie stores just the csrf portion.
+const CSRF = 'valid_state'
+const RETURN_ORIGIN = 'http://localhost:3010'
+const VALID_STATE = `${CSRF}|${RETURN_ORIGIN}`
+
 describe('GET /api/auth/callback', () => {
   beforeEach(() => {
     vi.stubEnv('GITHUB_CLIENT_ID', 'test_client_id')
     vi.stubEnv('GITHUB_CLIENT_SECRET', 'test_client_secret')
     vi.resetAllMocks()
-    mockCookieGet.mockReturnValue({ value: 'valid_state' })
+    // Cookie stores only the csrf token (not the full state string)
+    mockCookieGet.mockReturnValue({ value: CSRF })
   })
 
   function makeRequest(params: Record<string, string>) {
@@ -28,28 +34,31 @@ describe('GET /api/auth/callback', () => {
   }
 
   it('redirects to error page when error param is present', async () => {
-    const req = makeRequest({ error: 'access_denied', state: 'valid_state' })
+    const req = makeRequest({ error: 'access_denied', state: VALID_STATE })
     const response = await GET(req)
     expect(response.status).toBe(302)
-    expect(response.headers.get('location')).toContain('auth_error=access_denied')
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('auth_error=access_denied')
+    // Should redirect to the return origin extracted from state, not the callback host
+    expect(location).toContain(RETURN_ORIGIN)
   })
 
   it('redirects to error page when state is missing', async () => {
     mockCookieGet.mockReturnValue(undefined)
-    const req = makeRequest({ code: 'abc123', state: 'valid_state' })
+    const req = makeRequest({ code: 'abc123', state: VALID_STATE })
     const response = await GET(req)
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toContain('auth_error=invalid_state')
   })
 
-  it('redirects to error page when state does not match', async () => {
-    const req = makeRequest({ code: 'abc123', state: 'wrong_state' })
+  it('redirects to error page when csrf portion of state does not match cookie', async () => {
+    const req = makeRequest({ code: 'abc123', state: `wrong_csrf|${RETURN_ORIGIN}` })
     const response = await GET(req)
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toContain('auth_error=invalid_state')
   })
 
-  it('exchanges code for token and redirects with fragment on success', async () => {
+  it('exchanges code for token and redirects with fragment to the return origin', async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ access_token: 'gho_token123' }), {
@@ -62,13 +71,38 @@ describe('GET /api/auth/callback', () => {
         }),
       )
 
-    const req = makeRequest({ code: 'abc123', state: 'valid_state' })
+    const req = makeRequest({ code: 'abc123', state: VALID_STATE })
     const response = await GET(req)
     expect(response.status).toBe(302)
     const location = response.headers.get('location') ?? ''
     expect(location).toContain('token=gho_token123')
     expect(location).toContain('username=arun-gupta')
     expect(location).toContain('#')
+    // Should redirect to the return origin from the state, not the callback's own host
+    expect(location.startsWith(RETURN_ORIGIN)).toBe(true)
+  })
+
+  it('falls back to the callback host origin when state has no return origin', async () => {
+    // Handles old-format state (no pipe separator) gracefully
+    mockCookieGet.mockReturnValue({ value: 'bare_csrf' })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'gho_fallback' }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ login: 'user' }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+    const req = makeRequest({ code: 'abc123', state: 'bare_csrf' })
+    const response = await GET(req)
+    expect(response.status).toBe(302)
+    const location = response.headers.get('location') ?? ''
+    // Falls back to the request origin (localhost in this test)
+    expect(location.startsWith('http://localhost')).toBe(true)
   })
 
   it('redirects to error page when token exchange fails', async () => {
@@ -78,7 +112,7 @@ describe('GET /api/auth/callback', () => {
       }),
     )
 
-    const req = makeRequest({ code: 'bad_code', state: 'valid_state' })
+    const req = makeRequest({ code: 'bad_code', state: VALID_STATE })
     const response = await GET(req)
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toContain('auth_error=token_exchange_failed')

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -8,21 +8,28 @@ export async function GET(request: Request) {
   const url = new URL(request.url)
   const error = url.searchParams.get('error')
   const code = url.searchParams.get('code')
-  const state = url.searchParams.get('state')
+  const state = url.searchParams.get('state') ?? ''
 
+  // State format: "{csrf}|{returnOrigin}" — extract both parts.
+  // The return origin is the host that initiated the login (may differ from
+  // the callback host when GitHub's registered callback URL is on Vercel but
+  // the user started the flow on localhost or a preview deployment).
+  const pipeIdx = state.indexOf('|')
+  const csrfFromState = pipeIdx >= 0 ? state.slice(0, pipeIdx) : state
+  const returnOriginFromState = pipeIdx >= 0 ? state.slice(pipeIdx + 1) : ''
   const { origin } = new URL(request.url)
-  const appUrl = origin
+  const appUrl = returnOriginFromState || origin
 
   // Handle user denial or GitHub error
   if (error) {
     return Response.redirect(`${appUrl}/?auth_error=${encodeURIComponent(error)}`, 302)
   }
 
-  // Validate CSRF state
+  // Validate CSRF state — compare cookie against the csrf portion of state.
   const cookieStore = await cookies()
   const storedState = cookieStore.get(OAUTH_STATE_COOKIE)?.value
 
-  if (!storedState || storedState !== state) {
+  if (!storedState || storedState !== csrfFromState) {
     return Response.redirect(`${appUrl}/?auth_error=invalid_state`, 302)
   }
 

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -25,7 +25,22 @@ export async function GET(request: Request) {
     return Response.redirect(`${appUrl}/?auth_error=${encodeURIComponent(error)}`, 302)
   }
 
-  // Validate CSRF state — compare cookie against the csrf portion of state.
+  // Cross-domain relay: when the login originated on a different host than
+  // this registered callback (e.g. localhost dev server vs. Vercel callback),
+  // the CSRF cookie set by the login is not accessible here. Redirect the
+  // browser back to the originating host's /api/auth/relay, which has the
+  // cookie and can complete CSRF validation and token exchange there.
+  if (returnOriginFromState && returnOriginFromState !== origin) {
+    if (!code) {
+      return Response.redirect(`${appUrl}/?auth_error=missing_code`, 302)
+    }
+    const relayUrl = new URL('/api/auth/relay', returnOriginFromState)
+    relayUrl.searchParams.set('code', code)
+    relayUrl.searchParams.set('state', state)
+    return Response.redirect(relayUrl.toString(), 302)
+  }
+
+  // Same-origin path: validate CSRF via cookie, then exchange code for token.
   const cookieStore = await cookies()
   const storedState = cookieStore.get(OAUTH_STATE_COOKIE)?.value
 
@@ -35,7 +50,10 @@ export async function GET(request: Request) {
 
   cookieStore.delete(OAUTH_STATE_COOKIE)
 
-  // Exchange code for access token
+  return exchangeCodeForToken(code, appUrl)
+}
+
+async function exchangeCodeForToken(code: string | null, appUrl: string): Promise<Response> {
   const clientId = process.env.GITHUB_CLIENT_ID
   const clientSecret = process.env.GITHUB_CLIENT_SECRET
 
@@ -58,7 +76,6 @@ export async function GET(request: Request) {
     return Response.redirect(`${appUrl}/?auth_error=token_exchange_failed`, 302)
   }
 
-  // Fetch GitHub username
   const userResponse = await fetch('https://api.github.com/user', {
     headers: {
       Authorization: `Bearer ${tokenData.access_token}`,
@@ -70,7 +87,6 @@ export async function GET(request: Request) {
   const username = userData.login ?? 'unknown'
   const scopes = tokenData.scope ?? ''
 
-  // Return token to client via URL fragment (never sent to server)
   const fragment = `token=${encodeURIComponent(tokenData.access_token)}&username=${encodeURIComponent(username)}&scopes=${encodeURIComponent(scopes)}`
   return Response.redirect(`${appUrl}/#${fragment}`, 302)
 }

--- a/app/api/auth/login/route.test.ts
+++ b/app/api/auth/login/route.test.ts
@@ -41,10 +41,14 @@ describe('GET /api/auth/login', () => {
     expect(location).toContain('scope=')
   })
 
-  it('includes a state parameter', async () => {
-    const response = await GET(mockRequest())
+  it('includes a state parameter containing a csrf token and the return origin', async () => {
+    const response = await GET(mockRequest('http://localhost:3010/api/auth/login'))
     const location = response.headers.get('location') ?? ''
-    expect(location).toMatch(/state=[a-zA-Z0-9_-]+/)
+    const stateParam = new URL(location).searchParams.get('state') ?? ''
+    // Format: "{uuid}|{origin}"
+    const [csrf, returnOrigin] = stateParam.split('|')
+    expect(csrf).toMatch(/^[0-9a-f-]{36}$/)
+    expect(returnOrigin).toBe('http://localhost:3010')
   })
 
   it('returns 500 when GITHUB_CLIENT_ID is not configured (and no dev PAT)', async () => {

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -63,10 +63,17 @@ export async function GET(request: Request) {
     return Response.json({ error: 'GitHub OAuth is not configured.' }, { status: 500 })
   }
 
-  const state = crypto.randomUUID()
+  const csrf = crypto.randomUUID()
+  const returnOrigin = new URL(request.url).origin
+  // Encode return origin into the state so the callback can redirect the user
+  // back to whichever host initiated the flow, even if GitHub sends the
+  // callback to a different registered URL (e.g. the Vercel deployment).
+  const state = `${csrf}|${returnOrigin}`
   const cookieStore = await cookies()
 
-  cookieStore.set(OAUTH_STATE_COOKIE, state, {
+  // Store only the CSRF token in the cookie — the return origin travels via
+  // the state parameter, which GitHub echoes back in the callback URL.
+  cookieStore.set(OAUTH_STATE_COOKIE, csrf, {
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',

--- a/app/api/auth/relay/route.test.ts
+++ b/app/api/auth/relay/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { GET } from './route'
+
+const mockCookieGet = vi.fn()
+const mockCookieDelete = vi.fn()
+
+vi.mock('next/headers', () => ({
+  cookies: () => ({
+    get: mockCookieGet,
+    delete: mockCookieDelete,
+  }),
+}))
+
+global.fetch = vi.fn()
+
+const RELAY_ORIGIN = 'http://localhost:3010'
+const CSRF = 'valid_csrf'
+const VALID_STATE = `${CSRF}|${RELAY_ORIGIN}`
+
+describe('GET /api/auth/relay', () => {
+  beforeEach(() => {
+    vi.stubEnv('GITHUB_CLIENT_ID', 'test_client_id')
+    vi.stubEnv('GITHUB_CLIENT_SECRET', 'test_client_secret')
+    vi.resetAllMocks()
+    mockCookieGet.mockReturnValue({ value: CSRF })
+  })
+
+  function makeRequest(params: Record<string, string>) {
+    const url = new URL(`${RELAY_ORIGIN}/api/auth/relay`)
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
+    return new Request(url.toString())
+  }
+
+  it('redirects to invalid_state when CSRF cookie is missing', async () => {
+    mockCookieGet.mockReturnValue(undefined)
+    const req = makeRequest({ code: 'abc123', state: VALID_STATE })
+    const response = await GET(req)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toContain('auth_error=invalid_state')
+  })
+
+  it('redirects to invalid_state when CSRF does not match cookie', async () => {
+    const req = makeRequest({ code: 'abc123', state: `wrong_csrf|${RELAY_ORIGIN}` })
+    const response = await GET(req)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toContain('auth_error=invalid_state')
+  })
+
+  it('exchanges code for token and redirects with fragment to the relay host on success', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'gho_relay_token' }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ login: 'arun-gupta' }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+    const req = makeRequest({ code: 'abc123', state: VALID_STATE })
+    const response = await GET(req)
+    expect(response.status).toBe(302)
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('token=gho_relay_token')
+    expect(location).toContain('username=arun-gupta')
+    expect(location).toContain('#')
+    expect(location.startsWith(RELAY_ORIGIN)).toBe(true)
+    expect(mockCookieDelete).toHaveBeenCalled()
+  })
+
+  it('redirects to error page when token exchange fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'bad_code' }), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const req = makeRequest({ code: 'bad_code', state: VALID_STATE })
+    const response = await GET(req)
+    expect(response.status).toBe(302)
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('auth_error=token_exchange_failed')
+    expect(location.startsWith(RELAY_ORIGIN)).toBe(true)
+  })
+})

--- a/app/api/auth/relay/route.ts
+++ b/app/api/auth/relay/route.ts
@@ -1,0 +1,69 @@
+import { cookies } from 'next/headers'
+
+export const runtime = 'nodejs'
+
+const OAUTH_STATE_COOKIE = 'repo_pulse_oauth_state'
+
+/**
+ * Cross-domain OAuth relay endpoint.
+ *
+ * When the GitHub OAuth App's registered callback URL is on a different host
+ * than where the login was initiated (e.g. Vercel callback, localhost login),
+ * the Vercel callback cannot read the CSRF cookie set by localhost. It
+ * redirects here instead, on the originating host, where the cookie IS
+ * accessible. This route validates CSRF and completes the token exchange.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const code = url.searchParams.get('code')
+  const state = url.searchParams.get('state') ?? ''
+  const { origin } = url
+
+  const pipeIdx = state.indexOf('|')
+  const csrfFromState = pipeIdx >= 0 ? state.slice(0, pipeIdx) : state
+
+  const cookieStore = await cookies()
+  const storedState = cookieStore.get(OAUTH_STATE_COOKIE)?.value
+
+  if (!storedState || storedState !== csrfFromState) {
+    return Response.redirect(`${origin}/?auth_error=invalid_state`, 302)
+  }
+
+  cookieStore.delete(OAUTH_STATE_COOKIE)
+
+  const clientId = process.env.GITHUB_CLIENT_ID
+  const clientSecret = process.env.GITHUB_CLIENT_SECRET
+
+  const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code }),
+  })
+
+  const tokenData = (await tokenResponse.json()) as {
+    access_token?: string
+    scope?: string
+    error?: string
+  }
+
+  if (!tokenData.access_token) {
+    return Response.redirect(`${origin}/?auth_error=token_exchange_failed`, 302)
+  }
+
+  const userResponse = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${tokenData.access_token}`,
+      Accept: 'application/vnd.github+json',
+    },
+  })
+
+  const userData = (await userResponse.json()) as { login?: string }
+  const username = userData.login ?? 'unknown'
+  const scopes = tokenData.scope ?? ''
+
+  const fragment = `token=${encodeURIComponent(tokenData.access_token)}&username=${encodeURIComponent(username)}&scopes=${encodeURIComponent(scopes)}`
+  return Response.redirect(`${origin}/#${fragment}`, 302)
+}


### PR DESCRIPTION
## Summary

Fixes the \"Sign-in failed: invalid state\" error when clicking Sign in with GitHub from any host other than the registered Vercel callback URL (localhost, preview deployments).

**Root cause (two layers):**
1. No `redirect_uri` → GitHub always sends the callback to the registered Vercel URL, regardless of where the user started.
2. The CSRF cookie set by localhost can't be read by the Vercel callback (different domain), so the CSRF check always fails there.

**Fix — two-hop relay:**

```
Before:
  localhost:3010 /api/auth/login  →  GitHub OAuth
  GitHub  →  vercel/api/auth/callback   (cookie from localhost not readable here)
  ❌ CSRF check fails → "invalid state"

After:
  localhost:3010 /api/auth/login  →  GitHub OAuth
                                       state = "{csrf}|http://localhost:3010"
  GitHub  →  vercel/api/auth/callback
              ↳ detects returnOrigin ≠ own host
              ↳ relays browser to localhost:3010/api/auth/relay?code=…&state=…
  localhost:3010/api/auth/relay
              ↳ reads CSRF cookie (same origin as login) ✓
              ↳ exchanges code for token
              ↳ redirects to localhost:3010/#token=…  ✓
```

Same-origin flows (Vercel → Vercel in production) are unaffected: the relay triggers only when `returnOrigin ≠ callbackOrigin`.

**Changed files:**
- `app/api/auth/login/route.ts` — state now carries `{csrf}|{returnOrigin}`; cookie stores only `csrf`
- `app/api/auth/callback/route.ts` — cross-domain: relays to `/api/auth/relay`; same-origin: existing CSRF + token exchange (now via shared `exchangeCodeForToken`)
- `app/api/auth/relay/route.ts` *(new)* — reads CSRF cookie, validates, exchanges code, returns token

## Test plan

### Automated

```
npx vitest run app/api/auth/login/route.test.ts app/api/auth/callback/route.test.ts app/api/auth/relay/route.test.ts
→ 28 passed (0 failed)

npm test → 1984/1991 passed
  (1 pre-existing file crash: AuthGate.test.tsx worker segfault on this machine, unrelated)
npm run lint → 0 errors
npm run typecheck → clean
```

New/updated tests:
- `login/route.test.ts`: verifies state includes `{uuid}|{origin}` format
- `callback/route.test.ts`: same-origin CSRF + token exchange; cross-domain relay; missing-code error
- `relay/route.test.ts` *(new)*: CSRF mismatch error; token exchange success; token exchange failure

### Manual

- [ ] **localhost sign-in** — visit `http://localhost:3010`, click "Sign in with GitHub", complete auth on GitHub; verify you land back on `http://localhost:3010` with a valid session. Requires a real GitHub OAuth flow.
- [ ] **Error redirect on localhost** — deny access on GitHub after clicking sign-in from localhost; verify the error page appears on localhost, not Vercel.
- [ ] **Vercel production regression** — sign in from `https://repopulse-arun-gupta.vercel.app`; verify sign-in still works (same-origin path, relay not triggered).
- [ ] **`/api/auth/relay` unreachable** — if localhost dev server is stopped and GitHub redirects to Vercel, the relay redirect lands on a dead server; expected result is a browser connection error (acceptable — the dev server must be running for dev OAuth to work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #527