### PR TITLE
Fix Copy Link omitting selected repos in Repositories mode

### DIFF
--- a/components/repo-input/RepoInputClient.tsx
+++ b/components/repo-input/RepoInputClient.tsx
@@ -31,7 +31,7 @@ import type { AspirantReadinessResult, CNCFFieldBadge, FoundationTarget } from '
 import type { OrgInventoryResponse } from '@/lib/analyzer/org-inventory'
 import type { ResultTabDefinition, ResultTabId } from '@/specs/006-results-shell/contracts/results-shell-props'
 import { resultTabs } from '@/lib/results-shell/tabs'
-import { decodeFoundationUrl, isValidRepoSlug } from '@/lib/export/shareable-url'
+import { decodeFoundationUrl, isValidRepoSlug, reposReplaceStatePath } from '@/lib/export/shareable-url'
 import { parseRepos } from '@/lib/parse-repos'
 import { parseFoundationInput } from '@/lib/foundation/parse-foundation-input'
 import { fetchBoardRepos, type SkippedIssue } from '@/lib/foundation/fetch-board-repos'
@@ -81,6 +81,9 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
   const [loadingRepos, setLoadingRepos] = useState<string[]>([])
   const [loadingOrg, setLoadingOrg] = useState<string | null>(null)
   const [resultsResetKey, setResultsResetKey] = useState(0)
+  // Bumped on full reset (logo click) to remount RepoInputForm so its internal
+  // input state re-seeds from the now-cleared URL.
+  const [inputResetKey, setInputResetKey] = useState(0)
   const [inputMode, setInputMode] = useState<'repos' | 'org' | 'foundation' | 'university'>(initialInputMode)
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const [emptyQuoteIndex, setEmptyQuoteIndex] = useState(() => getRandomQuoteIndex(null))
@@ -318,8 +321,11 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
       setFoundationTarget(target)
       params.set('foundation', target)
       if (foundationInput) params.set('input', foundationInput)
+    } else if (analyzedRepos.length > 0) {
+      // repos is the default — no mode param needed, but keep the analyzed repos
+      // in the URL so a shared link survives switching tabs.
+      params.set('repos', analyzedRepos.join(','))
     }
-    // repos is the default — no mode param needed
     const qs = params.toString()
     window.history.replaceState(null, '', qs ? `/?${qs}` : '/')
   }
@@ -358,6 +364,10 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setFoundationLoadingItems([])
     setPendingBoardScan(null)
     previousFoundationResultRef.current = null
