### PR TITLE
feat(universities): add university logos and move Add your university link

### DIFF
--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -90,10 +90,22 @@ export function UniversityBrowser() {
           <span className="text-slate-900 dark:text-slate-100">{selected.entry.university}</span>
         </nav>
         <header>
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{selected.entry.university}</h2>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
-          </p>
+          <div className="flex items-center gap-3">
+            {UNIVERSITY_LOGOS[selected.entry.slug] && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={UNIVERSITY_LOGOS[selected.entry.slug]}
+                alt=""
+                className="h-12 w-12 rounded-full object-contain flex-shrink-0 bg-white"
+              />
+            )}
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{selected.entry.university}</h2>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
+              </p>
+            </div>
+          </div>
         </header>
         <OrgInventorySummary summary={summary} />
         <RepoSummaryTable results={selected.results} />

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -109,6 +109,11 @@ export function UniversityBrowser() {
                   </span>
                 )}
               </p>
+              {selected.entry.discoveryThreshold !== undefined && (
+                <p className="mt-0.5 text-xs text-slate-400 dark:text-slate-500">
+                  Affiliation threshold: {selected.entry.discoveryThreshold}
+                </p>
+              )}
             </div>
           </div>
         </header>

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -103,6 +103,11 @@ export function UniversityBrowser() {
               <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{selected.entry.university}</h2>
               <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
                 {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
+                {selected.results.length < selected.entry.totalRepos && (
+                  <span className="ml-1 text-slate-400 dark:text-slate-500">
+                    · {(selected.entry.totalRepos - selected.results.length).toLocaleString()} could not be scored (empty, deleted, or private)
+                  </span>
+                )}
               </p>
             </div>
           </div>

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -9,6 +9,12 @@ import { buildUniversitySummary } from '@/lib/university/summary'
 
 const RAW_BASE = 'https://raw.githubusercontent.com/arun-gupta/repofinder/repo-pulse-integration/exports/universities'
 
+const UNIVERSITY_LOGOS: Record<string, string> = {
+  ucb: 'https://upload.wikimedia.org/wikipedia/commons/a/a1/Seal_of_University_of_California%2C_Berkeley.svg',
+  ucd: 'https://upload.wikimedia.org/wikipedia/commons/f/f3/The_University_of_California_Davis.svg',
+  ucsc: 'https://upload.wikimedia.org/wikipedia/commons/5/53/The_University_of_California_1868_UCSC.svg',
+}
+
 interface ManifestEntry {
   slug: string
   university: string
@@ -98,26 +104,30 @@ export function UniversityBrowser() {
 
   return (
     <div className="space-y-4">
-      <p className="text-sm text-slate-600 dark:text-slate-300">
-        OSS health scores for GitHub repositories affiliated with universities, sourced from{' '}
-        <a
-          href="https://github.com/arun-gupta/repofinder"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sky-700 hover:underline dark:text-sky-400"
-        >
-          repofinder
-        </a>
-        . Data is pre-scored and refreshed periodically.{' '}
-        <a
-          href="https://github.com/arun-gupta/repo-pulse/blob/main/docs/add-university.md"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sky-700 hover:underline dark:text-sky-400"
-        >
-          Add your university →
-        </a>
-      </p>
+      <div className="text-sm text-slate-600 dark:text-slate-300">
+        <p>
+          OSS health scores for GitHub repositories affiliated with universities, sourced from{' '}
+          <a
+            href="https://github.com/arun-gupta/repofinder"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sky-700 hover:underline dark:text-sky-400"
+          >
+            repofinder
+          </a>
+          . Data is pre-scored and refreshed periodically.
+        </p>
+        <p className="mt-1">
+          <a
+            href="https://github.com/arun-gupta/repo-pulse/blob/main/docs/add-university.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sky-700 hover:underline dark:text-sky-400"
+          >
+            Add your university →
+          </a>
+        </p>
+      </div>
       {detailError && (
         <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
       )}
@@ -130,10 +140,20 @@ export function UniversityBrowser() {
             disabled={loadingSlug !== null}
             className="group block rounded-2xl border border-slate-200 bg-white p-6 shadow-sm text-left transition hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-sky-500"
           >
-            <h3 className="text-lg font-semibold text-slate-900 group-hover:text-sky-700 dark:text-slate-100 dark:group-hover:text-sky-300">
-              {loadingSlug === u.slug ? 'Loading…' : u.university}
-            </h3>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            <div className="flex items-center gap-3 mb-3">
+              {UNIVERSITY_LOGOS[u.slug] && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={UNIVERSITY_LOGOS[u.slug]}
+                  alt=""
+                  className="h-10 w-10 rounded-full object-contain flex-shrink-0 bg-white"
+                />
+              )}
+              <h3 className="text-lg font-semibold text-slate-900 group-hover:text-sky-700 dark:text-slate-100 dark:group-hover:text-sky-300">
+                {loadingSlug === u.slug ? 'Loading…' : u.university}
+              </h3>
+            </div>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
               {u.analyzedRepos.toLocaleString()} of {u.totalRepos.toLocaleString()} repositories scored
               {u.analyzedRepos < u.totalRepos && (
                 <span className="ml-1 text-slate-400 dark:text-slate-500">

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -138,6 +138,11 @@ export function UniversityBrowser() {
             repofinder
           </a>
           . Data is pre-scored and refreshed periodically.
+          {manifest.length > 0 && (() => {
+            const latest = manifest.reduce((a, b) => a.generatedAt > b.generatedAt ? a : b)
+            const date = new Date(latest.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+            return <span className="text-slate-400 dark:text-slate-500"> Last refreshed: {date}.</span>
+          })()}
         </p>
         <p className="mt-1">
           <a


### PR DESCRIPTION
## Summary

- Each university card shows the university seal (40px circular) to the left of the name, sourced from Wikimedia Commons (UCB, UCD, UCSC)
- Logos degrade gracefully — cards without a logo entry render unchanged
- \"Add your university →\" moved to its own line below the description paragraph

## Logo sources (Wikimedia Commons, stable URLs)
- UC Berkeley: Seal_of_University_of_California,_Berkeley.svg
- UC Davis: The_University_of_California_Davis.svg
- UC Santa Cruz: The_University_of_California_1868_UCSC.svg

## Test plan

- [x] UCB, UCD, UCSC cards each show a circular seal logo
- [x] \"Add your university →\" appears on its own line
- [x] Cards without a logo entry render without the image (no broken img)
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)