### PR TITLE
refactor(nav): move Universities from header nav into input tab row

### DIFF
--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Image from 'next/image'
-import Link from 'next/link'
 import { getCalibrationMeta } from '@/lib/scoring/config-loader'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import type { ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
@@ -130,12 +129,6 @@ export function ResultsShell({
 
           {/* Desktop nav */}
           <div className="hidden items-center gap-3 sm:flex">
-            <Link
-              href="/university"
-              className="rounded-full border border-sky-700 bg-sky-950/25 px-3 py-2 text-xs font-medium text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
-            >
-              Universities
-            </Link>
             <a
               href="/baseline"
               target="_blank"
@@ -184,12 +177,6 @@ export function ResultsShell({
             {mobileMenuOpen ? (
               <div className="absolute right-0 top-full z-50 mt-2 w-48 rounded-lg border border-sky-700 bg-sky-900 p-3 shadow-lg dark:border-slate-700 dark:bg-slate-900 sm:w-56">
                 <nav className="flex flex-col gap-2">
-                  <Link
-                    href="/university"
-                    className="rounded-md px-3 py-2 text-sm font-medium text-sky-50 transition hover:bg-sky-800"
-                  >
-                    Universities
-                  </Link>
                   <a
                     href="/baseline"
                     target="_blank"

--- a/components/repo-input/RepoInputForm.test.tsx
+++ b/components/repo-input/RepoInputForm.test.tsx
@@ -39,6 +39,13 @@ describe('RepoInputForm — US1 (valid input)', () => {
 
     expect(screen.getByRole('button', { name: /^analyze$/i })).toHaveAttribute('title', expect.stringContaining('health dashboard'))
   })
+
+  it('keeps Foundation as a local toggle and renders Universities as a route link', () => {
+    render(<RepoInputForm onSubmitRepos={vi.fn()} onSubmitOrg={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: /^foundation$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^universities$/i })).toHaveAttribute('href', '/university')
+  })
 })
 
 describe('RepoInputForm — format tooltip', () => {

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -5,6 +5,7 @@ import { normalizeOrgInput } from '@/lib/analyzer/org-inventory'
 import { parseRepos } from '@/lib/parse-repos'
 import type { FoundationTarget } from '@/lib/cncf-sandbox/types'
 import { FoundationInputSection } from '@/components/foundation/FoundationInputSection'
+import Link from 'next/link'
 import { CopyLinkButton } from '@/components/shared/CopyLinkButton'
 
 interface RepoInputFormProps {
@@ -120,6 +121,12 @@ export function RepoInputForm({
               {m === 'repos' ? 'Repositories' : m === 'org' ? 'Organization' : 'Foundation'}
             </button>
           ))}
+          <Link
+            href="/university"
+            className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+          >
+            Universities
+          </Link>
         </div>
         <div className="ml-auto">
           <CopyLinkButton />

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -210,6 +210,7 @@ export function RepoInputForm({
       )}
       <button
         type="submit"
+        title="Analyze repositories and open the health dashboard"
         className="mt-3 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-2 dark:focus:ring-offset-slate-900"
       >
         Analyze


### PR DESCRIPTION
## Summary

- Moves the **Universities** link from the top header nav (alongside Scoring Methodology and GitHub) into the input tab row, alongside Repositories, Organization, and Foundation
- Removes the now-unused `Link` import from `ResultsShell.tsx`

## Why

Users expected Universities to appear next to the other mode tabs (Repositories / Organization / Foundation) since it represents another way to explore OSS health scores, not a utility nav item. The header nav placement was less discoverable.

The Universities tab renders as a route link (`<Link href="/university">`) rather than a local panel toggle. Unlike Repositories, Organization, and Foundation — which are buttons that switch the input panel in-place — Universities navigates to its own dedicated page at `/university`.

## Test plan

- [ ] Home page shows **Repositories | Organization | Foundation | Universities** tab row — Universities tab navigates to `/university`
- [ ] Header nav no longer shows a Universities pill (only Scoring Methodology, GitHub, theme, user)
- [ ] Mobile hamburger menu no longer shows Universities

🤖 Generated with [Claude Code](https://claude.com/claude-code)