### PR TITLE
feat(university): render universities inline as a first-class SPA mode

### DIFF
--- a/components/chat/serialize-context.ts
+++ b/components/chat/serialize-context.ts
@@ -182,12 +182,40 @@ function resolveLicense(spdxId: string | null | undefined, name: string | null |
   return null
 }
 
+function summarizeRepoForUniversity(r: AnalysisResult): object {
+  const doc = r.documentationResult && typeof r.documentationResult === 'object' && 'fileChecks' in r.documentationResult
+    ? r.documentationResult as import('@/lib/analyzer/analysis-result').DocumentationResult
+    : null
+  const sec = r.securityResult && typeof r.securityResult === 'object' && 'directChecks' in r.securityResult
+    ? r.securityResult as import('@/lib/security/analysis-result').SecurityResult
+    : null
+  const lic = r.licensingResult && typeof r.licensingResult === 'object' && 'license' in r.licensingResult
+    ? r.licensingResult as import('@/lib/analyzer/analysis-result').LicensingResult
+    : null
+  return {
+    repo: r.repo,
+    lang: r.primaryLanguage && r.primaryLanguage !== 'unavailable' ? r.primaryLanguage : null,
+    stars: typeof r.stars === 'number' ? r.stars : null,
+    forks: typeof r.forks === 'number' ? r.forks : null,
+    commits90d: typeof r.commits90d === 'number' ? r.commits90d : null,
+    prsOpened90d: typeof r.prsOpened90d === 'number' ? r.prsOpened90d : null,
+    issuesOpen: typeof r.issuesOpen === 'number' ? r.issuesOpen : null,
+    authors90d: typeof r.uniqueCommitAuthors90d === 'number' ? r.uniqueCommitAuthors90d : null,
+    contributors: typeof r.totalContributors === 'number' ? r.totalContributors : null,
+    releases12mo: typeof r.releases12mo === 'number' ? r.releases12mo : null,
+    hasReadme: doc ? doc.fileChecks?.some((f) => f.name === 'readme' && f.found) ?? false : null,
+    hasLicense: lic ? (lic.license?.spdxId !== null && lic.license?.spdxId !== 'NOASSERTION') : null,
+    securityScore: sec && sec.scorecard && typeof sec.scorecard === 'object' && 'overallScore' in sec.scorecard
+      ? sec.scorecard.overallScore : null,
+  }
+}
+
 export function serializeUniversityContext(
   university: string,
   results: AnalysisResult[],
   opts: { maxRepos?: number } = {},
 ): SerializedChatContext {
-  const { maxRepos = 300 } = opts
+  const { maxRepos = 150 } = opts
 
   const stars = results.flatMap((r) => (typeof r.stars === 'number' ? [r.stars] : []))
   const totalStars = stars.reduce((s, v) => s + v, 0)
@@ -218,7 +246,7 @@ export function serializeUniversityContext(
       activeRepos,
       languageDistribution,
     },
-    repos: sorted.slice(0, maxRepos).map(summarizeRepo),
+    repos: sorted.slice(0, maxRepos).map(summarizeRepoForUniversity),
   }
 
   const text = [
@@ -226,7 +254,7 @@ export function serializeUniversityContext(
     `University: ${university} (${results.length} repos analyzed, ${totalStars.toLocaleString()} total stars)`,
     '',
     '```json',
-    JSON.stringify(payload, null, 2),
+    JSON.stringify(payload),
     '```',
   ].join('\n')
 

--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -37,6 +37,7 @@ import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
 import { fetchBoardRepos, type SkippedIssue } from '@/lib/foundation/fetch-board-repos'
 import { LOADING_QUOTES, getRandomQuoteIndex } from '@/lib/loading-quotes'
 import { RepoInputForm } from './RepoInputForm'
+import { UniversityBrowser } from '@/components/university/UniversityBrowser'
 import { FoundationResultsView, type FoundationResult } from '@/components/foundation/FoundationResultsView'
 import { FoundationNudge } from '@/components/foundation/FoundationNudge'
 import { ChatPanel } from '@/components/chat/ChatPanel'
@@ -60,15 +61,15 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const initialFoundationState = decodeFoundationUrl(searchParams.toString())
   const rawUrlMode = searchParams.get('mode')
   const rawUrlFoundation = searchParams.get('foundation')
-  const urlMode: 'repos' | 'org' | 'foundation' | null =
-    rawUrlMode === 'repos' || rawUrlMode === 'org' || rawUrlMode === 'foundation' ? rawUrlMode : null
+  const urlMode: 'repos' | 'org' | 'foundation' | 'university' | null =
+    rawUrlMode === 'repos' || rawUrlMode === 'org' || rawUrlMode === 'foundation' || rawUrlMode === 'university' ? rawUrlMode : null
   const urlFoundation: FoundationTarget | null =
     rawUrlFoundation === 'cncf-sandbox' || rawUrlFoundation === 'cncf-incubating' ||
     rawUrlFoundation === 'cncf-graduation' || rawUrlFoundation === 'apache-incubator' || rawUrlFoundation === 'none'
       ? rawUrlFoundation : null
   const initialFoundationTarget: FoundationTarget =
     initialFoundationState?.foundation ?? urlFoundation ?? (urlMode === 'foundation' ? 'cncf-sandbox' : 'none')
-  const initialInputMode: 'repos' | 'org' | 'foundation' =
+  const initialInputMode: 'repos' | 'org' | 'foundation' | 'university' =
     initialFoundationState ? 'foundation' : urlMode ?? 'repos'
   const initialTab = (searchParams.get('tab') ?? 'overview') as ResultTabId
   const autoTriggeredRef = useRef(false)
@@ -80,7 +81,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [loadingRepos, setLoadingRepos] = useState<string[]>([])
   const [loadingOrg, setLoadingOrg] = useState<string | null>(null)
   const [resultsResetKey, setResultsResetKey] = useState(0)
-  const [inputMode, setInputMode] = useState<'repos' | 'org' | 'foundation'>(initialInputMode)
+  const [inputMode, setInputMode] = useState<'repos' | 'org' | 'foundation' | 'university'>(initialInputMode)
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const [emptyQuoteIndex, setEmptyQuoteIndex] = useState(() => getRandomQuoteIndex(null))
   const [quoteIndex, setQuoteIndex] = useState<number | null>(null)
@@ -301,13 +302,15 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     return () => clearTimeout(timeout)
   }, [searchQuery])
 
