### PR TITLE
refactor(chat): share two-phase filter between org and university Ask AI

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -6,7 +6,7 @@ import type { Message } from 'ai'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
 import type { OrgInventoryResponse, OrgRepoSummary } from '@/lib/analyzer/org-inventory'
 import type { OrgSummaryViewModel } from '@/lib/org-aggregation/types'
-import { parseStructuredSearchQuery, matchesStructuredSearch } from '@/lib/org-inventory/structured-search'
+import { parseStructuredSearchQuery, matchesStructuredSearch, analysisResultToFilterable } from '@/lib/org-inventory/structured-search'
 import { serializeReposContext, serializeOrgContext, serializeOrgInventoryContext, serializeUniversityContext } from './serialize-context'
 import { PROVIDERS, type ProviderId } from './providers'
 
@@ -430,13 +430,19 @@ export function ChatPanel({
     return { ...orgInventory, results: orgInventory.results.filter((r) => matchesStructuredSearch(r, parsed)) }
   }, [orgInventory, repoQuery])
 
+  const filteredUniversityResults = useMemo(() => {
+    if (!universityResults || !repoQuery.trim()) return universityResults
+    const parsed = parseStructuredSearchQuery(repoQuery)
+    return universityResults.filter((r) => matchesStructuredSearch(analysisResultToFilterable(r), parsed))
+  }, [universityResults, repoQuery])
+
   const context = useMemo(() => {
     if (contextType === 'repos' && repoResults) return serializeReposContext(repoResults).text
     if (contextType === 'org' && orgView && org) return serializeOrgContext(org, orgView, { maxRepos: MAX_CONTEXT_REPOS, sortBy: 'stars', orgRepos }).text
     if (contextType === 'org' && filteredInventory) return serializeOrgInventoryContext(filteredInventory, { maxRepos: MAX_CONTEXT_REPOS, sortBy: 'stars' }).text
-    if (contextType === 'university' && university && universityResults) return serializeUniversityContext(university, universityResults, { maxRepos: MAX_CONTEXT_REPOS }).text
+    if (contextType === 'university' && university && filteredUniversityResults) return serializeUniversityContext(university, filteredUniversityResults, { maxRepos: MAX_CONTEXT_REPOS }).text
     return ''
-  }, [contextType, repoResults, orgView, org, orgRepos, filteredInventory, university, universityResults])
+  }, [contextType, repoResults, orgView, org, orgRepos, filteredInventory, university, filteredUniversityResults])
 
   const activeProvider = userKey ? provider : (serverProvider ?? 'anthropic')
 