+    // Clear the shareable URL and remount the input so the repos don't linger
+    // after returning to the home/empty state.
+    window.history.replaceState(null, '', '/')
+    setInputResetKey((k) => k + 1)
   }
 
   async function handleFoundationSubmit(input: string) {
@@ -491,6 +501,12 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
     setInputMode('repos')
     setLoadingRepos(repos)
     setLoadingOrg(null)
+
+    // Reflect the selected repos in the URL immediately so Copy Link is shareable
+    // right away — even while the analysis runs. Done synchronously here in the
+    // submit handler (like handleModeChange) so the write isn't lost to the
+    // re-render that the post-await completion setState would trigger.
+    window.history.replaceState(null, '', reposReplaceStatePath(repos))
 
     try {
       const response = onAnalyze
@@ -656,6 +672,7 @@ export function RepoInputClient({ onAnalyze, onAnalyzeOrg }: RepoInputClientProp
 
   const analysisPanel = (
     <RepoInputForm
+      key={inputResetKey}
       mode={inputMode}
       onModeChange={handleModeChange}
       onSubmitRepos={handleSubmit}

--- a/lib/export/shareable-url.test.ts
+++ b/lib/export/shareable-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { encodeRepos, decodeRepos, encodeFoundationUrl, decodeFoundationUrl, isValidRepoSlug } from './shareable-url'
+import { encodeRepos, decodeRepos, encodeFoundationUrl, decodeFoundationUrl, isValidRepoSlug, reposReplaceStatePath } from './shareable-url'
 
 describe('isValidRepoSlug', () => {
   it.each([
@@ -107,6 +107,33 @@ describe('decodeRepos', () => {
     expect(
       decodeRepos('?repos=facebook%2Freact,%2Fbad,bare,vercel%2Fnext.js,owner%2F')
     ).toEqual(['facebook/react', 'vercel/next.js'])
+  })
+})
+
+describe('reposReplaceStatePath', () => {
+  it('builds a relative path with a single repo', () => {
+    expect(reposReplaceStatePath(['facebook/react'])).toBe('/?repos=facebook%2Freact')
+  })
+
+  it('builds a relative path with multiple comma-separated repos', () => {
+    const path = reposReplaceStatePath(['facebook/react', 'vercel/next.js'])
+    const params = new URLSearchParams(path.split('?')[1])
+    expect(params.get('repos')).toBe('facebook/react,vercel/next.js')
+  })
+
+  it('returns "/" for an empty list', () => {
+    expect(reposReplaceStatePath([])).toBe('/')
+  })
+
+  it('emits no mode param (Repositories is the default)', () => {
+    const path = reposReplaceStatePath(['facebook/react'])
+    expect(path).not.toContain('mode=')
+  })
+
+  it('round-trips reposReplaceStatePath → decodeRepos', () => {
+    const repos = ['facebook/react', 'vercel/next.js']
+    const search = '?' + reposReplaceStatePath(repos).split('?')[1]
+    expect(decodeRepos(search)).toEqual(repos)
   })
 })
 

--- a/lib/export/shareable-url.ts
+++ b/lib/export/shareable-url.ts
@@ -10,6 +10,18 @@ export function encodeRepos(repos: string[]): string {
 }
 
 /**
+ * Builds the relative path (no origin) for `history.replaceState` so the
+ * selected repos are reflected in the address bar and Copy Link is shareable.
+ * Repositories is the default mode, so no `mode` param is emitted — only
+ * `?repos=`. Returns `/` for an empty list.
+ */
+export function reposReplaceStatePath(repos: string[]): string {
+  if (repos.length === 0) return '/'
+  const params = new URLSearchParams({ repos: repos.join(',') })
+  return `/?${params.toString()}`
+}
+
+/**
  * Returns true for valid `owner/repo` slugs — exactly one `/` with non-empty
  * owner and repo segments. Silently rejects leading slashes, bare names, and
  * deeply-nested paths that would otherwise reach the analysis flow.


### PR DESCRIPTION
## Summary
Fixes #562. In **Repositories** mode, **Copy Link** copied the bare origin (`https://…/`) instead of a shareable `?repos=…` URL — the selected repos were lost.

**Root cause:** `CopyLinkButton` copies `window.location.href` verbatim, but the repos submit path never wrote the selected repos into the address bar. (`handleSubmit` updated React state only, unlike the org/foundation handlers which sync the URL via `history.replaceState`.)

## Changes
- **`lib/export/shareable-url.ts`** — add `reposReplaceStatePath(repos)`, a pure helper that builds the relative `/?repos=…` path (or `/` when empty). No `mode` param, since Repositories is the default.
- **`components/repo-input/RepoInputClient.tsx`**
  - `handleSubmit`: write the selected repos to the URL **synchronously at submit-start** (mirroring `handleModeChange`). This makes Copy Link shareable **immediately** — even while the ~2-minute analysis runs — and avoids losing the write to the re-render that the post-`await` completion `setState` triggers.
  - `handleModeChange`: preserve the `repos` param when switching back to Repositories mode, so a shared link survives tab switches.
  - `handleReset` (RepoPulse logo click): clear the URL back to `/` and remount the input form so the repos don't linger after returning to the home/empty state.
- **`lib/export/shareable-url.test.ts`** — unit tests for `reposReplaceStatePath`, including a `decodeRepos` round-trip.

The encode/decode helpers and the page-load parser were already correct; the only gap was that the param was never written.

## Test plan
- [x] `npm run test` — `lib/export/shareable-url.test.ts` (40/40) and `RepoInputClient.test.tsx` (38/38) pass
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Manual: Repositories mode → enter multiple repos → **Analyze** → URL updates to `?repos=owner/repo,…` immediately on click
- [x] Manual: Copy Link → pasted URL contains the full `?repos=…` list
- [x] Manual: open the copied URL in a new tab → repos are pre-populated (and analysis auto-runs)
- [x] Manual: switch to Org/Foundation and back to Repositories → `repos` param is retained
- [x] Manual: click the RepoPulse logo → URL clears to `/`, input box clears, results reset

> Note: a pre-existing hydration warning (client-side auth state + a `Math.random()` quote-index seed) is unrelated to this change and present on the baseline. Pre-existing unit-test failures in `OrgInventoryView.test.tsx` and `RepoInputForm.test.tsx` also predate this branch and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)