### PR TITLE
feat(university): university pages L&F, consolidated overview, and nav visual cue

### DIFF
--- a/app/university/[slug]/page.tsx
+++ b/app/university/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { AuthProvider } from '@/components/auth/AuthContext'
-import { DemoBanner } from '@/components/demo/DemoBanner'
+import { AppHeader } from '@/components/app-shell/AppHeader'
 import { OrgInventorySummary } from '@/components/org-inventory/OrgInventorySummary'
 import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
 import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
@@ -45,24 +45,27 @@ export default async function UniversityPage({ params }: { params: Promise<{ slu
 
   return (
     <AuthProvider>
-      <DemoBanner generatedAt={generatedAt} label="Static snapshot" showSignIn={false} />
-      <main className="mx-auto max-w-7xl px-4 py-6">
-        <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400">
-          <Link href="/university" className="hover:text-sky-700 dark:hover:text-sky-300">Universities</Link>
-          <span aria-hidden="true">/</span>
-          <span className="text-slate-900 dark:text-slate-100">{university}</span>
-        </nav>
-        <header className="mb-6">
-          <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{university}</h1>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            {results.length} of {totalRepos} repositories scored
-          </p>
-        </header>
-        <div className="mb-8">
-          <OrgInventorySummary summary={summary} />
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 dark:bg-slate-800/60">
+        <AppHeader />
+        <div className="mx-auto max-w-5xl px-4 py-6">
+          <nav aria-label="Breadcrumb" className="mb-4 flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400">
+            <Link href="/university" className="hover:text-sky-700 dark:hover:text-sky-300">Universities</Link>
+            <span aria-hidden="true">/</span>
+            <span className="text-slate-900 dark:text-slate-100">{university}</span>
+          </nav>
+          <header className="mb-6">
+            <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{university}</h1>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              {results.length} of {totalRepos} repositories scored
+              {generatedAt ? <> · scored {new Date(generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</> : null}
+            </p>
+          </header>
+          <div className="mb-8">
+            <OrgInventorySummary summary={summary} />
+          </div>
+          <RepoSummaryTable results={results} />
         </div>
-        <RepoSummaryTable results={results} />
-      </main>
+      </div>
     </AuthProvider>
   )
 }

--- a/app/university/[slug]/page.tsx
+++ b/app/university/[slug]/page.tsx
@@ -2,8 +2,10 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { AuthProvider } from '@/components/auth/AuthContext'
 import { DemoBanner } from '@/components/demo/DemoBanner'
+import { OrgInventorySummary } from '@/components/org-inventory/OrgInventorySummary'
 import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
 import type { AnalyzeResponse } from '@/lib/analyzer/analysis-result'
+import { buildUniversitySummary } from '@/lib/university/summary'
 
 const REPOFINDER_RAW_BASE =
   'https://raw.githubusercontent.com/arun-gupta/repofinder/repo-pulse-integration/exports/universities'
@@ -39,6 +41,7 @@ export default async function UniversityPage({ params }: { params: Promise<{ slu
   if (!fixture) notFound()
 
   const { generatedAt, university, slug: _slug, totalRepos, results } = fixture
+  const summary = buildUniversitySummary(results)
 
   return (
     <AuthProvider>
@@ -55,6 +58,9 @@ export default async function UniversityPage({ params }: { params: Promise<{ slu
             {results.length} of {totalRepos} repositories scored
           </p>
         </header>
+        <div className="mb-8">
+          <OrgInventorySummary summary={summary} />
+        </div>
         <RepoSummaryTable results={results} />
       </main>
     </AuthProvider>

--- a/app/university/page.tsx
+++ b/app/university/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { AuthProvider } from '@/components/auth/AuthContext'
-import { DemoBanner } from '@/components/demo/DemoBanner'
+import { AppHeader } from '@/components/app-shell/AppHeader'
 
 const REPOFINDER_RAW_BASE =
   'https://raw.githubusercontent.com/arun-gupta/repofinder/repo-pulse-integration/exports/universities'
@@ -30,13 +30,12 @@ export const metadata = {
 
 export default async function UniversitiesPage() {
   const universities = await fetchManifest()
-  const latestGeneratedAt = universities.reduce((latest, u) => u.generatedAt > latest ? u.generatedAt : latest, '')
 
   return (
     <AuthProvider>
-      {latestGeneratedAt && <DemoBanner generatedAt={latestGeneratedAt} label="Static snapshot" showSignIn={false} />}
-      <main className="min-h-screen bg-slate-50 px-4 py-10 dark:bg-slate-950 sm:py-16">
-        <div className="mx-auto max-w-4xl space-y-8">
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 dark:bg-slate-800/60">
+        <AppHeader />
+        <div className="mx-auto max-w-5xl px-4 py-6 space-y-6">
           <header>
             <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Universities</h1>
             <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
@@ -44,7 +43,7 @@ export default async function UniversitiesPage() {
               <a href="https://github.com/arun-gupta/repofinder" className="text-sky-700 hover:underline dark:text-sky-300">
                 repofinder
               </a>
-              .
+              . Data is pre-scored and refreshed periodically.
             </p>
           </header>
 
@@ -72,7 +71,7 @@ export default async function UniversitiesPage() {
             </div>
           )}
         </div>
-      </main>
+      </div>
     </AuthProvider>
   )
 }

--- a/components/app-shell/AppHeader.tsx
+++ b/components/app-shell/AppHeader.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { ThemeToggle } from '@/components/theme/ThemeToggle'
+import { UserBadge } from '@/components/auth/UserBadge'
+
+interface AppHeaderProps {
+  onLogoClick?: () => void
+}
+
+export function AppHeader({ onLogoClick }: AppHeaderProps) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!mobileMenuOpen) return
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMobileMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [mobileMenuOpen])
+
+  const logoContent = (
+    <>
+      <Image
+        src="/repo-pulse-banner.png"
+        alt=""
+        width={32}
+        height={32}
+        className="h-8 w-8 shrink-0 rounded object-cover"
+        aria-hidden="true"
+      />
+      <h1 className="text-2xl font-semibold tracking-tight text-white">RepoPulse</h1>
+    </>
+  )
+
+  return (
+    <header className="w-full bg-sky-900 text-white dark:bg-slate-900">
+      <div className="mx-auto flex max-w-5xl items-start justify-between gap-4 px-4 py-5">
+        <div className="min-w-0">
+          {onLogoClick ? (
+            <button
+              type="button"
+              onClick={onLogoClick}
+              aria-label="RepoPulse — return to home"
+              className="flex items-center gap-2 text-left hover:opacity-80 transition-opacity"
+            >
+              {logoContent}
+            </button>
+          ) : (
+            <Link
+              href="/"
+              aria-label="RepoPulse — go to home"
+              className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+            >
+              {logoContent}
+            </Link>
+          )}
+          <p className="mt-1 text-sm text-sky-100 sm:hidden">
+            OSS Health Score for open source projects.
+          </p>
+          <p className="mt-1 hidden text-sm text-sky-100 sm:block md:text-base">
+            OSS Health Score — percentile-based scoring for open source projects.
+          </p>
+        </div>
+
+        {/* Desktop nav */}
+        <div className="hidden items-center gap-3 sm:flex">
+          <a
+            href="/baseline"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-full border border-sky-700 bg-sky-950/25 px-3 py-2 text-xs font-medium text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
+          >
+            Scoring Methodology
+          </a>
+          <a
+            href="https://github.com/arun-gupta/repo-pulse"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="GitHub repository"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-sky-700 bg-sky-950/25 text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current">
+              <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.47c.53.1.72-.23.72-.52v-1.85c-2.94.64-3.56-1.25-3.56-1.25-.48-1.2-1.16-1.52-1.16-1.52-.95-.65.07-.64.07-.64 1.06.08 1.62 1.08 1.62 1.08.94 1.61 2.46 1.15 3.06.88.1-.68.37-1.15.67-1.42-2.35-.27-4.82-1.17-4.82-5.2 0-1.15.41-2.1 1.08-2.84-.11-.27-.47-1.37.1-2.86 0 0 .88-.28 2.89 1.08a9.98 9.98 0 0 1 5.26 0c2.01-1.36 2.89-1.08 2.89-1.08.57 1.49.21 2.59.1 2.86.67.74 1.08 1.69 1.08 2.84 0 4.04-2.48 4.93-4.84 5.19.38.33.72.98.72 1.98v2.93c0 .29.19.63.73.52A10.5 10.5 0 0 0 12 1.5Z" />
+            </svg>
+          </a>
+          <ThemeToggle />
+          <div className="h-6 w-px bg-sky-700 dark:bg-slate-700" />
+          <UserBadge />
+        </div>
+
+        {/* Mobile hamburger */}
+        <div className="flex items-center gap-2 sm:hidden">
+          <ThemeToggle />
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setMobileMenuOpen((prev) => !prev)}
+              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={mobileMenuOpen}
+              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-sky-700 bg-sky-950/25 text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
+            >
+              {mobileMenuOpen ? (
+                <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-none stroke-current stroke-2">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-none stroke-current stroke-2">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
+            {mobileMenuOpen && (
+              <div className="absolute right-0 top-full z-50 mt-2 w-48 rounded-lg border border-sky-700 bg-sky-900 p-3 shadow-lg dark:border-slate-700 dark:bg-slate-900 sm:w-56">
+                <nav className="flex flex-col gap-2">
+                  <a
+                    href="/baseline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded-md px-3 py-2 text-sm font-medium text-sky-50 transition hover:bg-sky-800"
+                  >
+                    Scoring Methodology
+                  </a>
+                  <a
+                    href="https://github.com/arun-gupta/repo-pulse"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-sky-50 transition hover:bg-sky-800"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4 fill-current">
+                      <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.47c.53.1.72-.23.72-.52v-1.85c-2.94.64-3.56-1.25-3.56-1.25-.48-1.2-1.16-1.52-1.16-1.52-.95-.65.07-.64.07-.64 1.06.08 1.62 1.08 1.62 1.08.94 1.61 2.46 1.15 3.06.88.1-.68.37-1.15.67-1.42-2.35-.27-4.82-1.17-4.82-5.2 0-1.15.41-2.1 1.08-2.84-.11-.27-.47-1.37.1-2.86 0 0 .88-.28 2.89 1.08a9.98 9.98 0 0 1 5.26 0c2.01-1.36 2.89-1.08 2.89-1.08.57 1.49.21 2.59.1 2.86.67.74 1.08 1.69 1.08 2.84 0 4.04-2.48 4.93-4.84 5.19.38.33.72.98.72 1.98v2.93c0 .29.19.63.73.52A10.5 10.5 0 0 0 12 1.5Z" />
+                    </svg>
+                    GitHub
+                  </a>
+                  <div className="my-1 h-px bg-sky-700" />
+                  <div className="px-3 py-2">
+                    <UserBadge />
+                  </div>
+                </nav>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/app-shell/ResultsShell.tsx
+++ b/components/app-shell/ResultsShell.tsx
@@ -1,16 +1,14 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import Image from 'next/image'
+import { useEffect, useMemo, useState } from 'react'
 import { getCalibrationMeta } from '@/lib/scoring/config-loader'
 import { resultTabs } from '@/lib/results-shell/tabs'
 import type { ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import type { ResultTabDefinition } from '@/specs/006-results-shell/contracts/results-shell-props'
-import { UserBadge } from '@/components/auth/UserBadge'
 import { ElevatedScopeBanner } from '@/components/auth/ElevatedScopeBanner'
-import { ThemeToggle } from '@/components/theme/ThemeToggle'
 import type { TabMatchCounts } from '@/lib/search/types'
 import { useHighlightMatches } from '@/components/search/useHighlightMatches'
+import { AppHeader } from './AppHeader'
 import { ResultsTabs } from './ResultsTabs'
 
 interface ResultsShellProps {
@@ -43,19 +41,6 @@ export function ResultsShell({
   chatPanel,
 }: ResultsShellProps) {
   const [activeTab, setActiveTab] = useState<ResultTabId>(initialActiveTab)
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!mobileMenuOpen) return
-    function handleClickOutside(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMobileMenuOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [mobileMenuOpen])
 
   const calibrationMeta = getCalibrationMeta()
   const isStale = useMemo(() => {
@@ -99,114 +84,7 @@ export function ResultsShell({
   return (
     <main className="min-h-screen bg-slate-50 dark:bg-slate-950 dark:bg-slate-800/60">
       <ElevatedScopeBanner />
-      <header className="w-full bg-sky-900 text-white dark:bg-slate-900">
-        <div className="mx-auto flex max-w-5xl items-start justify-between gap-4 px-4 py-5">
-          <div className="min-w-0">
-            <button
-              type="button"
-              onClick={onReset}
-              aria-label="RepoPulse — return to home"
-              className="flex items-center gap-2 text-left hover:opacity-80 transition-opacity disabled:cursor-default"
-              disabled={!onReset}
-            >
-              <Image
-                src="/repo-pulse-banner.png"
-                alt=""
-                width={32}
-                height={32}
-                className="h-8 w-8 shrink-0 rounded object-cover"
-                aria-hidden="true"
-              />
-              <h1 className="text-2xl font-semibold tracking-tight text-white">RepoPulse</h1>
-            </button>
-            <p className="mt-1 text-sm text-sky-100 sm:hidden">
-              OSS Health Score for open source projects.
-            </p>
-            <p className="mt-1 hidden text-sm text-sky-100 sm:block md:text-base">
-              OSS Health Score — percentile-based scoring for open source projects.
-            </p>
-          </div>
-
-          {/* Desktop nav */}
-          <div className="hidden items-center gap-3 sm:flex">
-            <a
-              href="/baseline"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-full border border-sky-700 bg-sky-950/25 px-3 py-2 text-xs font-medium text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
-            >
-              Scoring Methodology
-            </a>
-            <a
-              href="https://github.com/arun-gupta/repo-pulse"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="GitHub repository"
-              className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-sky-700 bg-sky-950/25 text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-current">
-                <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.47c.53.1.72-.23.72-.52v-1.85c-2.94.64-3.56-1.25-3.56-1.25-.48-1.2-1.16-1.52-1.16-1.52-.95-.65.07-.64.07-.64 1.06.08 1.62 1.08 1.62 1.08.94 1.61 2.46 1.15 3.06.88.1-.68.37-1.15.67-1.42-2.35-.27-4.82-1.17-4.82-5.2 0-1.15.41-2.1 1.08-2.84-.11-.27-.47-1.37.1-2.86 0 0 .88-.28 2.89 1.08a9.98 9.98 0 0 1 5.26 0c2.01-1.36 2.89-1.08 2.89-1.08.57 1.49.21 2.59.1 2.86.67.74 1.08 1.69 1.08 2.84 0 4.04-2.48 4.93-4.84 5.19.38.33.72.98.72 1.98v2.93c0 .29.19.63.73.52A10.5 10.5 0 0 0 12 1.5Z" />
-              </svg>
-            </a>
-            <ThemeToggle />
-            <div className="h-6 w-px bg-sky-700 dark:bg-slate-700" />
-            <UserBadge />
-          </div>
-
-          {/* Mobile hamburger + theme toggle */}
-          <div className="flex items-center gap-2 sm:hidden">
-            <ThemeToggle />
-          <div className="relative" ref={menuRef}>
-            <button
-              type="button"
-              onClick={() => setMobileMenuOpen((prev) => !prev)}
-              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
-              aria-expanded={mobileMenuOpen}
-              className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-sky-700 bg-sky-950/25 text-sky-50 transition hover:border-sky-400 hover:bg-sky-950/40 hover:text-white"
-            >
-              {mobileMenuOpen ? (
-                <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-none stroke-current stroke-2">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              ) : (
-                <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5 fill-none stroke-current stroke-2">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-              )}
-            </button>
-            {mobileMenuOpen ? (
-              <div className="absolute right-0 top-full z-50 mt-2 w-48 rounded-lg border border-sky-700 bg-sky-900 p-3 shadow-lg dark:border-slate-700 dark:bg-slate-900 sm:w-56">
-                <nav className="flex flex-col gap-2">
-                  <a
-                    href="/baseline"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="rounded-md px-3 py-2 text-sm font-medium text-sky-50 transition hover:bg-sky-800"
-                  >
-                    Scoring Methodology
-                  </a>
-                  <a
-                    href="https://github.com/arun-gupta/repo-pulse"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-sky-50 transition hover:bg-sky-800"
-                  >
-                    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-4 w-4 fill-current">
-                      <path d="M12 1.5a10.5 10.5 0 0 0-3.32 20.47c.53.1.72-.23.72-.52v-1.85c-2.94.64-3.56-1.25-3.56-1.25-.48-1.2-1.16-1.52-1.16-1.52-.95-.65.07-.64.07-.64 1.06.08 1.62 1.08 1.62 1.08.94 1.61 2.46 1.15 3.06.88.1-.68.37-1.15.67-1.42-2.35-.27-4.82-1.17-4.82-5.2 0-1.15.41-2.1 1.08-2.84-.11-.27-.47-1.37.1-2.86 0 0 .88-.28 2.89 1.08a9.98 9.98 0 0 1 5.26 0c2.01-1.36 2.89-1.08 2.89-1.08.57 1.49.21 2.59.1 2.86.67.74 1.08 1.69 1.08 2.84 0 4.04-2.48 4.93-4.84 5.19.38.33.72.98.72 1.98v2.93c0 .29.19.63.73.52A10.5 10.5 0 0 0 12 1.5Z" />
-                    </svg>
-                    GitHub
-                  </a>
-                  <div className="my-1 h-px bg-sky-700" />
-                  <div className="px-3 py-2">
-                    <UserBadge />
-                  </div>
-                </nav>
-              </div>
-            ) : null}
-          </div>
-          </div>
-        </div>
-      </header>
+      <AppHeader onLogoClick={onReset} />
 
       <div className={`mx-auto max-w-5xl px-4 py-6${chatPanel ? ' pb-16' : ''}`}>
         {isStale ? (

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -123,9 +123,13 @@ export function RepoInputForm({
           ))}
           <Link
             href="/university"
-            className="rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+            title="Pre-scored static data — refreshed periodically"
+            className="inline-flex items-center gap-1.5 rounded-full border border-dashed border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-500 transition hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200"
           >
             Universities
+            <svg aria-hidden="true" viewBox="0 0 12 12" className="h-3 w-3 opacity-60" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M2.5 9.5 9.5 2.5M5 2.5h4.5V7" />
+            </svg>
           </Link>
         </div>
         <div className="ml-auto">

--- a/lib/university/summary.test.ts
+++ b/lib/university/summary.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { buildUniversitySummary } from './summary'
+
+describe('university/summary', () => {
+  it('returns the empty-state summary for no repositories', () => {
+    expect(buildUniversitySummary([])).toEqual({
+      totalPublicRepos: 0,
+      totalStars: 'unavailable',
+      mostStarredRepos: [],
+      mostRecentlyActiveRepos: [],
+      languageDistribution: [],
+      archivedRepoCount: 0,
+      activeRepoCount: 0,
+    })
+  })
+
+  it('builds totals, language buckets, and alphabetical tie-breakers from analyzed repos', () => {
+    const summary = buildUniversitySummary([
+      buildResult('mit/atlas', {
+        stars: 10,
+        primaryLanguage: 'TypeScript',
+        commitTimestamps365d: ['2026-04-03T00:00:00Z'],
+      }),
+      buildResult('mit/mars', {
+        stars: 10,
+        primaryLanguage: 'TypeScript',
+        commitTimestamps365d: ['2026-04-01T00:00:00Z', '2026-04-03T00:00:00Z'],
+      }),
+      buildResult('mit/zeus', {
+        stars: 5,
+        primaryLanguage: 'Python',
+        commitTimestamps365d: 'unavailable',
+      }),
+      buildResult('mit/apollo', {
+        stars: 'unavailable',
+        primaryLanguage: 'unavailable',
+        commitTimestamps365d: [],
+      }),
+      buildResult('mit/borealis', {
+        stars: 'unavailable',
+        primaryLanguage: 'unavailable',
+        commitTimestamps365d: ['not-a-date'],
+      }),
+    ])
+
+    expect(summary.totalPublicRepos).toBe(5)
+    expect(summary.totalStars).toBe(25)
+    expect(summary.activeRepoCount).toBe(5)
+    expect(summary.archivedRepoCount).toBe(0)
+    expect(summary.mostStarredRepos).toEqual([
+      { repo: 'mit/atlas', stars: 10 },
+      { repo: 'mit/mars', stars: 10 },
+      { repo: 'mit/zeus', stars: 5 },
+    ])
+    expect(summary.languageDistribution).toEqual([
+      { language: 'TypeScript', repoCount: 2 },
+      { language: 'Unavailable', repoCount: 2 },
+      { language: 'Python', repoCount: 1 },
+    ])
+  })
+
+  it('orders recent activity by latest commit timestamp and falls back to unavailable when no valid timestamps exist', () => {
+    const summary = buildUniversitySummary([
+      buildResult('mit/gamma', {
+        commitTimestamps365d: ['2026-04-02T00:00:00Z'],
+      }),
+      buildResult('mit/alpha', {
+        commitTimestamps365d: ['2026-04-03T00:00:00Z'],
+      }),
+      buildResult('mit/beta', {
+        commitTimestamps365d: ['2026-04-03T00:00:00Z', '2026-04-01T00:00:00Z'],
+      }),
+      buildResult('mit/delta', {
+        commitTimestamps365d: [],
+      }),
+    ])
+
+    expect(summary.mostRecentlyActiveRepos).toEqual([
+      { repo: 'mit/alpha', pushedAt: '2026-04-03T00:00:00Z' },
+      { repo: 'mit/beta', pushedAt: '2026-04-03T00:00:00Z' },
+      { repo: 'mit/gamma', pushedAt: '2026-04-02T00:00:00Z' },
+    ])
+  })
+})
+
+function buildResult(repo: string, overrides: Partial<AnalysisResult> = {}): AnalysisResult {
+  return {
+    repo,
+    name: repo.split('/')[1] ?? repo,
+    description: 'Repo description',
+    createdAt: '2026-01-01T00:00:00Z',
+    primaryLanguage: 'TypeScript',
+    stars: 1,
+    forks: 1,
+    watchers: 1,
+    commits30d: 1,
+    commits90d: 1,
+    releases12mo: 1,
+    prsOpened90d: 1,
+    prsMerged90d: 1,
+    issuesOpen: 1,
+    issuesClosed90d: 1,
+    uniqueCommitAuthors90d: 1,
+    totalContributors: 1,
+    maintainerCount: 1,
+    commitCountsByAuthor: { alice: 1 },
+    commitCountsByExperimentalOrg: 'unavailable',
+    experimentalAttributedAuthors90d: 'unavailable',
+    experimentalUnattributedAuthors90d: 'unavailable',
+    commitTimestamps365d: ['2026-04-01T00:00:00Z'],
+    issueFirstResponseTimestamps: [],
+    issueCloseTimestamps: [],
+    prMergeTimestamps: [],
+    documentationResult: 'unavailable',
+    licensingResult: 'unavailable',
+    defaultBranchName: 'main',
+    topics: [],
+    inclusiveNamingResult: 'unavailable',
+    securityResult: 'unavailable',
+    missingFields: [],
+    ...overrides,
+  }
+}

--- a/lib/university/summary.ts
+++ b/lib/university/summary.ts
@@ -1,62 +1,48 @@
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
-import type { OrgInventorySummary } from '@/lib/org-inventory/summary'
+import type { OrgRepoSummary } from '@/lib/analyzer/org-inventory'
+import { buildOrgInventorySummary, type OrgInventorySummary } from '@/lib/org-inventory/summary'
 
 export function buildUniversitySummary(results: AnalysisResult[]): OrgInventorySummary {
-  const starValues = results.flatMap((r) => (typeof r.stars === 'number' ? [r.stars] : []))
-  const totalStars = starValues.length > 0 ? starValues.reduce((sum, v) => sum + v, 0) : 'unavailable'
+  return buildOrgInventorySummary(results.map(toUniversityRepoSummary))
+}
 
-  const languageCounts = new Map<string, number>()
-  for (const r of results) {
-    const lang = r.primaryLanguage === 'unavailable' ? 'Unavailable' : r.primaryLanguage
-    languageCounts.set(lang, (languageCounts.get(lang) ?? 0) + 1)
-  }
-
+function toUniversityRepoSummary(result: AnalysisResult): OrgRepoSummary {
   return {
-    totalPublicRepos: results.length,
-    totalStars,
-    mostStarredRepos: [...results]
-      .sort((a, b) => compareNumeric(b.stars, a.stars) || a.repo.localeCompare(b.repo))
-      .slice(0, 3)
-      .map((r) => ({ repo: r.repo, stars: r.stars })),
-    mostRecentlyActiveRepos: [...results]
-      .sort((a, b) => compareByActivity(b, a) || a.repo.localeCompare(b.repo))
-      .slice(0, 3)
-      .map((r) => ({ repo: r.repo, pushedAt: deriveLastActive(r) })),
-    languageDistribution: [...languageCounts.entries()]
-      .map(([language, repoCount]) => ({ language, repoCount }))
-      .sort((a, b) => b.repoCount - a.repoCount || a.language.localeCompare(b.language)),
-    archivedRepoCount: 0,
-    activeRepoCount: results.length,
+    repo: result.repo,
+    name: result.name === 'unavailable' ? result.repo.split('/')[1] ?? result.repo : result.name,
+    description: result.description,
+    primaryLanguage: result.primaryLanguage,
+    stars: result.stars,
+    forks: result.forks,
+    watchers: result.watchers,
+    openIssues: result.issuesOpen,
+    pushedAt: deriveLastActive(result),
+    // Repofinder's university export currently curates active repositories only.
+    // Keep the archived count at zero until the upstream fixture includes an
+    // archived signal we can map through explicitly.
+    archived: false,
+    isFork: false,
+    topics: result.topics,
+    url: `https://github.com/${result.repo}`,
   }
 }
 
-function deriveLastActive(r: AnalysisResult): string | 'unavailable' {
-  if (Array.isArray(r.commitTimestamps365d) && r.commitTimestamps365d.length > 0) {
-    const sorted = [...r.commitTimestamps365d].sort()
-    return sorted[sorted.length - 1]
+function deriveLastActive(result: AnalysisResult): string | 'unavailable' {
+  if (!Array.isArray(result.commitTimestamps365d) || result.commitTimestamps365d.length === 0) {
+    return 'unavailable'
   }
-  return 'unavailable'
-}
 
-function compareByActivity(a: AnalysisResult, b: AnalysisResult): number {
-  const aTs = latestTimestamp(a)
-  const bTs = latestTimestamp(b)
-  if (aTs === null && bTs === null) return compareNumeric(a.commits30d, b.commits30d)
-  if (aTs === null) return -1
-  if (bTs === null) return 1
-  return aTs - bTs
-}
+  let latestTimestamp = 'unavailable' as string | 'unavailable'
+  let latestTime = Number.NEGATIVE_INFINITY
 
-function latestTimestamp(r: AnalysisResult): number | null {
-  if (!Array.isArray(r.commitTimestamps365d) || r.commitTimestamps365d.length === 0) return null
-  const sorted = [...r.commitTimestamps365d].sort()
-  const t = new Date(sorted[sorted.length - 1]).getTime()
-  return Number.isNaN(t) ? null : t
-}
+  for (const timestamp of result.commitTimestamps365d) {
+    const parsed = new Date(timestamp).getTime()
+    if (Number.isNaN(parsed) || parsed <= latestTime) {
+      continue
+    }
+    latestTime = parsed
+    latestTimestamp = timestamp
+  }
 
-function compareNumeric(left: number | 'unavailable', right: number | 'unavailable') {
-  if (typeof left !== 'number' && typeof right !== 'number') return 0
-  if (typeof left !== 'number') return -1
-  if (typeof right !== 'number') return 1
-  return left - right
+  return latestTimestamp
 }

--- a/lib/university/summary.ts
+++ b/lib/university/summary.ts
@@ -7,7 +7,7 @@ export function buildUniversitySummary(results: AnalysisResult[]): OrgInventoryS
 
   const languageCounts = new Map<string, number>()
   for (const r of results) {
-    const lang = r.primaryLanguage === 'unavailable' ? 'Unavailable' : (r.primaryLanguage ?? 'Unavailable')
+    const lang = r.primaryLanguage === 'unavailable' ? 'Unavailable' : r.primaryLanguage
     languageCounts.set(lang, (languageCounts.get(lang) ?? 0) + 1)
   }
 

--- a/lib/university/summary.ts
+++ b/lib/university/summary.ts
@@ -1,0 +1,62 @@
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import type { OrgInventorySummary } from '@/lib/org-inventory/summary'
+
+export function buildUniversitySummary(results: AnalysisResult[]): OrgInventorySummary {
+  const starValues = results.flatMap((r) => (typeof r.stars === 'number' ? [r.stars] : []))
+  const totalStars = starValues.length > 0 ? starValues.reduce((sum, v) => sum + v, 0) : 'unavailable'
+
+  const languageCounts = new Map<string, number>()
+  for (const r of results) {
+    const lang = r.primaryLanguage === 'unavailable' ? 'Unavailable' : (r.primaryLanguage ?? 'Unavailable')
+    languageCounts.set(lang, (languageCounts.get(lang) ?? 0) + 1)
+  }
+
+  return {
+    totalPublicRepos: results.length,
+    totalStars,
+    mostStarredRepos: [...results]
+      .sort((a, b) => compareNumeric(b.stars, a.stars) || a.repo.localeCompare(b.repo))
+      .slice(0, 3)
+      .map((r) => ({ repo: r.repo, stars: r.stars })),
+    mostRecentlyActiveRepos: [...results]
+      .sort((a, b) => compareByActivity(b, a) || a.repo.localeCompare(b.repo))
+      .slice(0, 3)
+      .map((r) => ({ repo: r.repo, pushedAt: deriveLastActive(r) })),
+    languageDistribution: [...languageCounts.entries()]
+      .map(([language, repoCount]) => ({ language, repoCount }))
+      .sort((a, b) => b.repoCount - a.repoCount || a.language.localeCompare(b.language)),
+    archivedRepoCount: 0,
+    activeRepoCount: results.length,
+  }
+}
+
+function deriveLastActive(r: AnalysisResult): string | 'unavailable' {
+  if (Array.isArray(r.commitTimestamps365d) && r.commitTimestamps365d.length > 0) {
+    const sorted = [...r.commitTimestamps365d].sort()
+    return sorted[sorted.length - 1]
+  }
+  return 'unavailable'
+}
+
+function compareByActivity(a: AnalysisResult, b: AnalysisResult): number {
+  const aTs = latestTimestamp(a)
+  const bTs = latestTimestamp(b)
+  if (aTs === null && bTs === null) return compareNumeric(a.commits30d, b.commits30d)
+  if (aTs === null) return -1
+  if (bTs === null) return 1
+  return aTs - bTs
+}
+
+function latestTimestamp(r: AnalysisResult): number | null {
+  if (!Array.isArray(r.commitTimestamps365d) || r.commitTimestamps365d.length === 0) return null
+  const sorted = [...r.commitTimestamps365d].sort()
+  const t = new Date(sorted[sorted.length - 1]).getTime()
+  return Number.isNaN(t) ? null : t
+}
+
+function compareNumeric(left: number | 'unavailable', right: number | 'unavailable') {
+  if (typeof left !== 'number' && typeof right !== 'number') return 0
+  if (typeof left !== 'number') return -1
+  if (typeof right !== 'number') return 1
+  return left - right
+}


### PR DESCRIPTION
## Summary

Lands three university-related features on main:

- **Visual cue on Universities tab** — dashed border + ↗ icon signals static/external data, distinguishing it from the live Repos/Org/Foundation tabs
- **Consolidated overview on slug pages** — 4 stat cards (Total repos, Stars, Active, Archived) + Most Starred / Most Recently Active / Language Distribution panels above the repo table, matching the Organization tab layout
- **L&F consistency** — extracts `AppHeader` from `ResultsShell` into a shared component; `/university` and `/university/[slug]` pages now show the full RepoPulse dark nav header instead of the plain `DemoBanner`

Closes #533

## Test plan

- [ ] Universities tab in input row has dashed border and ↗ icon
- [ ] `/university` — full dark RepoPulse header (logo, Scoring Methodology, GitHub, theme toggle, user badge)
- [ ] `/university/ucsc` — same header + breadcrumb + 4 stat cards + 3 list panels + repo table
- [ ] Logo on university pages navigates to `/` (Link, not disabled button)
- [ ] Mobile hamburger works on university pages
- [ ] Main app header still renders correctly and logo click resets state

🤖 Generated with [Claude Code](https://claude.com/claude-code)