@@ -605,7 +611,7 @@ export function ChatPanel({
             </div>
 
             {/* Structured search filter */}
-            {contextType === 'org' && onRepoQueryChange && (
+            {(contextType === 'org' || contextType === 'university') && onRepoQueryChange && (
               <SearchFilter value={repoQuery} onChange={onRepoQueryChange} />
             )}
 
@@ -615,6 +621,11 @@ export function ChatPanel({
               {repoQuery.trim() && filteredInventory && (
                 <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-medium text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
                   scoped to {filteredInventory.results.length} filtered repos
+                </span>
+              )}
+              {repoQuery.trim() && filteredUniversityResults && (
+                <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[10px] font-medium text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                  scoped to {filteredUniversityResults.length} filtered repos
                 </span>
               )}
               {/* Show dots here only when the flow guide isn't visible */}

--- a/components/university/UniversityChatPanel.tsx
+++ b/components/university/UniversityChatPanel.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useAuth } from '@/components/auth/AuthContext'
 import { ChatPanel } from '@/components/chat/ChatPanel'
 import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
@@ -11,6 +12,7 @@ interface Props {
 
 export function UniversityChatPanel({ university, results }: Props) {
   const { session } = useAuth()
+  const [repoQuery, setRepoQuery] = useState('')
   if (!session?.token) return null
   return (
     <ChatPanel
@@ -18,6 +20,8 @@ export function UniversityChatPanel({ university, results }: Props) {
       university={university}
       universityResults={results}
       githubToken={session.token}
+      repoQuery={repoQuery}
+      onRepoQueryChange={setRepoQuery}
     />
   )
 }

--- a/lib/org-inventory/structured-search.ts
+++ b/lib/org-inventory/structured-search.ts
@@ -1,4 +1,44 @@
 import type { OrgRepoSummary } from '@/lib/analyzer/org-inventory'
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+
+export interface FilterableRepo {
+  repo: string
+  name?: string | null
+  primaryLanguage?: string | null
+  stars?: number | 'unavailable'
+  forks?: number | 'unavailable'
+  watchers?: number | 'unavailable'
+  openIssues?: number | 'unavailable'
+  sizeKb?: number | 'unavailable'
+  pushedAt?: string | 'unavailable'
+  archived?: boolean
+  isFork?: boolean
+  visibility?: string | null
+  licenseSpdxId?: string | null
+  licenseName?: string | null
+  topics?: string[] | null
+}
+
+export function orgRepoSummaryToFilterable(r: OrgRepoSummary): FilterableRepo {
+  return r
+}
+
+export function analysisResultToFilterable(r: AnalysisResult): FilterableRepo {
+  const latestCommit = Array.isArray(r.commitTimestamps365d) && r.commitTimestamps365d.length > 0
+    ? [...r.commitTimestamps365d].sort().at(-1)
+    : undefined
+  return {
+    repo: r.repo,
+    name: r.name,
+    primaryLanguage: r.primaryLanguage,
+    stars: r.stars,
+    forks: r.forks,
+    watchers: r.watchers,
+    openIssues: r.issuesOpen,
+    pushedAt: latestCommit ?? 'unavailable',
+    topics: r.topics,
+  }
+}
 
 export type StructuredSearchKey =
   | 'company'
@@ -87,7 +127,7 @@ export function parseStructuredSearchQuery(query: string): StructuredSearchParse
   return { freeTextTerms, tokens, invalidTokens, hasArchivedToken, hasForkToken }
 }
 
-export function matchesStructuredSearch(row: OrgRepoSummary, parsed: StructuredSearchParseResult): boolean {
+export function matchesStructuredSearch(row: FilterableRepo, parsed: StructuredSearchParseResult): boolean {
   const searchableText = `${row.repo} ${row.name}`.toLowerCase()
 
   if (parsed.freeTextTerms.some((term) => !searchableText.includes(term))) {
@@ -103,16 +143,16 @@ export function matchesStructuredSearch(row: OrgRepoSummary, parsed: StructuredS
   return true
 }
 
-function matchesToken(row: OrgRepoSummary, token: StructuredSearchToken): boolean {
+function matchesToken(row: FilterableRepo, token: StructuredSearchToken): boolean {
   switch (token.key) {
     case 'company':
       return row.repo.split('/')[0]?.toLowerCase() === token.raw.toLowerCase()
     case 'lang':
-      return row.primaryLanguage !== 'unavailable' && row.primaryLanguage.toLowerCase() === token.raw.toLowerCase()
+      return row.primaryLanguage != null && row.primaryLanguage !== 'unavailable' && row.primaryLanguage.toLowerCase() === token.raw.toLowerCase()
     case 'archived':
-      return row.archived === parseBooleanValue(token.raw)
+      return row.archived != null && row.archived === parseBooleanValue(token.raw)
     case 'fork':
-      return row.isFork === parseBooleanValue(token.raw)
+      return row.isFork != null && row.isFork === parseBooleanValue(token.raw)
     case 'topic':
       return (row.topics ?? []).some((topic) => topic.toLowerCase() === token.raw.toLowerCase())
     case 'visibility':
@@ -123,17 +163,17 @@ function matchesToken(row: OrgRepoSummary, token: StructuredSearchToken): boolea
       }
       return row.licenseName != null && row.licenseName !== 'unavailable' && row.licenseName.toLowerCase() === token.raw.toLowerCase()
     case 'stars':
-      return matchesNumericValue(row.stars, token.raw)
+      return matchesNumericValue(row.stars ?? 'unavailable', token.raw)
     case 'forks':
-      return matchesNumericValue(row.forks, token.raw)
+      return matchesNumericValue(row.forks ?? 'unavailable', token.raw)
     case 'watchers':
-      return matchesNumericValue(row.watchers, token.raw)
+      return matchesNumericValue(row.watchers ?? 'unavailable', token.raw)
     case 'issues':
-      return matchesNumericValue(row.openIssues, token.raw)
+      return matchesNumericValue(row.openIssues ?? 'unavailable', token.raw)
     case 'size':
       return matchesNumericValue(row.sizeKb ?? 'unavailable', token.raw)
     case 'pushed':
-      return matchesDateValue(row.pushedAt, token.raw)
+      return matchesDateValue(row.pushedAt ?? 'unavailable', token.raw)
   }
 }
 


### PR DESCRIPTION
## Summary

Extracts `FilterableRepo` from `matchesStructuredSearch` so the local filter logic is shared between the org and university Ask AI contexts — no duplication of the numeric/date/text matching code.

**`lib/org-inventory/structured-search.ts`**
- New `FilterableRepo` interface — all fields optional except `repo`, covering all filter keys
- `orgRepoSummaryToFilterable` — identity (OrgRepoSummary already satisfies the shape)
- `analysisResultToFilterable` — maps `issuesOpen → openIssues`, derives `pushedAt` from `commitTimestamps365d`; org-only fields (`archived`, `isFork`, `visibility`, `license`) are absent and gracefully return `false` for those filter tokens
- `matchesStructuredSearch` signature changed from `OrgRepoSummary` → `FilterableRepo`

**`components/chat/ChatPanel.tsx`**
- `filteredUniversityResults` useMemo mirrors `filteredInventory` — applies structured filter before serialising university context
- `SearchFilter` and "scoped to N filtered repos" badge now shown for `contextType='university'` too

**`components/university/UniversityChatPanel.tsx`**
- Owns `repoQuery` state and passes it down to `ChatPanel`

## Test plan

- [ ] Org Ask AI: `matchesStructuredSearch` behaviour unchanged — `lang:go`, `stars:>100`, `archived:false`, `pushed:>2024-01-01` all filter correctly
- [ ] University Ask AI (`/university/ucsc`): `SearchFilter` visible; `lang:Python` narrows context and shows badge; LLM response references only Python repos
- [ ] `stars:>1000` works for both org and university

🤖 Generated with [Claude Code](https://claude.com/claude-code)