### PR TITLE
feat(universities): Stanford/MIT logos, intuitive sort order, and sort control

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -149,8 +149,16 @@ export async function POST(request: Request) {
     }
 
     // Run GitHub analysis only for repos that need it.
+    // 120s hard timeout guards against repos that cause GitHub API calls to hang indefinitely,
+    // which otherwise exhausts the server's connection pool across successive batch requests.
+    const ANALYSIS_TIMEOUT_MS = 300_000
     const response: AnalyzeResponse = reposToAnalyze.length > 0
-      ? await analyze({ repos: reposToAnalyze, token })
+      ? await Promise.race([
+          analyze({ repos: reposToAnalyze, token }),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error(`Analysis timed out after ${ANALYSIS_TIMEOUT_MS / 1000}s`)), ANALYSIS_TIMEOUT_MS)
+          ),
+        ])
       : { results: [], failures: [], rateLimit: null }
 
     // Attach aspirant evaluation results to analyzed repos.

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -189,11 +189,6 @@ export function UniversityBrowser() {
             repofinder
           </a>
           . Data is pre-scored and refreshed periodically.
-          {manifest.length > 0 && (() => {
-            const latest = manifest.reduce((a, b) => a.generatedAt > b.generatedAt ? a : b)
-            const date = new Date(latest.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
-            return <span className="text-slate-400 dark:text-slate-500"> Last refreshed: {date}.</span>
-          })()}
         </p>
         <p className="mt-1">
           <a

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -19,6 +19,25 @@ const UNIVERSITY_LOGOS: Record<string, string> = {
   mit: 'https://upload.wikimedia.org/wikipedia/commons/0/0c/MIT_logo.svg',
 }
 
+type SortOption = 'name' | 'repos' | 'updated'
+
+function sortKey(university: string): string {
+  return university
+    .replace(/^University of California,\s+/i, '')
+    .replace(/^University of\s+/i, '')
+    .replace(/^The\s+/i, '')
+    .toLowerCase()
+}
+
+function applySort(entries: ManifestEntry[], sort: SortOption): ManifestEntry[] {
+  return [...entries].sort((a, b) => {
+    if (sort === 'name') return sortKey(a.university).localeCompare(sortKey(b.university))
+    if (sort === 'repos') return b.analyzedRepos - a.analyzedRepos
+    if (sort === 'updated') return b.generatedAt.localeCompare(a.generatedAt)
+    return 0
+  })
+}
+
 interface ManifestEntry {
   slug: string
   university: string
@@ -47,12 +66,13 @@ export function UniversityBrowser() {
   const [selected, setSelected] = useState<Selected | null>(null)
   const [loadingSlug, setLoadingSlug] = useState<string | null>(null)
   const [detailError, setDetailError] = useState<string | null>(null)
+  const [sortBy, setSortBy] = useState<SortOption>('name')
   const autoSelectDone = useRef(false)
 
   useEffect(() => {
     fetch(`${RAW_BASE}/manifest.json`)
       .then((r) => r.json())
-      .then((data: ManifestEntry[]) => setManifest([...data].sort((a, b) => a.university.localeCompare(b.university))))
+      .then((data: ManifestEntry[]) => setManifest(data))
       .catch(() => setManifestError(true))
   }, [])
 
@@ -189,8 +209,21 @@ export function UniversityBrowser() {
       {detailError && (
         <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
       )}
+      <div className="flex items-center justify-end gap-2">
+        <label htmlFor="uni-sort" className="text-xs text-slate-500 dark:text-slate-400">Sort by</label>
+        <select
+          id="uni-sort"
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as SortOption)}
+          className="text-xs border border-slate-200 dark:border-slate-700 rounded px-2 py-1 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-1 focus:ring-sky-400"
+        >
+          <option value="name">Name (A–Z)</option>
+          <option value="repos">Repos scored</option>
+          <option value="updated">Last updated</option>
+        </select>
+      </div>
       <div className="grid gap-4 sm:grid-cols-2">
-        {manifest.map((u) => (
+        {applySort(manifest, sortBy).map((u) => (
           <button
             key={u.slug}
             type="button"

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -6,7 +6,7 @@ import { OrgInventorySummary } from '@/components/org-inventory/OrgInventorySumm
 import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
 import { UniversityChatPanel } from './UniversityChatPanel'
 import { UniversityScoreDistribution } from './UniversityScoreDistribution'
-import type { AnalysisResult, AnalyzeResponse } from '@/lib/analyzer/analysis-result'
+import type { AnalysisResult, AnalyzeResponse, RepositoryFetchFailure } from '@/lib/analyzer/analysis-result'
 import { buildUniversitySummary } from '@/lib/university/summary'
 
 const RAW_BASE = 'https://raw.githubusercontent.com/arun-gupta/repofinder/repo-pulse-integration/exports/universities'
@@ -56,6 +56,7 @@ interface UniversityFixture extends AnalyzeResponse {
 interface Selected {
   entry: ManifestEntry
   results: AnalysisResult[]
+  unscoredRepos: RepositoryFetchFailure[]
   generatedAt: string
 }
 
@@ -100,7 +101,15 @@ export function UniversityBrowser() {
       const res = await fetch(`${RAW_BASE}/${entry.slug}-scored.json`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const fixture: UniversityFixture = await res.json()
-      setSelected({ entry, results: fixture.results, generatedAt: fixture.generatedAt })
+      // Deduplicate failures by repo name (keep last), then exclude repos that were
+      // successfully scored — earlier runs may have failed before a later run succeeded.
+      const scoredSet = new Set(fixture.results.map((r) => r.repo.toLowerCase()))
+      const dedupedFailures = new Map<string, RepositoryFetchFailure>()
+      for (const f of (fixture.failures ?? [])) {
+        dedupedFailures.set(f.repo.toLowerCase(), f)
+      }
+      const unscoredRepos = [...dedupedFailures.values()].filter((f) => !scoredSet.has(f.repo.toLowerCase()))
+      setSelected({ entry, results: fixture.results, unscoredRepos, generatedAt: fixture.generatedAt })
     } catch {
       setDetailError(`Failed to load data for ${entry.university}.`)
     } finally {
@@ -153,9 +162,9 @@ export function UniversityBrowser() {
               <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{selected.entry.university}</h2>
               <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
                 {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
-                {selected.results.length < selected.entry.totalRepos && (
+                {selected.unscoredRepos.length > 0 && (
                   <span className="ml-1 text-slate-400 dark:text-slate-500">
-                    · {(selected.entry.totalRepos - selected.results.length).toLocaleString()} could not be scored (empty, deleted, or private)
+                    · {selected.unscoredRepos.length.toLocaleString()} could not be scored
                   </span>
                 )}
               </p>
@@ -170,6 +179,41 @@ export function UniversityBrowser() {
         <UniversityScoreDistribution results={selected.results} />
         <OrgInventorySummary summary={summary} />
         <RepoSummaryTable results={selected.results} />
+        {selected.unscoredRepos.length > 0 && (
+          <details className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+            <summary className="cursor-pointer px-6 py-4 text-sm font-medium text-slate-700 dark:text-slate-300 select-none list-none flex items-center justify-between">
+              <span>{selected.unscoredRepos.length.toLocaleString()} unscored repositories</span>
+              <span className="text-xs text-slate-400 dark:text-slate-500">click to expand</span>
+            </summary>
+            <div className="px-6 pb-4 overflow-x-auto">
+              <table className="w-full text-xs text-left">
+                <thead>
+                  <tr className="border-b border-slate-100 dark:border-slate-800">
+                    <th className="py-2 pr-4 font-medium text-slate-500 dark:text-slate-400">Repository</th>
+                    <th className="py-2 font-medium text-slate-500 dark:text-slate-400">Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selected.unscoredRepos.map((f) => (
+                    <tr key={f.repo} className="border-b border-slate-50 dark:border-slate-800/50 hover:bg-slate-50 dark:hover:bg-slate-800/30">
+                      <td className="py-1.5 pr-4 font-mono">
+                        <a
+                          href={`https://github.com/${f.repo}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-sky-700 hover:underline dark:text-sky-400"
+                        >
+                          {f.repo}
+                        </a>
+                      </td>
+                      <td className="py-1.5 text-slate-500 dark:text-slate-400">{f.reason}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        )}
         <UniversityChatPanel university={selected.entry.university} results={selected.results} />
       </div>
     )

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -15,6 +15,8 @@ const UNIVERSITY_LOGOS: Record<string, string> = {
   ucb: 'https://upload.wikimedia.org/wikipedia/commons/a/a1/Seal_of_University_of_California%2C_Berkeley.svg',
   ucd: 'https://upload.wikimedia.org/wikipedia/commons/f/f3/The_University_of_California_Davis.svg',
   ucsc: 'https://upload.wikimedia.org/wikipedia/commons/5/53/The_University_of_California_1868_UCSC.svg',
+  stanford: 'https://upload.wikimedia.org/wikipedia/commons/b/b5/Seal_of_Leland_Stanford_Junior_University.svg',
+  mit: 'https://upload.wikimedia.org/wikipedia/commons/0/0c/MIT_logo.svg',
 }
 
 interface ManifestEntry {

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -252,11 +252,10 @@ export function UniversityBrowser() {
                 </span>
               )}
             </p>
-            {u.discoveryThreshold !== undefined && (
-              <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
-                Affiliation threshold: {u.discoveryThreshold}
-              </p>
-            )}
+            <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+              {u.discoveryThreshold !== undefined && <>Affiliation threshold: {u.discoveryThreshold} · </>}
+              Data from {new Date(u.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+            </p>
           </button>
         ))}
       </div>

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -16,7 +16,7 @@ const UNIVERSITY_LOGOS: Record<string, string> = {
   ucd: 'https://upload.wikimedia.org/wikipedia/commons/f/f3/The_University_of_California_Davis.svg',
   ucsc: 'https://upload.wikimedia.org/wikipedia/commons/5/53/The_University_of_California_1868_UCSC.svg',
   stanford: 'https://upload.wikimedia.org/wikipedia/commons/b/b5/Seal_of_Leland_Stanford_Junior_University.svg',
-  mit: 'https://upload.wikimedia.org/wikipedia/commons/0/0c/MIT_logo.svg',
+  mit: 'https://upload.wikimedia.org/wikipedia/en/4/44/MIT_Seal.svg',
 }
 
 type SortOption = 'name' | 'repos' | 'updated'

--- a/scripts/score-university.ts
+++ b/scripts/score-university.ts
@@ -101,13 +101,20 @@ async function fetchRepoList(slug: string): Promise<UniversityRepo[]> {
 }
 
 async function analyzeBatch(repos: string[], token: string): Promise<AnalyzeResponse> {
-  const res = await fetch(`${BASE_URL}/api/analyze`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ repos, token }),
-  })
-  if (!res.ok) throw new Error(`/api/analyze failed: HTTP ${res.status}`)
-  return res.json() as Promise<AnalyzeResponse>
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), 300_000) // 5 min per batch
+  try {
+    const res = await fetch(`${BASE_URL}/api/analyze`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repos, token }),
+      signal: controller.signal,
+    })
+    if (!res.ok) throw new Error(`/api/analyze failed: HTTP ${res.status}`)
+    return res.json() as Promise<AnalyzeResponse>
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
 async function main() {
@@ -135,10 +142,19 @@ async function main() {
     const totalBatches = Math.ceil(repos.length / batchSize)
     process.stdout.write(`  Batch ${batchNum}/${totalBatches} (${batch.length} repos)...`)
 
-    const response = await analyzeBatch(batch, TOKEN)
-    results.push(...response.results)
-    failures.push(...(response.failures ?? []))
-    console.log(` done (${response.results.length} ok, ${response.failures?.length ?? 0} failed)`)
+    try {
+      const response = await analyzeBatch(batch, TOKEN)
+      results.push(...response.results)
+      failures.push(...(response.failures ?? []))
+      console.log(` done (${response.results.length} ok, ${response.failures?.length ?? 0} failed)`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.log(` batch error: ${msg}`)
+      failures.push(...batch.map((repo) => ({ repo, reason: msg, code: 'BATCH_ERROR' })))
+      // Give the server time to finish the in-flight GitHub API calls so its
+      // connection pool drains before we send the next batch.
+      await new Promise((resolve) => setTimeout(resolve, 90_000))
+    }
   }
 
   const generatedAt = new Date().toISOString()


### PR DESCRIPTION
## Summary
- Adds Stanford seal and MIT seal to the \`UNIVERSITY_LOGOS\` map (fixed broken commons URL, uses \`wikipedia/en\` seal SVG)
- Fixes sort order: strips \"University of California, \" and \"University of \" prefix so Berkeley/Davis/Santa Cruz sort before MIT/Stanford alphabetically
- Adds \"Sort by\" dropdown on the university grid (Name A–Z, Repos scored, Last updated)
- Shows per-university data date on each card (e.g. \"Data from May 15, 2026\")
- Hardens scorer: per-batch AbortController (300s timeout) + 90s cooldown on error
- Adds 300s \`Promise.race\` timeout in \`/api/analyze\` to prevent connection pool exhaustion

## Test plan
- [x] MIT and Stanford logos appear on university cards
- [x] Default card order is: Berkeley, Davis, MIT, Santa Cruz, Stanford
- [x] Each card shows \"Data from [date]\" reflecting that university's scored date
- [x] \"Sort by\" dropdown changes card order correctly
- [x] Sort by \"Repos scored\" puts highest-count university first
- [x] Sort by \"Last updated\" puts most recently scored university first