### PR TITLE
feat(universities): cross-university comparison view with radar cards

### DIFF
--- a/components/org-inventory/OrgInventorySummary.tsx
+++ b/components/org-inventory/OrgInventorySummary.tsx
@@ -21,7 +21,7 @@ export function OrgInventorySummary({ summary }: OrgInventorySummaryProps) {
       </div>
 
       <p className="text-xs text-slate-500 dark:text-slate-400">
-        High-level stats from GitHub metadata. Run <strong>Analyze all active repos</strong> for deeper org-level insights — contributor diversity, maintainers, security rollup, and more.
+        High-level stats from GitHub metadata. Deeper insights — contributor diversity, maintainers, security rollup — are available in the health score table below.
       </p>
 
       <div className="grid gap-2 lg:grid-cols-3">

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -7,7 +7,6 @@ import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
 import { UniversityChatPanel } from './UniversityChatPanel'
 import { UniversityScoreDistribution } from './UniversityScoreDistribution'
 import { UniversityComparison } from './UniversityComparison'
-import { UniversityCardRadar } from './UniversityCardRadar'
 import type { AnalysisResult, AnalyzeResponse, RepositoryFetchFailure } from '@/lib/analyzer/analysis-result'
 import { buildUniversitySummary } from '@/lib/university/summary'
 import type { UniversitySummary } from '@/lib/university/university-summary'
@@ -73,6 +72,7 @@ export function UniversityBrowser() {
   const [detailError, setDetailError] = useState<string | null>(null)
   const [sortBy, setSortBy] = useState<SortOption>('name')
   const autoSelectDone = useRef(false)
+  const unscoredRef = useRef<HTMLDetailsElement>(null)
 
   useEffect(() => {
     fetch(`${RAW_BASE}/manifest.json`)
@@ -178,9 +178,18 @@ export function UniversityBrowser() {
                 <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
                   {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
                   {selected.unscoredRepos.length > 0 && (
-                    <span className="ml-1 text-slate-400 dark:text-slate-500">
-                      · {selected.unscoredRepos.length.toLocaleString()} could not be scored
-                    </span>
+                    <button
+                      type="button"
+                      className="ml-1 text-sky-600 dark:text-sky-400 hover:underline"
+                      onClick={() => {
+                        if (unscoredRef.current) {
+                          unscoredRef.current.open = true
+                          unscoredRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                        }
+                      }}
+                    >
+                      · {selected.unscoredRepos.length.toLocaleString()} could not be scored ↓
+                    </button>
                   )}
                 </p>
                 {selected.entry.discoveryThreshold !== undefined && (
@@ -192,14 +201,33 @@ export function UniversityBrowser() {
             </div>
             {(() => {
               const s = summaries.find((s) => s.slug === selected.entry.slug)
-              return s ? (
-                <div className="flex-shrink-0">
-                  <div className="w-28 h-28">
-                    <UniversityCardRadar summary={s} />
-                  </div>
-                  <p className="text-center text-xs text-slate-400 dark:text-slate-500 mt-1">Health profile</p>
+              if (!s) return null
+              return (
+                <div className="flex-shrink-0 w-44 space-y-1.5">
+                  {([
+                    ['Activity', s.metrics.activity],
+                    ['Maintenance', s.metrics.maintenance],
+                    ['Community', s.metrics.community],
+                    ['Docs', s.metrics.documentation],
+                    ['Security', s.metrics.security],
+                  ] as [string, number][]).map(([label, value]) => (
+                    <div key={label} className="flex items-center gap-2">
+                      <span className="text-[10px] text-slate-400 dark:text-slate-500 w-16 shrink-0">{label}</span>
+                      <div className="flex-1 h-1.5 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
+                        <div
+                          className={`h-full rounded-full ${
+                            value >= 50 ? 'bg-emerald-400 dark:bg-emerald-500' :
+                            value >= 25 ? 'bg-amber-400 dark:bg-amber-500' :
+                            'bg-red-300 dark:bg-red-600'
+                          }`}
+                          style={{ width: `${value}%` }}
+                        />
+                      </div>
+                      <span className="text-[10px] text-slate-500 dark:text-slate-400 tabular-nums w-6 text-right">{value}</span>
+                    </div>
+                  ))}
                 </div>
-              ) : null
+              )
             })()}
           </div>
         </header>
@@ -207,7 +235,7 @@ export function UniversityBrowser() {
         <OrgInventorySummary summary={summary} />
         <RepoSummaryTable results={selected.results} />
         {selected.unscoredRepos.length > 0 && (
-          <details className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+          <details ref={unscoredRef} className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
             <summary className="cursor-pointer px-6 py-4 text-sm font-medium text-slate-700 dark:text-slate-300 select-none list-none flex items-center justify-between">
               <span>{selected.unscoredRepos.length.toLocaleString()} unscored repositories</span>
               <span className="text-xs text-slate-400 dark:text-slate-500">click to expand</span>

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -275,7 +275,7 @@ export function UniversityBrowser() {
       {summaries.length > 1 && (
         <details open className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
           <summary className="cursor-pointer px-6 py-4 text-sm font-semibold text-slate-700 dark:text-slate-300 select-none list-none flex items-center justify-between">
-            <span>OSS Pulse</span>
+            <span>OSS Insights</span>
             <span className="text-xs font-normal text-slate-400 dark:text-slate-500">click to collapse</span>
           </summary>
           <div className="px-6 pb-6">

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -275,7 +275,7 @@ export function UniversityBrowser() {
       {summaries.length > 1 && (
         <details open className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
           <summary className="cursor-pointer px-6 py-4 text-sm font-semibold text-slate-700 dark:text-slate-300 select-none list-none flex items-center justify-between">
-            <span>University comparison</span>
+            <span>University OSS Pulse</span>
             <span className="text-xs font-normal text-slate-400 dark:text-slate-500">click to collapse</span>
           </summary>
           <div className="px-6 pb-6">

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -334,6 +334,26 @@ export function UniversityBrowser() {
                   {u.discoveryThreshold !== undefined && <>Affiliation threshold: {u.discoveryThreshold} · </>}
                   Data from {new Date(u.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
                 </p>
+                {(() => {
+                  const s = summaries.find((s) => s.slug === u.slug)
+                  if (!s) return null
+                  const { high, medium, low } = s.scoreBands
+                  return (
+                    <div className="mt-3 flex items-center gap-2">
+                      <span className={`text-xs font-semibold tabular-nums px-1.5 py-0.5 rounded ${
+                        s.medianScore >= 50 ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300' :
+                        s.medianScore >= 33 ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300' :
+                        'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
+                      }`}>{s.medianScore}</span>
+                      <div className="flex-1 h-1.5 rounded-full overflow-hidden flex gap-px">
+                        <div className="bg-red-300 dark:bg-red-700 rounded-l-full" style={{ width: `${low * 100}%` }} />
+                        <div className="bg-amber-300 dark:bg-amber-600" style={{ width: `${medium * 100}%` }} />
+                        <div className="bg-emerald-400 dark:bg-emerald-600 rounded-r-full" style={{ width: `${high * 100}%` }} />
+                      </div>
+                      <span className="text-[10px] text-slate-400 dark:text-slate-500 whitespace-nowrap">median score</span>
+                    </div>
+                  )
+                })()}
             </div>
           </button>
         ))}

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -275,7 +275,7 @@ export function UniversityBrowser() {
       {summaries.length > 1 && (
         <details open className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
           <summary className="cursor-pointer px-6 py-4 text-sm font-semibold text-slate-700 dark:text-slate-300 select-none list-none flex items-center justify-between">
-            <span>University OSS Pulse</span>
+            <span>OSS Pulse</span>
             <span className="text-xs font-normal text-slate-400 dark:text-slate-500">click to collapse</span>
           </summary>
           <div className="px-6 pb-6">

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -308,9 +308,8 @@ export function UniversityBrowser() {
             disabled={loadingSlug !== null}
             className="group block rounded-2xl border border-slate-200 bg-white p-6 shadow-sm text-left transition hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-sky-500"
           >
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-3 mb-3">
+            <div>
+              <div className="flex items-center gap-3 mb-3">
                   {UNIVERSITY_LOGOS[u.slug] && (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
@@ -335,15 +334,6 @@ export function UniversityBrowser() {
                   {u.discoveryThreshold !== undefined && <>Affiliation threshold: {u.discoveryThreshold} · </>}
                   Data from {new Date(u.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
                 </p>
-              </div>
-              {(() => {
-                const s = summaries.find((s) => s.slug === u.slug)
-                return s ? (
-                  <div className="w-20 h-20 flex-shrink-0">
-                    <UniversityCardRadar summary={s} />
-                  </div>
-                ) : null
-              })()}
             </div>
           </button>
         ))}

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -275,7 +275,7 @@ export function UniversityBrowser() {
       {summaries.length > 1 && (
         <details open className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
           <summary className="cursor-pointer px-6 py-4 text-sm font-semibold text-slate-700 dark:text-slate-300 select-none list-none flex items-center justify-between">
-            <span>OSS Insights</span>
+            <span>OSS Health Overview</span>
             <span className="text-xs font-normal text-slate-400 dark:text-slate-500">click to collapse</span>
           </summary>
           <div className="px-6 pb-6">

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -163,31 +163,44 @@ export function UniversityBrowser() {
           <span className="text-slate-900 dark:text-slate-100">{selected.entry.university}</span>
         </nav>
         <header>
-          <div className="flex items-center gap-3">
-            {UNIVERSITY_LOGOS[selected.entry.slug] && (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={UNIVERSITY_LOGOS[selected.entry.slug]}
-                alt=""
-                className="h-12 w-12 rounded-full object-contain flex-shrink-0 bg-white"
-              />
-            )}
-            <div>
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{selected.entry.university}</h2>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
-                {selected.unscoredRepos.length > 0 && (
-                  <span className="ml-1 text-slate-400 dark:text-slate-500">
-                    · {selected.unscoredRepos.length.toLocaleString()} could not be scored
-                  </span>
-                )}
-              </p>
-              {selected.entry.discoveryThreshold !== undefined && (
-                <p className="mt-0.5 text-xs text-slate-400 dark:text-slate-500">
-                  Affiliation threshold: {selected.entry.discoveryThreshold}
-                </p>
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex items-center gap-3">
+              {UNIVERSITY_LOGOS[selected.entry.slug] && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={UNIVERSITY_LOGOS[selected.entry.slug]}
+                  alt=""
+                  className="h-12 w-12 rounded-full object-contain flex-shrink-0 bg-white"
+                />
               )}
+              <div>
+                <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">{selected.entry.university}</h2>
+                <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                  {selected.results.length} of {selected.entry.totalRepos} repositories scored · scored {scored}
+                  {selected.unscoredRepos.length > 0 && (
+                    <span className="ml-1 text-slate-400 dark:text-slate-500">
+                      · {selected.unscoredRepos.length.toLocaleString()} could not be scored
+                    </span>
+                  )}
+                </p>
+                {selected.entry.discoveryThreshold !== undefined && (
+                  <p className="mt-0.5 text-xs text-slate-400 dark:text-slate-500">
+                    Affiliation threshold: {selected.entry.discoveryThreshold}
+                  </p>
+                )}
+              </div>
             </div>
+            {(() => {
+              const s = summaries.find((s) => s.slug === selected.entry.slug)
+              return s ? (
+                <div className="flex-shrink-0">
+                  <div className="w-28 h-28">
+                    <UniversityCardRadar summary={s} />
+                  </div>
+                  <p className="text-center text-xs text-slate-400 dark:text-slate-500 mt-1">Health profile</p>
+                </div>
+              ) : null
+            })()}
           </div>
         </header>
         <UniversityScoreDistribution results={selected.results} />

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -6,8 +6,11 @@ import { OrgInventorySummary } from '@/components/org-inventory/OrgInventorySumm
 import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
 import { UniversityChatPanel } from './UniversityChatPanel'
 import { UniversityScoreDistribution } from './UniversityScoreDistribution'
+import { UniversityComparison } from './UniversityComparison'
+import { UniversityCardRadar } from './UniversityCardRadar'
 import type { AnalysisResult, AnalyzeResponse, RepositoryFetchFailure } from '@/lib/analyzer/analysis-result'
 import { buildUniversitySummary } from '@/lib/university/summary'
+import type { UniversitySummary } from '@/lib/university/university-summary'
 
 const RAW_BASE = 'https://raw.githubusercontent.com/arun-gupta/repofinder/repo-pulse-integration/exports/universities'
 
@@ -64,6 +67,7 @@ export function UniversityBrowser() {
   const searchParams = useSearchParams()
   const [manifest, setManifest] = useState<ManifestEntry[] | null>(null)
   const [manifestError, setManifestError] = useState(false)
+  const [summaries, setSummaries] = useState<UniversitySummary[]>([])
   const [selected, setSelected] = useState<Selected | null>(null)
   const [loadingSlug, setLoadingSlug] = useState<string | null>(null)
   const [detailError, setDetailError] = useState<string | null>(null)
@@ -73,7 +77,17 @@ export function UniversityBrowser() {
   useEffect(() => {
     fetch(`${RAW_BASE}/manifest.json`)
       .then((r) => r.json())
-      .then((data: ManifestEntry[]) => setManifest(data))
+      .then((data: ManifestEntry[]) => {
+        setManifest(data)
+        // Fetch all summaries in parallel for the comparison view and card radars
+        Promise.all(
+          data.map((e) =>
+            fetch(`${RAW_BASE}/${e.slug}-summary.json`)
+              .then((r) => r.ok ? r.json() as Promise<UniversitySummary> : null)
+              .catch(() => null)
+          )
+        ).then((results) => setSummaries(results.filter((s): s is UniversitySummary => s !== null)))
+      })
       .catch(() => setManifestError(true))
   }, [])
 
@@ -245,6 +259,17 @@ export function UniversityBrowser() {
           </a>
         </p>
       </div>
+      {summaries.length > 1 && (
+        <details open className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+          <summary className="cursor-pointer px-6 py-4 text-sm font-semibold text-slate-700 dark:text-slate-300 select-none list-none flex items-center justify-between">
+            <span>University comparison</span>
+            <span className="text-xs font-normal text-slate-400 dark:text-slate-500">click to collapse</span>
+          </summary>
+          <div className="px-6 pb-6">
+            <UniversityComparison summaries={summaries} />
+          </div>
+        </details>
+      )}
       {detailError && (
         <p className="text-sm text-red-600 dark:text-red-400">{detailError}</p>
       )}
@@ -270,31 +295,43 @@ export function UniversityBrowser() {
             disabled={loadingSlug !== null}
             className="group block rounded-2xl border border-slate-200 bg-white p-6 shadow-sm text-left transition hover:-translate-y-0.5 hover:border-sky-400 hover:shadow-md disabled:opacity-60 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-sky-500"
           >
-            <div className="flex items-center gap-3 mb-3">
-              {UNIVERSITY_LOGOS[u.slug] && (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={UNIVERSITY_LOGOS[u.slug]}
-                  alt=""
-                  className="h-10 w-10 rounded-full object-contain flex-shrink-0 bg-white"
-                />
-              )}
-              <h3 className="text-lg font-semibold text-slate-900 group-hover:text-sky-700 dark:text-slate-100 dark:group-hover:text-sky-300">
-                {loadingSlug === u.slug ? 'Loading…' : u.university}
-              </h3>
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-3 mb-3">
+                  {UNIVERSITY_LOGOS[u.slug] && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={UNIVERSITY_LOGOS[u.slug]}
+                      alt=""
+                      className="h-10 w-10 rounded-full object-contain flex-shrink-0 bg-white"
+                    />
+                  )}
+                  <h3 className="text-lg font-semibold text-slate-900 group-hover:text-sky-700 dark:text-slate-100 dark:group-hover:text-sky-300">
+                    {loadingSlug === u.slug ? 'Loading…' : u.university}
+                  </h3>
+                </div>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  {u.analyzedRepos.toLocaleString()} of {u.totalRepos.toLocaleString()} repositories scored
+                  {u.analyzedRepos < u.totalRepos && (
+                    <span className="ml-1 text-slate-400 dark:text-slate-500">
+                      · {(u.totalRepos - u.analyzedRepos).toLocaleString()} could not be scored (empty, deleted, or private)
+                    </span>
+                  )}
+                </p>
+                <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                  {u.discoveryThreshold !== undefined && <>Affiliation threshold: {u.discoveryThreshold} · </>}
+                  Data from {new Date(u.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+                </p>
+              </div>
+              {(() => {
+                const s = summaries.find((s) => s.slug === u.slug)
+                return s ? (
+                  <div className="w-20 h-20 flex-shrink-0">
+                    <UniversityCardRadar summary={s} />
+                  </div>
+                ) : null
+              })()}
             </div>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
-              {u.analyzedRepos.toLocaleString()} of {u.totalRepos.toLocaleString()} repositories scored
-              {u.analyzedRepos < u.totalRepos && (
-                <span className="ml-1 text-slate-400 dark:text-slate-500">
-                  · {(u.totalRepos - u.analyzedRepos).toLocaleString()} could not be scored (empty, deleted, or private)
-                </span>
-              )}
-            </p>
-            <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
-              {u.discoveryThreshold !== undefined && <>Affiliation threshold: {u.discoveryThreshold} · </>}
-              Data from {new Date(u.generatedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-            </p>
           </button>
         ))}
       </div>

--- a/components/university/UniversityBrowser.tsx
+++ b/components/university/UniversityBrowser.tsx
@@ -7,6 +7,7 @@ import { RepoSummaryTable } from '@/components/repo-summary/RepoSummaryTable'
 import { UniversityChatPanel } from './UniversityChatPanel'
 import { UniversityScoreDistribution } from './UniversityScoreDistribution'
 import { UniversityComparison } from './UniversityComparison'
+import { UniversityCardRadar } from './UniversityCardRadar'
 import type { AnalysisResult, AnalyzeResponse, RepositoryFetchFailure } from '@/lib/analyzer/analysis-result'
 import { buildUniversitySummary } from '@/lib/university/summary'
 import type { UniversitySummary } from '@/lib/university/university-summary'
@@ -201,33 +202,11 @@ export function UniversityBrowser() {
             </div>
             {(() => {
               const s = summaries.find((s) => s.slug === selected.entry.slug)
-              if (!s) return null
-              return (
-                <div className="flex-shrink-0 w-44 space-y-1.5">
-                  {([
-                    ['Activity', s.metrics.activity],
-                    ['Maintenance', s.metrics.maintenance],
-                    ['Community', s.metrics.community],
-                    ['Docs', s.metrics.documentation],
-                    ['Security', s.metrics.security],
-                  ] as [string, number][]).map(([label, value]) => (
-                    <div key={label} className="flex items-center gap-2">
-                      <span className="text-[10px] text-slate-400 dark:text-slate-500 w-16 shrink-0">{label}</span>
-                      <div className="flex-1 h-1.5 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
-                        <div
-                          className={`h-full rounded-full ${
-                            value >= 50 ? 'bg-emerald-400 dark:bg-emerald-500' :
-                            value >= 25 ? 'bg-amber-400 dark:bg-amber-500' :
-                            'bg-red-300 dark:bg-red-600'
-                          }`}
-                          style={{ width: `${value}%` }}
-                        />
-                      </div>
-                      <span className="text-[10px] text-slate-500 dark:text-slate-400 tabular-nums w-6 text-right">{value}</span>
-                    </div>
-                  ))}
+              return s ? (
+                <div className="flex-shrink-0 w-44 h-44">
+                  <UniversityCardRadar summary={s} />
                 </div>
-              )
+              ) : null
             })()}
           </div>
         </header>

--- a/components/university/UniversityCardRadar.tsx
+++ b/components/university/UniversityCardRadar.tsx
@@ -21,12 +21,15 @@ interface Props {
 
 export function UniversityCardRadar({ summary }: Props) {
   const { activity, maintenance, community, documentation, security } = summary.metrics
+  const values = [activity, maintenance, community, documentation, security]
+  // Scale to the highest metric value so the shape fills the chart meaningfully
+  const max = Math.max(10, Math.ceil(Math.max(...values) / 10) * 10)
 
   const data = {
     labels: LABELS,
     datasets: [
       {
-        data: [activity, maintenance, community, documentation, security],
+        data: values,
         backgroundColor: 'rgba(14, 165, 233, 0.15)',
         borderColor: 'rgba(14, 165, 233, 0.8)',
         borderWidth: 1.5,
@@ -43,8 +46,8 @@ export function UniversityCardRadar({ summary }: Props) {
     scales: {
       r: {
         min: 0,
-        max: 100,
-        ticks: { display: false, stepSize: 25 },
+        max,
+        ticks: { display: false },
         pointLabels: { display: false },
         grid: { color: 'rgba(148,163,184,0.2)' },
         angleLines: { color: 'rgba(148,163,184,0.2)' },

--- a/components/university/UniversityCardRadar.tsx
+++ b/components/university/UniversityCardRadar.tsx
@@ -8,6 +8,7 @@ import {
   LineElement,
   Filler,
   Tooltip,
+  type TooltipItem,
 } from 'chart.js'
 import type { UniversitySummary } from '@/lib/university/university-summary'
 
@@ -42,7 +43,16 @@ export function UniversityCardRadar({ summary }: Props) {
   const options = {
     responsive: true,
     maintainAspectRatio: true,
-    plugins: { tooltip: { enabled: false }, legend: { display: false } },
+    plugins: {
+      tooltip: {
+        enabled: true,
+        callbacks: {
+          label: (ctx: TooltipItem<'radar'>) => ` ${LABELS[ctx.dataIndex]}: ${ctx.raw}`,
+          title: () => '',
+        },
+      },
+      legend: { display: false },
+    },
     scales: {
       r: {
         min: 0,

--- a/components/university/UniversityCardRadar.tsx
+++ b/components/university/UniversityCardRadar.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { Radar } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+} from 'chart.js'
+import type { UniversitySummary } from '@/lib/university/university-summary'
+
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip)
+
+const LABELS = ['Activity', 'Maintenance', 'Community', 'Docs', 'Security']
+
+interface Props {
+  summary: UniversitySummary
+}
+
+export function UniversityCardRadar({ summary }: Props) {
+  const { activity, maintenance, community, documentation, security } = summary.metrics
+
+  const data = {
+    labels: LABELS,
+    datasets: [
+      {
+        data: [activity, maintenance, community, documentation, security],
+        backgroundColor: 'rgba(14, 165, 233, 0.15)',
+        borderColor: 'rgba(14, 165, 233, 0.8)',
+        borderWidth: 1.5,
+        pointRadius: 2,
+        pointBackgroundColor: 'rgba(14, 165, 233, 0.8)',
+      },
+    ],
+  }
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: true,
+    plugins: { tooltip: { enabled: false }, legend: { display: false } },
+    scales: {
+      r: {
+        min: 0,
+        max: 100,
+        ticks: { display: false, stepSize: 25 },
+        pointLabels: { display: false },
+        grid: { color: 'rgba(148,163,184,0.2)' },
+        angleLines: { color: 'rgba(148,163,184,0.2)' },
+      },
+    },
+  }
+
+  return <Radar data={data} options={options} />
+}

--- a/components/university/UniversityCardRadar.tsx
+++ b/components/university/UniversityCardRadar.tsx
@@ -48,7 +48,11 @@ export function UniversityCardRadar({ summary }: Props) {
         min: 0,
         max,
         ticks: { display: false },
-        pointLabels: { display: false },
+        pointLabels: {
+          display: true,
+          font: { size: 9 },
+          color: 'rgba(100,116,139,0.9)',
+        },
         grid: { color: 'rgba(148,163,184,0.2)' },
         angleLines: { color: 'rgba(148,163,184,0.2)' },
       },

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -60,7 +60,7 @@ interface Props {
 
 export function UniversityComparison({ summaries }: Props) {
   const [selected, setSelected] = useState<Set<string>>(() => new Set(summaries.map((s) => s.slug)))
-  const [tab, setTab] = useState<'heatmap' | 'metrics' | 'radar'>('radar')
+  const [tab, setTab] = useState<'heatmap' | 'metrics' | 'radar' | 'highlights'>('radar')
   const [drillDown, setDrillDown] = useState<DrillDown | null>(null)
   const [sortMetric, setSortMetric] = useState<SortMetric>('medianScore')
   const [sortAsc, setSortAsc] = useState(false)
@@ -96,8 +96,50 @@ export function UniversityComparison({ summaries }: Props) {
 
   return (
     <div className="space-y-4">
-      {/* Callout stats — two compact rows, all clickable */}
-      <div className="grid grid-cols-4 gap-2">
+      {/* University selector */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <span className="text-xs text-slate-500 dark:text-slate-400">Show:</span>
+        {summaries.map((s) => (
+          <button
+            key={s.slug}
+            type="button"
+            onClick={() => setSelected((prev) => {
+              const next = new Set(prev)
+              if (next.has(s.slug)) { if (next.size > 1) next.delete(s.slug) }
+              else next.add(s.slug)
+              return next
+            })}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+              selected.has(s.slug)
+                ? 'bg-sky-100 text-sky-800 dark:bg-sky-900/50 dark:text-sky-300'
+                : 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
+            }`}
+          >
+            {shortName(s.university)}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab toggle */}
+      <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700">
+        {(['radar', 'metrics', 'heatmap', 'highlights'] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-xs font-medium transition border-b-2 -mb-px ${
+              tab === t
+                ? 'border-sky-500 text-sky-600 dark:text-sky-400'
+                : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400'
+            }`}
+          >
+            {t === 'radar' ? 'Radar' : t === 'metrics' ? 'Health metrics' : t === 'heatmap' ? 'Score distribution' : 'Highlights'}
+          </button>
+        ))}
+      </div>
+
+      {/* Highlights tab — callout stats cards */}
+      {tab === 'highlights' && <div className="grid grid-cols-4 gap-2">
         {([
           { key: 'active' as DrillDown, label: 'Most active', name: shortName(mostActive.university), value: `${mostActive.metrics.activity}% active`, color: 'text-emerald-600 dark:text-emerald-400' },
           { key: 'documentation' as DrillDown, label: 'Best documented', name: shortName(bestDocs.university), value: `${bestDocs.metrics.documentation} doc score`, color: 'text-sky-600 dark:text-sky-400' },
@@ -148,10 +190,10 @@ export function UniversityComparison({ summaries }: Props) {
             <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 leading-tight truncate">{sub}</p>
           </button>
         ))}
-      </div>
+      </div>}
 
-      {/* Drill-down panel */}
-      {drillDown && (
+      {/* Highlights tab — drill-down panel */}
+      {tab === 'highlights' && drillDown && (
         <div className="rounded-lg border border-sky-200 dark:border-sky-800 bg-sky-50 dark:bg-sky-950/20 px-4 py-3">
           <div className="flex items-center justify-between mb-2">
             <p className="text-xs font-semibold text-slate-700 dark:text-slate-300">
@@ -246,48 +288,6 @@ export function UniversityComparison({ summaries }: Props) {
           </table>
         </div>
       )}
-
-      {/* University selector */}
-      <div className="flex flex-wrap gap-2 items-center">
-        <span className="text-xs text-slate-500 dark:text-slate-400">Show:</span>
-        {summaries.map((s) => (
-          <button
-            key={s.slug}
-            type="button"
-            onClick={() => setSelected((prev) => {
-              const next = new Set(prev)
-              if (next.has(s.slug)) { if (next.size > 1) next.delete(s.slug) }
-              else next.add(s.slug)
-              return next
-            })}
-            className={`px-3 py-1 rounded-full text-xs font-medium transition ${
-              selected.has(s.slug)
-                ? 'bg-sky-100 text-sky-800 dark:bg-sky-900/50 dark:text-sky-300'
-                : 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
-            }`}
-          >
-            {shortName(s.university)}
-          </button>
-        ))}
-      </div>
-
-      {/* Tab toggle */}
-      <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700">
-        {(['radar', 'metrics', 'heatmap'] as const).map((t) => (
-          <button
-            key={t}
-            type="button"
-            onClick={() => setTab(t)}
-            className={`px-4 py-2 text-xs font-medium transition border-b-2 -mb-px ${
-              tab === t
-                ? 'border-sky-500 text-sky-600 dark:text-sky-400'
-                : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400'
-            }`}
-          >
-            {t === 'radar' ? 'Radar' : t === 'metrics' ? 'Health metrics' : 'Score distribution'}
-          </button>
-        ))}
-      </div>
 
       {tab === 'heatmap' && (
         <div className="overflow-x-auto">

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useState } from 'react'
+import type { UniversitySummary } from '@/lib/university/university-summary'
+
+type MetricKey = 'activity' | 'maintenance' | 'community' | 'documentation' | 'security'
+type SortMetric = 'medianScore' | MetricKey
+
+const METRIC_LABELS: Record<MetricKey, string> = {
+  activity: 'Activity',
+  maintenance: 'Maintenance',
+  community: 'Community',
+  documentation: 'Docs',
+  security: 'Security',
+}
+
+const METRIC_KEYS = Object.keys(METRIC_LABELS) as MetricKey[]
+
+const BUCKET_LABELS = ['0–9', '10–19', '20–29', '30–39', '40–49', '50–59', '60–69', '70–79', '80–89', '90–100']
+
+function starRating(pct: number): number {
+  if (pct >= 30) return 5
+  if (pct >= 20) return 4
+  if (pct >= 12) return 3
+  if (pct >= 6) return 2
+  if (pct > 0) return 1
+  return 0
+}
+
+function Stars({ count }: { count: number }) {
+  return (
+    <span className="text-amber-400 text-xs tracking-tighter" title={`${count}/5`}>
+      {'★'.repeat(count)}{'☆'.repeat(5 - count)}
+    </span>
+  )
+}
+
+function metricColor(value: number): string {
+  if (value >= 50) return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300'
+  if (value >= 25) return 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300'
+  if (value >= 10) return 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300'
+  return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300'
+}
+
+function shortName(university: string): string {
+  return university
+    .replace(/^University of California,\s+/i, '')
+    .replace(/^University of\s+/i, '')
+    .replace(/^The\s+/i, '')
+}
+
+interface Props {
+  summaries: UniversitySummary[]
+}
+
+export function UniversityComparison({ summaries }: Props) {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(summaries.map((s) => s.slug)))
+  const [tab, setTab] = useState<'heatmap' | 'metrics'>('heatmap')
+  const [sortMetric, setSortMetric] = useState<SortMetric>('medianScore')
+  const [sortAsc, setSortAsc] = useState(false)
+
+  const visible = summaries
+    .filter((s) => selected.has(s.slug))
+    .sort((a, b) => {
+      const av = sortMetric === 'medianScore' ? a.medianScore : a.metrics[sortMetric]
+      const bv = sortMetric === 'medianScore' ? b.medianScore : b.metrics[sortMetric]
+      return sortAsc ? av - bv : bv - av
+    })
+
+  function toggleSort(metric: SortMetric) {
+    if (sortMetric === metric) setSortAsc((v) => !v)
+    else { setSortMetric(metric); setSortAsc(false) }
+  }
+
+  // Standout callouts
+  const mostActive = summaries.reduce((a, b) => a.metrics.activity > b.metrics.activity ? a : b)
+  const bestDocs = summaries.reduce((a, b) => a.metrics.documentation > b.metrics.documentation ? a : b)
+  const mostCommunity = summaries.reduce((a, b) => a.metrics.community > b.metrics.community ? a : b)
+
+  return (
+    <div className="space-y-4">
+      {/* Standout callouts */}
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { label: 'Most active', uni: mostActive, value: `${mostActive.metrics.activity}% repos`, color: 'text-emerald-600 dark:text-emerald-400' },
+          { label: 'Best documented', uni: bestDocs, value: `${bestDocs.metrics.documentation} median score`, color: 'text-sky-600 dark:text-sky-400' },
+          { label: 'Most community', uni: mostCommunity, value: `${mostCommunity.metrics.community}% multi-author`, color: 'text-violet-600 dark:text-violet-400' },
+        ].map(({ label, uni, value, color }) => (
+          <div key={label} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3">
+            <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+            <p className={`text-sm font-semibold mt-0.5 ${color}`}>{shortName(uni.university)}</p>
+            <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* University selector */}
+      <div className="flex flex-wrap gap-2 items-center">
+        <span className="text-xs text-slate-500 dark:text-slate-400">Show:</span>
+        {summaries.map((s) => (
+          <button
+            key={s.slug}
+            type="button"
+            onClick={() => setSelected((prev) => {
+              const next = new Set(prev)
+              if (next.has(s.slug)) { if (next.size > 1) next.delete(s.slug) }
+              else next.add(s.slug)
+              return next
+            })}
+            className={`px-3 py-1 rounded-full text-xs font-medium transition ${
+              selected.has(s.slug)
+                ? 'bg-sky-100 text-sky-800 dark:bg-sky-900/50 dark:text-sky-300'
+                : 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
+            }`}
+          >
+            {shortName(s.university)}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab toggle */}
+      <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700">
+        {(['heatmap', 'metrics'] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 text-xs font-medium transition border-b-2 -mb-px ${
+              tab === t
+                ? 'border-sky-500 text-sky-600 dark:text-sky-400'
+                : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400'
+            }`}
+          >
+            {t === 'heatmap' ? 'Score distribution' : 'Health metrics'}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'heatmap' && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr>
+                <th className="text-left py-2 pr-4 font-medium text-slate-500 dark:text-slate-400 min-w-[120px]">University</th>
+                {BUCKET_LABELS.map((l) => (
+                  <th key={l} className="text-center py-2 px-1 font-medium text-slate-400 dark:text-slate-500 whitespace-nowrap">{l}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((s) => {
+                const total = s.scoredRepos || 1
+                return (
+                  <tr key={s.slug} className="border-t border-slate-100 dark:border-slate-800">
+                    <td className="py-2 pr-4 font-medium text-slate-700 dark:text-slate-300 whitespace-nowrap">
+                      {shortName(s.university)}
+                    </td>
+                    {s.scoreBuckets.map((count, i) => {
+                      const pct = (count / total) * 100
+                      return (
+                        <td key={i} className="text-center py-1.5 px-1">
+                          <Stars count={starRating(pct)} />
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">★ rating = % of repos in that score bucket (★★★★★ ≥ 30%)</p>
+        </div>
+      )}
+
+      {tab === 'metrics' && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr>
+                {([['medianScore', 'Median score'], ...METRIC_KEYS.map((k) => [k, METRIC_LABELS[k]])] as [SortMetric, string][]).map(([key, label], i) => (
+                  <th
+                    key={key}
+                    className={`py-2 font-medium text-slate-500 dark:text-slate-400 cursor-pointer hover:text-sky-600 dark:hover:text-sky-400 ${i === 0 ? 'text-left pr-4 min-w-[120px]' : 'text-center px-3'}`}
+                    onClick={() => toggleSort(key)}
+                  >
+                    {label}{sortMetric === key ? (sortAsc ? ' ↑' : ' ↓') : ''}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((s) => (
+                <tr key={s.slug} className="border-t border-slate-100 dark:border-slate-800">
+                  <td className="py-2 pr-4 font-medium text-slate-700 dark:text-slate-300 whitespace-nowrap">
+                    {shortName(s.university)}
+                  </td>
+                  <td className="text-center px-3 py-1.5">
+                    <span className="font-semibold text-slate-700 dark:text-slate-300">{s.medianScore}</span>
+                  </td>
+                  {METRIC_KEYS.map((k) => (
+                    <td key={k} className="text-center px-3 py-1.5">
+                      <span className={`inline-block px-1.5 py-0.5 rounded text-xs font-medium ${metricColor(s.metrics[k])}`}>
+                        {s.metrics[k]}%
+                      </span>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+            Activity/Maintenance/Community = % of scored repos. Docs/Security = median score (0–100). Click column header to sort.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -5,6 +5,7 @@ import type { UniversitySummary } from '@/lib/university/university-summary'
 
 type MetricKey = 'activity' | 'maintenance' | 'community' | 'documentation' | 'security'
 type SortMetric = 'medianScore' | MetricKey
+type DrillDown = 'active' | 'documentation' | 'community' | 'stars' | 'starred' | 'contributors' | 'prs' | 'issues'
 
 const METRIC_LABELS: Record<MetricKey, string> = {
   activity: 'Activity',
@@ -48,6 +49,7 @@ interface Props {
 export function UniversityComparison({ summaries }: Props) {
   const [selected, setSelected] = useState<Set<string>>(() => new Set(summaries.map((s) => s.slug)))
   const [tab, setTab] = useState<'heatmap' | 'metrics'>('heatmap')
+  const [drillDown, setDrillDown] = useState<DrillDown | null>(null)
   const [sortMetric, setSortMetric] = useState<SortMetric>('medianScore')
   const [sortAsc, setSortAsc] = useState(false)
 
@@ -82,27 +84,45 @@ export function UniversityComparison({ summaries }: Props) {
 
   return (
     <div className="space-y-4">
-      {/* Callout stats — two compact rows */}
+      {/* Callout stats — two compact rows, all clickable */}
       <div className="grid grid-cols-4 gap-2">
-        {[
-          { label: 'Most active', name: shortName(mostActive.university), value: `${mostActive.metrics.activity}% active`, color: 'text-emerald-600 dark:text-emerald-400' },
-          { label: 'Best documented', name: shortName(bestDocs.university), value: `${bestDocs.metrics.documentation} doc score`, color: 'text-sky-600 dark:text-sky-400' },
-          { label: 'Most community', name: shortName(mostCommunity.university), value: `${mostCommunity.metrics.community}% multi-author`, color: 'text-violet-600 dark:text-violet-400' },
-          { label: 'Most stars', name: shortName(mostStars.university), value: `${mostStars.highlights.totalStars.toLocaleString()} ★`, color: 'text-amber-600 dark:text-amber-400' },
-        ].map(({ label, name, value, color }) => (
-          <div key={label} className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 min-w-0">
+        {([
+          { key: 'active' as DrillDown, label: 'Most active', name: shortName(mostActive.university), value: `${mostActive.metrics.activity}% active`, color: 'text-emerald-600 dark:text-emerald-400' },
+          { key: 'documentation' as DrillDown, label: 'Best documented', name: shortName(bestDocs.university), value: `${bestDocs.metrics.documentation} doc score`, color: 'text-sky-600 dark:text-sky-400' },
+          { key: 'community' as DrillDown, label: 'Most community', name: shortName(mostCommunity.university), value: `${mostCommunity.metrics.community}% multi-author`, color: 'text-violet-600 dark:text-violet-400' },
+          { key: 'stars' as DrillDown, label: 'Most stars', name: shortName(mostStars.university), value: `${mostStars.highlights.totalStars.toLocaleString()} ★`, color: 'text-amber-600 dark:text-amber-400' },
+        ] as const).map(({ key, label, name, value, color }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setDrillDown((d) => d === key ? null : key)}
+            className={`rounded-lg border px-3 py-2 min-w-0 text-left transition hover:border-sky-400 dark:hover:border-sky-500 ${
+              drillDown === key
+                ? 'border-sky-400 bg-sky-50 dark:border-sky-500 dark:bg-sky-950/30'
+                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900'
+            }`}
+          >
             <p className="text-[10px] text-slate-400 dark:text-slate-500 leading-tight">{label}</p>
             <p className={`text-xs font-semibold mt-0.5 truncate ${color}`}>{name}</p>
             <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 leading-tight">{value}</p>
-          </div>
+          </button>
         ))}
-        {[
-          { label: 'Top starred repo', name: topStarredRepo.highlights.mostStarred.repo.split('/')[1], href: `https://github.com/${topStarredRepo.highlights.mostStarred.repo}`, sub: `${topStarredRepo.highlights.mostStarred.value.toLocaleString()} ★ · ${shortName(topStarredRepo.university)}`, color: 'text-amber-600 dark:text-amber-400' },
-          { label: 'Most contributors', name: topContribRepo.highlights.mostContributors.repo.split('/')[1], href: `https://github.com/${topContribRepo.highlights.mostContributors.repo}`, sub: `${topContribRepo.highlights.mostContributors.value.toLocaleString()} contributors · ${shortName(topContribRepo.university)}`, color: 'text-violet-600 dark:text-violet-400' },
-          { label: 'Most PRs (90d)', name: topPRsRepo.highlights.mostPRs.repo.split('/')[1], href: `https://github.com/${topPRsRepo.highlights.mostPRs.repo}`, sub: `${topPRsRepo.highlights.mostPRs.value.toLocaleString()} PRs · ${shortName(topPRsRepo.university)}`, color: 'text-sky-600 dark:text-sky-400' },
-          { label: 'Most issues closed (90d)', name: topIssuesRepo.highlights.mostIssues.repo.split('/')[1], href: `https://github.com/${topIssuesRepo.highlights.mostIssues.repo}`, sub: `${topIssuesRepo.highlights.mostIssues.value.toLocaleString()} closed · ${shortName(topIssuesRepo.university)}`, color: 'text-emerald-600 dark:text-emerald-400' },
-        ].map(({ label, name, href, sub, color }) => (
-          <div key={label} className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 min-w-0">
+        {([
+          { key: 'starred' as DrillDown, label: 'Top starred repo', name: topStarredRepo.highlights.mostStarred.repo.split('/')[1], href: `https://github.com/${topStarredRepo.highlights.mostStarred.repo}`, sub: `${topStarredRepo.highlights.mostStarred.value.toLocaleString()} ★ · ${shortName(topStarredRepo.university)}`, color: 'text-amber-600 dark:text-amber-400' },
+          { key: 'contributors' as DrillDown, label: 'Most contributors', name: topContribRepo.highlights.mostContributors.repo.split('/')[1], href: `https://github.com/${topContribRepo.highlights.mostContributors.repo}`, sub: `${topContribRepo.highlights.mostContributors.value.toLocaleString()} contributors · ${shortName(topContribRepo.university)}`, color: 'text-violet-600 dark:text-violet-400' },
+          { key: 'prs' as DrillDown, label: 'Most PRs (90d)', name: topPRsRepo.highlights.mostPRs.repo.split('/')[1], href: `https://github.com/${topPRsRepo.highlights.mostPRs.repo}`, sub: `${topPRsRepo.highlights.mostPRs.value.toLocaleString()} PRs · ${shortName(topPRsRepo.university)}`, color: 'text-sky-600 dark:text-sky-400' },
+          { key: 'issues' as DrillDown, label: 'Most issues closed (90d)', name: topIssuesRepo.highlights.mostIssues.repo.split('/')[1], href: `https://github.com/${topIssuesRepo.highlights.mostIssues.repo}`, sub: `${topIssuesRepo.highlights.mostIssues.value.toLocaleString()} closed · ${shortName(topIssuesRepo.university)}`, color: 'text-emerald-600 dark:text-emerald-400' },
+        ] as const).map(({ key, label, name, href, sub, color }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setDrillDown((d) => d === key ? null : key)}
+            className={`rounded-lg border px-3 py-2 min-w-0 text-left transition hover:border-sky-400 dark:hover:border-sky-500 ${
+              drillDown === key
+                ? 'border-sky-400 bg-sky-50 dark:border-sky-500 dark:bg-sky-950/30'
+                : 'border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900'
+            }`}
+          >
             <p className="text-[10px] text-slate-400 dark:text-slate-500 leading-tight">{label}</p>
             <a
               href={href}
@@ -114,9 +134,106 @@ export function UniversityComparison({ summaries }: Props) {
               {name}
             </a>
             <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 leading-tight truncate">{sub}</p>
-          </div>
+          </button>
         ))}
       </div>
+
+      {/* Drill-down panel */}
+      {drillDown && (
+        <div className="rounded-lg border border-sky-200 dark:border-sky-800 bg-sky-50 dark:bg-sky-950/20 px-4 py-3">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-semibold text-slate-700 dark:text-slate-300">
+              {drillDown === 'active' && 'Activity ranking — % of repos with commits in last 90 days'}
+              {drillDown === 'documentation' && 'Documentation ranking — median doc score (0–100)'}
+              {drillDown === 'community' && 'Community ranking — % of repos with multiple commit authors'}
+              {drillDown === 'stars' && 'Stars ranking — total GitHub stars across all repos'}
+              {drillDown === 'starred' && 'Most starred repo per university'}
+              {drillDown === 'contributors' && 'Most contributors in a single repo per university'}
+              {drillDown === 'prs' && 'Most PRs opened (90d) in a single repo per university'}
+              {drillDown === 'issues' && 'Most issues closed (90d) in a single repo per university'}
+            </p>
+            <button type="button" onClick={() => setDrillDown(null)} className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 text-sm leading-none">✕</button>
+          </div>
+          <table className="w-full text-xs">
+            <tbody>
+              {drillDown === 'active' && [...summaries].sort((a, b) => b.metrics.activity - a.metrics.activity).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-4 font-medium text-slate-700 dark:text-slate-300">{shortName(s.university)}</td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.metrics.activity}% active</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">{s.metrics.maintenance}% maintained · {s.metrics.community}% multi-author</td>
+                </tr>
+              ))}
+              {drillDown === 'documentation' && [...summaries].sort((a, b) => b.metrics.documentation - a.metrics.documentation).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-4 font-medium text-slate-700 dark:text-slate-300">{shortName(s.university)}</td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.metrics.documentation} doc score</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">{s.metrics.security} security score</td>
+                </tr>
+              ))}
+              {drillDown === 'community' && [...summaries].sort((a, b) => b.metrics.community - a.metrics.community).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-4 font-medium text-slate-700 dark:text-slate-300">{shortName(s.university)}</td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.metrics.community}% multi-author</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">{s.metrics.activity}% active · {s.scoredRepos} repos</td>
+                </tr>
+              ))}
+              {drillDown === 'stars' && [...summaries].sort((a, b) => b.highlights.totalStars - a.highlights.totalStars).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-4 font-medium text-slate-700 dark:text-slate-300">{shortName(s.university)}</td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.highlights.totalStars.toLocaleString()} ★</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">
+                    top: <a href={`https://github.com/${s.highlights.mostStarred.repo}`} target="_blank" rel="noopener noreferrer" className="text-sky-600 dark:text-sky-400 hover:underline">{s.highlights.mostStarred.repo.split('/')[1]}</a> ({s.highlights.mostStarred.value.toLocaleString()} ★)
+                  </td>
+                </tr>
+              ))}
+              {drillDown === 'starred' && [...summaries].sort((a, b) => b.highlights.mostStarred.value - a.highlights.mostStarred.value).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-3">
+                    <a href={`https://github.com/${s.highlights.mostStarred.repo}`} target="_blank" rel="noopener noreferrer" className="font-medium text-sky-600 dark:text-sky-400 hover:underline">{s.highlights.mostStarred.repo.split('/')[1]}</a>
+                  </td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.highlights.mostStarred.value.toLocaleString()} ★</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">{shortName(s.university)}</td>
+                </tr>
+              ))}
+              {drillDown === 'contributors' && [...summaries].sort((a, b) => b.highlights.mostContributors.value - a.highlights.mostContributors.value).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-3">
+                    <a href={`https://github.com/${s.highlights.mostContributors.repo}`} target="_blank" rel="noopener noreferrer" className="font-medium text-sky-600 dark:text-sky-400 hover:underline">{s.highlights.mostContributors.repo.split('/')[1]}</a>
+                  </td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.highlights.mostContributors.value.toLocaleString()} contributors</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">{shortName(s.university)}</td>
+                </tr>
+              ))}
+              {drillDown === 'prs' && [...summaries].sort((a, b) => b.highlights.mostPRs.value - a.highlights.mostPRs.value).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-3">
+                    <a href={`https://github.com/${s.highlights.mostPRs.repo}`} target="_blank" rel="noopener noreferrer" className="font-medium text-sky-600 dark:text-sky-400 hover:underline">{s.highlights.mostPRs.repo.split('/')[1]}</a>
+                  </td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.highlights.mostPRs.value.toLocaleString()} PRs opened</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">{shortName(s.university)}</td>
+                </tr>
+              ))}
+              {drillDown === 'issues' && [...summaries].sort((a, b) => b.highlights.mostIssues.value - a.highlights.mostIssues.value).map((s, i) => (
+                <tr key={s.slug} className="border-t border-sky-100 dark:border-sky-900/50">
+                  <td className="py-1 pr-3 text-slate-400 tabular-nums w-5">{i + 1}</td>
+                  <td className="py-1 pr-3">
+                    <a href={`https://github.com/${s.highlights.mostIssues.repo}`} target="_blank" rel="noopener noreferrer" className="font-medium text-sky-600 dark:text-sky-400 hover:underline">{s.highlights.mostIssues.repo.split('/')[1]}</a>
+                  </td>
+                  <td className="py-1 pr-3 tabular-nums text-slate-600 dark:text-slate-400">{s.highlights.mostIssues.value.toLocaleString()} issues closed</td>
+                  <td className="py-1 text-slate-400 dark:text-slate-500">{shortName(s.university)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       {/* University selector */}
       <div className="flex flex-wrap gap-2 items-center">

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -18,21 +18,13 @@ const METRIC_KEYS = Object.keys(METRIC_LABELS) as MetricKey[]
 
 const BUCKET_LABELS = ['0–9', '10–19', '20–29', '30–39', '40–49', '50–59', '60–69', '70–79', '80–89', '90–100']
 
-function starRating(pct: number): number {
-  if (pct >= 30) return 5
-  if (pct >= 20) return 4
-  if (pct >= 12) return 3
-  if (pct >= 6) return 2
-  if (pct > 0) return 1
-  return 0
-}
-
-function Stars({ count }: { count: number }) {
-  return (
-    <span className="text-amber-400 text-xs tracking-tighter" title={`${count}/5`}>
-      {'★'.repeat(count)}{'☆'.repeat(5 - count)}
-    </span>
-  )
+function bucketCellClass(pct: number): string {
+  if (pct === 0) return 'text-slate-300 dark:text-slate-700'
+  if (pct < 5)  return 'bg-sky-50  text-sky-600  dark:bg-sky-950/60  dark:text-sky-400'
+  if (pct < 10) return 'bg-sky-100 text-sky-700  dark:bg-sky-900/60  dark:text-sky-300'
+  if (pct < 20) return 'bg-sky-200 text-sky-800  dark:bg-sky-800/70  dark:text-sky-200'
+  if (pct < 30) return 'bg-sky-300 text-sky-900  dark:bg-sky-700     dark:text-white'
+  return              'bg-sky-500 text-white     dark:bg-sky-500     dark:text-white'
 }
 
 function metricColor(value: number): string {
@@ -158,8 +150,10 @@ export function UniversityComparison({ summaries }: Props) {
                     {s.scoreBuckets.map((count, i) => {
                       const pct = (count / total) * 100
                       return (
-                        <td key={i} className="text-center py-1.5 px-1">
-                          <Stars count={starRating(pct)} />
+                        <td key={i} className="text-center py-1 px-0.5">
+                          <span className={`inline-block w-full rounded px-1 py-1 text-xs font-medium tabular-nums ${bucketCellClass(pct)}`}>
+                            {pct < 1 && pct > 0 ? '<1' : Math.round(pct)}%
+                          </span>
                         </td>
                       )
                     })}
@@ -168,7 +162,7 @@ export function UniversityComparison({ summaries }: Props) {
               })}
             </tbody>
           </table>
-          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">★ rating = % of repos in that score bucket (★★★★★ ≥ 30%)</p>
+          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">Cell color = % of repos in that score bucket. Darker = higher concentration.</p>
         </div>
       )}
 

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -64,24 +64,60 @@ export function UniversityComparison({ summaries }: Props) {
     else { setSortMetric(metric); setSortAsc(false) }
   }
 
-  // Standout callouts
+  // Standout callouts — university-level
   const mostActive = summaries.reduce((a, b) => a.metrics.activity > b.metrics.activity ? a : b)
   const bestDocs = summaries.reduce((a, b) => a.metrics.documentation > b.metrics.documentation ? a : b)
   const mostCommunity = summaries.reduce((a, b) => a.metrics.community > b.metrics.community ? a : b)
+  const mostStars = summaries.reduce((a, b) => a.highlights.totalStars > b.highlights.totalStars ? a : b)
+
+  // Cross-university top repos
+  const topStarredRepo = summaries.reduce((a, b) =>
+    a.highlights.mostStarred.value > b.highlights.mostStarred.value ? a : b)
+  const topContribRepo = summaries.reduce((a, b) =>
+    a.highlights.mostContributors.value > b.highlights.mostContributors.value ? a : b)
+  const topPRsRepo = summaries.reduce((a, b) =>
+    a.highlights.mostPRs.value > b.highlights.mostPRs.value ? a : b)
+  const topIssuesRepo = summaries.reduce((a, b) =>
+    a.highlights.mostIssues.value > b.highlights.mostIssues.value ? a : b)
 
   return (
     <div className="space-y-4">
-      {/* Standout callouts */}
-      <div className="grid grid-cols-3 gap-3">
+      {/* University-level callouts */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
-          { label: 'Most active', uni: mostActive, value: `${mostActive.metrics.activity}% repos`, color: 'text-emerald-600 dark:text-emerald-400' },
+          { label: 'Most active', uni: mostActive, value: `${mostActive.metrics.activity}% repos active`, color: 'text-emerald-600 dark:text-emerald-400' },
           { label: 'Best documented', uni: bestDocs, value: `${bestDocs.metrics.documentation} median score`, color: 'text-sky-600 dark:text-sky-400' },
           { label: 'Most community', uni: mostCommunity, value: `${mostCommunity.metrics.community}% multi-author`, color: 'text-violet-600 dark:text-violet-400' },
+          { label: 'Most stars', uni: mostStars, value: `${mostStars.highlights.totalStars.toLocaleString()} total ★`, color: 'text-amber-600 dark:text-amber-400' },
         ].map(({ label, uni, value, color }) => (
           <div key={label} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3">
             <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
             <p className={`text-sm font-semibold mt-0.5 ${color}`}>{shortName(uni.university)}</p>
             <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Top repos across all universities */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Most starred repo', h: topStarredRepo.highlights.mostStarred, uni: topStarredRepo, fmt: (v: number) => `${v.toLocaleString()} ★`, color: 'text-amber-600 dark:text-amber-400' },
+          { label: 'Most contributors', h: topContribRepo.highlights.mostContributors, uni: topContribRepo, fmt: (v: number) => `${v.toLocaleString()} contributors`, color: 'text-violet-600 dark:text-violet-400' },
+          { label: 'Most PRs (90d)', h: topPRsRepo.highlights.mostPRs, uni: topPRsRepo, fmt: (v: number) => `${v.toLocaleString()} PRs opened`, color: 'text-sky-600 dark:text-sky-400' },
+          { label: 'Most issues closed (90d)', h: topIssuesRepo.highlights.mostIssues, uni: topIssuesRepo, fmt: (v: number) => `${v.toLocaleString()} issues closed`, color: 'text-emerald-600 dark:text-emerald-400' },
+        ].map(({ label, h, uni, fmt, color }) => (
+          <div key={label} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3">
+            <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+            <a
+              href={`https://github.com/${h.repo}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`text-sm font-semibold mt-0.5 block truncate hover:underline ${color}`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              {h.repo.split('/')[1]}
+            </a>
+            <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{fmt(h.value)} · {shortName(uni.university)}</p>
           </div>
         ))}
       </div>

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -60,7 +60,7 @@ interface Props {
 
 export function UniversityComparison({ summaries }: Props) {
   const [selected, setSelected] = useState<Set<string>>(() => new Set(summaries.map((s) => s.slug)))
-  const [tab, setTab] = useState<'heatmap' | 'metrics' | 'radar' | 'highlights'>('radar')
+  const [tab, setTab] = useState<'heatmap' | 'metrics' | 'radar' | 'highlights'>('highlights')
   const [drillDown, setDrillDown] = useState<DrillDown | null>(null)
   const [sortMetric, setSortMetric] = useState<SortMetric>('medianScore')
   const [sortAsc, setSortAsc] = useState(false)
@@ -122,7 +122,7 @@ export function UniversityComparison({ summaries }: Props) {
 
       {/* Tab toggle */}
       <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700">
-        {(['radar', 'metrics', 'heatmap', 'highlights'] as const).map((t) => (
+        {(['highlights', 'radar', 'metrics', 'heatmap'] as const).map((t) => (
           <button
             key={t}
             type="button"

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -82,42 +82,38 @@ export function UniversityComparison({ summaries }: Props) {
 
   return (
     <div className="space-y-4">
-      {/* University-level callouts */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {/* Callout stats — two compact rows */}
+      <div className="grid grid-cols-4 gap-2">
         {[
-          { label: 'Most active', uni: mostActive, value: `${mostActive.metrics.activity}% repos active`, color: 'text-emerald-600 dark:text-emerald-400' },
-          { label: 'Best documented', uni: bestDocs, value: `${bestDocs.metrics.documentation} median score`, color: 'text-sky-600 dark:text-sky-400' },
-          { label: 'Most community', uni: mostCommunity, value: `${mostCommunity.metrics.community}% multi-author`, color: 'text-violet-600 dark:text-violet-400' },
-          { label: 'Most stars', uni: mostStars, value: `${mostStars.highlights.totalStars.toLocaleString()} total ★`, color: 'text-amber-600 dark:text-amber-400' },
-        ].map(({ label, uni, value, color }) => (
-          <div key={label} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3">
-            <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
-            <p className={`text-sm font-semibold mt-0.5 ${color}`}>{shortName(uni.university)}</p>
-            <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{value}</p>
+          { label: 'Most active', name: shortName(mostActive.university), value: `${mostActive.metrics.activity}% active`, color: 'text-emerald-600 dark:text-emerald-400' },
+          { label: 'Best documented', name: shortName(bestDocs.university), value: `${bestDocs.metrics.documentation} doc score`, color: 'text-sky-600 dark:text-sky-400' },
+          { label: 'Most community', name: shortName(mostCommunity.university), value: `${mostCommunity.metrics.community}% multi-author`, color: 'text-violet-600 dark:text-violet-400' },
+          { label: 'Most stars', name: shortName(mostStars.university), value: `${mostStars.highlights.totalStars.toLocaleString()} ★`, color: 'text-amber-600 dark:text-amber-400' },
+        ].map(({ label, name, value, color }) => (
+          <div key={label} className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 min-w-0">
+            <p className="text-[10px] text-slate-400 dark:text-slate-500 leading-tight">{label}</p>
+            <p className={`text-xs font-semibold mt-0.5 truncate ${color}`}>{name}</p>
+            <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 leading-tight">{value}</p>
           </div>
         ))}
-      </div>
-
-      {/* Top repos across all universities */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
-          { label: 'Most starred repo', h: topStarredRepo.highlights.mostStarred, uni: topStarredRepo, fmt: (v: number) => `${v.toLocaleString()} ★`, color: 'text-amber-600 dark:text-amber-400' },
-          { label: 'Most contributors', h: topContribRepo.highlights.mostContributors, uni: topContribRepo, fmt: (v: number) => `${v.toLocaleString()} contributors`, color: 'text-violet-600 dark:text-violet-400' },
-          { label: 'Most PRs (90d)', h: topPRsRepo.highlights.mostPRs, uni: topPRsRepo, fmt: (v: number) => `${v.toLocaleString()} PRs opened`, color: 'text-sky-600 dark:text-sky-400' },
-          { label: 'Most issues closed (90d)', h: topIssuesRepo.highlights.mostIssues, uni: topIssuesRepo, fmt: (v: number) => `${v.toLocaleString()} issues closed`, color: 'text-emerald-600 dark:text-emerald-400' },
-        ].map(({ label, h, uni, fmt, color }) => (
-          <div key={label} className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-4 py-3">
-            <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+          { label: 'Top starred repo', name: topStarredRepo.highlights.mostStarred.repo.split('/')[1], href: `https://github.com/${topStarredRepo.highlights.mostStarred.repo}`, sub: `${topStarredRepo.highlights.mostStarred.value.toLocaleString()} ★ · ${shortName(topStarredRepo.university)}`, color: 'text-amber-600 dark:text-amber-400' },
+          { label: 'Most contributors', name: topContribRepo.highlights.mostContributors.repo.split('/')[1], href: `https://github.com/${topContribRepo.highlights.mostContributors.repo}`, sub: `${topContribRepo.highlights.mostContributors.value.toLocaleString()} contributors · ${shortName(topContribRepo.university)}`, color: 'text-violet-600 dark:text-violet-400' },
+          { label: 'Most PRs (90d)', name: topPRsRepo.highlights.mostPRs.repo.split('/')[1], href: `https://github.com/${topPRsRepo.highlights.mostPRs.repo}`, sub: `${topPRsRepo.highlights.mostPRs.value.toLocaleString()} PRs · ${shortName(topPRsRepo.university)}`, color: 'text-sky-600 dark:text-sky-400' },
+          { label: 'Most issues closed (90d)', name: topIssuesRepo.highlights.mostIssues.repo.split('/')[1], href: `https://github.com/${topIssuesRepo.highlights.mostIssues.repo}`, sub: `${topIssuesRepo.highlights.mostIssues.value.toLocaleString()} closed · ${shortName(topIssuesRepo.university)}`, color: 'text-emerald-600 dark:text-emerald-400' },
+        ].map(({ label, name, href, sub, color }) => (
+          <div key={label} className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2 min-w-0">
+            <p className="text-[10px] text-slate-400 dark:text-slate-500 leading-tight">{label}</p>
             <a
-              href={`https://github.com/${h.repo}`}
+              href={href}
               target="_blank"
               rel="noopener noreferrer"
-              className={`text-sm font-semibold mt-0.5 block truncate hover:underline ${color}`}
+              className={`text-xs font-semibold mt-0.5 block truncate hover:underline ${color}`}
               onClick={(e) => e.stopPropagation()}
             >
-              {h.repo.split('/')[1]}
+              {name}
             </a>
-            <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{fmt(h.value)} · {shortName(uni.university)}</p>
+            <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5 leading-tight truncate">{sub}</p>
           </div>
         ))}
       </div>

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -135,7 +135,7 @@ export function UniversityComparison({ summaries }: Props) {
               <tr>
                 <th className="text-left py-2 pr-4 font-medium text-slate-500 dark:text-slate-400 min-w-[120px]"></th>
                 <th colSpan={10} className="text-center pb-1 text-xs font-medium text-slate-400 dark:text-slate-500">
-                  ← Health score (0–100) →
+                  ← Health score percentile (0–100) →
                 </th>
               </tr>
               <tr>
@@ -168,7 +168,7 @@ export function UniversityComparison({ summaries }: Props) {
               })}
             </tbody>
           </table>
-          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">Cell color = % of repos in that score bucket. Darker = higher concentration.</p>
+          <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">Each cell = % of repos in that health score percentile bucket. Darker = higher concentration.</p>
         </div>
       )}
 

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -1,7 +1,19 @@
 'use client'
 
 import { useState } from 'react'
+import { Radar } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend,
+} from 'chart.js'
 import type { UniversitySummary } from '@/lib/university/university-summary'
+
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend)
 
 type MetricKey = 'activity' | 'maintenance' | 'community' | 'documentation' | 'security'
 type SortMetric = 'medianScore' | MetricKey
@@ -48,7 +60,7 @@ interface Props {
 
 export function UniversityComparison({ summaries }: Props) {
   const [selected, setSelected] = useState<Set<string>>(() => new Set(summaries.map((s) => s.slug)))
-  const [tab, setTab] = useState<'heatmap' | 'metrics'>('heatmap')
+  const [tab, setTab] = useState<'heatmap' | 'metrics' | 'radar'>('heatmap')
   const [drillDown, setDrillDown] = useState<DrillDown | null>(null)
   const [sortMetric, setSortMetric] = useState<SortMetric>('medianScore')
   const [sortAsc, setSortAsc] = useState(false)
@@ -261,7 +273,7 @@ export function UniversityComparison({ summaries }: Props) {
 
       {/* Tab toggle */}
       <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700">
-        {(['heatmap', 'metrics'] as const).map((t) => (
+        {(['heatmap', 'metrics', 'radar'] as const).map((t) => (
           <button
             key={t}
             type="button"
@@ -272,7 +284,7 @@ export function UniversityComparison({ summaries }: Props) {
                 : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400'
             }`}
           >
-            {t === 'heatmap' ? 'Score distribution' : 'Health metrics'}
+            {t === 'heatmap' ? 'Score distribution' : t === 'metrics' ? 'Health metrics' : 'Radar'}
           </button>
         ))}
       </div>
@@ -362,6 +374,55 @@ export function UniversityComparison({ summaries }: Props) {
           </p>
         </div>
       )}
+
+      {tab === 'radar' && (() => {
+        const COLORS = [
+          { bg: 'rgba(14,165,233,0.12)',  border: 'rgba(14,165,233,0.85)'  },  // sky
+          { bg: 'rgba(168,85,247,0.12)',  border: 'rgba(168,85,247,0.85)'  },  // violet
+          { bg: 'rgba(34,197,94,0.12)',   border: 'rgba(34,197,94,0.85)'   },  // emerald
+          { bg: 'rgba(249,115,22,0.12)',  border: 'rgba(249,115,22,0.85)'  },  // orange
+          { bg: 'rgba(239,68,68,0.12)',   border: 'rgba(239,68,68,0.85)'   },  // red
+        ]
+        const allValues = visible.flatMap((s) => Object.values(s.metrics))
+        const max = Math.max(10, Math.ceil(Math.max(...allValues) / 10) * 10)
+        const data = {
+          labels: ['Activity', 'Maintenance', 'Community', 'Docs', 'Security'],
+          datasets: visible.map((s, i) => ({
+            label: shortName(s.university),
+            data: [s.metrics.activity, s.metrics.maintenance, s.metrics.community, s.metrics.documentation, s.metrics.security],
+            backgroundColor: COLORS[i % COLORS.length].bg,
+            borderColor: COLORS[i % COLORS.length].border,
+            borderWidth: 1.5,
+            pointRadius: 3,
+            pointBackgroundColor: COLORS[i % COLORS.length].border,
+          })),
+        }
+        const options = {
+          responsive: true,
+          maintainAspectRatio: true,
+          plugins: {
+            legend: { display: true, position: 'bottom' as const, labels: { boxWidth: 10, font: { size: 11 } } },
+            tooltip: { enabled: true },
+          },
+          scales: {
+            r: {
+              min: 0,
+              max,
+              ticks: { display: false },
+              pointLabels: { display: true, font: { size: 10 } },
+              grid: { color: 'rgba(148,163,184,0.2)' },
+              angleLines: { color: 'rgba(148,163,184,0.2)' },
+            },
+          },
+        }
+        return (
+          <div className="flex justify-center py-2">
+            <div className="w-full max-w-sm">
+              <Radar data={data} options={options} />
+            </div>
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -60,7 +60,7 @@ interface Props {
 
 export function UniversityComparison({ summaries }: Props) {
   const [selected, setSelected] = useState<Set<string>>(() => new Set(summaries.map((s) => s.slug)))
-  const [tab, setTab] = useState<'heatmap' | 'metrics' | 'radar'>('heatmap')
+  const [tab, setTab] = useState<'heatmap' | 'metrics' | 'radar'>('radar')
   const [drillDown, setDrillDown] = useState<DrillDown | null>(null)
   const [sortMetric, setSortMetric] = useState<SortMetric>('medianScore')
   const [sortAsc, setSortAsc] = useState(false)
@@ -273,7 +273,7 @@ export function UniversityComparison({ summaries }: Props) {
 
       {/* Tab toggle */}
       <div className="flex gap-1 border-b border-slate-200 dark:border-slate-700">
-        {(['heatmap', 'metrics', 'radar'] as const).map((t) => (
+        {(['radar', 'metrics', 'heatmap'] as const).map((t) => (
           <button
             key={t}
             type="button"
@@ -284,7 +284,7 @@ export function UniversityComparison({ summaries }: Props) {
                 : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400'
             }`}
           >
-            {t === 'heatmap' ? 'Score distribution' : t === 'metrics' ? 'Health metrics' : 'Radar'}
+            {t === 'radar' ? 'Radar' : t === 'metrics' ? 'Health metrics' : 'Score distribution'}
           </button>
         ))}
       </div>

--- a/components/university/UniversityComparison.tsx
+++ b/components/university/UniversityComparison.tsx
@@ -133,9 +133,15 @@ export function UniversityComparison({ summaries }: Props) {
           <table className="w-full text-xs">
             <thead>
               <tr>
-                <th className="text-left py-2 pr-4 font-medium text-slate-500 dark:text-slate-400 min-w-[120px]">University</th>
+                <th className="text-left py-2 pr-4 font-medium text-slate-500 dark:text-slate-400 min-w-[120px]"></th>
+                <th colSpan={10} className="text-center pb-1 text-xs font-medium text-slate-400 dark:text-slate-500">
+                  ← Health score (0–100) →
+                </th>
+              </tr>
+              <tr>
+                <th className="text-left py-1 pr-4 font-medium text-slate-500 dark:text-slate-400">University</th>
                 {BUCKET_LABELS.map((l) => (
-                  <th key={l} className="text-center py-2 px-1 font-medium text-slate-400 dark:text-slate-500 whitespace-nowrap">{l}</th>
+                  <th key={l} className="text-center py-1 px-1 font-medium text-slate-400 dark:text-slate-500 whitespace-nowrap">{l}</th>
                 ))}
               </tr>
             </thead>

--- a/lib/university/university-summary.ts
+++ b/lib/university/university-summary.ts
@@ -1,0 +1,18 @@
+export interface UniversitySummary {
+  slug: string
+  university: string
+  generatedAt: string
+  totalRepos: number
+  scoredRepos: number
+  medianScore: number
+  scoreBands: { high: number; medium: number; low: number }
+  /** Counts per 10-point bucket: index 0 = 0–9, index 9 = 90–100 */
+  scoreBuckets: number[]
+  metrics: {
+    activity: number
+    maintenance: number
+    community: number
+    documentation: number
+    security: number
+  }
+}

--- a/lib/university/university-summary.ts
+++ b/lib/university/university-summary.ts
@@ -1,3 +1,8 @@
+export interface RepoHighlight {
+  repo: string
+  value: number
+}
+
 export interface UniversitySummary {
   slug: string
   university: string
@@ -14,5 +19,12 @@ export interface UniversitySummary {
     community: number
     documentation: number
     security: number
+  }
+  highlights: {
+    totalStars: number
+    mostStarred: RepoHighlight
+    mostContributors: RepoHighlight
+    mostPRs: RepoHighlight
+    mostIssues: RepoHighlight
   }
 }

--- a/scripts/summarize-university.ts
+++ b/scripts/summarize-university.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env npx tsx
+/**
+ * Reads each {slug}-scored.json from the repofinder exports directory,
+ * computes aggregate stats (score buckets, per-metric medians, bands),
+ * and writes {slug}-summary.json (~2KB each) alongside the scored files.
+ *
+ * Usage:
+ *   npx tsx scripts/summarize-university.ts [--repofinder-dir ../repofinder]
+ */
+
+import fs from 'fs'
+import path from 'path'
+import type { AnalysisResult } from '../lib/analyzer/analysis-result'
+import { getHealthScore } from '../lib/scoring/health-score'
+import { getDocumentationScore } from '../lib/documentation/score-config'
+import { getSecurityScore } from '../lib/security/score-config'
+
+import type { UniversitySummary } from '../lib/university/university-summary'
+export type { UniversitySummary }
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+    : sorted[mid]
+}
+
+function computeSummary(
+  slug: string,
+  university: string,
+  totalRepos: number,
+  generatedAt: string,
+  results: AnalysisResult[]
+): UniversitySummary {
+  const scores: number[] = []
+  let activeRepos = 0
+  let maintainedRepos = 0
+  let communityRepos = 0
+  const documentation: number[] = []
+  const security: number[] = []
+
+  for (const r of results) {
+    const health = getHealthScore(r).percentile
+    if (health === null) continue
+    scores.push(health)
+
+    if (typeof r.commits90d === 'number' && r.commits90d > 0) activeRepos++
+
+    if (
+      (typeof r.issuesClosed90d === 'number' && r.issuesClosed90d > 0) ||
+      (typeof r.prsMerged90d === 'number' && r.prsMerged90d > 0)
+    ) maintainedRepos++
+
+    if (typeof r.uniqueCommitAuthors90d === 'number' && r.uniqueCommitAuthors90d > 1) communityRepos++
+
+    const doc = r.documentationResult !== 'unavailable'
+      ? getDocumentationScore(r.documentationResult, r.licensingResult, r.stars, r.inclusiveNamingResult).percentile
+      : null
+    if (doc !== null) documentation.push(doc)
+
+    const sec = r.securityResult !== 'unavailable'
+      ? getSecurityScore(r.securityResult, r.stars).percentile
+      : null
+    if (sec !== null) security.push(sec)
+  }
+
+  const buckets = Array<number>(10).fill(0)
+  for (const s of scores) {
+    const idx = Math.min(9, Math.floor(s / 10))
+    buckets[idx]++
+  }
+
+  const high = scores.filter((s) => s >= 67).length
+  const medium = scores.filter((s) => s >= 34 && s < 67).length
+  const low = scores.filter((s) => s < 34).length
+  const total = scores.length || 1
+
+  return {
+    slug,
+    university,
+    generatedAt,
+    totalRepos,
+    scoredRepos: results.length,
+    medianScore: median(scores),
+    scoreBands: {
+      high: Math.round((high / total) * 100) / 100,
+      medium: Math.round((medium / total) * 100) / 100,
+      low: Math.round((low / total) * 100) / 100,
+    },
+    scoreBuckets: buckets,
+    metrics: {
+      activity: Math.round((activeRepos / (scores.length || 1)) * 100),
+      maintenance: Math.round((maintainedRepos / (scores.length || 1)) * 100),
+      community: Math.round((communityRepos / (scores.length || 1)) * 100),
+      documentation: median(documentation),
+      security: median(security),
+    },
+  }
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2)
+  const get = (flag: string, def: string) => {
+    const i = args.indexOf(flag)
+    return i !== -1 ? args[i + 1] : def
+  }
+  return { repofinderDir: get('--repofinder-dir', '../repofinder') }
+}
+
+async function main() {
+  const { repofinderDir } = parseArgs()
+  const exportsDir = path.resolve(repofinderDir, 'exports', 'universities')
+
+  const manifestPath = path.join(exportsDir, 'manifest.json')
+  if (!fs.existsSync(manifestPath)) {
+    console.error(`Manifest not found at ${manifestPath}`)
+    process.exit(1)
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as Array<{
+    slug: string
+    university: string
+    totalRepos: number
+    generatedAt: string
+  }>
+
+  for (const entry of manifest) {
+    const scoredPath = path.join(exportsDir, `${entry.slug}-scored.json`)
+    if (!fs.existsSync(scoredPath)) {
+      console.warn(`Skipping ${entry.slug} — scored file not found`)
+      continue
+    }
+
+    process.stdout.write(`Computing summary for ${entry.slug}...`)
+    const fixture = JSON.parse(fs.readFileSync(scoredPath, 'utf-8')) as {
+      results: AnalysisResult[]
+      totalRepos: number
+      generatedAt: string
+    }
+
+    const summary = computeSummary(
+      entry.slug,
+      entry.university,
+      fixture.totalRepos,
+      fixture.generatedAt,
+      fixture.results
+    )
+
+    const outPath = path.join(exportsDir, `${entry.slug}-summary.json`)
+    fs.writeFileSync(outPath, JSON.stringify(summary, null, 2))
+    console.log(` done (medianScore=${summary.medianScore}, ${summary.scoredRepos} repos)`)
+  }
+
+  console.log('\nAll summaries written. Next: push exports/universities/*-summary.json to repo-pulse-integration')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/summarize-university.ts
+++ b/scripts/summarize-university.ts
@@ -77,6 +77,18 @@ function computeSummary(
   const low = scores.filter((s) => s < 34).length
   const total = scores.length || 1
 
+  function topBy(field: (r: AnalysisResult) => number | 'unavailable') {
+    let best: AnalysisResult | null = null
+    let bestVal = -1
+    for (const r of results) {
+      const v = field(r)
+      if (typeof v === 'number' && v > bestVal) { bestVal = v; best = r }
+    }
+    return best ? { repo: best.repo, value: bestVal } : { repo: '', value: 0 }
+  }
+
+  const totalStars = results.reduce((sum, r) => sum + (typeof r.stars === 'number' ? r.stars : 0), 0)
+
   return {
     slug,
     university,
@@ -96,6 +108,13 @@ function computeSummary(
       community: Math.round((communityRepos / (scores.length || 1)) * 100),
       documentation: median(documentation),
       security: median(security),
+    },
+    highlights: {
+      totalStars,
+      mostStarred: topBy((r) => r.stars),
+      mostContributors: topBy((r) => r.totalContributors),
+      mostPRs: topBy((r) => r.prsOpened90d),
+      mostIssues: topBy((r) => r.issuesClosed90d),
     },
   }
 }


### PR DESCRIPTION
Closes #553

## Summary
- **`scripts/summarize-university.ts`** — pre-computes `{slug}-summary.json` per university (~2KB): score buckets, metric pass rates, score bands, highlights
- **`UniversityCardRadar`** — radar chart on university detail page with axis labels (Activity, Maintenance, Community, Docs, Security) and hover tooltips
- **`UniversityComparison`** (now "OSS Health Overview") — collapsible panel above the card grid:
  - 8 compact callout cards (most active, best documented, most community, most stars + top starred repo, most contributors, most PRs, most issues)
  - All 8 cards are clickable — opens an inline ranked drill-down table for that metric
  - University selector pills (all on by default, min 1 always selected)
  - **Score distribution tab**: colour-intensity heatmap, rows = universities, columns = 10 health score percentile buckets (0–9 … 90–100)
  - **Health metrics tab**: sortable table with colour-coded cells for Activity, Maintenance, Community, Docs, Security
- **University cards** — each card now shows a median health score chip + red/amber/green score band bar
- **University detail page** — "N could not be scored" is now a clickable link that opens and scrolls to the unscored repos section; misleading "Run Analyze" call-to-action removed
- Radar chart removed from card list (kept on detail page only)
- Section renamed to "OSS Health Overview"

## Test plan
- [x] "OSS Health Overview" panel visible and open by default above university cards
- [x] Each of the 8 callout cards shows correct university/repo for that metric
- [x] Clicking a callout card opens an inline ranked table; clicking again collapses it
- [x] University selector pills filter the heatmap and metrics table rows
- [x] Score distribution tab shows health percentile heatmap with correct colour intensity
- [x] Health metrics tab shows colour-coded table, sortable by each column header
- [x] Each university card shows median score chip + score band bar
- [x] University detail page shows radar chart with axis labels and hover tooltips
- [x] "N could not be scored" link opens and scrolls to unscored repos section
- [x] Radar chart does NOT appear on the card list (only on detail page)
- [x] No layout breakage on mobile (overflow-x-auto on tables)