### PR TITLE
feat(universities): health score distribution bar on detail page

### DIFF
--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { OrgInventorySummary } from '@/components/org-inventory/OrgInventorySummary'
 import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
 import { UniversityChatPanel } from './UniversityChatPanel'
+import { UniversityScoreDistribution } from './UniversityScoreDistribution'
 import type { AnalysisResult, AnalyzeResponse } from '@/lib/analyzer/analysis-result'
 import { buildUniversitySummary } from '@/lib/university/summary'
 
@@ -117,6 +118,7 @@ export function UniversityBrowser() {
             </div>
           </div>
         </header>
+        <UniversityScoreDistribution results={selected.results} />
         <OrgInventorySummary summary={summary} />
         <RepoSummaryTable results={selected.results} />
         <UniversityChatPanel university={selected.entry.university} results={selected.results} />

--- a/components/university/UniversityScoreDistribution.tsx
+++ b/components/university/UniversityScoreDistribution.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import type { AnalysisResult } from '@/lib/analyzer/analysis-result'
+import { getHealthScore } from '@/lib/scoring/health-score'
+
+interface Props {
+  results: AnalysisResult[]
+}
+
+const BANDS = [
+  { label: 'High (67–100)', min: 67, max: 100, bg: 'bg-emerald-500', text: 'text-emerald-700 dark:text-emerald-400' },
+  { label: 'Medium (34–66)', min: 34, max: 66, bg: 'bg-amber-400', text: 'text-amber-700 dark:text-amber-400' },
+  { label: 'Low (0–33)', min: 0, max: 33, bg: 'bg-red-400', text: 'text-red-700 dark:text-red-400' },
+]
+
+export function UniversityScoreDistribution({ results }: Props) {
+  const scored = results.flatMap((r) => {
+    const p = getHealthScore(r).percentile
+    return p !== null ? [p] : []
+  })
+
+  if (scored.length === 0) return null
+
+  const counts = BANDS.map((b) => ({
+    ...b,
+    count: scored.filter((p) => p >= b.min && p <= b.max).length,
+  }))
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">Health score distribution</p>
+      <div className="flex h-4 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
+        {/* Render high→medium→low so green is on the left */}
+        {counts.map((b) => {
+          const pct = (b.count / scored.length) * 100
+          if (pct === 0) return null
+          return (
+            <div
+              key={b.label}
+              className={`${b.bg} transition-all`}
+              style={{ width: `${pct}%` }}
+              title={`${b.label}: ${b.count} repos (${Math.round(pct)}%)`}
+            />
+          )
+        })}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {counts.map((b) => (
+          <span key={b.label} className={`text-xs ${b.text}`}>
+            <span className="font-medium">{Math.round((b.count / scored.length) * 100)}%</span>
+            {' '}{b.label.split(' ')[0].toLowerCase()} ({b.count})
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a stacked horizontal bar above the repo table on each university detail page showing how repos are distributed across health score bands:

- **Green** — High (67–100)
- **Amber** — Medium (34–66)  
- **Red** — Low (0–33)

Each segment is proportional to the count of repos in that band. Hovering shows the exact count and percentage. A legend below the bar shows percentages and counts for each band.

Repos without a computable health score (insufficient data) are excluded from the distribution.

Closes #548

## Test plan

- [x] Distribution bar appears on UC Davis, UC Berkeley, and UC Santa Cruz detail pages
- [x] Green/amber/red segments are proportional to repo counts
- [x] Hover tooltips show correct counts and percentages
- [x] Repos with null health scores are excluded gracefully
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)