### PR TITLE
fix(nav): open Universities in a new tab to preserve main app state

### DIFF
--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -123,6 +123,8 @@ export function RepoInputForm({
           ))}
           <Link
             href="/university"
+            target="_blank"
+            rel="noopener noreferrer"
             title="Pre-scored static data — refreshed periodically"
             className="inline-flex items-center gap-1.5 rounded-full border border-dashed border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-500 transition hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200"
           >


### PR DESCRIPTION
## Summary

Clicking Universities navigated away from the SPA, silently losing the Repos / Org / Foundation tabs and any in-progress analysis. The ↗ icon on the tab already signals external navigation — adding `target="_blank" rel="noopener noreferrer"` makes the behaviour match the visual cue.

## Test plan

- [ ] Click Universities from the main app — opens in a new tab, original tab retains Repos/Org/Foundation tabs and any results
- [ ] Middle-click / Cmd+click still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)