-  function handleModeChange(mode: 'repos' | 'org' | 'foundation') {
+  function handleModeChange(mode: 'repos' | 'org' | 'foundation' | 'university') {
     setInputMode(mode)
     if (mode === 'org') {
       setAspirantResult(null)
     }
     const params = new URLSearchParams()
-    if (mode === 'org') {
+    if (mode === 'university') {
+      params.set('mode', 'university')
+    } else if (mode === 'org') {
       params.set('mode', 'org')
     } else if (mode === 'foundation') {
       params.set('mode', 'foundation')
@@ -715,6 +718,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
 
   const overviewContent = (
     <div className="space-y-4">
+      {inputMode === 'university' ? <UniversityBrowser /> : null}
       {inputMode === 'foundation' && !foundationResult && !foundationError && !loadingFoundation && !pendingBoardScan ? (
         <div className="space-y-3">
           <p className="text-sm text-slate-500 dark:text-slate-400">
@@ -1084,7 +1088,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       initialActiveTab={initialTab}
       onReset={handleReset}
       analysisPanel={analysisPanel}
-      hideTabs={inputMode === 'foundation'}
+      hideTabs={inputMode === 'foundation' || inputMode === 'university'}
       toolbar={inputMode === 'org' && orgAnalysisComplete ? <OrgWindowSelector selected={orgWindow} onChange={setOrgWindow} /> : exportToolbar}
       tabs={showOrgWorkspace ? orgInventoryTabs : repoTabs}
       searchQuery={debouncedQuery}

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -5,15 +5,16 @@ import { normalizeOrgInput } from '@/lib/analyzer/org-inventory'
 import { parseRepos } from '@/lib/parse-repos'
 import type { FoundationTarget } from '@/lib/cncf-sandbox/types'
 import { FoundationInputSection } from '@/components/foundation/FoundationInputSection'
-import Link from 'next/link'
 import { CopyLinkButton } from '@/components/shared/CopyLinkButton'
+
+export type InputMode = 'repos' | 'org' | 'foundation' | 'university'
 
 interface RepoInputFormProps {
   onSubmitRepos: (repos: string[]) => void
   onSubmitOrg: (org: string) => void
   onSubmitFoundation?: (input: string) => void
-  mode?: 'repos' | 'org' | 'foundation'
-  onModeChange?: (mode: 'repos' | 'org' | 'foundation') => void
+  mode?: InputMode
+  onModeChange?: (mode: InputMode) => void
   initialRepoValue?: string
   foundationTarget?: FoundationTarget
   onFoundationTargetChange?: (target: FoundationTarget) => void
@@ -39,7 +40,7 @@ export function RepoInputForm({
   verifyRepos = false,
   onVerifyReposChange,
 }: RepoInputFormProps) {
-  const [uncontrolledMode, setUncontrolledMode] = useState<'repos' | 'org' | 'foundation'>('repos')
+  const [uncontrolledMode, setUncontrolledMode] = useState<InputMode>('repos')
   const [repoValue, setRepoValue] = useState(initialRepoValue)
   const [orgValue, setOrgValue] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -67,7 +68,7 @@ export function RepoInputForm({
     textarea.style.height = `${textarea.scrollHeight}px`
   }, [mode, repoValue])
 
-  function updateMode(nextMode: 'repos' | 'org' | 'foundation') {
+  function updateMode(nextMode: InputMode) {
     onModeChange?.(nextMode)
     if (controlledMode === undefined) {
       setUncontrolledMode(nextMode)
@@ -121,16 +122,14 @@ export function RepoInputForm({
               {m === 'repos' ? 'Repositories' : m === 'org' ? 'Organization' : 'Foundation'}
             </button>
           ))}
-          <Link
-            href="/university"
+          <button
+            type="button"
             title="Pre-scored static data — refreshed periodically"
-            className="inline-flex items-center gap-1.5 rounded-full border border-dashed border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-500 transition hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200"
+            className={`inline-flex items-center gap-1.5 rounded-full border px-4 py-2 text-sm font-medium transition ${mode === 'university' ? 'border-slate-900 bg-slate-900 text-white dark:border-slate-100 dark:bg-slate-100 dark:text-slate-900' : 'border-dashed border-slate-300 bg-white text-slate-500 hover:border-slate-400 hover:text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500 dark:hover:text-slate-200'}`}
+            onClick={() => { updateMode('university'); setError(null) }}
           >
             Universities
-            <svg aria-hidden="true" viewBox="0 0 12 12" className="h-3 w-3 opacity-60" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M2.5 9.5 9.5 2.5M5 2.5h4.5V7" />
-            </svg>
-          </Link>
+          </button>
         </div>
         <div className="ml-auto">
           <CopyLinkButton />
@@ -212,13 +211,15 @@ export function RepoInputForm({
           ) : null}
         </div>
       )}
-      <button
-        type="submit"
-        title="Analyze repositories and open the health dashboard"
-        className="mt-3 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-2 dark:focus:ring-offset-slate-900"
-      >
-        Analyze
-      </button>
+      {mode !== 'university' && (
+        <button
+          type="submit"
+          title="Analyze repositories and open the health dashboard"
+          className="mt-3 rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+        >
+          Analyze
+        </button>
+      )}
     </form>
   )
 }

--- a/components/repo-input/RepoInputForm.tsx
+++ b/components/repo-input/RepoInputForm.tsx
@@ -194,7 +194,7 @@ export function RepoInputForm({
             </p>
           ) : null}
         </div>
-      ) : (
+      ) : mode === 'university' ? null : (
         <div>
           <input
             value={orgValue}

--- a/components/repo-summary/RepoSummaryTable.tsx
+++ b/components/repo-summary/RepoSummaryTable.tsx
@@ -28,6 +28,8 @@ function getAuthors(result: AnalysisResult, window: ContributorWindowDays): numb
   return null
 }
 
+const HEALTH_TOOLTIP = 'Composite OSS health percentile ranked against ~10 000 public GitHub repos. Weighted from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%), and Security (15%). Higher = healthier relative to peers.'
+
 function PercentileBadge({ value }: { value: number | null }) {
   if (value === null) return <span className="text-slate-400 dark:text-slate-500">N/A</span>
   const color =
@@ -36,7 +38,7 @@ function PercentileBadge({ value }: { value: number | null }) {
     : value >= 25 ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300'
     : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
   return (
-    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
+    <span title={HEALTH_TOOLTIP} className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${color}`}>
       {value}th
     </span>
   )
@@ -47,6 +49,7 @@ interface ColHeader {
   label: string
   group?: string
   align?: 'left' | 'right'
+  tooltip?: string
 }
 
 const COLUMNS: ColHeader[] = [
@@ -57,7 +60,7 @@ const COLUMNS: ColHeader[] = [
   { key: 'prsOpened90d',     label: 'PRs (90d)',     group: 'Attention',  align: 'right' },
   { key: 'authors',          label: 'Authors',       group: 'Engagement', align: 'right' },
   { key: 'totalContributors',label: 'Contributors',  group: 'Engagement', align: 'right' },
-  { key: 'percentile',       label: 'Health',        align: 'right' },
+  { key: 'percentile',       label: 'Health',        align: 'right', tooltip: HEALTH_TOOLTIP },
 ]
 
 interface Row {
@@ -269,7 +272,16 @@ export function RepoSummaryTable({ results }: RepoSummaryTableProps) {
                   }`}
                   onClick={() => handleSort(col.key)}
                 >
-                  {col.key === 'authors' ? `Authors (${activeWindow}d)` : col.label}
+                  <span className="inline-flex items-center gap-1">
+                    {col.key === 'authors' ? `Authors (${activeWindow}d)` : col.label}
+                    {col.tooltip && (
+                      <span title={col.tooltip} className="cursor-help text-slate-400 dark:text-slate-500">
+                        <svg viewBox="0 0 14 14" className="h-3 w-3 fill-current" aria-hidden="true">
+                          <path fillRule="evenodd" clipRule="evenodd" d="M7 1a6 6 0 1 0 0 12A6 6 0 0 0 7 1ZM6.25 5a.75.75 0 1 1 1.5 0 .75.75 0 0 1-1.5 0ZM6 7a1 1 0 0 1 2 0v2.5a.5.5 0 0 1-1 0V8a.25.25 0 0 0-.25-.25H6.5A.5.5 0 0 1 6 7.25V7Z" />
+                        </svg>
+                      </span>
+                    )}
+                  </span>
                   {sortKey === col.key && (
                     <span className="ml-1 text-sky-600 dark:text-sky-400">
                       {sortDir === 'desc' ? '↓' : '↑'}

--- a/components/repo-summary/RepoSummaryTable.tsx
+++ b/components/repo-summary/RepoSummaryTable.tsx
@@ -28,7 +28,7 @@ function getAuthors(result: AnalysisResult, window: ContributorWindowDays): numb
   return null
 }
 
-const HEALTH_TOOLTIP = 'Composite OSS health percentile ranked against ~10 000 public GitHub repos. Weighted from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%), and Security (15%). Higher = healthier relative to peers.'
+const HEALTH_TOOLTIP = 'Composite OSS health percentile. Weighted from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%), and Security (15%). Score is a percentile rank within a calibration set of ~400 repos per star bracket (emerging/growing/established/popular). Higher = healthier relative to peers.'
 
 function PercentileBadge({ value }: { value: number | null }) {
   if (value === null) return <span className="text-slate-400 dark:text-slate-500">N/A</span>

--- a/components/repo-summary/RepoSummaryTable.tsx
+++ b/components/repo-summary/RepoSummaryTable.tsx
@@ -28,7 +28,7 @@ function getAuthors(result: AnalysisResult, window: ContributorWindowDays): numb
   return null
 }
 
-const HEALTH_TOOLTIP = 'Composite OSS health percentile. Weighted from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%), and Security (15%). Score is a percentile rank within a calibration set of ~400 repos per star bracket (emerging/growing/established/popular). Higher = healthier relative to peers.'
+const HEALTH_TOOLTIP = 'Composite OSS health percentile. Weighted from Contributors (23%), Activity (25%), Responsiveness (25%), Documentation (12%), and Security (15%). Score is a percentile rank within a calibration set of ~2,400 repos across 6 star brackets (solo-tiny, solo-small, emerging, growing, established, popular). Higher = healthier relative to peers.'
 
 function PercentileBadge({ value }: { value: number | null }) {
   if (value === null) return <span className="text-slate-400 dark:text-slate-500">N/A</span>

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { OrgInventorySummary } from '@/components/org-inventory/OrgInventorySummary'
+import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
+import { UniversityChatPanel } from './UniversityChatPanel'
+import type { AnalysisResult, AnalyzeResponse } from '@/lib/analyzer/analysis-result'
+import { buildUniversitySummary } from '@/lib/university/summary'
+
+const RAW_BASE = 'https://raw.githubusercontent.com/arun-gupta/repofinder/repo-pulse-integration/exports/universities'
+
+interface ManifestEntry {
+  slug: string
+  university: string
+  totalRepos: number
+  analyzedRepos: number
+  generatedAt: string
+}
+
+interface UniversityFixture extends AnalyzeResponse {
+  university: string
+  totalRepos: number
+  generatedAt: string
+}
+
+interface Selected {
+  entry: ManifestEntry
+  results: AnalysisResult[]
+  generatedAt: string
+}
+
+export function UniversityBrowser() {
+  const [manifest, setManifest] = useState<ManifestEntry[] | null>(null)
+  const [manifestError, setManifestError] = useState(false)
+  const [selected, setSelected] = useState<Selected | null>(null)
+  const [loadingSlug, setLoadingSlug] = useState<string | null>(null)
+  const [detailError, setDetailError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch(`${RAW_BASE}/manifest.json`)
+      .then((r) => r.json())
+      .then((data: ManifestEntry[]) => setManifest(data))
+      .catch(() => setManifestError(true))
+  }, [])
+
+  async function handleSelect(entry: ManifestEntry) {
+    setLoadingSlug(entry.slug)
+    setDetailError(null)
+    try {
+      const res = await fetch(`${RAW_BASE}/${entry.slug}-scored.json`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const fixture: UniversityFixture = await res.json()
+      setSelected({ entry, results: fixture.results, generatedAt: fixture.generatedAt })
+    } catch {
+      setDetailError(`Failed to load data for ${entry.university}.`)
+    } finally {
+      setLoadingSlug(null)
+    }
+  }
+
+  if (manifestError) {
+    return <p className="text-sm text-red-600 dark:text-red-400">Failed to load university list.</p>
+  }
+
+  if (!manifest) {
+    return <p className="text-sm text-slate-500 dark:text-slate-400">Loading universities…</p>
+  }
+
+  if (selected) {
+    const summary = buildUniversitySummary(selected.results)
+    const scored = new Date(selected.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+    return (
+      <div className="space-y-6 pb-16">
+        <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-sm text-slate-500 dark:text-slate-400">
+          <button
+            type="button"
+            onClick={() => setSelected(null)}
+            className="hover:text-sky-700 dark:hover:text-sky-300"
+          >
+            Universities
+          </button>
+          <span aria-hidden="true">/</span>
+          <span className="text-slate-900 dark:text-slate-100">{selected.entry.university}</span>
+        </nav>
+        <header>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{selected.entry.university}</h2>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
+          </p>
+        </header>
+        <OrgInventorySummary summary={summary} />
+        <RepoSummaryTable results={selected.results} />
+        <UniversityChatPanel university={selected.entry.university} results={selected.results} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-600 dark:text-slate-300">
+        OSS health scores for GitHub repositories affiliated with universities, sourced from{' '}
+        <a
+          href="https://github.com/arun-gupta/repofinder"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sky-700 hover:underline dark:text-sky-400"
+        >
+          repofinder
+        </a>
+        . Data is pre-scored and refreshed periodically.
+      </p>
+      {detailError && (
+        <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
+      )}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {manifest.map((u) => (
+          <button
+            key={u.slug}
+            type="button"
+            onClick={() => handleSelect(u)}
+            disabled={loadingSlug !== null}
+            className="group block rounded-2xl border border-slate-200 bg-white p-6 shadow-sm text-left transition hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-sky-500"
+          >
+            <h3 className="text-lg font-semibold text-slate-900 group-hover:text-sky-700 dark:text-slate-100 dark:group-hover:text-sky-300">
+              {loadingSlug === u.slug ? 'Loading…' : u.university}
+            </h3>
+            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+              {u.analyzedRepos.toLocaleString()} of {u.totalRepos.toLocaleString()} repositories scored
+            </p>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Replaces the external link with a proper inline mode so clicking Universities stays within the app — the header, other tabs, and any in-progress analysis are preserved.

**`InputMode`** — extends to `'repos' | 'org' | 'foundation' | 'university'`

**`RepoInputForm`** — Universities is now a tab button alongside the others. Dashed border when inactive (signals static data), filled when active. Analyze button hidden in university mode (nothing to submit).

**`RepoInputClient`** — `'university'` mode sets `hideTabs`, pushes `?mode=university` to the URL, and renders `UniversityBrowser` in the `overview` slot.

**`UniversityBrowser`** — new client component:
- Fetches `manifest.json` on mount, shows a grid of university cards
- On card click, fetches the scored JSON and renders `OrgInventorySummary` + `RepoSummaryTable` + `UniversityChatPanel` inline
- Breadcrumb back to the list, scored date shown under the university name

## Test plan

- [x] Click **Universities** tab — stays on the same page, header and other tabs remain; URL updates to `?mode=university`
- [x] University list (UCSC card) renders with repo counts
- [x] Click UCSC — stats cards, most-starred/active/language panels, and repo table load inline
- [x] Breadcrumb "Universities /" back link returns to the list
- [x] Switching to **Repositories** tab from university mode restores the repo input form
- [x] Any in-progress analysis results survive clicking Universities and clicking back
- [x] Ask AI appears in university detail view when signed in
- [x] `?mode=university` in URL lands directly in university mode on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)